### PR TITLE
Improve act4-build image caching

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -28,8 +28,37 @@ jobs:
         type=sha,format=long
       meta-flavor: |
         latest=${{ github.ref == 'refs/heads/act4' }}
+      target: act4-build
     secrets:
       registry-auths: |
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+  act4-image:
+    needs: act4-build-image
+    uses: docker/github-builder/.github/workflows/build.yml@7d2a02426d4b989616ba5aaee4e879afd4134b0d # v1.6.0
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    with:
+      output: image
+      push: true
+      cache: true
+      cache-mode: min
+      platforms: linux/amd64,linux/arm64
+      meta-images: ghcr.io/${{ github.repository_owner }}/act4
+      meta-tags: |
+        type=ref,event=tag
+        type=ref,event=branch
+        type=sha,format=long
+      meta-flavor: |
+        latest=false
+      target: act4
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+    if: ${{ github.ref != 'refs/heads/act4' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,16 +119,26 @@ RUN mkdir -p /home/shared
 # Install mise itself into ~/.local/bin
 RUN curl -fsSL https://mise.jdx.dev/install.sh | sh
 
-# Copy the full repo from the build context.
-# mise and bundler need .mise.toml and the Gemfile(s); uv needs pyproject.toml / uv.lock.
-COPY . /act4/
+# mise and bundler need .mise.toml and the Gemfile(s); uv needs .python-version / pyproject.toml / uv.lock.
+COPY \
+    .mise.toml \
+        framework/src/act/data/Gemfile framework/src/act/data/Gemfile.lock \
+        .python-version pyproject.toml uv.lock README.md \
+    /act4/
+# Copy files of other workspace members
+COPY framework/pyproject.toml /act4/framework/pyproject.toml
+COPY framework/src/act/__init__.py /act4/framework/src/act/__init__.py
+COPY generators/coverage/pyproject.toml /act4/generators/coverage/pyproject.toml
+COPY generators/coverage/src/covergroupgen/__init__.py /act4/generators/coverage/src/covergroupgen/__init__.py
+COPY generators/testgen/pyproject.toml /act4/generators/testgen/pyproject.toml
+COPY generators/testgen/src/testgen/__init__.py /act4/generators/testgen/src/testgen/__init__.py
 
 # Install uv and Ruby at the versions pinned in .mise.toml
 # Pre-install the riscv-unified-db gem into the mise-managed Ruby's gem dir so `bundle install` is a no-op at runtime.
 # Pre-download all Python dependencies so `uv sync` is a no-op at runtime.
 RUN cd /act4 \
   && mise install \
-  && mise exec -- bundle install --gemfile=framework/src/act/data/Gemfile \
+  && mise exec -- bundle install \
   && mise exec -- uv sync
 
 # Stage 3: final runtime image
@@ -166,7 +176,7 @@ RUN SAIL_OS="$(uname -s)" \
   | tar xz --directory="${SAIL_PREFIX}" --strip-components=1
 
 COPY --from=toolchain-builder "${RISCV_TOOLCHAIN_PREFIX}" "${RISCV_TOOLCHAIN_PREFIX}"
-COPY --from=mise-fetcher      /act4                       /act4
+COPY --from=mise-fetcher      /act4/.venv                 /act4/.venv
 COPY --from=mise-fetcher      /home/shared                /home/shared
 
 # Fix home ownership so that any user can use it
@@ -183,3 +193,5 @@ USER ubuntu
 WORKDIR /act4
 
 CMD ["/bin/bash"]
+
+COPY --chmod=777 . /act4

--- a/Dockerfile
+++ b/Dockerfile
@@ -141,8 +141,11 @@ RUN cd /act4 \
   && mise exec -- bundle install \
   && mise exec -- uv sync
 
+# Fix permissions so that any user can use it
+RUN chmod -R 777 /act4 /home/shared
+
 # Stage 3: final runtime image
-FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS act4-build
 
 LABEL description="RISC-V Architectural Certification Tests (ACT4) build env"
 LABEL org.opencontainers.image.source="https://github.com/riscv/riscv-arch-test"
@@ -176,11 +179,7 @@ RUN SAIL_OS="$(uname -s)" \
   | tar xz --directory="${SAIL_PREFIX}" --strip-components=1
 
 COPY --from=toolchain-builder "${RISCV_TOOLCHAIN_PREFIX}" "${RISCV_TOOLCHAIN_PREFIX}"
-COPY --from=mise-fetcher      /act4/.venv                 /act4/.venv
 COPY --from=mise-fetcher      /home/shared                /home/shared
-
-# Fix home ownership so that any user can use it
-RUN chmod -R 777 /act4 /home/shared
 
 # Smoke-test: verify all the binaries landed correctly (runs as root during build, before USER switch)
 RUN riscv64-unknown-elf-gcc --version \
@@ -194,4 +193,7 @@ WORKDIR /act4
 
 CMD ["/bin/bash"]
 
+FROM act4-build AS act4
+
+COPY --from=mise-fetcher /act4/.venv /act4/.venv
 COPY --chmod=777 . /act4


### PR DESCRIPTION
This reduced the diff to a single layer when dependencies remain the same.

As a small piece of related feedback, it'd be nice if `/work` was the only writable directory during ELF building. Currently other directories are modified too.