### PR TITLE
[ACT4] Add support for register pairs and instructions with different types/coverpoints per XLEN

### DIFF
--- a/generators/coverage/covergroupgen.py
+++ b/generators/coverage/covergroupgen.py
@@ -25,13 +25,14 @@ from typing import TextIO
 # the value being a list of covergroups for that instruction
 
 
-def read_testplans(testplans_dir: Path) -> tuple[dict[str, dict[str, list[str]]], dict[str, str]]:
+def read_testplans(testplans_dir: Path) -> tuple[dict[str, dict[tuple[str, str], list[str]]], dict[str, str]]:
     """
     Iterates over all of the CSV testplan files in the provided directory. It populates a dictionary of dictionaries with
-    the top level key being the architecture/extension (e.g. RV64I), the second level key being the instruction mnemonic (e.g. add),
-    and the value being a list of covergroups for that instruction.
+    the top level key being the architecture/extension (e.g. RV64I), the second level key being a tuple of
+    (instruction mnemonic, type) to allow duplicate instructions with different types, and the value being a list
+    of coverpoints for that instruction.
     """
-    testplans: dict[str, dict[str, list[str]]] = {}
+    testplans: dict[str, dict[tuple[str, str], list[str]]] = {}
     arch_sources: dict[str, str] = {}
     coverplan_dirs = [(testplans_dir, "unpriv")]
     for coverplan_dir, source in coverplan_dirs:
@@ -41,13 +42,14 @@ def read_testplans(testplans_dir: Path) -> tuple[dict[str, dict[str, list[str]]]
             arch = file.stem
             with file.open() as csvfile:
                 reader = csv.DictReader(csvfile)
-                tp: dict[str, list[str]] = {}
+                tp: dict[tuple[str, str], list[str]] = {}
                 for row in reader:
                     if "Instruction" not in row:
                         raise ValueError(
                             f"Error reading testplan {file.name}.  Did you remember to shrink the .csv files after expanding?"
                         )
                     instr = row["Instruction"]
+                    instr_type = row["Type"]
                     cps: list[str] = []
                     del row["Instruction"]
                     for key, value in row.items():
@@ -60,7 +62,7 @@ def read_testplans(testplans_dir: Path) -> tuple[dict[str, dict[str, list[str]]]
                                 ):  # for special entries, append the entry name (e.g. cp_rd_edges becomes cp_rd_edges_lui)
                                     key = f"{key}_{value}"
                                 cps.append(key)
-                    tp[instr] = cps
+                    tp[(instr, instr_type)] = cps
             testplans[arch] = tp
             arch_sources[arch] = source
             if arch == "I":  # duplicate I testplan for E
@@ -118,18 +120,18 @@ def customize_template(covergroup_templates: dict[str, str], name: str, arch: st
     return template
 
 
-def any_exclusion(rv: str, instrs: list[str], tp: dict[str, list[str]]) -> bool:
+def any_exclusion(rv: str, instrs: list[tuple[str, str]], tp: dict[tuple[str, str], list[str]]) -> bool:
     """Check if any instruction in this extension is not available in the specified RV32 or RV64."""
-    for instr in instrs:
-        cps = tp[instr]
+    for instr_key in instrs:
+        cps = tp[instr_key]
         if rv not in cps:
             return True
     return False
 
 
-def any_effew_exclusion(effew: str, instrs: list[str], tp: dict[str, list[str]]) -> bool:
-    for instr in instrs:
-        cps = tp[instr]
+def any_effew_exclusion(effew: str, instrs: list[tuple[str, str]], tp: dict[tuple[str, str], list[str]]) -> bool:
+    for instr_key in instrs:
+        cps = tp[instr_key]
         if effew not in cps:
             return True
     return False
@@ -154,16 +156,17 @@ SEW_DEPENDENT_CPS = [
 def write_instrs(
     f: TextIO,
     finit: TextIO,
-    k: list[str],
+    k: list[tuple[str, str]],
     covergroupTemplates: dict[str, str],
-    tp: dict[str, list[str]],
+    tp: dict[tuple[str, str], list[str]],
     arch: str,
     hasRV32: bool,
     hasRV64: bool,
 ) -> None:
     """Write the instructions if they match the RV32/RV64 criteria."""
-    for instr in k:
-        cps = tp[instr]
+    for instr_key in k:
+        instr, _instr_type = instr_key
+        cps = tp[instr_key]
         match32 = ("RV32" in cps) ^ (not hasRV32)
         match64 = ("RV64" in cps) ^ (not hasRV64)
         vectorwiden = (arch.startswith("Vx") or arch.startswith("Vls") or arch.startswith("Vf")) and (
@@ -203,15 +206,16 @@ def write_instrs(
 
 def write_covergroup_sample_functions(
     f: TextIO,
-    k: list[str],
+    k: list[tuple[str, str]],
     covergroupTemplates: dict[str, str],
-    tp: dict[str, list[str]],
+    tp: dict[tuple[str, str], list[str]],
     arch: str,
     hasRV32: bool,
     hasRV64: bool,
 ) -> None:
-    for instr in k:
-        cps = tp[instr]
+    for instr_key in k:
+        instr, _instr_type = instr_key
+        cps = tp[instr_key]
         match32 = ("RV32" in cps) ^ (not hasRV32)
         match64 = ("RV64" in cps) ^ (not hasRV64)
         if match32 and match64:
@@ -231,15 +235,16 @@ def write_covergroup_sample_functions(
 
 def write_instruction_sample_function(
     f: TextIO,
-    k: list[str],
+    k: list[tuple[str, str]],
     covergroupTemplates: dict[str, str],
-    tp: dict[str, list[str]],
+    tp: dict[tuple[str, str], list[str]],
     arch: str,
     hasRV32: bool,
     hasRV64: bool,
 ) -> None:
-    for instr in k:
-        cps = tp[instr]
+    for instr_key in k:
+        instr, _instr_type = instr_key
+        cps = tp[instr_key]
         match32 = ("RV32" in cps) ^ (not hasRV32)
         match64 = ("RV64" in cps) ^ (not hasRV64)
         if match32 and match64:
@@ -252,7 +257,7 @@ def get_effew(arch: str) -> str:
     match = re.search(r"(\d+)$", arch)
     if match:
         effew = match.group(1)
-    elif (arch in ["Zvfhmin", "Zvfbfmin", "Zvfbfwma"]):
+    elif arch in ["Zvfhmin", "Zvfbfmin", "Zvfbfwma"]:
         effew = "16"
     else:
         raise ValueError(f"Arch does not contain an expected integer: '{arch}'")
@@ -260,7 +265,7 @@ def get_effew(arch: str) -> str:
 
 
 def write_coverage_headers(
-    test_plans: dict[str, dict[str, list[str]]],
+    test_plans: dict[str, dict[tuple[str, str], list[str]]],
     arch_sources: dict[str, str],
     covergroup_dir: Path,
     covergroup_templates: dict[str, str],
@@ -299,7 +304,7 @@ def write_coverage_headers(
 # writeCovergroups iterates over the testplans and covergroup templates to generate the covergroups for
 # all instructions in each testplan
 def write_covergroups(
-    test_plans: dict[str, dict[str, list[str]]],
+    test_plans: dict[str, dict[tuple[str, str], list[str]]],
     covergroup_templates: dict[str, str],
     arch_sources: dict[str, str],
     output_dir: Path,
@@ -333,7 +338,7 @@ def write_covergroups(
                 k = list(tp.keys())
                 k.sort()
                 if vector:
-                    k = [instr for instr in k if f"EFFEW{effew}" in tp[instr]]
+                    k = [instr_key for instr_key in k if f"EFFEW{effew}" in tp[instr_key]]
 
                 write_instrs(f, finit, k, covergroup_templates, tp, arch, True, True)
                 if any_exclusion("RV64", k, tp):

--- a/generators/coverage/templates/cmp_rd_rs1_nx0_pair.txt
+++ b/generators/coverage/templates/cmp_rd_rs1_nx0_pair.txt
@@ -1,0 +1,5 @@
+    cmp_rd_rs1_nx0_pair : coverpoint ins.get_gpr_reg(ins.current.rd)  iff (ins.current.rd == ins.current.rs1 & ins.trap == 0 )  {
+        // Compare assignments of all even registers excluding x0
+        ignore_bins x0 = {x0};
+        bins reg_pair[] = {[$:$]} with (item % 2 == 0);
+    }

--- a/generators/coverage/templates/cmp_rd_rs1_rs2_nx0.txt
+++ b/generators/coverage/templates/cmp_rd_rs1_rs2_nx0.txt
@@ -1,4 +1,4 @@
     cmp_rd_rs1_rs2_nx0 : coverpoint ins.get_gpr_reg(ins.current.rd)  iff (ins.current.rd == ins.current.rs1 & ins.current.rd == ins.current.rs2 & ins.trap == 0 )  {
-        // Compare assignments of all registers
+        // Compare assignments of all registers excluding x0
         ignore_bins x0 = {x0};
     }

--- a/generators/coverage/templates/cmp_rd_rs1_rs2_nx0_pair.txt
+++ b/generators/coverage/templates/cmp_rd_rs1_rs2_nx0_pair.txt
@@ -1,0 +1,5 @@
+    cmp_rd_rs1_rs2_nx0_pair : coverpoint ins.get_gpr_reg(ins.current.rd)  iff (ins.current.rd == ins.current.rs1 & ins.current.rd == ins.current.rs2 & ins.trap == 0 )  {
+        // Compare assignments of all even registers excluding x0
+        ignore_bins x0 = {x0};
+        bins reg_pair[] = {[$:$]} with (item % 2 == 0);
+    }

--- a/generators/coverage/templates/cmp_rd_rs2_pair.txt
+++ b/generators/coverage/templates/cmp_rd_rs2_pair.txt
@@ -1,0 +1,4 @@
+    cmp_rd_rs2_pair : coverpoint ins.get_gpr_reg(ins.current.rd)  iff (ins.current.rd == ins.current.rs2 & ins.trap == 0 )  {
+        // Compare assignments of all even registers
+        bins reg_pair[] = {[$:$]} with (item % 2 == 0);
+    }

--- a/generators/coverage/templates/cmp_rs1_rs2_nx0_pair.txt
+++ b/generators/coverage/templates/cmp_rs1_rs2_nx0_pair.txt
@@ -1,0 +1,5 @@
+    cmp_rs1_rs2_nx0_pair : coverpoint ins.get_gpr_reg(ins.current.rs1)  iff (ins.current.rs1 == ins.current.rs2 & ins.trap == 0 )  {
+        // Compare assignments of all even registers excluding x0
+        ignore_bins x0 = {x0};
+        bins reg_pair[] = {[$:$]} with (item % 2 == 0);
+    }

--- a/generators/coverage/templates/cp_rd_pair.txt
+++ b/generators/coverage/templates/cp_rd_pair.txt
@@ -1,0 +1,4 @@
+    cp_rd_pair : coverpoint ins.get_gpr_reg(ins.current.rd)  iff (ins.trap == 0 )  {
+        // RD register assignment, even registers only
+        bins reg_pair[] = {[$:$]} with (item % 2 == 0);
+    }

--- a/generators/coverage/templates/cp_rs2_pair.txt
+++ b/generators/coverage/templates/cp_rs2_pair.txt
@@ -1,0 +1,4 @@
+    cp_rs2_pair : coverpoint ins.get_gpr_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
+        // RS2 register assignment, even registers only
+        bins reg_pair[] = {[$:$]} with (item % 2 == 0);
+    }

--- a/generators/coverage/templates/sample_AP.txt
+++ b/generators/coverage/templates/sample_AP.txt
@@ -1,0 +1,5 @@
+        "INSTR"     : begin
+            ins.add_rd(0);
+            ins.add_rs2(1);
+            ins.add_rs1(2);
+        end

--- a/generators/testgen/src/testgen/coverpoints/cmp_regs.py
+++ b/generators/testgen/src/testgen/coverpoints/cmp_regs.py
@@ -24,7 +24,7 @@ def make_cmp_rd_rs1(instr_name: str, instr_type: str, coverpoint: str, test_data
     elif coverpoint.endswith("_nx0"):
         regs = range(1, test_data.int_regs.reg_count)  # Exclude x0
     elif coverpoint.endswith("_c"):
-        regs = range(8, 16)  # x8-x15 for compressed instructions"):
+        regs = range(8, 16)  # x8-x15 for compressed instructions
     elif coverpoint.endswith("_nx0_pair"):
         regs = range(2, test_data.int_regs.reg_count, 2)  # Even registers for pair instructions, exclude x0
         is_pair = True

--- a/generators/testgen/src/testgen/coverpoints/cmp_regs.py
+++ b/generators/testgen/src/testgen/coverpoints/cmp_regs.py
@@ -18,12 +18,19 @@ from testgen.formatters.params import generate_random_params
 def make_cmp_rd_rs1(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
     """Generate tests where rd = rs1."""
     # Determine which rd registers to test based on coverpoint variant
+    is_pair = False
     if coverpoint == "cmp_rd_rs1":
         regs = range(test_data.int_regs.reg_count)
     elif coverpoint.endswith("_nx0"):
         regs = range(1, test_data.int_regs.reg_count)  # Exclude x0
     elif coverpoint.endswith("_c"):
-        regs = range(8, 16)  # x8-x15 for compressed instructions
+        regs = range(8, 16)  # x8-x15 for compressed instructions"):
+    elif coverpoint.endswith("_nx0_pair"):
+        regs = range(2, test_data.int_regs.reg_count, 2)  # Even registers for pair instructions, exclude x0
+        is_pair = True
+    elif coverpoint.endswith("_pair"):
+        regs = range(0, test_data.int_regs.reg_count, 2)  # Even registers for pair instructions
+        is_pair = True
     else:
         raise ValueError(f"Unknown cmp_rd_rs1 coverpoint variant: {coverpoint} for {instr_name}")
 
@@ -32,7 +39,10 @@ def make_cmp_rd_rs1(instr_name: str, instr_type: str, coverpoint: str, test_data
     # Generate tests
     for reg in regs:
         test_lines.append(test_data.add_testcase(coverpoint))
-        test_lines.append(test_data.int_regs.consume_registers([reg]))
+        if is_pair:
+            test_lines.append(test_data.int_regs.consume_register_pair(reg))
+        else:
+            test_lines.append(test_data.int_regs.consume_registers([reg]))
         params = generate_random_params(test_data, instr_type, rd=reg, rs1=reg)
         desc = f"{coverpoint} (Test rd = rs1 = x{reg})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
@@ -45,12 +55,19 @@ def make_cmp_rd_rs1(instr_name: str, instr_type: str, coverpoint: str, test_data
 def make_cmp_rd_rs2(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
     """Generate tests where rd = rs2."""
     # Determine which rd registers to test based on coverpoint variant
+    is_pair = False
     if coverpoint == "cmp_rd_rs2":
         regs = range(test_data.int_regs.reg_count)
     elif coverpoint.endswith("_nx0"):
         regs = range(1, test_data.int_regs.reg_count)  # Exclude x0
     elif coverpoint.endswith("_c"):
         regs = range(8, 16)  # x8-x15 for compressed instructions
+    elif coverpoint.endswith("_nx0_pair"):
+        regs = range(2, test_data.int_regs.reg_count, 2)  # Even registers for pair instructions, exclude x0
+        is_pair = True
+    elif coverpoint.endswith("_pair"):
+        regs = range(0, test_data.int_regs.reg_count, 2)  # Even registers for pair instructions
+        is_pair = True
     else:
         raise ValueError(f"Unknown cmp_rd_rs2 coverpoint variant: {coverpoint} for {instr_name}")
 
@@ -59,7 +76,10 @@ def make_cmp_rd_rs2(instr_name: str, instr_type: str, coverpoint: str, test_data
     # Generate tests
     for reg in regs:
         test_lines.append(test_data.add_testcase(coverpoint))
-        test_lines.append(test_data.int_regs.consume_registers([reg]))
+        if is_pair:
+            test_lines.append(test_data.int_regs.consume_register_pair(reg))
+        else:
+            test_lines.append(test_data.int_regs.consume_registers([reg]))
         params = generate_random_params(test_data, instr_type, rd=reg, rs2=reg)
         desc = f"{coverpoint} (Test rd = rs2 = x{reg})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
@@ -72,12 +92,19 @@ def make_cmp_rd_rs2(instr_name: str, instr_type: str, coverpoint: str, test_data
 def make_cmp_rs1_rs2(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
     """Generate tests where rs1 = rs2."""
     # Determine which rd registers to test based on coverpoint variant
+    is_pair = False
     if coverpoint == "cmp_rs1_rs2":
         regs = range(test_data.int_regs.reg_count)
     elif coverpoint.endswith("_nx0"):
         regs = range(1, test_data.int_regs.reg_count)  # Exclude x0
     elif coverpoint.endswith("_c"):
         regs = range(8, 16)  # x8-x15 for compressed instructions
+    elif coverpoint.endswith("_nx0_pair"):
+        regs = range(2, test_data.int_regs.reg_count, 2)  # Even registers for pair instructions, exclude x0
+        is_pair = True
+    elif coverpoint.endswith("_pair"):
+        regs = range(0, test_data.int_regs.reg_count, 2)  # Even registers for pair instructions
+        is_pair = True
     else:
         raise ValueError(f"Unknown cmp_rs1_rs2 coverpoint variant: {coverpoint} for {instr_name}")
 
@@ -86,7 +113,10 @@ def make_cmp_rs1_rs2(instr_name: str, instr_type: str, coverpoint: str, test_dat
     # Generate tests
     for reg in regs:
         test_lines.append(test_data.add_testcase(coverpoint))
-        test_lines.append(test_data.int_regs.consume_registers([reg]))
+        if is_pair:
+            test_lines.append(test_data.int_regs.consume_register_pair(reg))
+        else:
+            test_lines.append(test_data.int_regs.consume_registers([reg]))
         params = generate_random_params(test_data, instr_type, rs1=reg, rs2=reg)
         desc = f"{coverpoint} (Test rs1 = rs2 = x{reg})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
@@ -99,10 +129,17 @@ def make_cmp_rs1_rs2(instr_name: str, instr_type: str, coverpoint: str, test_dat
 def make_cmp_rd_rs1_rs2(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
     """Generate tests where rd = rs1 = rs2."""
     # Determine which rd registers to test based on coverpoint variant
+    is_pair = False
     if coverpoint == "cmp_rd_rs1_rs2":
         regs = range(test_data.int_regs.reg_count)
     elif coverpoint.endswith("_nx0"):
         regs = range(1, test_data.int_regs.reg_count)  # Exclude x0
+    elif coverpoint.endswith("_nx0_pair"):
+        regs = range(2, test_data.int_regs.reg_count, 2)  # Even registers for pair instructions, exclude x0
+        is_pair = True
+    elif coverpoint.endswith("_pair"):
+        regs = range(0, test_data.int_regs.reg_count, 2)  # Even registers for pair instructions
+        is_pair = True
     else:
         raise ValueError(f"Unknown cmp_rd_rs1_rs2 coverpoint variant: {coverpoint} for {instr_name}")
 
@@ -111,7 +148,10 @@ def make_cmp_rd_rs1_rs2(instr_name: str, instr_type: str, coverpoint: str, test_
     # Generate tests
     for reg in regs:
         test_lines.append(test_data.add_testcase(coverpoint))
-        test_lines.append(test_data.int_regs.consume_registers([reg]))
+        if is_pair:
+            test_lines.append(test_data.int_regs.consume_register_pair(reg))
+        else:
+            test_lines.append(test_data.int_regs.consume_registers([reg]))
         params = generate_random_params(test_data, instr_type, rd=reg, rs1=reg, rs2=reg)
         desc = f"{coverpoint} (Test rd = rs1 = rs2 = x{reg})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))

--- a/generators/testgen/src/testgen/coverpoints/cp_regs.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_regs.py
@@ -18,12 +18,17 @@ from testgen.formatters.params import generate_random_params
 def make_rd(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
     """Generate tests for destination register coverpoints."""
     # Determine which rd registers to test based on coverpoint variant
+    is_pair = False
     if coverpoint == "cp_rd":
         rd_regs = list(range(test_data.int_regs.reg_count))
     elif coverpoint.endswith("_nx0"):
         rd_regs = list(range(1, test_data.int_regs.reg_count))  # Exclude x0
     elif coverpoint.endswith("rd_p"):
         rd_regs = list(range(8, 16))  # x8-x15 for compressed instructions
+    elif coverpoint.endswith("_pair"):
+        # Only even registers for pair instructions
+        rd_regs = list(range(0, test_data.int_regs.reg_count, 2))
+        is_pair = True
     else:
         raise ValueError(f"Unknown cp_rd coverpoint variant: {coverpoint} for {instr_name}")
 
@@ -32,7 +37,10 @@ def make_rd(instr_name: str, instr_type: str, coverpoint: str, test_data: TestDa
     # Generate tests
     for rd in rd_regs:
         test_lines.append(test_data.add_testcase(coverpoint))
-        test_lines.append(test_data.int_regs.consume_registers([rd]))
+        if is_pair:
+            test_lines.append(test_data.int_regs.consume_register_pair(rd))
+        else:
+            test_lines.append(test_data.int_regs.consume_registers([rd]))
         params = generate_random_params(test_data, instr_type, rd=rd)
         desc = f"{coverpoint} (Test destination rd = x{rd})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
@@ -45,15 +53,20 @@ def make_rd(instr_name: str, instr_type: str, coverpoint: str, test_data: TestDa
 def make_rs1(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
     """Generate tests for source register 1 coverpoints."""
     # Determine which rs1 registers to test based on coverpoint variant
+    is_pair = False
     if coverpoint == "cp_rs1":
-        rs1_regs = range(test_data.int_regs.reg_count)
+        rs1_regs = list(range(test_data.int_regs.reg_count))
     elif coverpoint.endswith("_nx0"):
-        rs1_regs = range(1, test_data.int_regs.reg_count)  # Exclude x0
+        rs1_regs = list(range(1, test_data.int_regs.reg_count))  # Exclude x0
     elif coverpoint.endswith("_nx2"):
         rs1_regs = list(range(1, test_data.int_regs.reg_count))  # Exclude x0
         rs1_regs.remove(2)  # Exclude x2
     elif coverpoint.endswith("_p"):
-        rs1_regs = range(8, 16)  # x8-x15 for compressed instructions
+        rs1_regs = list(range(8, 16))  # x8-x15 for compressed instructions
+    elif coverpoint.endswith("_pair"):
+        # Only even registers for pair instructions
+        rs1_regs = list(range(0, test_data.int_regs.reg_count, 2))
+        is_pair = True
     else:
         raise ValueError(f"Unknown cp_rs1 coverpoint variant: {coverpoint} for {instr_name}")
 
@@ -62,7 +75,10 @@ def make_rs1(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
     # Generate tests
     for rs1 in rs1_regs:
         test_lines.append(test_data.add_testcase(coverpoint))
-        test_lines.append(test_data.int_regs.consume_registers([rs1]))
+        if is_pair:
+            test_lines.append(test_data.int_regs.consume_register_pair(rs1))
+        else:
+            test_lines.append(test_data.int_regs.consume_registers([rs1]))
         params = generate_random_params(test_data, instr_type, rs1=rs1)
         desc = f"{coverpoint} (Test source rs1 = x{rs1})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
@@ -75,12 +91,17 @@ def make_rs1(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
 def make_rs2(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
     """Generate tests for source register 2 coverpoints."""
     # Determine which rs2 registers to test based on coverpoint variant
+    is_pair = False
     if coverpoint == "cp_rs2":
-        rs2_regs = range(test_data.int_regs.reg_count)
+        rs2_regs = list(range(test_data.int_regs.reg_count))
     elif coverpoint.endswith("_nx0"):
-        rs2_regs = range(1, test_data.int_regs.reg_count)  # Exclude x0
+        rs2_regs = list(range(1, test_data.int_regs.reg_count))  # Exclude x0
     elif coverpoint.endswith("_p"):
-        rs2_regs = range(8, 16)  # x8-x15 for compressed instructions
+        rs2_regs = list(range(8, 16))  # x8-x15 for compressed instructions
+    elif coverpoint.endswith("_pair"):
+        # Only even registers for pair instructions
+        rs2_regs = list(range(0, test_data.int_regs.reg_count, 2))
+        is_pair = True
     else:
         raise ValueError(f"Unknown cp_rs2 coverpoint variant: {coverpoint} for {instr_name}")
 
@@ -89,7 +110,10 @@ def make_rs2(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
     # Generate tests
     for rs2 in rs2_regs:
         test_lines.append(test_data.add_testcase(coverpoint))
-        test_lines.append(test_data.int_regs.consume_registers([rs2]))
+        if is_pair:
+            test_lines.append(test_data.int_regs.consume_register_pair(rs2))
+        else:
+            test_lines.append(test_data.int_regs.consume_registers([rs2]))
         params = generate_random_params(test_data, instr_type, rs2=rs2)
         desc = f"{coverpoint} (Test source rs2 = x{rs2})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))

--- a/generators/testgen/src/testgen/data/params.py
+++ b/generators/testgen/src/testgen/data/params.py
@@ -24,9 +24,13 @@ class InstructionParams:
 
     # Integer registers
     rs1: int | None = None
+    rs1_is_pair: bool = False
     rs2: int | None = None
+    rs2_is_pair: bool = False
     rs3: int | None = None
+    rs3_is_pair: bool = False
     rd: int | None = None
+    rd_is_pair: bool = False
     temp_reg: int | None = None  # Temporary register for use in test setup/teardown
 
     # Integer register values
@@ -64,9 +68,17 @@ class InstructionParams:
     def used_int_regs(self) -> list[int]:
         """Return list of all integer registers used in this test."""
         regs: list[int] = []
-        for reg in [self.rs1, self.rs2, self.rs3, self.rd, self.temp_reg]:
+        for reg, reg_is_pair in [
+            (self.rs1, self.rs1_is_pair),
+            (self.rs2, self.rs2_is_pair),
+            (self.rs3, self.rs3_is_pair),
+            (self.rd, self.rd_is_pair),
+            (self.temp_reg, False),
+        ]:
             if reg is not None:
                 regs.append(reg)
+                if reg_is_pair:
+                    regs.append(reg + 1)
         return regs
 
     @property

--- a/generators/testgen/src/testgen/data/registers.py
+++ b/generators/testgen/src/testgen/data/registers.py
@@ -18,17 +18,6 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def select_registers(num_regs: int, reg_list: list[int]) -> list[int]:
-    """Select a specified number of unique registers from a list of available registers."""
-    if num_regs > len(reg_list):
-        raise ValueError(
-            f"Not enough registers available to select from. Requested {num_regs}, but only {len(reg_list)} available."
-        )
-
-    selected_regs = random.sample(reg_list, num_regs)
-    return selected_regs
-
-
 class RegisterFile:
     """Class to represent a register file and provide methods to select registers."""
 
@@ -67,7 +56,11 @@ class RegisterFile:
             exclude_regs.extend([reg for reg in self.reg_list if reg not in reg_range])
         available_regs = [reg for reg in self.reg_list if reg not in exclude_regs]
         # Select random registers and remove them from the available list
-        selected_regs = select_registers(num_regs, available_regs)
+        if num_regs > len(available_regs):
+            raise ValueError(
+                f"Not enough registers available to select from. Requested {num_regs}, but only {len(available_regs)} available."
+            )
+        selected_regs = random.sample(available_regs, num_regs)
         for reg in selected_regs:
             self.reg_list.remove(reg)
         logger.debug(
@@ -155,6 +148,60 @@ class IntegerRegisterFile(RegisterFile):
     @property
     def link_reg(self) -> int:
         return self._link_reg
+
+    def get_register_pair(self, *, exclude_regs: list[int] | None = None, reg_range: list[int] | None = None) -> int:
+        """Get an even register where both it and the following odd register are available.
+
+        For register pair instructions, the even register is specified in the instruction
+        but both registers are used.
+
+        Returns:
+            The even register number of the pair.
+        """
+        if exclude_regs is None:
+            exclude_regs = []
+
+        # Find even registers where both the even and odd register are available
+        available_pairs: list[int] = []
+        for reg in self.reg_list:
+            is_even = reg % 2 == 0
+            odd_available = (reg + 1) in self.reg_list
+            not_excluded = reg not in exclude_regs and (reg + 1) not in exclude_regs
+            in_range = reg_range is None or (reg in reg_range and (reg + 1) in reg_range)
+            if is_even and odd_available and not_excluded and in_range:
+                available_pairs.append(reg)
+
+        if not available_pairs:
+            raise ValueError("No register pairs available")
+
+        even_reg = random.choice(available_pairs)
+        self.reg_list.remove(even_reg)
+        self.reg_list.remove(even_reg + 1)
+        logger.debug(f"Getting register pair: x{even_reg}/x{even_reg + 1}")
+        return even_reg
+
+    def consume_register_pair(self, even_reg: int) -> str:
+        """Mark a register pair as used/unavailable, handling special register conflicts.
+
+        Args:
+            even_reg: The even register number of the pair.
+
+        Returns:
+            Assembly code needed to relocate any conflicting special registers.
+        """
+        if even_reg % 2 != 0:
+            raise ValueError(f"Register {even_reg} is not an even register for a pair")
+        return self.consume_registers([even_reg, even_reg + 1])
+
+    def return_register_pair(self, even_reg: int) -> None:
+        """Mark a register pair as available again.
+
+        Args:
+            even_reg: The even register number of the pair.
+        """
+        if even_reg % 2 != 0:
+            raise ValueError(f"Register {even_reg} is not an even register for a pair")
+        self.return_registers([even_reg, even_reg + 1])
 
     def move_sig_reg(self, new_reg: int) -> str:
         """Move the signature register to a specified register.

--- a/generators/testgen/src/testgen/formatters/params.py
+++ b/generators/testgen/src/testgen/formatters/params.py
@@ -74,6 +74,7 @@ def generate_random_params(
         raise ValueError(
             f"Unknown params for instruction type '{instr_type}'. Please add it to the instruction formatter decorator."
         )
+    pair_regs = instr_type_config.pair_regs or set()  # Registers that need pairs
 
     # Determine the register range to use (extracted from formatters)
     reg_range_raw = instr_type_config.reg_range if instr_type_config.reg_range is not None else range(0, 32)
@@ -82,23 +83,58 @@ def generate_random_params(
         exclude_regs = []
 
     # Fill in missing integer register parameters (only if required)
-    if "rd" in required_params and params.rd is None:
-        params.rd = test_data.int_regs.get_register(exclude_regs=exclude_regs, reg_range=reg_range)
+    # Use get_register_pair for registers that need pairs
+    if "rd" in required_params:
+        if params.rd is None:
+            if "rd" in pair_regs:
+                params.rd = test_data.int_regs.get_register_pair(exclude_regs=exclude_regs, reg_range=reg_range)
+            else:
+                params.rd = test_data.int_regs.get_register(exclude_regs=exclude_regs, reg_range=reg_range)
+        # Set the pair flag based on instruction type, regardless of whether the register was provided
+        if "rd" in pair_regs:
+            params.rd_is_pair = True
 
     if "rdval" in required_params and params.rdval is None:
         params.rdval = random_int(bits=test_data.xlen)
 
-    if "rs1" in required_params and params.rs1 is None:
-        params.rs1 = test_data.int_regs.get_register(exclude_regs=exclude_regs, reg_range=reg_range)
+    if "rs1" in required_params:
+        if params.rs1 is None:
+            if "rs1" in pair_regs:
+                params.rs1 = test_data.int_regs.get_register_pair(exclude_regs=exclude_regs, reg_range=reg_range)
+            else:
+                params.rs1 = test_data.int_regs.get_register(exclude_regs=exclude_regs, reg_range=reg_range)
+        # Set the pair flag based on instruction type, regardless of whether the register was provided
+        if "rs1" in pair_regs:
+            params.rs1_is_pair = True
 
     if "rs1val" in required_params and params.rs1val is None:
         params.rs1val = random_int(bits=test_data.xlen)
 
-    if "rs2" in required_params and params.rs2 is None:
-        params.rs2 = test_data.int_regs.get_register(exclude_regs=exclude_regs, reg_range=reg_range)
+    if "rs2" in required_params:
+        if params.rs2 is None:
+            if "rs2" in pair_regs:
+                params.rs2 = test_data.int_regs.get_register_pair(exclude_regs=exclude_regs, reg_range=reg_range)
+            else:
+                params.rs2 = test_data.int_regs.get_register(exclude_regs=exclude_regs, reg_range=reg_range)
+        # Set the pair flag based on instruction type, regardless of whether the register was provided
+        if "rs2" in pair_regs:
+            params.rs2_is_pair = True
 
     if "rs2val" in required_params and params.rs2val is None:
         params.rs2val = random_int(bits=test_data.xlen)
+
+    if "rs3" in required_params:
+        if params.rs3 is None:
+            if "rs3" in pair_regs:
+                params.rs3 = test_data.int_regs.get_register_pair(exclude_regs=exclude_regs, reg_range=reg_range)
+            else:
+                params.rs3 = test_data.int_regs.get_register(exclude_regs=exclude_regs, reg_range=reg_range)
+        # Set the pair flag based on instruction type, regardless of whether the register was provided
+        if "rs3" in pair_regs:
+            params.rs3_is_pair = True
+
+    if "rs3val" in required_params and params.rs3val is None:
+        params.rs3val = random_int(bits=test_data.xlen)
 
     if "temp_reg" in required_params and params.temp_reg is None:
         params.temp_reg = test_data.int_regs.get_register(exclude_regs=[*exclude_regs, 0, 2], reg_range=reg_range)

--- a/generators/testgen/src/testgen/formatters/registry.py
+++ b/generators/testgen/src/testgen/formatters/registry.py
@@ -38,7 +38,21 @@ class MissingInstructionFormatterError(MissingRegistryItemError):
 
 @dataclass
 class InstructionTypeConfig:
-    """Configuration for an instruction type."""
+    """Configuration for an instruction type.
+
+    This dataclass holds metadata about an instruction type needed for parameter
+    generation and validation, such as required parameters, register ranges, and
+    immediate value constraints.
+
+    Attributes:
+        required_params: Set of parameters required for this instruction type (rs1, rdval, immval, etc.).
+        reg_range: Iterable of valid register numbers for this instruction type.
+        imm_bits: Number of bits for immediates. Can also be "xlen", "xlen_log2", "flen", or "flen_log2".
+        imm_range: Explicit (min, max) range for immediate values. Mutually exclusive with imm_bits.
+        imm_signed: Whether the immediate value is signed (default: True).
+        imm_nonzero: Whether the immediate value must be nonzero (default: False).
+        pair_regs: Set of registers that use even register pairs (e.g., {"rd", "rs2"}).
+    """
 
     required_params: set[str] | None = None
     reg_range: Iterable[int] | None = None
@@ -46,6 +60,7 @@ class InstructionTypeConfig:
     imm_range: tuple[int, int] | None = None  # Explicit (min, max) range
     imm_signed: bool = True
     imm_nonzero: bool = False
+    pair_regs: set[str] | None = None  # Registers that use register pairs (e.g., {"rd", "rs2"})
 
 
 # Registry: dict mapping instruction type to (instruction_formatter, instruction_type_config)

--- a/generators/testgen/src/testgen/formatters/types/ap_type.py
+++ b/generators/testgen/src/testgen/formatters/types/ap_type.py
@@ -1,0 +1,47 @@
+##################################
+# ap_type.py
+#
+# jcarlin@hmc.edu Feb 2026
+# SPDX-License-Identifier: Apache-2.0
+##################################
+
+from testgen.asm.helpers import load_int_reg, write_sigupd
+from testgen.data.params import InstructionParams
+from testgen.data.state import TestData
+from testgen.formatters.registry import InstructionTypeConfig, add_instruction_formatter
+
+ap_config = InstructionTypeConfig(
+    required_params={"rd", "rs1", "rs1val", "rs2", "rs2val", "temp_reg"}, pair_regs={"rs2", "rd"}
+)
+
+
+@add_instruction_formatter("AP", ap_config)
+def format_ap_type(
+    instr_name: str, test_data: TestData, params: InstructionParams
+) -> tuple[list[str], list[str], list[str]]:
+    """Format AP-type instruction."""
+    assert params.rs1 is not None and params.rs1val is not None
+    assert params.rs2 is not None and params.rs2val is not None
+    assert params.rd is not None and params.temp_reg is not None
+
+    # Ensure rs1 is not x0 (base address)
+    if params.rs1 == 0:
+        test_data.int_regs.return_register(params.rs1)
+        params.rs1 = test_data.int_regs.get_register(exclude_regs=[0])
+
+    setup = [
+        load_int_reg("value in memory", params.temp_reg, params.rs1val, test_data),
+        load_int_reg("rs2", params.rs2, params.rs2val, test_data),
+        f"LA(x{params.rs1}, scratch) # load base address into rs1",
+        f"SREG x{params.temp_reg}, 0(x{params.rs1}) # store value into memory at address in rs1",
+    ]
+    test = [
+        f"{instr_name} x{params.rd}, x{params.rs2}, (x{params.rs1}) # perform operation",
+    ]
+    check = [
+        write_sigupd(params.rd, test_data, "int"),
+        f"LA(x{params.rs1}, scratch) # reload base address into rs1" if params.rs1 == params.rd else "",
+        f"LREG x{params.rs1}, 0(x{params.rs1}) # Load the updated value from memory",
+        write_sigupd(params.rs1, test_data, "int"),
+    ]
+    return (setup, test, check)

--- a/generators/testgen/src/testgen/generate/unpriv.py
+++ b/generators/testgen/src/testgen/generate/unpriv.py
@@ -49,13 +49,13 @@ def generate_unpriv_extension_tests(
     test_config = TestConfig(xlen=xlen, flen=flen, testsuite=testsuite, E_ext=E_ext, config_dependent=config_dependent)
 
     # Iterate through each instruction in the testsuite; generate separate test files for each
-    for instr_name, instr_data in sorted(instructions.items()):
+    for instr_data in instructions:
         # Skip instructions not valid for this xlen
         if (xlen == 32 and not instr_data.rv32) or (xlen == 64 and not instr_data.rv64):
             continue
 
         _generate_unpriv_tests_for_instruction(
-            instr_name,
+            instr_data.instr_name,
             instr_data.instr_type,
             instr_data.coverpoints,
             test_config,

--- a/generators/testgen/src/testgen/io/testplans.py
+++ b/generators/testgen/src/testgen/io/testplans.py
@@ -28,15 +28,16 @@ def get_extensions(testplan_dir: Path) -> list[str]:
 class TestPlanData:
     """Data structure for information on a single instruction parsed from a testplan."""
 
+    instr_name: str
     instr_type: str
     rv32: bool
     rv64: bool
     coverpoints: list[str]
 
 
-def read_testplan(testplan_path: Path) -> dict[str, TestPlanData]:
-    """Read a testplan and return a dictionary of instructions and their associated data (type, coverpoints, etc.)."""
-    instructions: dict[str, TestPlanData] = {}
+def read_testplan(testplan_path: Path) -> list[TestPlanData]:
+    """Read a testplan and return a list of instructions and their associated data (type, coverpoints, etc.)."""
+    instructions: list[TestPlanData] = []
     with testplan_path.open() as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
@@ -62,5 +63,7 @@ def read_testplan(testplan_path: Path) -> dict[str, TestPlanData]:
                     ):  # for special entries, append the entry name (e.g. cp_rd_edges becomes cp_rd_edges_lui)
                         key = key + "_" + value
                     coverpoints.append(key)
-            instructions[instr] = TestPlanData(instr_type=instr_type, rv32=rv32, rv64=rv64, coverpoints=coverpoints)
+            instructions.append(
+                TestPlanData(instr_name=instr, instr_type=instr_type, rv32=rv32, rv64=rv64, coverpoints=coverpoints)
+            )
     return instructions

--- a/testplans/Zacas.csv
+++ b/testplans/Zacas.csv
@@ -1,4 +1,5 @@
 Instruction,Type,RV32,RV64,cp_asm_count,cp_rs1,cp_rs2,cp_rd,cp_rs2_edges,cmp_rs1_rs2,cmp_rd_rs1,cmp_rd_rs2,cmp_rd_rs1_rs2,cp_align
 amocas.w,A,x,x,x,nx0,x,x,x,nx0,nx0,x,nx0,word
 amocas.d,A,,x,x,nx0,x,x,x,nx0,nx0,x,nx0,
-amocas.q,A,,,x,nx0,x,x,x,nx0,nx0,x,nx0,
+amocas.d,AP,x,,x,nx0,pair,pair,x,nx0_pair,nx0_pair,pair,nx0_pair,
+amocas.q,AP,,x,x,nx0,pair,pair,x,nx0_pair,nx0_pair,pair,nx0_pair,


### PR DESCRIPTION
Full coverage of Zacas extension. This required support for register pairs in test generation.

The coverpoints for rv32 and rv64 are different for `amocas.d`, so `covergroupgen` and `testgen` needed to be extended to use more than just the instruction name as the key for generation.