### PR TITLE
grift: update for new directory structure

### DIFF
--- a/riscv-target/grift/device/rv32i/Makefile.include
+++ b/riscv-target/grift/device/rv32i/Makefile.include
@@ -8,7 +8,7 @@ RUN_TARGET=\
     $(TARGET_SIM) $(TARGET_FLAGS) --arch=RV32I \
         --mem-dump-begin=begin_signature --mem-dump-end=end_signature \
 	--halt-pc=grift_stop_addr \
-        $(work_dir_isa)/$< > $(work_dir_isa)/$(*).signature.output 2> $(work_dir_isa)/$@;
+        $< > $(*).signature.output 2> $@;
 
 RISCV_PREFIX   ?= riscv32-unknown-elf-
 RISCV_GCC      ?= $(RISCV_PREFIX)gcc
@@ -16,10 +16,10 @@ RISCV_OBJDUMP  ?= $(RISCV_PREFIX)objdump
 RISCV_GCC_OPTS ?= -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
 
 COMPILE_TARGET=\
-	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
+	$$(RISCV_GCC) $(1) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
 		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
-		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
-		-o $(work_dir_isa)/$$@; \
-	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump
+		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$(<) \
+		-o $$@; \
+	$$(RISCV_OBJDUMP) -D $$@ > $$@.objdump


### PR DESCRIPTION
The directory structure was changed in 5a978cfd444d5e640150d46703deda99057b2bbb. However, as stated in
this commit it was only tested with riscvOVPsim and spike. Unfortunately, the commit broke the grift target as paths weren't adjusted accordingly for it. This commit updates the paths accordingly.