### PR TITLE
annotating tags during release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Tag
         if: github.ref == 'refs/heads/master'
         run: |
-          git tag ${{ steps.get_version.outputs.version }}
+          git tag -a ${{ steps.get_version.outputs.version }}
           git push origin ${{ steps.get_version.outputs.version }}
 
       - name: Build PDF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [2.4.4] - 2021-07-19
+  - Annotating tags during releases
+
 ## [2.4.3] - 2021-05-20
   - added new 64-bit K crypto tests as per the test-plan presented by the scalar crypto task group
     [here](https://github.com/riscv/riscv-crypto/blob/d89dfee25780f79c162da4eb69cd9076dd701c88/tests/compliance/test-plan-scalar.adoc)


### PR DESCRIPTION
Annotating the releases will allow riscof to gather more information about the latest commit using a simple `git describe` command. This will enable better reporting and book-keeping. Refer [here](https://git-scm.com/book/en/v2/Git-Basics-Tagging) for details on annotated tags vs lightweight tags.