### PR TITLE
Add ratified Svrsw60t59b extension tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [3.10.1] - 2025-03-16
+- Add unratified Svrsw60t59b extension
+
 ## [3.10.0] - 2024-11-04
 - Add support for Zvk* extensions
 - Split float and double test cases into smaller ones

--- a/riscv-test-suite/env/encoding.h
+++ b/riscv-test-suite/env/encoding.h
@@ -202,6 +202,9 @@
 #define PTE_D     0x080 // Dirty
 #define PTE_SOFT  0x300 // Reserved for Software
 
+#define PTE_RSW   0x1800000000000000 /* Svrsw60t59b: Reserved for software use */
+#define PTE_RSVD  0x07C0000000000000 /* Reserved for future standard use */
+
 #define PTE_PPN_SHIFT 10
 
 #define PTE_TABLE(PTE) (((PTE) & (PTE_V | PTE_R | PTE_W | PTE_X)) == PTE_V)

--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -150,6 +150,50 @@ Mend_PMP:                                    ;\
     and t0, t0, PTE_V | PTE_U | PTE_R | PTE_W | PTE_X | PTE_A | PTE_D                   ;\
     RVTEST_SIGUPD(x1,t0,offset)
 
+#define TEST_SVRSW60T59B(swreg, PTE_ADDR, VA, offset)                                    \
+    LREG t2, (PTE_ADDR)                                                                 ;\
+    li   t1, ~PTE_RSW                                                                   ;\
+    and  t2, t2, t1                                                                     ;\
+    li   t1, (0x0 << 59)                                                                ;\
+    or   t2, t2, t1                                                                     ;\
+    SREG t2, (PTE_ADDR)                                                                 ;\
+    RVTEST_SIGUPD(x1,t2,offset)                                                         ;\
+    sfence.vma                                                                          ;\
+    la   t0, VA                                                                         ;\
+    LREG x0, (t0)                                                                       ;\
+                                                                                        ;\
+    LREG t2, (PTE_ADDR)                                                                 ;\
+    li   t1, ~PTE_RSW                                                                   ;\
+    and  t2, t2, t1                                                                     ;\
+    li   t1, (0x1 << 59)                                                                ;\
+    or   t2, t2, t1                                                                     ;\
+    SREG t2, (PTE_ADDR)                                                                 ;\
+    RVTEST_SIGUPD(x1,t2,offset)                                                         ;\
+    sfence.vma                                                                          ;\
+    la   t0, VA                                                                         ;\
+    LREG x0, (t0)                                                                       ;\
+                                                                                        ;\
+    LREG t2, (PTE_ADDR)                                                                 ;\
+    li   t1, ~PTE_RSW                                                                   ;\
+    and  t2, t2, t1                                                                     ;\
+    li   t1, (0x2 << 59)                                                                ;\
+    or   t2, t2, t1                                                                     ;\
+    SREG t2, (PTE_ADDR)                                                                 ;\
+    RVTEST_SIGUPD(x1,t2,offset)                                                         ;\
+    sfence.vma                                                                          ;\
+    la   t0, VA                                                                         ;\
+    LREG x0, (t0)                                                                       ;\
+                                                                                        ;\
+    LREG t2, (PTE_ADDR)                                                                 ;\
+    li   t1, ~PTE_RSW                                                                   ;\
+    and  t2, t2, t1                                                                     ;\
+    li   t1, (0x3 << 59)                                                                ;\
+    or   t2, t2, t1                                                                     ;\
+    SREG t2, (PTE_ADDR)                                                                 ;\
+    RVTEST_SIGUPD(x1,t2,offset)                                                         ;\
+    sfence.vma                                                                          ;\
+    la   t0, VA                                                                         ;\
+    LREG x0, (t0)
 
 #define ALL_MEM_PMP                                               ;\
     	li t2, -1                                                 ;\

--- a/riscv-test-suite/rv64i_m/Svrsw60t59b/src/svadu_sv39.S
+++ b/riscv-test-suite/rv64i_m/Svrsw60t59b/src/svadu_sv39.S
@@ -1,0 +1,75 @@
+// -----------
+// Copyright (c) 2020. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// -----------
+//
+// This assembly file tests the Svrsw60t59b extension
+// 
+#include "model_test.h"
+#include "arch_test.h"
+
+# Test Virtual Machine (TVM) used by program.
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+  RVTEST_CASE(1,"//check ISA:=regex(.*64.*);check ISA:=regex(.*I.*);check ISA:=regex(.*Svrsw60t59b.*);def rvtest_mtrap_routine=True;def TEST_CASE_1=True;",svrsw60t59b_sv39)
+
+  RVTEST_SIGBASE(x1, signature_x1_0)
+
+  # Setup PMP to cover 4G of address space
+  SETUP_PMP_SVADU_TEST(x1, offset, t0, t1, t2)
+
+  # Idenity map the page_4k
+  la t1, page_4k
+  mv t2, t1
+  PTE_SETUP_SV39(t1, PTE_V, t0, s2, t2, 2)
+
+  # enable virtual memory in Sv39 mode
+  SATP_SETUP(t0, t1, ((SATP_MODE & ~(SATP_MODE<<1)) * SATP_MODE_SV39))
+
+  # test svrsw60t59b
+  TEST_SVRSW60T59B(x1, s2, page_4k, offset)
+#endif
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+  .align 12
+   page_4k:
+  .fill   4096/REGWIDTH, REGWIDTH, 0
+RVTEST_DATA_END
+
+  .align 12
+rvtest_Sroot_pg_tbl:
+  .fill   4096/REGWIDTH, REGWIDTH, 0
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+signature_x1_0:
+  .fill 64*(XLEN/32),4,0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 128*4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/Svrsw60t59b/src/svadu_sv48.S
+++ b/riscv-test-suite/rv64i_m/Svrsw60t59b/src/svadu_sv48.S
@@ -1,0 +1,75 @@
+// -----------
+// Copyright (c) 2020. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// -----------
+//
+// This assembly file tests the Svrsw60t59b extension
+// 
+#include "model_test.h"
+#include "arch_test.h"
+
+# Test Virtual Machine (TVM) used by program.
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+  RVTEST_CASE(1,"//check ISA:=regex(.*64.*);check ISA:=regex(.*I.*);check ISA:=regex(.*Svrsw60t59b.*);def rvtest_mtrap_routine=True;def TEST_CASE_1=True;",svrsw60t59b_sv48)
+
+  RVTEST_SIGBASE(x1, signature_x1_0)
+
+  # Setup PMP to cover 4G of address space
+  SETUP_PMP_SVADU_TEST(x1, offset, t0, t1, t2)
+
+  # Identity map the page_4k
+  la t1, page_4k
+  mv t2, t1
+  PTE_SETUP_SV48(t1, PTE_V, t0, s2, t2, 3)
+
+  # enable virtual memory in Sv48 mode
+  SATP_SETUP(t0, t1, ((SATP_MODE & ~(SATP_MODE<<1)) * SATP_MODE_SV48))
+
+  # test svrsw60t59b
+  TEST_SVRSW60T59B(x1, s2, page_4k, offset)
+#endif
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+  .align 12
+   page_4k:
+  .fill   4096/REGWIDTH, REGWIDTH, 0
+RVTEST_DATA_END
+
+  .align 12
+rvtest_Sroot_pg_tbl:
+  .fill   4096/REGWIDTH, REGWIDTH, 0
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+signature_x1_0:
+  .fill 64*(XLEN/32),4,0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 128*4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/Svrsw60t59b/src/svadu_sv57.S
+++ b/riscv-test-suite/rv64i_m/Svrsw60t59b/src/svadu_sv57.S
@@ -1,0 +1,75 @@
+// -----------
+// Copyright (c) 2020. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// -----------
+//
+// This assembly file tests the Svrsw60t59b extension
+// 
+#include "model_test.h"
+#include "arch_test.h"
+
+# Test Virtual Machine (TVM) used by program.
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+  RVTEST_CASE(1,"//check ISA:=regex(.*64.*);check ISA:=regex(.*I.*);check ISA:=regex(.*Svrsw60t59b.*);def rvtest_mtrap_routine=True;def TEST_CASE_1=True;",svrsw60t59b_sv57)
+
+  RVTEST_SIGBASE(x1, signature_x1_0)
+
+  # Setup PMP to cover 4G of address space
+  SETUP_PMP_SVADU_TEST(x1, offset, t0, t1, t2)
+
+  # Identity map the page_4k
+  la t1, page_4k
+  mv t2, t1
+  PTE_SETUP_SV57(t1, PTE_V, t0, s2, t2, 4)
+
+  # enable virtual memory in Sv57 mode
+  SATP_SETUP(t0, t1, ((SATP_MODE & ~(SATP_MODE<<1)) * SATP_MODE_SV57))
+
+  # test svrsw60t59b
+  TEST_SVRSW60T59B(x1, s2, page_4k, offset)
+#endif
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+  .align 12
+   page_4k:
+  .fill   4096/REGWIDTH, REGWIDTH, 0
+RVTEST_DATA_END
+
+  .align 12
+rvtest_Sroot_pg_tbl:
+  .fill   4096/REGWIDTH, REGWIDTH, 0
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+signature_x1_0:
+  .fill 64*(XLEN/32),4,0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 128*4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> Add tests for Svrsw60t59b extension. A test macro was added for the test that sets the RSW bits 60:59 to the four possible values.

riscv-config: https://github.com/riscv-software-src/riscv-config/pull/195
Spike: https://github.com/riscv-software-src/riscv-isa-sim/pull/1936
Sail: https://github.com/riscv/sail-riscv/pull/797

### Related Issues

> NA

### Ratified/Unratified Extensions

- [X] Ratified
- [] Unratified

### List Extensions

> https://github.com/riscv/riscv-isa-manual/pull/1907

### Reference Model Used

- [X] SAIL
- [X] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [X] All tests are compliant with the test-format spec present in this repo ?
  - [X] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >

### Optional Checklist:

  - [X] Were the tests hand-written/modified ? Yes
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [X] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
