### PR TITLE
feat: add ACT4 config for StarFive VisionFive 2 (JH7110 RV64GC)

### DIFF
--- a/config/cores/starfive/visionfive2/README.md
+++ b/config/cores/starfive/visionfive2/README.md
@@ -1,0 +1,222 @@
+# ACT4 Configuration: StarFive VisionFive 2
+
+> **Status: Work In Progress** — Tracking issue [#1306](https://github.com/riscv/riscv-arch-test/issues/1306)
+
+This directory provides an ACT4 framework configuration for running
+RISC-V Architecture Compliance Tests (ACT) on the **StarFive VisionFive 2**
+single-board computer (SBC) using its JH7110 SoC.
+
+---
+
+## Board Overview
+
+| Property | Detail |
+|---|---|
+| **Board** | StarFive VisionFive 2 |
+| **SoC** | JH7110 (StarFive) |
+| **ISA** | RV64GC (+ Zba, Zbb, Zbs, Sv39, Sv48) |
+| **DRAM** | 4 GB or 8 GB LPDDR4, base at `0x40000000` |
+| **UART** | NS16550-compatible UART0 at `0x10000000` |
+| **Boot** | SPL → OpenSBI (M-mode) → U-Boot → ELF |
+
+---
+
+## Key Design Decision: M-Mode Ownership
+
+OpenSBI claims M-mode at boot time on this board. All software running
+after OpenSBI (including our ACT ELFs launched via `go`) runs in **S-mode or U-mode**.
+
+Therefore, `test_config.yaml` sets:
+```yaml
+include_priv_tests: false
+```
+
+This excludes:
+- `Sm` (M-mode exception/interrupt tests)
+- `ExceptionsSm`, `InterruptsSm`
+- Any test requiring direct CLINT access
+
+All other ACT tests (I, M, A, F, D, C, B, S-mode, U-mode) run normally.
+
+---
+
+## File Structure
+
+```
+config/cores/starfive/visionfive2/
+├── README.md               ← This file
+├── test_config.yaml        ← ACT4 framework settings
+├── visionfive2-rv64gc.yaml ← UDB architecture description (JH7110)
+├── rvmodel_macros.h        ← DUT-specific macros (UART, HALT, tohost)
+├── rvtest_config.h         ← Supported extension flags (for C preprocessor)
+├── rvtest_config.svh       ← SystemVerilog coverage config
+├── sail.json               ← Sail reference model memory map config
+└── link.ld                 ← Linker script (ELFs at 0x42000000)
+```
+
+---
+
+## Memory Map Used
+
+| Region | Base Address | Size | Notes |
+|---|---|---|---|
+| OpenSBI firmware | `0x40000000` | 2 MB | Do not overwrite |
+| U-Boot | `0x40200000` | ~1 MB | Temporary; reclaimed after `go` |
+| **ACT ELF load address** | **`0x42000000`** | up to 64 MB | Load tests here |
+| UART0 (NS16550) | `0x10000000` | 64 KB | PASS/FAIL output |
+| CLINT | `0x02000000` | 64 KB | Managed by OpenSBI |
+
+---
+
+## How `RVMODEL_HALT_PASS` / `RVMODEL_HALT_FAIL` Work
+
+On this platform, there is no host-side process polling the `tohost` symbol.
+
+The current implementation:
+1. Writes to the `tohost` symbol in DRAM (value `1` for pass, `3` for fail) — kept for
+   compatibility with any future host-side polling via `/dev/mem`.
+2. Spins in an infinite loop (the ACT framework has already printed `RVCP-SUMMARY:` over
+   UART before calling halt).
+
+**UART output format** (printed by the ACT framework automatically):
+```
+RVCP-SUMMARY: TEST PASSED - Test File "add-01.S"
+```
+or
+```
+RVCP-SUMMARY: TEST FAILED - Test File "add-01.S"
+```
+
+A host script on the UART-connected PC collects these lines and produces a summary.
+
+---
+
+## Prerequisites
+
+### On the VisionFive 2 (U-Boot prompt)
+
+No special setup needed. U-Boot is used purely as an ELF loader.
+
+### On the build host (Linux / WSL2)
+
+```bash
+# RISC-V toolchain
+sudo apt install gcc-riscv64-unknown-elf
+
+# Or use the prebuilt toolchain from riscv-collab
+# https://github.com/riscv-collab/riscv-gnu-toolchain/releases
+
+# ACT4 framework
+pip install act4   # or follow README.md in repo root
+```
+
+---
+
+## Building ACT ELFs
+
+```bash
+cd /path/to/riscv-arch-test
+
+# Generate and compile tests for VisionFive 2
+act --config config/cores/starfive/visionfive2/test_config.yaml
+
+# ELFs are placed in: work/visionfive2-rv64gc/elfs/
+```
+
+---
+
+## Running Tests on Hardware
+
+### Step 1: Transfer ELF to VisionFive 2
+
+**Via TFTP (recommended):**
+```bash
+# On build host — serve the ELF directory
+python3 -m http.server 8080 --directory work/visionfive2-rv64gc/elfs/
+```
+
+**Via SD card:** Copy ELFs to the FAT partition of the boot SD card.
+
+### Step 2: Load and Run from U-Boot
+
+```
+# In U-Boot serial console:
+VF2# setenv loadaddr 0x42000000
+VF2# tftpboot ${loadaddr} add-01.elf
+VF2# go ${loadaddr}
+```
+
+or from SD card:
+```
+VF2# fatload mmc 0:3 ${loadaddr} add-01.elf
+VF2# go ${loadaddr}
+```
+
+### Step 3: Collect Results
+
+Monitor the UART console (115200 baud, 8N1) for `RVCP-SUMMARY:` lines.
+
+A helper script to automate result collection is planned. See issue [#1306](https://github.com/riscv/riscv-arch-test/issues/1306).
+
+---
+
+## Running All Tests (Batch Mode)
+
+A wrapper script will be added to iterate over all ELFs automatically.
+The planned workflow:
+
+```bash
+# Future: automated batch runner
+./scripts/run_vf2_tests.sh \
+  --elf-dir work/visionfive2-rv64gc/elfs/ \
+  --uart /dev/ttyUSB0 \
+  --output work/visionfive2-rv64gc/results.log
+```
+
+---
+
+## Known Limitations
+
+| Limitation | Reason | Workaround |
+|---|---|---|
+| M-mode tests excluded | OpenSBI owns M-mode | Set `include_priv_tests: false` |
+| No automated CI | No remote JTAG/serial CI runner | Manual UART-based testing |
+| CLINT not directly writable | SBI ecall required | Timer tests excluded |
+| `tohost` not monitored | No host-side process | UART-based PASS/FAIL |
+| Access fault address TBD | Fully-populated DRAM on some configs | Verify `0x00000000` causes fault |
+
+---
+
+## UART Connection
+
+Connect a USB-UART adapter to the VisionFive 2 GPIO header:
+
+| VisionFive 2 Pin | Signal | USB-UART |
+|---|---|---|
+| Pin 6 | GND | GND |
+| Pin 8 | UART TX (JH7110 → host) | RX |
+| Pin 10 | UART RX (host → JH7110) | TX |
+
+Speed: **115200 baud, 8N1, no flow control**
+
+---
+
+## Contributing
+
+This configuration is a work in progress. Contributions welcome:
+- Verify extension flags against JH7110 Technical Reference Manual
+- Add PMP grain/count corrections if discovered
+- Implement host-side UART result collection script
+- Test with Milk-V Jupiter (SpacemiT K1, same memory map layout)
+
+See [CONTRIBUTING.md](../../../../CONTRIBUTING.md) for project guidelines.
+
+---
+
+## References
+
+- [StarFive VisionFive 2 Datasheet](https://github.com/starfive-tech/VisionFive2)
+- [JH7110 Technical Reference Manual](https://doc-en.rvspace.org/JH7110/TRM/)
+- [OpenSBI Firmware](https://github.com/riscv-software-src/opensbi)
+- [ACT4 Framework README](../../../../README.md)
+- [Tracking Issue #1306](https://github.com/riscv/riscv-arch-test/issues/1306)

--- a/config/cores/starfive/visionfive2/link.ld
+++ b/config/cores/starfive/visionfive2/link.ld
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* link.ld — Linker script for StarFive VisionFive 2 (JH7110 SoC)
+ *
+ * Memory map (JH7110 / VisionFive 2):
+ *   0x00000000 - 0x3FFFFFFF : Unmapped / peripheral space
+ *   0x40000000 - 0xFFFFFFFF : DRAM (8 GB physical)
+ *
+ * This linker script places the ELF at 0x42000000, leaving room below
+ * for OpenSBI (0x40000000) and U-Boot (0x40200000 default load address).
+ *
+ * Load via U-Boot:
+ *   => tftpboot 0x42000000 <test>.elf; go 0x42000000
+ *   OR
+ *   => load mmc 0:1 0x42000000 <test>.elf; go 0x42000000
+ *
+ * The entry point rvtest_entry_point is called directly by 'go'.
+ * RVMODEL_BOOT runs first (UART init), then the test body executes.
+ */
+
+OUTPUT_ARCH("riscv")
+ENTRY(rvtest_entry_point)
+
+SECTIONS
+{
+  /* -----------------------------------------------------------
+   * Base address: 0x42000000
+   * Below this: OpenSBI @ 0x40000000, U-Boot @ 0x40200000
+   * ----------------------------------------------------------- */
+  . = 0x42000000;
+
+  /* Boot/init code — must be first, at the entry point address */
+  .text.init    : { *(.text.init) }
+
+  /* ACT test code */
+  .text.rvtest  : { *(.text.rvtest) *(.text.rvtest.*) }
+
+  /* 16 KB alignment before data to simplify PMP setup if needed */
+  . = ALIGN(0x4000);
+
+  /* Test data and signatures */
+  .data         : { *(.data) }
+
+  /* 4 KB alignment for model-specific code */
+  . = ALIGN(0x1000);
+
+  /* DUT-specific code (RVMODEL macros, UART routines, etc.)
+   * MUST follow .data so variable-size model code does not
+   * affect the addresses of test data symbols (begin_signature etc.) */
+  .text.rvmodel : { *(.text.rvmodel) *(.text.rvmodel.*) *(.text) *(.text.*) }
+
+  . = ALIGN(0x1000);
+  _end = .;
+}

--- a/config/cores/starfive/visionfive2/rvmodel_macros.h
+++ b/config/cores/starfive/visionfive2/rvmodel_macros.h
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// rvmodel_macros.h
+// DUT-specific macro implementations for the StarFive VisionFive 2 (JH7110 SoC)
+//
+// Board:     StarFive VisionFive 2
+// SoC:       JH7110 (quad-core RV64GC)
+// Boot flow: SPL -> OpenSBI (M-mode) -> U-Boot -> [ELF loaded via 'go' command]
+//
+// IMPORTANT: OpenSBI claims M-mode by the time U-Boot runs.
+// Therefore include_priv_tests must be set to false in test_config.yaml.
+// All ACT tests run in S-mode or U-mode under OpenSBI supervision.
+//
+// UART: NS16550-compatible at base address 0x10000000 (UART0 on JH7110)
+// DRAM: Starts at 0x40000000 (load ELFs here via U-Boot 'go' command)
+// CLINT: At 0x2000000 (managed by OpenSBI; do NOT write directly)
+//
+// Usage: Load ELF via U-Boot:
+//   => tftpboot 0x42000000 <test>.elf
+//   => go 0x42000000
+//   (PASS/FAIL printed over UART as: RVCP-SUMMARY: TEST PASSED/FAILED)
+
+#ifndef _RVMODEL_MACROS_H
+#define _RVMODEL_MACROS_H
+
+// ---------------------------------------------------------------------------
+// DATA SECTION: tohost/fromhost symbols required by the ACT framework.
+// On real hardware these are not polled by a testbench, but must still
+// exist as symbols for the ELF to link correctly. PASS/FAIL is instead
+// communicated over UART (see RVMODEL_HALT_PASS / RVMODEL_HALT_FAIL below).
+// ---------------------------------------------------------------------------
+#define RVMODEL_DATA_SECTION                                        \
+        .pushsection .tohost,"aw",@progbits;                        \
+        .align 8; .global tohost;   tohost:   .dword 0;            \
+        .align 8; .global fromhost; fromhost: .dword 0;            \
+        .popsection;
+
+// ---------------------------------------------------------------------------
+// UART register layout (NS16550 / 8250 compatible)
+// JH7110 UART0 base: 0x10000000
+// Register width: 8-bit, stride: 1 byte (byte-addressable)
+// ---------------------------------------------------------------------------
+.EQU VF2_UART_BASE,  0x10000000
+.EQU VF2_UART_THR,  (VF2_UART_BASE + 0)   /* Transmit Holding Register */
+.EQU VF2_UART_IER,  (VF2_UART_BASE + 1)   /* Interrupt Enable Register */
+.EQU VF2_UART_FCR,  (VF2_UART_BASE + 2)   /* FIFO Control Register     */
+.EQU VF2_UART_LCR,  (VF2_UART_BASE + 3)   /* Line Control Register     */
+.EQU VF2_UART_MCR,  (VF2_UART_BASE + 4)   /* Modem Control Register    */
+.EQU VF2_UART_LSR,  (VF2_UART_BASE + 5)   /* Line Status Register      */
+
+// ---------------------------------------------------------------------------
+// RVMODEL_BOOT: Called at the very start of rvtest_entry_point.
+// OpenSBI has already initialized UART, so we only need to ensure
+// the FIFO is enabled and the format is 8N1.
+// ---------------------------------------------------------------------------
+#define RVMODEL_BOOT                                                \
+  vf2_uart_boot:                                                   ;\
+    li   t0, VF2_UART_LCR                                          ;\
+    li   t1, 0x03          /* 8-bit, 1 stop bit, no parity */      ;\
+    sb   t1, 0(t0)                                                  ;\
+    li   t0, VF2_UART_FCR                                          ;\
+    li   t1, 0x07          /* Enable & clear TX/RX FIFOs */        ;\
+    sb   t1, 0(t0)                                                  ;\
+    li   t0, VF2_UART_IER                                          ;\
+    sb   zero, 0(t0)       /* Disable all UART interrupts */        ;\
+
+// ---------------------------------------------------------------------------
+// RVMODEL_IO_INIT: Additional IO initialization (UART already done in BOOT).
+// _R1, _R2, _R3 are available as scratch registers.
+// ---------------------------------------------------------------------------
+#define RVMODEL_IO_INIT(_R1, _R2, _R3)  /* UART initialized in RVMODEL_BOOT */
+
+// ---------------------------------------------------------------------------
+// RVMODEL_IO_WRITE_STR: Print null-terminated string over UART.
+// Polls LSR bit 5 (THRE - Transmit Holding Register Empty) before each byte.
+// _STR_PTR: register holding pointer to string (modified by macro).
+// _R1, _R2, _R3: scratch registers.
+// ---------------------------------------------------------------------------
+#define RVMODEL_IO_WRITE_STR(_R1, _R2, _R3, _STR_PTR)              \
+  vf2_uart_str_loop##_STR_PTR:                                      \
+    lbu  _R1, 0(_STR_PTR)          /* load next character */       ;\
+    beqz _R1, vf2_uart_str_done##_STR_PTR /* stop at null */       ;\
+  vf2_uart_wait##_STR_PTR:                                          \
+    li   _R2, VF2_UART_LSR                                         ;\
+    lbu  _R3, 0(_R2)               /* read LSR */                   ;\
+    andi _R3, _R3, 0x20            /* check THRE (bit 5) */         ;\
+    beqz _R3, vf2_uart_wait##_STR_PTR /* wait until TX ready */    ;\
+    li   _R2, VF2_UART_THR                                         ;\
+    sb   _R1, 0(_R2)               /* transmit character */         ;\
+    addi _STR_PTR, _STR_PTR, 1    /* advance pointer */             ;\
+    j    vf2_uart_str_loop##_STR_PTR                                ;\
+  vf2_uart_str_done##_STR_PTR:
+
+// ---------------------------------------------------------------------------
+// RVMODEL_HALT_PASS: Signal test PASSED.
+// Writes tohost=1 (for any host-side monitor), then spins.
+// The RVCP-SUMMARY string is printed by the ACT framework before calling
+// rvmodel_halt_pass, so no extra print is needed here.
+// ---------------------------------------------------------------------------
+#define RVMODEL_HALT_PASS                                           \
+    li   x1, 1                     /* tohost pass code = 1 */      ;\
+    la   t0, tohost                                                 ;\
+  vf2_write_pass:                                                   ;\
+    sw   x1, 0(t0)                 /* write to tohost */            ;\
+    sw   zero, 4(t0)                                                ;\
+  vf2_spin_pass:                                                    ;\
+    j    vf2_spin_pass             /* infinite loop */              ;\
+
+// ---------------------------------------------------------------------------
+// RVMODEL_HALT_FAIL: Signal test FAILED.
+// Writes tohost=3 (fail code), then spins.
+// ---------------------------------------------------------------------------
+#define RVMODEL_HALT_FAIL                                           \
+    li   x1, 3                     /* tohost fail code = 3 */      ;\
+    la   t0, tohost                                                 ;\
+  vf2_write_fail:                                                   ;\
+    sw   x1, 0(t0)                 /* write to tohost */            ;\
+    sw   zero, 4(t0)                                                ;\
+  vf2_spin_fail:                                                    ;\
+    j    vf2_spin_fail             /* infinite loop */              ;\
+
+// ---------------------------------------------------------------------------
+// ACCESS FAULT: The JH7110 memory map has unmapped regions at low addresses.
+// Address 0x00000000 is not mapped and will trigger a load/store access fault.
+// Note: Under OpenSBI, access faults may be handled differently than bare metal.
+// Set to "na" if access faults cannot be reliably triggered in your setup.
+// ---------------------------------------------------------------------------
+#define RVMODEL_ACCESS_FAULT_ADDRESS 0x00000000
+
+// ---------------------------------------------------------------------------
+// TIMER/INTERRUPT MACROS
+// OpenSBI manages the CLINT on VisionFive 2. Direct CLINT writes from S-mode
+// will be intercepted by OpenSBI via SBI ecalls. These macros are left empty
+// because include_priv_tests: false excludes all M-mode timer/interrupt tests.
+// ---------------------------------------------------------------------------
+#define RVMODEL_MTIME_ADDRESS        /* Not directly accessible; managed by OpenSBI */
+#define RVMODEL_MTIMECMP_ADDRESS     /* Not directly accessible; managed by OpenSBI */
+#define RVMODEL_TIMER_INT_SOON_DELAY 0
+#define RVMODEL_INTERRUPT_LATENCY    0
+
+#define RVMODEL_SET_MEXT_INT(_R1, _R2)   /* Not supported: OpenSBI owns M-mode */
+#define RVMODEL_CLR_MEXT_INT(_R1, _R2)
+#define RVMODEL_SET_MSW_INT(_R1, _R2)    /* Not supported: OpenSBI owns CLINT */
+#define RVMODEL_CLR_MSW_INT(_R1, _R2)
+#define RVMODEL_SET_SEXT_INT(_R1, _R2)   /* Platform-specific PLIC; not implemented */
+#define RVMODEL_CLR_SEXT_INT(_R1, _R2)
+#define RVMODEL_SET_SSW_INT(_R1, _R2)    /* Use SBI ecall in future extension */
+#define RVMODEL_CLR_SSW_INT(_R1, _R2)
+
+#endif // _RVMODEL_MACROS_H

--- a/config/cores/starfive/visionfive2/rvtest_config.h
+++ b/config/cores/starfive/visionfive2/rvtest_config.h
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// rvtest_config.h — Supported extensions for StarFive VisionFive 2 (JH7110)
+//
+// JH7110 ISA: RV64GC (I, M, A, F, D, C extensions)
+// Running under OpenSBI: S-mode and U-mode tests only.
+// M-mode tests excluded (include_priv_tests: false in test_config.yaml).
+
+// PMP: OpenSBI configures PMP entries at boot. Not directly controllable.
+// Set grain and count to match JH7110 hardware (8 PMP entries, grain=0).
+#define RVMODEL_PMP_GRAIN 0
+#define RVMODEL_NUM_PMPS  8
+
+// Base ISA extensions supported by JH7110
+#define F_SUPPORTED
+#define D_SUPPORTED
+
+// Bit-manipulation (B extension = Zba + Zbb + Zbs on JH7110)
+#define ZBA_SUPPORTED
+#define ZBB_SUPPORTED
+#define ZBS_SUPPORTED
+
+// Atomics
+#define ZAAMO_SUPPORTED
+#define ZALRSC_SUPPORTED
+
+// Compressed instructions
+#define ZCA_SUPPORTED
+#define ZCB_SUPPORTED
+#define ZCD_SUPPORTED
+
+// Counters (time CSR available via OpenSBI)
+#define TIME_CSR_IMPLEMENTED 1
+
+// Virtual memory: JH7110 supports Sv39 and Sv48
+#define SV39_SUPPORTED
+#define SV48_SUPPORTED
+
+// Supervisor mode supported (OpenSBI delegates S-mode to the OS)
+#define S_SUPPORTED

--- a/config/cores/starfive/visionfive2/rvtest_config.svh
+++ b/config/cores/starfive/visionfive2/rvtest_config.svh
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// rvtest_config.svh — SystemVerilog coverage config for VisionFive 2 (JH7110)
+// Note: No RTL simulation is used with this SBC target.
+// This file is included for completeness and framework compatibility.
+
+// XLEN and FLEN
+`define XLEN64
+`define FLEN64
+
+// PMP grain (G=0 for JH7110)
+`define G 0
+
+// PMP mode — JH7110 has 8 PMP entries
+`define PMP_16   // Using PMP_16 as closest available option
+
+// Base addresses for VisionFive 2 DRAM layout
+`define RAM_BASE_ADDR       32'h42000000   // ELF load address
+`define LARGEST_PROGRAM     32'h00010000   // 64 KB max test size
+
+// Access fault address (unmapped region below DRAM)
+`define RVMODEL_ACCESS_FAULT_ADDRESS 64'h00000000
+
+// CLINT base (managed by OpenSBI; not directly writable from S-mode)
+`define CLINT_BASE 64'h02000000
+
+// Supported extensions
+`define F_SUPPORTED
+`define D_SUPPORTED
+`define ZBA_SUPPORTED
+`define ZBB_SUPPORTED
+`define ZBS_SUPPORTED
+`define ZAAMO_SUPPORTED
+`define ZALRSC_SUPPORTED
+`define ZCA_SUPPORTED
+`define ZCB_SUPPORTED
+`define ZCD_SUPPORTED
+`define SV39_SUPPORTED
+`define SV48_SUPPORTED
+
+// Timer CSR available via OpenSBI (read-only from S-mode)
+`define TIME_CSR_IMPLEMENTED

--- a/config/cores/starfive/visionfive2/sail.json
+++ b/config/cores/starfive/visionfive2/sail.json
@@ -1,0 +1,276 @@
+{
+  "$schema": "/opt/riscv/share/sail-riscv/sail_riscv_config_schema.json",
+  "base": {
+    "xlen": 64,
+    "E": false,
+    "writable_misa": false,
+    "writable_fiom": true,
+    "writable_hpm_counters": {
+      "len": 32,
+      "value": "0x0000_00FF"   // HPM counters 3-10 enabled on JH7110
+    },
+    // Exception value reporting — matches JH7110/Linux behavior
+    "xtval_nonzero": {
+      "illegal_instruction": true,
+      "software_breakpoint": true,
+      "hardware_breakpoint": true,
+      "load_address_misaligned": true,
+      "load_access_fault": true,
+      "load_page_fault": true,
+      "samo_address_misaligned": true,
+      "samo_access_fault": true,
+      "samo_page_fault": true,
+      "fetch_address_misaligned": true,
+      "fetch_access_fault": true,
+      "fetch_page_fault": true,
+      "software_check": false,
+      "reserved_exceptions": false
+    },
+    "reserved_behavior": {
+      "amocas_odd_register": "AMOCAS_Illegal",
+      "fcsr_rm": "Fcsr_RM_Illegal",
+      "pmpcfg_write_only": "PMP_ClearPermissions",
+      "xenvcfg_cbie": "Xenvcfg_ClearPermissions",
+      "rv32zdinx_odd_register": "Zdinx_Illegal"
+    }
+  },
+  "memory": {
+    "pmp": {
+      "grain": 0,
+      // JH7110 has 8 PMP entries (OpenSBI uses the top entries for its own regions)
+      "count": 8,
+      "usable_count": 8,
+      "tor_supported": true,
+      "na4_supported": true,
+      "napot_supported": true
+    },
+    "misaligned": {
+      "supported": false,        // JH7110 does NOT support hardware misaligned access
+      "byte_by_byte": false,
+      "order_decreasing": false,
+      "allowed_within_exp": 0
+    },
+    "translation": {
+      "dirty_update": false
+    },
+    "dtb_address": {
+      "len": 64,
+      "value": "0x40000000"    // OpenSBI places DTB at DRAM start
+    },
+    "regions": [
+      // QSPI / SPI Flash region (not used by ACT tests)
+      {
+        "base": {
+          "len": 64,
+          "value": "0x21000000"
+        },
+        "size": {
+          "len": 64,
+          "value": "0x01000000"
+        },
+        "attributes": {
+          "cacheable": false,
+          "coherent": false,
+          "executable": true,
+          "readable": true,
+          "writable": false,
+          "read_idempotent": true,
+          "write_idempotent": true,
+          "misaligned_fault": "AlignmentFault",
+          "reservability": "RsrvNone",
+          "supports_cbo_zero": false
+        },
+        "include_in_device_tree": false
+      },
+      // CLINT / Timer (managed by OpenSBI — here for Sail reference model completeness)
+      {
+        "base": {
+          "len": 64,
+          "value": "0x02000000"
+        },
+        "size": {
+          "len": 64,
+          "value": "0x00010000"
+        },
+        "attributes": {
+          "cacheable": false,
+          "coherent": true,
+          "executable": false,
+          "readable": true,
+          "writable": true,
+          "read_idempotent": false,
+          "write_idempotent": false,
+          "misaligned_fault": "AlignmentFault",
+          "reservability": "RsrvNone",
+          "supports_cbo_zero": false
+        },
+        "include_in_device_tree": false
+      },
+      // UART0 memory-mapped IO (NS16550 at 0x10000000)
+      {
+        "base": {
+          "len": 64,
+          "value": "0x10000000"
+        },
+        "size": {
+          "len": 64,
+          "value": "0x00010000"
+        },
+        "attributes": {
+          "cacheable": false,
+          "coherent": true,
+          "executable": false,
+          "readable": true,
+          "writable": true,
+          "read_idempotent": false,
+          "write_idempotent": false,
+          "misaligned_fault": "AlignmentFault",
+          "reservability": "RsrvNone",
+          "supports_cbo_zero": false
+        },
+        "include_in_device_tree": false
+      },
+      // Main DRAM — ACT ELFs load here (0x40000000 base, ELFs at 0x42000000)
+      {
+        "base": {
+          "len": 64,
+          "value": "0x40000000"
+        },
+        "size": {
+          "len": 64,
+          "value": "0x200000000"  // 8 GB physical on VisionFive 2
+        },
+        "attributes": {
+          "cacheable": true,
+          "coherent": true,
+          "executable": true,
+          "readable": true,
+          "writable": true,
+          "read_idempotent": true,
+          "write_idempotent": true,
+          "misaligned_fault": "NoFault",
+          "reservability": "RsrvEventual",
+          "supports_cbo_zero": false  // Zicboz not implemented on JH7110
+        },
+        "include_in_device_tree": true
+      }
+    ]
+  },
+  "platform": {
+    "vendorid": 0,           // StarFive vendor ID (TBD)
+    "archid": 0,             // JH7110 arch ID (TBD)
+    "impid": 0,
+    "hartid": 0,
+    "cache_block_size_exp": 6,    // 64-byte cache lines on JH7110
+    "reservation_set_size_exp": 3,
+    "clint": {
+      // CLINT base on JH7110 — managed by OpenSBI
+      // ACT tests do NOT write to CLINT directly (include_priv_tests: false)
+      "base": 33554432,           // 0x02000000
+      "size": 65536
+    },
+    "clock_frequency": 1500000000, // JH7110 runs at 1.5 GHz
+    "instructions_per_tick": 2,
+    "wfi_is_nop": false
+  },
+  "extensions": {
+    "M": { "supported": true },
+    "A": { "supported": true },
+    "F": { "supported": true },
+    "D": { "supported": true },
+    "V": {
+      "support_level": "Disabled",
+      "vlen_exp": 7,
+      "elen_exp": 6,
+      "vl_use_ceil": false
+    },
+    "B": { "supported": true },
+    "S": { "supported": true },
+    "U": { "supported": true },
+    "Zibi":      { "supported": false },
+    "Zicbom":    { "supported": false },  // Not confirmed on JH7110
+    "Zicbop":    { "supported": false },
+    "Zicboz":    { "supported": false },
+    "Zic64b":    { "supported": false },
+    "Zicfilp":   { "supported": false },
+    "Zicond":    { "supported": false },
+    "Zicntr":    { "supported": true },
+    "Zicsr":     { "supported": true },
+    "Zifencei":  { "supported": true },
+    "Zihintntl": { "supported": false },
+    "Zihintpause":{ "supported": false },
+    "Zihpm":     { "supported": true },
+    "Zimop":     { "supported": false },
+    "Zmmul":     { "supported": false },
+    "Zaamo":     { "supported": false },  // A extension used as whole
+    "Zabha":     { "supported": false },
+    "Zacas":     { "supported": false },
+    "Zalrsc":    { "supported": false },  // A extension used as whole
+    "Zawrs":     { "supported": false, "nto": { "is_nop": false }, "sto": { "is_nop": false } },
+    "Zfa":       { "supported": false },
+    "Zfbfmin":   { "supported": false },
+    "Zfh":       { "supported": false },
+    "Zfhmin":    { "supported": false },
+    "Zfinx":     { "supported": false },
+    "Zdinx":     { "supported": false },
+    "Zca":       { "supported": true },
+    "Zcf":       { "supported": false },
+    "Zcd":       { "supported": true },
+    "Zcb":       { "supported": false },  // To be confirmed
+    "Zcmop":     { "supported": false },
+    "Zba":       { "supported": true },
+    "Zbb":       { "supported": true },
+    "Zbs":       { "supported": true },
+    "Zbc":       { "supported": false },
+    "Zbkb":      { "supported": false },
+    "Zbkc":      { "supported": false },
+    "Zbkx":      { "supported": false },
+    "Zknd":      { "supported": false },
+    "Zkne":      { "supported": false },
+    "Zknh":      { "supported": false },
+    "Zkr":       { "supported": false, "sseed_reset_value": false, "useed_reset_value": false,
+                   "sseed_read_only_zero": false, "useed_read_only_zero": false },
+    "Zksed":     { "supported": false },
+    "Zksh":      { "supported": false },
+    "Zkt":       { "supported": false },
+    "Zhinx":     { "supported": false },
+    "Zhinxmin":  { "supported": false },
+    "Zvabd":     { "supported": false },
+    "Zvfbfmin":  { "supported": false },
+    "Zvfbfwma":  { "supported": false },
+    "Zvfh":      { "supported": false },
+    "Zvfhmin":   { "supported": false },
+    "Zvbb":      { "supported": false },
+    "Zvbc":      { "supported": false },
+    "Zvkb":      { "supported": false },
+    "Zvkg":      { "supported": false },
+    "Zvkned":    { "supported": false },
+    "Zvknha":    { "supported": false },
+    "Zvknhb":    { "supported": false },
+    "Zvksed":    { "supported": false },
+    "Zvksh":     { "supported": false },
+    "Zvkt":      { "supported": false },
+    "Sscofpmf":  { "supported": false },
+    "Sstc":      { "supported": false },
+    "Sstvala":   { "supported": false },
+    "Svinval":   { "supported": false },
+    "Svrsw60t59b":{ "supported": false },
+    "Smcntrpmf": { "supported": false },
+    "Svbare":    { "supported": true, "sfence_vma_illegal_if_svbare_only": true },
+    "Sv32":      { "supported": false },
+    "Sv39":      { "supported": true },
+    "Sv48":      { "supported": true },
+    "Sv57":      { "supported": false },
+    "Stateen": {
+      "Smstateen": { "supported": false },
+      "Ssstateen": { "supported": false },
+      "C_readonly_zero": true,
+      "SE0_readonly_zero": true
+    },
+    "Ssqosid": {
+      "supported": false,
+      "rcid_length": 12,
+      "mcid_length": 12
+    }
+  }
+}

--- a/config/cores/starfive/visionfive2/test_config.yaml
+++ b/config/cores/starfive/visionfive2/test_config.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# test_config.yaml — ACT4 Framework configuration for StarFive VisionFive 2
+#
+# Board:   StarFive VisionFive 2 (JH7110 SoC, quad-core RV64GC)
+# Issue:   https://github.com/riscv/riscv-arch-test/issues/1306
+#
+# IMPORTANT: include_priv_tests is set to false because OpenSBI owns M-mode
+# on this board at runtime. All ACT tests run in S-mode or U-mode.
+# M-mode tests (Sm, PMP, ExceptionsSm, InterruptsSm) are excluded.
+
+name: visionfive2-rv64gc
+compiler_exe: riscv64-unknown-elf-gcc     # executable on $PATH or full path
+objdump_exe: riscv64-unknown-elf-objdump  # optional but recommended for debug
+ref_model_exe: sail_riscv_sim             # RISC-V Sail reference model v0.10+
+udb_config: visionfive2-rv64gc.yaml       # UDB architecture configuration
+linker_script: link.ld                    # VisionFive 2 DRAM memory map
+dut_include_dir: .                        # directory containing rvmodel_macros.h
+include_priv_tests: false                 # M-mode owned by OpenSBI; exclude priv tests

--- a/config/cores/starfive/visionfive2/visionfive2-rv64gc.yaml
+++ b/config/cores/starfive/visionfive2/visionfive2-rv64gc.yaml
@@ -1,0 +1,129 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/riscv/riscv-unified-db/main/spec/schemas/config_schema.json
+---
+$schema: config_schema.json#
+kind: architecture configuration
+type: fully configured
+name: visionfive2-rv64gc
+description: >
+  StarFive VisionFive 2 (JH7110 SoC) — RV64GC configuration.
+  Runs under OpenSBI firmware; ACT tests execute in S-mode and U-mode.
+  M-mode tests are excluded because OpenSBI owns machine mode at runtime.
+  Tracks issue: https://github.com/riscv/riscv-arch-test/issues/1306
+
+implemented_extensions:
+  # Base ISA
+  - { name: I,        version: "= 2.1" }
+  - { name: M,        version: "= 2.0" }
+  - { name: A,        version: "= 2.1.0" }
+  - { name: F,        version: "= 2.2.0" }
+  - { name: D,        version: "= 2.2.0" }
+  - { name: C,        version: "= 2.0" }
+  # Bit-manipulation (B = Zba + Zbb + Zbs on JH7110)
+  - { name: Zba,      version: "= 1.0.0" }
+  - { name: Zbb,      version: "= 1.0.0" }
+  - { name: Zbs,      version: "= 1.0.0" }
+  # Atomic sub-extensions
+  - { name: Zaamo,    version: "= 1.0.0" }
+  - { name: Zalrsc,   version: "= 1.0.0" }
+  # Compressed sub-extensions
+  - { name: Zca,      version: "= 1.0.0" }
+  - { name: Zcb,      version: "= 1.0.0" }
+  - { name: Zcd,      version: "= 1.0.0" }
+  # Counters and CSR
+  - { name: Zicntr,   version: "= 2.0" }
+  - { name: Zicsr,    version: "= 2.0" }
+  - { name: Zifencei, version: "= 2.0.0" }
+  - { name: Zihpm,    version: "= 2.0.0" }
+  - { name: Zmmul,    version: "= 1.0.0" }
+  # Privilege: S and U mode (M-mode owned by OpenSBI)
+  - { name: U,        version: "= 1.0.0" }
+  - { name: S,        version: "= 1.12.0" }
+  - { name: Sv39,     version: "= 1.12.0" }
+  - { name: Sv48,     version: "= 1.12.0" }
+  - { name: Svbare,   version: "= 1.0.0" }
+  - { name: Svade,    version: "= 1.0.0" }
+  # Machine mode present in hardware but managed by OpenSBI
+  # Listed here for completeness; priv tests are excluded via test_config.yaml
+  - { name: Sm,       version: "= 1.12.0" }
+
+params:
+  # A extension
+  MISALIGNED_AMO: false
+  LRSC_RESERVATION_STRATEGY: "reserve exactly enough to cover the access"
+  LRSC_FAIL_ON_VA_SYNONYM: false
+  LRSC_MISALIGNED_BEHAVIOR: "always raise access fault"
+  LRSC_FAIL_ON_NON_EXACT_LRSC: false
+  MUTABLE_MISA_A: false
+
+  # M extension
+  MUTABLE_MISA_M: false
+
+  # F/D extensions
+  MUTABLE_MISA_F: false
+  MUTABLE_MISA_D: false
+  HW_MSTATUS_FS_DIRTY_UPDATE: precise
+  MSTATUS_FS_LEGAL_VALUES: [0, 1, 2, 3]
+
+  # C extension
+  MUTABLE_MISA_C: false
+
+  # Counter CSRs
+  TIME_CSR_IMPLEMENTED: true  # time CSR available via OpenSBI read delegation
+
+  # U mode
+  MUTABLE_MISA_U: false
+  U_MODE_ENDIANNESS: little
+  UXLEN: [64]
+  TRAP_ON_ECALL_FROM_U: true
+
+  # S mode
+  MUTABLE_MISA_S: false
+  ASID_WIDTH: 16             # JH7110 supports 16-bit ASID
+  S_MODE_ENDIANNESS: little
+  SXLEN: [64]
+  SATP_MODE_BARE: true
+  TRAP_ON_ECALL_FROM_S: true
+  STVEC_MODE_DIRECT: true
+  STVEC_MODE_VECTORED: true
+
+  # Exception value reporting (JH7110 / Linux-style)
+  REPORT_VA_IN_MTVAL_ON_LOAD_PAGE_FAULT: true
+  REPORT_VA_IN_MTVAL_ON_STORE_AMO_PAGE_FAULT: true
+  REPORT_VA_IN_MTVAL_ON_INSTRUCTION_PAGE_FAULT: true
+  REPORT_VA_IN_STVAL_ON_LOAD_MISALIGNED: true
+  REPORT_VA_IN_STVAL_ON_STORE_AMO_MISALIGNED: true
+  REPORT_VA_IN_STVAL_ON_INSTRUCTION_MISALIGNED: true
+  REPORT_VA_IN_STVAL_ON_LOAD_ACCESS_FAULT: true
+  REPORT_VA_IN_STVAL_ON_STORE_AMO_ACCESS_FAULT: true
+  REPORT_VA_IN_STVAL_ON_INSTRUCTION_ACCESS_FAULT: true
+  REPORT_VA_IN_STVAL_ON_LOAD_PAGE_FAULT: true
+  REPORT_VA_IN_STVAL_ON_STORE_AMO_PAGE_FAULT: true
+  REPORT_VA_IN_STVAL_ON_INSTRUCTION_PAGE_FAULT: true
+  REPORT_ENCODING_IN_STVAL_ON_ILLEGAL_INSTRUCTION: true
+  STVAL_WIDTH: 64
+
+  # Sm params (hardware M-mode; managed by OpenSBI)
+  MXLEN: 64
+  PRECISE_SYNCHRONOUS_EXCEPTIONS: true
+  TRAP_ON_ECALL_FROM_M: true
+  TRAP_ON_EBREAK: true
+  TRAP_ON_ILLEGAL_WLRL: false
+  TRAP_ON_UNIMPLEMENTED_INSTRUCTION: true
+  TRAP_ON_UNIMPLEMENTED_CSR: true
+  REPORT_ENCODING_IN_MTVAL_ON_ILLEGAL_INSTRUCTION: true
+  MTVAL_WIDTH: 64
+  PHYS_ADDR_WIDTH: 34        # JH7110: 34-bit physical address space
+  M_MODE_ENDIANNESS: little
+  MISA_CSR_IMPLEMENTED: true
+  MTVEC_ACCESS: rw
+  MTVEC_MODES: [0, 1]
+  MTVEC_BASE_ALIGNMENT_DIRECT: 4
+  MTVEC_BASE_ALIGNMENT_VECTORED: 4
+  MTVEC_ILLEGAL_WRITE_BEHAVIOR: retain
+
+  # PMP: JH7110 has 8 PMP entries, grain=0
+  NUM_PMP_ENTRIES: 8
+  PMP_GRANULARITY: 0
+
+  CONFIG_PTR_ADDRESS: 0
+  PMA_GRANULARITY: 0


### PR DESCRIPTION
Closes #1306

Initial ACT4 configuration for the StarFive VisionFive 2 SBC (JH7110 RV64GC).

## What's included
- `rvmodel_macros.h` — NS16550 UART init, tohost write, UART-based PASS/FAIL
- `link.ld` — ELFs placed at 0x42000000 (above OpenSBI + U-Boot)
- `test_config.yaml` — `include_priv_tests: false` (OpenSBI owns M-mode)
- `visionfive2-rv64gc.yaml` — Full UDB architecture description
- `sail.json` — Sail reference model config with JH7110 memory map
- `README.md` — U-Boot loading flow, UART result collection, known limits

## Open questions (see #1306)
- [ ] Confirm correct PMP grain/count for JH7110
- [ ] Validate tohost strategy with maintainers
- [ ] Add host-side UART result collection script

Requesting early review before marking ready.
