### PR TITLE
Replaced nops in background region with return instruction

### DIFF
--- a/framework/src/act/fcov/coverage/RISCV_coverage_common.svh
+++ b/framework/src/act/fcov/coverage/RISCV_coverage_common.svh
@@ -38,9 +38,10 @@
 
 /*          To align with the starting address of a PMP region used in testing, the address is hardcoded here.
             Since the Sail data region begins at 0x80004000, we simply add the size of the test strings,
-            which has been fixed at 4 KB.
+            which has been fixed at 4 KB. PMP region starts at 80005004, because there is a return instruction at
+            80005000, which is there to make sure we fetch a proper inrtuction from the background region.
  */
-`define PMP_REGION_START   32'h80006000
+`define PMP_REGION_START   32'h80005004
 
 // Calculate region size g in bytes.
 `define g_tor       (2 ** (`G + 2))

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_all_entries_check.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_all_entries_check.S
@@ -666,8 +666,10 @@ RVTEST_DATA_BEGIN
 test_1_str: .string "\"test: 1; cp: cp_pmpm64_sw\""
 test_2_str: .string "\"test: 2; cp: cp_pmpm64_lw\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_all.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_all.S
@@ -407,8 +407,10 @@ test_62_str: .string "\"test: 62; cp: cp_cfg_A_all_test_62\""
 test_63_str: .string "\"test: 63; cp: cp_cfg_A_all_test_63\""
 test_64_str: .string "\"test: 64; cp: cp_cfg_A_all_test_64\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_off_all.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_off_all.S
@@ -336,8 +336,10 @@ test_1_str: .string "\"test: 1; cp: pmpm_cfg_A_off_all_jalr\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_A_off_all_sw\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_A_off_all_lw\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_tor_bot.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_tor_bot.S
@@ -205,9 +205,7 @@ test_8_str: .string "\"test: 8; cp: pmpm_cfg_A_tor_bot_load_access_at_pmpaddr1+4
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_tor_zero.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_tor_zero.S
@@ -167,9 +167,7 @@ test_4_str: .string "\"test: 4; cp: pmpm_cfg_A_tor_zero_load_access_at_pmpaddr0-
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_L_access_all.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_L_access_all.S
@@ -318,8 +318,10 @@ RVTEST_DATA_BEGIN
 test_1_str: .string "\"test: 1; cp: cp_cfg_L_access_all_lw and cp_none_lw\""
 test_2_str: .string "\"test: 2; cp: cp_cfg_L_access_all_sw and cp_none_sw\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_L_modify_napot.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_L_modify_napot.S
@@ -182,8 +182,10 @@ test_12_str: .string "\"test: 12; cp: cp_cfg_L_modify_test_12\""
 test_13_str: .string "\"test: 13; cp: cp_cfg_L_modify_test_13\""
 test_14_str: .string "\"test: 14; cp: cp_cfg_L_modify_test_14\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_L_modify_off.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_L_modify_off.S
@@ -181,8 +181,10 @@ test_12_str: .string "\"test: 12; cp: cp_cfg_L_modify_12\""
 test_13_str: .string "\"test: 13; cp: cp_cfg_L_modify_13\""
 test_14_str: .string "\"test: 14; cp: cp_cfg_L_modify_14\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_L_modify_tor.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_L_modify_tor.S
@@ -181,8 +181,10 @@ test_12_str: .string "\"test: 12; cp: cp_cfg_L_modify\""
 test_13_str: .string "\"test: 13; cp: cp_cfg_L_modify\""
 test_14_str: .string "\"test: 14; cp: cp_cfg_L_modify\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-01.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-01.S
@@ -277,8 +277,10 @@ test_7_str: .string "\"test: 7; cp: pmpm_cfg_XWR_all_lhu\""
 test_8_str: .string "\"test: 8; cp: pmpm_cfg_XWR_all_lw\""
 test_9_str: .string "\"test: 9; cp: pmpm_cfg_XWR_all_jalr\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-02.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-02.S
@@ -279,8 +279,10 @@ test_7_str: .string "\"test: 7; cp: pmpm_cfg_XWR_all_lhu\""
 test_8_str: .string "\"test: 8; cp: pmpm_cfg_XWR_all_lw\""
 test_9_str: .string "\"test: 9; cp: pmpm_cfg_XWR_all_jalr\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-03.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-03.S
@@ -276,8 +276,10 @@ test_7_str: .string "\"test: 7; cp: pmpm_cfg_XWR_all_lhu\""
 test_8_str: .string "\"test: 8; cp: pmpm_cfg_XWR_all_lw\""
 test_9_str: .string "\"test: 9; cp: pmpm_cfg_XWR_all_jalr\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-04.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-04.S
@@ -277,8 +277,10 @@ test_7_str: .string "\"test: 7; cp: pmpm_cfg_XWR_all_lhu\""
 test_8_str: .string "\"test: 8; cp: pmpm_cfg_XWR_all_lw\""
 test_9_str: .string "\"test: 9; cp: pmpm_cfg_XWR_all_jalr\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_na4_all.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_na4_all.S
@@ -279,9 +279,7 @@ test_3_str: .string "\"test: 3; cp: pmpm_cfg_na4_all_address+4\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_napot_all.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_napot_all.S
@@ -325,9 +325,7 @@ test_3_str: .string "\"test: 3; cp: pmpm_cfg_napot_all_address+4\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (SIZE/4)

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_all.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_all.S
@@ -181,8 +181,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_tor_all_lw\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_X:
+    jr ra
+
 TEST_FOR_EXECUTION_0:                       // Adding nops in TOR Region from 0x80001000 to 0x80001000 + g
     .rept ((1<<(RVMODEL_PMP_GRAIN+2))/4)
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-01.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-01.S
@@ -182,9 +182,7 @@ test_6_str: .string "\"test: 6; cp: pmpm_cfg_tor_check1_load_access_at_pmpaddr+4
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-02.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-02.S
@@ -186,9 +186,7 @@ test_6_str: .string "\"test: 6; cp: pmpm_cfg_tor_check1_load_access_at_pmpaddr+4
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-03.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-03.S
@@ -188,9 +188,7 @@ test_6_str: .string "\"test: 6; cp: pmpm_cfg_tor_check3_load_access_at_pmpaddr+4
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-1.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-1.S
@@ -159,8 +159,10 @@ test_8_str: .string "\"test: 7; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_8\""
 test_9_str: .string "\"test: 7; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_9\""
 test_10_str: .string "\"test: 7; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_10\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-10.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-10.S
@@ -77,8 +77,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_64\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-2.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-2.S
@@ -128,8 +128,10 @@ test_5_str: .string "\"test: 5; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_12\"
 test_6_str: .string "\"test: 6; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_13\""
 test_7_str: .string "\"test: 7; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_14\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-3.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-3.S
@@ -128,8 +128,10 @@ test_5_str: .string "\"test: 5; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_19\"
 test_6_str: .string "\"test: 6; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_20\""
 test_7_str: .string "\"test: 7; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_21\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-4.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-4.S
@@ -128,8 +128,10 @@ test_5_str: .string "\"test: 5; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_26\"
 test_6_str: .string "\"test: 6; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_27\""
 test_7_str: .string "\"test: 7; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_28\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-5.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-5.S
@@ -132,8 +132,10 @@ test_5_str: .string "\"test: 5; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_33\"
 test_6_str: .string "\"test: 6; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_34\""
 test_7_str: .string "\"test: 7; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_35\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-6.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-6.S
@@ -126,8 +126,10 @@ test_4_str: .string "\"test: 4; cp: cp_csr_walk\""
 test_5_str: .string "\"test: 5; cp: cp_csr_walk\""
 test_6_str: .string "\"test: 6; cp: cp_csr_walk\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-7.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-7.S
@@ -121,8 +121,10 @@ test_4_str: .string "\"test: 4; cp: cp_csr_walk\""
 test_5_str: .string "\"test: 5; cp: cp_csr_walk\""
 test_6_str: .string "\"test: 6; cp: cp_csr_walk\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-8.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-8.S
@@ -121,8 +121,10 @@ test_4_str: .string "\"test: 4; cp: cp_csr_walk\""
 test_5_str: .string "\"test: 5; cp: cp_csr_walk\""
 test_6_str: .string "\"test: 6; cp: cp_csr_walk\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-9.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-9.S
@@ -121,8 +121,10 @@ test_4_str: .string "\"test: 4; cp: cp_csr_walk\""
 test_5_str: .string "\"test: 5; cp: cp_csr_walk\""
 test_6_str: .string "\"test: 6; cp: cp_csr_walk\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_grain.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_grain.S
@@ -369,8 +369,10 @@ test_16_str: .string "\"test: 16; cp: cp_pmp_grain\""
 test_17_str: .string "\"test: 17; cp: cp_pmp_grain\""
 test_18_str: .string "\"test: 18; cp: cp_pmp_grain\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_grain_check.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_grain_check.S
@@ -96,8 +96,10 @@ RVTEST_DATA_BEGIN
 test_1_str: .string "\"test: 1; cp: cp_pmp_grain_check_1\""
 test_2_str: .string "\"test: 1; cp: cp_pmp_grain_check_2\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_misaligned_na4.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_misaligned_na4.S
@@ -191,9 +191,7 @@ test_10_str: .string "\"test: 10; cp: pmpm_misaligned_na4_lw_address+g-1\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_misaligned_napot.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_misaligned_napot.S
@@ -210,9 +210,7 @@ test_10_str: .string "\"test: 10; cp: pmpm_misaligned_na4_lw_address+g-1\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 TEST_FOR_EXECUTION:
     .rept SIZE
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_misaligned_off.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_misaligned_off.S
@@ -193,9 +193,7 @@ test_10_str: .string "\"test: 10; cp: pmpm_misaligned_na4_lw_address+g-1\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_misaligned_tor.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_misaligned_tor.S
@@ -196,9 +196,7 @@ test_10_str: .string "\"test: 10; cp: pmpm_misaligned_na4_lw_address+g-1\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_na4_legal_lwxr.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_na4_legal_lwxr.S
@@ -241,9 +241,7 @@ test_6_str: .string "\"test: 6; cp: pmpm_aligned_lw_address+4\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_napot_legal_lwxr.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_napot_legal_lwxr.S
@@ -371,9 +371,7 @@ test_16_str: .string "\"test: 16; cp: pmpm_aligned_lw_address+g\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_priority.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_priority.S
@@ -187,8 +187,10 @@ test_2_str: .string "\"test: 2; cp: pmpm_priority_lw\""
 test_3_str: .string "\"test: 3; cp: pmpm_priority_jalr\""
 
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_x:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (8*(1<<(RVMODEL_PMP_GRAIN+2)))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_priority_off.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_priority_off.S
@@ -140,8 +140,10 @@ test_1_str: .string "\"test: 1; cp: pmpm_priority_off_sw\""
 test_2_str: .string "\"test: 2; cp: pmpm_priority_off_lw\""
 test_3_str: .string "\"test: 2; cp: pmpm_priority_off_jalr\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_tor_legal_lwxr.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_tor_legal_lwxr.S
@@ -334,9 +334,7 @@ test_10_str: .string "\"test: 10; cp: pmpm_aligned_lw_address+g\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_aligned_na4.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_aligned_na4.S
@@ -125,7 +125,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_0:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION_1:               // Uncompressed return inside the first region
     jalr x0, x1, 0
 

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_aligned_napot.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_aligned_napot.S
@@ -146,7 +146,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_0:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION_1:
     jalr x0, x1, 0                                              // Uncompressed return inside the first region
     .rept ((REGION_SIZE - 4) / 2)                        //(region size - jalr size)/ compressed nop size

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_aligned_off.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_aligned_off.S
@@ -129,7 +129,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_0:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION_1:
     jalr x0, x1, 0                                              // Uncompressed return inside the first region
     .rept (((1<<(RVMODEL_PMP_GRAIN+2)) - 4) / 2)                        //(region size - jalr size)/ compressed nop size

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_aligned_tor.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_aligned_tor.S
@@ -130,7 +130,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_0:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION_1:
     jalr x0, x1, 0                                              // Uncompressed return inside the first region
     .rept (((1<<(RVMODEL_PMP_GRAIN+2)) - 4) / 2)

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_cret_na4.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_cret_na4.S
@@ -114,8 +114,8 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_cret_napot_execute\""
 
-.align 12
-.skip (0x1000-2)
+.align 11
+.skip (0x802)
 TEST_FOR_EXECUTION_0:
     ret                                                         // Compressed return just before the start of region
 

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_cret_napot.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_cret_napot.S
@@ -123,8 +123,8 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_cret_napot_execute\""
 
-.align 12
-.skip (0x1000-2)
+.align 11
+.skip (0x802)
 TEST_FOR_EXECUTION_0:
     ret                                                         // Compressed return just before the start of region
 

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_cret_tor.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_cret_tor.S
@@ -119,8 +119,8 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_cret_napot_execute\""
 
-.align 12
-.skip (0x1000-2)
+.align 11
+.skip (0x802)
 TEST_FOR_EXECUTION_0:
     ret                                                         // Compressed return just before the start of region
 

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_legal_lwrx.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_legal_lwrx.S
@@ -241,7 +241,10 @@ test_2_str: .string "\"test: 1; cp: pmpzca_legal_lxwr_lw\""
 test_3_str: .string "\"test: 1; cp: pmpzca_legal_lxwr_c.swsp\""
 test_4_str: .string "\"test: 1; cp: pmpzca_legal_lxwr_c.lwsp\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_0:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION:
     .rept (1<<RVMODEL_PMP_GRAIN+2)
     c.nop

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_misaligned_na4.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_misaligned_na4.S
@@ -133,7 +133,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_X:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION_0:
     nop
 

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_misaligned_napot.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_misaligned_napot.S
@@ -147,7 +147,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_0:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION_1:
     .rept ((REGION_SIZE / 2) -1)
     nop

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_misaligned_off.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_misaligned_off.S
@@ -128,7 +128,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_0:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION_1:
     .rept (((1<<(RVMODEL_PMP_GRAIN+2)) / 2) -1)
     nop

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_misaligned_tor.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_misaligned_tor.S
@@ -133,7 +133,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_misaligned_tor_start\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_0:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION_1:
     .rept (((1<<(RVMODEL_PMP_GRAIN+2)) / 2) -1)
     nop

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzcb_legal_lxwr.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzcb_legal_lxwr.S
@@ -226,8 +226,10 @@ test_4_str:  .string "\"test: 4;  cp: pmpzcb_cfg_wr_c.lhu\""
 test_5_str:  .string "\"test: 5;  cp: pmpzcb_cfg_wr_c.sh\""
 test_6_str:  .string "\"test: 6;  cp: pmpzcb_cfg_wr_c.shu\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_X:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzcd_legal_lxwr.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzcd_legal_lxwr.S
@@ -226,8 +226,10 @@ RVTEST_DATA_BEGIN
 test_1_str:  .string "\"test: 1;  cp: pmpzcb_cfg_wr_c.fsd\""
 test_2_str:  .string "\"test: 2;  cp: pmpzcb_cfg_wr_c.fld\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_X:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzcf_legal_lxwr.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzcf_legal_lxwr.S
@@ -221,8 +221,10 @@ RVTEST_DATA_BEGIN
 test_1_str:  .string "\"test: 1;  cp: pmpzcb_cfg_wr_c.fsw\""
 test_2_str:  .string "\"test: 2;  cp: pmpzcb_cfg_wr_c.flw\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_X:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_access_double_region.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_access_double_region.S
@@ -129,9 +129,7 @@ test_2_str: .string "\"test: 2; cp: cp_tor_doubleregionfail_ld\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_all_entries_check.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_all_entries_check.S
@@ -553,9 +553,7 @@ test_2_str: .string "\"test: 2; cp: cp_pmpm64_sw\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_all.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_all.S
@@ -194,9 +194,7 @@ test_32_str: .string "\"test: 32; cp: cp_cfg_A_all_test_32\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_off_all.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_off_all.S
@@ -357,9 +357,7 @@ test_3_str: .string "\"test: 3; cp: cp_cfg_A_off_all_x\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_tor_bot.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_tor_bot.S
@@ -206,9 +206,7 @@ test_8_str: .string "\"test: 8; cp: pmpm_cfg_A_tor_bot_load_access_at_pmpaddr1+4
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_tor_zero.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_tor_zero.S
@@ -168,9 +168,7 @@ test_4_str: .string "\"test: 4; cp: pmpm_cfg_A_tor_zero_load_access_at_pmpaddr0-
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_L_access_all.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_L_access_all.S
@@ -322,9 +322,7 @@ test_2_str: .string "\"test: 2; cp: cp_cfg_L_access_all_sw and cp_none_sw\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_L_modify_napot.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_L_modify_napot.S
@@ -183,9 +183,7 @@ test_14_str: .string "\"test: 14; cp: cp_cfg_L_modify_test_14\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_L_modify_off.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_L_modify_off.S
@@ -186,9 +186,7 @@ test_14_str: .string "\"test: 14; cp: cp_cfg_L_modify_14\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_L_modify_tor.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_L_modify_tor.S
@@ -183,9 +183,7 @@ test_14_str: .string "\"test: 14; cp: cp_cfg_L_modify\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-01.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-01.S
@@ -258,9 +258,7 @@ test_12_str: .string "\"test: 12; cp: pmpm_cfg_XWR_all_jalr\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-02.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-02.S
@@ -250,9 +250,7 @@ test_12_str: .string "\"test: 12; cp: pmpm_cfg_XWR_all_jalr\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-03.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-03.S
@@ -268,9 +268,7 @@ test_12_str: .string "\"test: 12; cp: pmpm_cfg_XWR_all_jalr\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-04.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-04.S
@@ -242,9 +242,7 @@ test_12_str: .string "\"test: 12; cp: pmpm_cfg_XWR_all_jalr\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-05.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-05.S
@@ -264,9 +264,7 @@ test_12_str: .string "\"test: 12; cp: pmpm_cfg_XWR_all_jalr\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-06.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-06.S
@@ -256,9 +256,7 @@ test_12_str: .string "\"test: 12; cp: pmpm_cfg_XWR_all_jalr\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-07.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-07.S
@@ -273,9 +273,7 @@ test_12_str: .string "\"test: 12; cp: pmpm_cfg_XWR_all_jalr\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-08.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-08.S
@@ -247,9 +247,7 @@ test_12_str: .string "\"test: 12; cp: pmpm_cfg_XWR_all_jalr\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_na4_all.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_na4_all.S
@@ -275,9 +275,7 @@ test_3_str: .string "\"test: 3; cp: pmpm_cfg_na4_all_address+4\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_napot_all.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_napot_all.S
@@ -320,9 +320,7 @@ test_3_str: .string "\"test: 3; cp: pmpm_cfg_napot_all_address+4\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (SIZE/4)

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_all.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_all.S
@@ -181,8 +181,10 @@ RVTEST_DATA_BEGIN
 
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_tor_all_lw\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_X:
+    jr ra
+
 TEST_FOR_EXECUTION_0:                        // Adding nops in TOR Region from 0x80001000 to 0x80001000 + g
     .rept (1<<(RVMODEL_PMP_GRAIN))
     nop

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_check-01.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_check-01.S
@@ -181,9 +181,7 @@ test_6_str: .string "\"test: 6; cp: pmpm_cfg_tor_check1_load_access_at_pmpaddr+4
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_check-02.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_check-02.S
@@ -184,9 +184,7 @@ test_6_str: .string "\"test: 6; cp: pmpm_cfg_tor_check2_load_access_at_pmpaddr+4
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_check-03.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_check-03.S
@@ -185,9 +185,7 @@ test_6_str: .string "\"test: 6; cp: pmpm_cfg_tor_check3_load_access_at_pmpaddr+4
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-01.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-01.S
@@ -173,9 +173,7 @@ test_10_str: .string "\"test: 7; cp: cp_csr_walk_test_10\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-02.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-02.S
@@ -142,9 +142,7 @@ test_14_str: .string "\"test: 14; cp: cp_csr_walk_test_14\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-03.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-03.S
@@ -142,9 +142,7 @@ test_21_str: .string "\"test: 21; cp: cp_csr_walk_test_21\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-04.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-04.S
@@ -142,9 +142,7 @@ test_28_str: .string "\"test: 28; cp: cp_csr_walk_test_28\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-05.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-05.S
@@ -142,9 +142,7 @@ test_35_str: .string "\"test: 35; cp: cp_csr_walk_test_35\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-06.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-06.S
@@ -142,9 +142,7 @@ test_42_str: .string "\"test: 42; cp: cp_csr_walk_test_42\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-07.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-07.S
@@ -142,9 +142,7 @@ test_49_str: .string "\"test: 49; cp: cp_csr_walk_test_49\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-08.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-08.S
@@ -142,9 +142,7 @@ test_56_str: .string "\"test: 56; cp: cp_csr_walk_test_56\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-09.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-09.S
@@ -142,9 +142,7 @@ test_63_str: .string "\"test: 63; cp: cp_csr_walk_test_63\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-10.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-10.S
@@ -150,9 +150,7 @@ test_69_str: .string "\"test: 69; cp: cp_csr_walk_test_69\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-11.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-11.S
@@ -134,9 +134,7 @@ test_75_str: .string "\"test: 75; cp: cp_csr_walk_test_75\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-12.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-12.S
@@ -143,9 +143,7 @@ test_82_str: .string "\"test: 82; cp: cp_csr_walk_test_82\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-13.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-13.S
@@ -134,9 +134,7 @@ test_88_str: .string "\"test: 88; cp: cp_csr_walk_test_88\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-14.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-14.S
@@ -132,9 +132,7 @@ test_94_str: .string "\"test: 94; cp: cp_csr_walk_test_94\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-15.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-15.S
@@ -132,9 +132,7 @@ test_100_str: .string "\"test: 100; cp: cp_csr_walk_test_100\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-16.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-16.S
@@ -132,9 +132,7 @@ test_106_str: .string "\"test: 106; cp: cp_csr_walk_test_106\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-17.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-17.S
@@ -132,9 +132,7 @@ test_112_str: .string "\"test: 112; cp: cp_csr_walk_test_112\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-18.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-18.S
@@ -132,9 +132,7 @@ test_118_str: .string "\"test: 125; cp: cp_csr_walk_test_118\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-19.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-19.S
@@ -92,9 +92,7 @@ test_120_str: .string "\"test: 120; cp: cp_csr_walk_120\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_grain.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_grain.S
@@ -374,9 +374,7 @@ test_18_str: .string "\"test: 18; cp: cp_pmp_grain\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_grain_check.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_grain_check.S
@@ -100,9 +100,7 @@ test_2_str: .string "\"test: 1; cp: cp_pmp_grain_check_2\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_misaligned_na4.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_misaligned_na4.S
@@ -211,9 +211,7 @@ test_16_str: .string "\"test: 16; cp: pmpm_misaligned_na4_lhu_address+3\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_misaligned_na4_wrap.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_misaligned_na4_wrap.S
@@ -122,9 +122,7 @@ test_2_str: .string "\"test: 1; cp: pmpm_mislaigned_na4_wrap_ld\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_misaligned_napot.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_misaligned_napot.S
@@ -242,9 +242,7 @@ test_16_str: .string "\"test: 16; cp: pmpm_misaligned_napot_ld_address+g-1\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_misaligned_off.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_misaligned_off.S
@@ -226,9 +226,7 @@ test_16_str: .string "\"test: 16; cp: pmpm_misaligned_napot_ld_address+g-1\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_misaligned_tor.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_misaligned_tor.S
@@ -229,9 +229,7 @@ test_16_str: .string "\"test: 16; cp: pmpm_misaligned_napot_ld_address+g-1\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_misaligned_tor_wrap.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_misaligned_tor_wrap.S
@@ -130,9 +130,7 @@ test_2_str: .string "\"test: 1; cp: pmpm_mislaigned_na4_wrap_ld\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_na4_boundary-01.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_na4_boundary-01.S
@@ -113,9 +113,7 @@ test_2_str: .string "\"test: 2; cp: cp_na4_boundary_sd\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_na4_boundary-02.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_na4_boundary-02.S
@@ -114,9 +114,7 @@ test_2_str: .string "\"test: 2; cp: cp_na4_boundary_sd\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_na4_legal_lwxr.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_na4_legal_lwxr.S
@@ -244,9 +244,7 @@ test_6_str: .string "\"test: 6; cp: cp_cfg_A_na4_lw_address+4\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_napot_legal_lxwr-01.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_napot_legal_lxwr-01.S
@@ -334,9 +334,7 @@ test_19_str: .string "\"test: 19; cp: cp_cfg_A_napot_lw_address+g\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_napot_legal_lxwr-02.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_napot_legal_lxwr-02.S
@@ -329,9 +329,7 @@ test_19_str: .string "\"test: 19; cp: cp_cfg_A_napot_lw_address+g\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_priority.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_priority.S
@@ -183,9 +183,7 @@ test_3_str: .string "\"test: 3; cp: pmpm_priority_jalr\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (8*(1<<(RVMODEL_PMP_GRAIN+2)))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_priority_off.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_priority_off.S
@@ -141,9 +141,7 @@ test_2_str: .string "\"test: 2; cp: pmpm_priority_off_lw\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_tor_boundary-01.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_tor_boundary-01.S
@@ -122,9 +122,7 @@ test_2_str: .string "\"test: 2; cp: cp_tor_boundary_ld\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_tor_boundary-02.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_tor_boundary-02.S
@@ -124,9 +124,7 @@ test_2_str: .string "\"test: 2; cp: cp_tor_boundary_ld\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_tor_legal_lxwr.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_tor_legal_lxwr.S
@@ -342,9 +342,7 @@ test_10_str: .string "\"test: 10; cp: cp_cfg_A_tor_lw_address+g\""
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
 TEST_FOR_EXECUTION_0:
-    .rept 1024
-    nop
-    .endr
+    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_aligned_na4.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_aligned_na4.S
@@ -125,7 +125,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_0:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION_1:               // Uncompressed return inside the first region
     jalr x0, x1, 0
 

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_aligned_napot.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_aligned_napot.S
@@ -146,7 +146,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_napot_region_execute\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_0:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION_1:
     jalr x0, x1, 0                                              // Uncompressed return inside the first region
     .rept ((REGION_SIZE - 4) / 2)                               //(region size - jalr size)/ compressed nop size

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_aligned_off.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_aligned_off.S
@@ -125,7 +125,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_off_region_execute\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_0:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION_1:
     jalr x0, x1, 0                                              // Uncompressed return inside the first region
     .rept (((1<<(RVMODEL_PMP_GRAIN+2)) - 4) / 2)                        //(region size - jalr size)/ compressed nop size

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_aligned_tor.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_aligned_tor.S
@@ -130,7 +130,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_tor_region_execute\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_0:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION_1:
     jalr x0, x1, 0                                              // Uncompressed return inside the first region
     .rept (((1<<(RVMODEL_PMP_GRAIN+2)) - 4) / 2)

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_cret_na4.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_cret_na4.S
@@ -115,8 +115,8 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_cret_napot_execute\""
 
-.align 12
-.skip (0x1000-2)
+.align 10
+.skip (0x802)
 TEST_FOR_EXECUTION_0:
     ret                                                         // Compressed return just before the start of region
 

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_cret_napot.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_cret_napot.S
@@ -124,8 +124,8 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_cret_napot_execute\""
 
-.align 12
-.skip (0x1000-2)
+.align 10
+.skip (0x802)
 TEST_FOR_EXECUTION_0:
     ret                                                         // Compressed return just before the start of region
 

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_cret_tor.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_cret_tor.S
@@ -122,8 +122,8 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_cret_napot_execute\""
 
-.align 12
-.skip (0x1000-2)
+.align 10
+.skip (0x802)
 TEST_FOR_EXECUTION_0:
     ret                                                         // Compressed return just before the start of region
 

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_legal_lwrx.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_legal_lwrx.S
@@ -275,7 +275,10 @@ test_3_str: .string "\"test: 3; cp: pmpzca_legal_lxwr_c.jalr\""
 test_4_str: .string "\"test: 4; cp: pmpzca_legal_lxwr_sd\""
 test_5_str: .string "\"test: 5; cp: pmpzca_legal_lxwr_ld\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_0:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION:
     .rept (1<<RVMODEL_PMP_GRAIN+2)
     c.nop

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_misaligned_na4.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_misaligned_na4.S
@@ -132,7 +132,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_X:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION_0:
     nop
 

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_misaligned_napot.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_misaligned_napot.S
@@ -147,7 +147,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_misaligned_napot_execute\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_0:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION_1:
     .rept ((REGION_SIZE / 2) -1)
     nop

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_misaligned_off.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_misaligned_off.S
@@ -127,7 +127,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_misaligned_off_execute\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_0:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION_1:
     .rept (((1<<(RVMODEL_PMP_GRAIN+2)) / 2) -1)
     nop

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_misaligned_tor.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_misaligned_tor.S
@@ -134,7 +134,10 @@ RVTEST_DATA_BEGIN
 // Test case strings for reporting
 test_1_str: .string "\"test: 1; cp: pmpzca_misaligned_tor_start\""
 
-.align 13
+.align 12
+TEST_FOR_EXECUTION_0:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION_1:
     .rept (((1<<(RVMODEL_PMP_GRAIN+2)) / 2) -1)
     nop

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzcb_legal_lwxr.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzcb_legal_lwxr.S
@@ -224,8 +224,10 @@ test_4_str:  .string "\"test: 4;  cp: pmpzcb_cfg_wr_c.lhu\""
 test_5_str:  .string "\"test: 5;  cp: pmpzcb_cfg_wr_c.sh\""
 test_6_str:  .string "\"test: 6;  cp: pmpzcb_cfg_wr_c.shu\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_X:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzcd_legal_lwxr.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzcd_legal_lwxr.S
@@ -220,8 +220,10 @@ RVTEST_DATA_BEGIN
 test_1_str:  .string "\"test: 1;  cp: pmpzcb_cfg_wr_c.fsd\""
 test_2_str:  .string "\"test: 2;  cp: pmpzcb_cfg_wr_c.fld\""
 
-.align 13
-.align (RVMODEL_PMP_GRAIN+2)
+.align 12
+TEST_FOR_EXECUTION_X:
+    jalr x0, x1, 0
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop


### PR DESCRIPTION
I have updated PMPSm and PMPZca tests only. Now there is a label TEST_FOR_EXECUTION_0/TEST_FOR_EXECUTION_X just before the PMP Region having a simple jr ra instruction.
PMPZca coverage : 100%
PMPSm coverage : 100%
Also, the address for PMP region has been changed from 80006000 to 80005004. 