### PR TITLE
config/cvw: sync sail.json extension flags with UDB YAML

### DIFF
--- a/config/cores/cvw/cvw-rv64gc/sail.json
+++ b/config/cores/cvw/cvw-rv64gc/sail.json
@@ -266,10 +266,10 @@
       "supported": false
     },
     "Zmmul": {
-      "supported": false
+      "supported": true
     },
     "Zaamo": {
-      "supported": false
+      "supported": true
     },
     "Zabha": {
       "supported": false
@@ -278,7 +278,7 @@
       "supported": false
     },
     "Zalrsc": {
-      "supported": false
+      "supported": true
     },
     "Zawrs": {
       "supported": false,
@@ -299,7 +299,7 @@
       "supported": true
     },
     "Zfhmin": {
-      "supported": false
+      "supported": true
     },
     "Zfinx": {
       "supported": false
@@ -323,13 +323,13 @@
       "supported": false
     },
     "Zba": {
-      "supported": false
+      "supported": true
     },
     "Zbb": {
-      "supported": false
+      "supported": true
     },
     "Zbs": {
-      "supported": false
+      "supported": true
     },
     "Zbc": {
       "supported": true


### PR DESCRIPTION
## Summary

- `sail.json` for `cvw-rv64gc` had 7 extensions marked `"supported": false` that `cvw-rv64gc.yaml` (the UDB ground truth) lists as implemented
- The flags have no functional impact today — Sail correctly inherits Zba/Zbb/Zbs from `B: true`, Zaamo/Zalrsc from `A: true`, Zmmul from `M: true`, and Zfhmin from `Zfh: true` — so no traps occur and no false FAILs are produced
- However the explicit `false` flags directly contradict the UDB YAML, give anyone reading the config a wrong picture of what the core supports, and would silently break if a future Sail version stops inheriting sub-extensions from parent extensions

## Fix

- Set `Zba`, `Zbb`, `Zbs`, `Zaamo`, `Zalrsc`, `Zmmul`, and `Zfhmin` to `"supported": true` in `sail.json`
- Brings the explicit flags into sync with `cvw-rv64gc.yaml` and both `rvtest_config.h` / `rvtest_config.svh` which already had the correct defines

## Test plan

- [x] All 7 extensions present in `implemented_extensions` of `cvw-rv64gc.yaml`
- [x] `rvtest_config.h` and `rvtest_config.svh` already consistent — sail.json now matches
- [x] No functional change to current Sail behaviour — parent extension inheritance already covers these
- [x] No other config files changed