### PR TITLE
Re-enable Sv for Spike's CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ WORKDIR     ?= work
 # EXCLUDE_EXTENSIONS overrides EXTENSIONS to exclude particular extensions from test generation. Applies as a negative filter after EXTENSIONS.
 # Default exclusion reasons:
 #  - Sm, S: Insufficient WARL configuration options.
-#  - InterruptsSm,InterruptsS,InterruptsU,PMPSm,PMPZca,Sv,SvaduPMP,SvPMP,SvPMPZicbo: Additional testing needed on a wider range of configs. Some missing config options to match ref model.
+#  - InterruptsSm,InterruptsS,InterruptsU,PMPSm,PMPZca,SvaduPMP,SvPMP,SvPMPZicbo: Additional testing needed on a wider range of configs. Some missing config options to match ref model.
 EXTENSIONS  ?=
-EXCLUDE_EXTENSIONS ?= Sm,S,InterruptsSm,InterruptsS,InterruptsU,ExceptionsZalrsc,ExceptionsZaamo,PMPF,PMPS,PMPSm,PMPU,PMPZaamo,PMPZalrsc,PMPZca,PMPZicbo,Sv,Svade,Svadu,SvaduPMP,SvPMP,SvZicbo,SvPMPZicbo
+EXCLUDE_EXTENSIONS ?= Sm,S,InterruptsSm,InterruptsS,InterruptsU,ExceptionsZalrsc,ExceptionsZaamo,PMPF,PMPS,PMPSm,PMPU,PMPZaamo,PMPZalrsc,PMPZca,PMPZicbo,Svade,Svadu,SvaduPMP,SvPMP,SvZicbo,SvPMPZicbo
 
 # Strip spaces from comma-separated lists so shell word-splitting doesn't break CLI arguments
 empty :=

--- a/config/spike/ci.yaml
+++ b/config/spike/ci.yaml
@@ -6,6 +6,6 @@
 ci_enabled: true
 # TODO: Priv tests mismatch due to config issues. Atomics failure still needs to be diagnosed.
 # TODO: remove za64rs from excluded_extensions when Sail supports UDB_LRSC_FAIL_ON_NON_EXACT_LRSC to match DUT
-exclude_extensions: "Sm,ExceptionsZc,S,InterruptsSm,PMPmisaligned,ExceptionsZalrsc,Sv,Svadu,SvaduPMP,Svnapot,Svpbmt,SvZicbo,ExceptionsZaamo,ExceptionsSvZaamo,ExceptionsSvZalrsc,Za64rs,PMPS,PMPF,PMPU,PMPSm"
+exclude_extensions: "Sm,ExceptionsZc,S,InterruptsSm,PMPmisaligned,ExceptionsZalrsc,Svadu,SvaduPMP,Svnapot,Svpbmt,SvZicbo,ExceptionsZaamo,ExceptionsSvZaamo,ExceptionsSvZalrsc,Za64rs,PMPS,PMPF,PMPU,PMPSm"
 install_script: ".github/scripts/install-spike.sh"
 apt_packages: "device-tree-compiler libboost-regex-dev libboost-system-dev"

--- a/config/spike/spike-rv64-max/sail.json
+++ b/config/spike/spike-rv64-max/sail.json
@@ -589,7 +589,7 @@
       "supported": true
     },
     "Svrsw60t59b": {
-      "supported": true
+      "supported": false
     },
     "Svnapot": {
       "supported": true

--- a/tests/env/failure_code.h
+++ b/tests/env/failure_code.h
@@ -464,7 +464,7 @@
         2:
         li a1, __riscv_xlen
         jal failedtest_hex_to_str
-        mv x7, a0           # move xepc
+        mv a2, a0           # move xepc
         LA(a0, ascii_buffer)
         call rvmodel_io_write_str
     failedtest_report_xepc_instr:
@@ -472,12 +472,12 @@
         LA(a0, xepcinstrstr)
         call rvmodel_io_write_str
         # Check if its a compressed instruction
-        lhu a0, 0(x7)       # load lower half of instruction at xepc
+        lhu a0, 0(a2)       # load lower half of instruction at xepc
         li a1, 16
         andi x8, a0, 3
         li x9, 3
         bne x8, x9, 1f      # compressed: only lower half needed
-        lhu x8, 2(x7)
+        lhu x8, 2(a2)
         slli x8, x8, 16
         or a0, a0, x8
         li a1, 32


### PR DESCRIPTION
@jordancarlin 3 tests were failing on spike due to a configuration issue. 
The reason for the error reporting being stuck in a loop was due to a bug that got introduced in PR #1264. 
```
        mv x7, a0           # move xepc
        LA(a0, ascii_buffer)
        call rvmodel_io_write_str
```
x7 gets overwritten by `rvmodel_io_write_str`, therefore instead of trying to read instr at xepc it was reading from some random address leading to a loop of faults.