### PR TITLE
Don't mark generated files as read-only

### DIFF
--- a/generators/coverage/src/covergroupgen/generate.py
+++ b/generators/coverage/src/covergroupgen/generate.py
@@ -42,23 +42,12 @@ VECTOR_PREFIXES = ("Vx", "Zv", "Vls", "Vf")
 # Subset of vector prefixes that support widening instructions.
 VECTOR_WIDEN_PREFIXES = ("Vx", "Vls", "Vf")
 
-# Generated coverage files are marked read-only (0o444) to deter manual edits.
-# Regeneration temporarily restores write permission (0o644) before overwriting.
-_READONLY_MODE = 0o444
-_WRITABLE_MODE = 0o644
 
-
-def _write_readonly(path: Path, content: str) -> None:
-    """Write content to a generated file and mark it read-only to deter manual edits.
-
-    Skips the write if the existing file already matches to avoid unnecessary rebuilds.
-    """
-    if path.exists():
-        if path.read_text() == content:
-            return
-        path.chmod(_WRITABLE_MODE)
+def _write_if_changed(path: Path, content: str) -> None:
+    """Write content only if it differs from the existing file, to avoid unnecessary rebuilds."""
+    if path.exists() and path.read_text() == content:
+        return
     path.write_text(content)
-    path.chmod(_READONLY_MODE)
 
 
 ##################################
@@ -488,8 +477,8 @@ def write_covergroups(
         lines.append(customize_template(templates, sample_end, arch))
 
         # Write both files
-        _write_readonly(unpriv_dir / f"{arch}_coverage.svh", "".join(lines))
-        _write_readonly(unpriv_dir / f"{arch}_coverage_init.svh", "".join(init_lines))
+        _write_if_changed(unpriv_dir / f"{arch}_coverage.svh", "".join(lines))
+        _write_if_changed(unpriv_dir / f"{arch}_coverage_init.svh", "".join(init_lines))
 
 
 def write_coverage_headers(
@@ -514,19 +503,19 @@ def write_coverage_headers(
         lines.append(f"`ifdef {arch.upper()}_COVERAGE\n")
         lines.append(f'  `include "{arch}_coverage.svh"\n')
         lines.append("`endif\n")
-    _write_readonly(coverage_dir / "RISCV_coverage_config.svh", "".join(lines))
+    _write_if_changed(coverage_dir / "RISCV_coverage_config.svh", "".join(lines))
 
     # RISCV_coverage_base_init.svh — init calls for each extension
     lines = [customize_template(templates, "base_init_header")]
     for arch in sorted_keys:
         lines.append(customize_template(templates, "coverageinit", arch))
-    _write_readonly(coverage_dir / "RISCV_coverage_base_init.svh", "".join(lines))
+    _write_if_changed(coverage_dir / "RISCV_coverage_base_init.svh", "".join(lines))
 
     # RISCV_coverage_base_sample.svh — sample calls for each extension
     lines = [customize_template(templates, "base_sample_header")]
     for arch in sorted_keys:
         lines.append(customize_template(templates, "coveragesample", arch))
-    _write_readonly(coverage_dir / "RISCV_coverage_base_sample.svh", "".join(lines))
+    _write_if_changed(coverage_dir / "RISCV_coverage_base_sample.svh", "".join(lines))
 
 
 def _merge_instruction_testplans(
@@ -577,7 +566,7 @@ def write_instruction_sample_file(
         lines.append(customize_template(templates, "end"))
 
     lines.append(customize_template(templates, "instruction_sample_end"))
-    _write_readonly(coverage_dir / "RISCV_instruction_sample.svh", "".join(lines))
+    _write_if_changed(coverage_dir / "RISCV_instruction_sample.svh", "".join(lines))
 
 
 ##################################

--- a/generators/coverage/src/covergroupgen/generate.py
+++ b/generators/coverage/src/covergroupgen/generate.py
@@ -49,8 +49,13 @@ _WRITABLE_MODE = 0o644
 
 
 def _write_readonly(path: Path, content: str) -> None:
-    """Write content to a generated file and mark it read-only to deter manual edits."""
+    """Write content to a generated file and mark it read-only to deter manual edits.
+
+    Skips the write if the existing file already matches to avoid unnecessary rebuilds.
+    """
     if path.exists():
+        if path.read_text() == content:
+            return
         path.chmod(_WRITABLE_MODE)
     path.write_text(content)
     path.chmod(_READONLY_MODE)

--- a/generators/testgen/src/testgen/io/writer.py
+++ b/generators/testgen/src/testgen/io/writer.py
@@ -125,6 +125,3 @@ def write_test_file(
     # Write test file if different from existing file. This avoids unnecessary rebuilds.
     if not test_file.exists() or test_file.read_text() != test_string:
         _write_readonly(test_file, test_string)
-    else:
-        # Content unchanged; still ensure the file is marked read-only in case it isn't already.
-        test_file.chmod(_READONLY_MODE)

--- a/generators/testgen/src/testgen/io/writer.py
+++ b/generators/testgen/src/testgen/io/writer.py
@@ -21,19 +21,6 @@ from testgen.io.templates import insert_footer_template, insert_header_template
 
 SIGUPD_MARGIN = 10
 
-# Generated test files are marked read-only (0o444) to deter manual edits.
-# Regeneration temporarily restores write permission (0o644) before overwriting.
-_READONLY_MODE = 0o444
-_WRITABLE_MODE = 0o644
-
-
-def _write_readonly(path: Path, content: str) -> None:
-    """Write content to a generated file and mark it read-only to deter manual edits."""
-    if path.exists():
-        path.chmod(_WRITABLE_MODE)
-    path.write_text(content)
-    path.chmod(_READONLY_MODE)
-
 
 def _reinit_pointer_registers(first_chunk: TestChunk) -> str:
     """Emit code to restore non-default signature/data pointer registers.
@@ -124,4 +111,4 @@ def write_test_file(
 
     # Write test file if different from existing file. This avoids unnecessary rebuilds.
     if not test_file.exists() or test_file.read_text() != test_string:
-        _write_readonly(test_file, test_string)
+        test_file.write_text(test_string)


### PR DESCRIPTION
It was causing permission issues and we already have a banner at the top that says they are generated. They are also checked in CI to make sure they haven't been changed.