### PR TITLE
Coverage fix for PMPF,PMPZicbo,PMPZaamo,PMPZalrsc

### DIFF
--- a/config/cores/cvw/ci.yaml
+++ b/config/cores/cvw/ci.yaml
@@ -4,7 +4,7 @@
 # Requires Verilator and the CVW repository
 
 ci_enabled: true
-exclude_extensions: "Sm,S,InterruptsSm,InterruptsS,InterruptsU,InterruptsSstc,PMPSm,ExceptionsZalrsc,ExceptionsZaamo,ExceptionsSvZalrsc,ExceptionsSvZaamo,Svnapot,Sv,SvPMP,SvPMPZicbo,SvZicbo,Svade,SvaduPMP,Svpbmt,Svinval,PMPS,PMPU,PMPF"
+exclude_extensions: "Sm,S,InterruptsSm,InterruptsS,InterruptsU,InterruptsSstc,PMPSm,ExceptionsZalrsc,ExceptionsZaamo,ExceptionsSvZalrsc,ExceptionsSvZaamo,Svnapot,Sv,SvPMP,SvPMPZicbo,SvZicbo,Svade,SvaduPMP,Svpbmt,Svinval,PMPS,PMPU"
 apt_packages: "autoconf flex bison help2man libfl-dev ccache"
 install_script: ".github/scripts/install-cvw.sh"
 setup_script: ".github/scripts/setup-cvw.sh"

--- a/config/sail/ci.yaml
+++ b/config/sail/ci.yaml
@@ -3,4 +3,4 @@
 # CI configuration for Sail reference model
 
 ci_enabled: true
-exclude_extensions: "PMPS,PMPU,PMPF,Sv,SvaduPMP,SvPMP,SvPMPZicbo,Svade,Svinval,SvZicbo,Svnapot,Svpbmt"
+exclude_extensions: "PMPS,PMPU,Sv,SvaduPMP,SvPMP,SvPMPZicbo,Svade,Svinval,SvZicbo,Svnapot,Svpbmt"

--- a/config/spike/ci.yaml
+++ b/config/spike/ci.yaml
@@ -7,6 +7,6 @@ ci_enabled: true
 # TODO: Priv tests mismatch due to config issues. Atomics failure still needs to be diagnosed.
 # TODO: remove za64rs from excluded_extensions when Sail supports UDB_LRSC_FAIL_ON_NON_EXACT_LRSC to match DUT
 # TODO: Remove Zama16b when spike starts supporting it.
-exclude_extensions: "Sm,ExceptionsZc,S,InterruptsSm,ExceptionsZalrsc,Sv,SvPMP,SvPMPZicbo,Svade,Svadu,SvaduPMP,Svnapot,Svpbmt,SvZicbo,ExceptionsZaamo,ExceptionsSvZaamo,ExceptionsSvZalrsc,Svinval,PMPS,PMPF,PMPU,PMPSm,Zama16b"
+exclude_extensions: "Sm,ExceptionsZc,S,InterruptsSm,ExceptionsZalrsc,Sv,SvPMP,SvPMPZicbo,Svade,Svadu,SvaduPMP,Svnapot,Svpbmt,SvZicbo,ExceptionsZaamo,ExceptionsSvZaamo,ExceptionsSvZalrsc,Svinval,PMPS,PMPU,PMPSm,Zama16b"
 install_script: ".github/scripts/install-spike.sh"
 apt_packages: "device-tree-compiler libboost-regex-dev libboost-system-dev"

--- a/config/whisper/ci.yaml
+++ b/config/whisper/ci.yaml
@@ -3,6 +3,6 @@
 # CI configuration for Whisper simulator
 
 ci_enabled: true
-exclude_extensions: "Sm,S,InterruptsSm,InterruptsU,ExceptionsZalrsc,ExceptionsZaamo,Zkr,PMPSm,PMPZca,Svinval,Svnapot,Svpbmt,Sv,Svade,SvaduPMP,SvPMP,SvZicbo,SvPMPZicbo,Zalrsc,ExceptionsSvZaamo,ExceptionsSvZalrsc,PMPU,PMPS,PMPF,Svadu"
+exclude_extensions: "Sm,S,InterruptsSm,InterruptsU,ExceptionsZalrsc,ExceptionsZaamo,Zkr,PMPSm,PMPZca,Svinval,Svnapot,Svpbmt,Sv,Svade,SvaduPMP,SvPMP,SvZicbo,SvPMPZicbo,Zalrsc,ExceptionsSvZaamo,ExceptionsSvZalrsc,PMPU,PMPS,Svadu"
 install_script: ".github/scripts/install-whisper.sh"
 apt_packages: "libboost-program-options-dev"

--- a/coverpoints/priv/PMPZaamo_coverage.svh
+++ b/coverpoints/priv/PMPZaamo_coverage.svh
@@ -15,7 +15,7 @@ covergroup PMPZaamo_cg with function sample(ins_t ins,logic [7:0] pmpcfg [63:0],
   `include  "general/RISCV_coverage_standard_coverpoints.svh"
 
   rs1_in_region: coverpoint ins.current.rs1_val {
-    bins at_region = {`PMP_REGION_START};
+    bins at_region = {`PMP_SPECIAL_REGION_START};
   }
 
   atomic_intrs: coverpoint ins.current.insn {
@@ -89,7 +89,7 @@ function void pmpzaamo_sample(int hart, int issue, ins_t ins);
   end
 
   for (int k = 0; k < 15; k++) begin  // Check for first 15 PMP regions
-    pmp_hit[k] = (pmpaddr[k] == `STANDARD_REGION) || (pmpaddr[k] == `NON_STANDARD_REGION);
+    pmp_hit[k] = (pmpaddr[k] == `SPECIAL_STANDARD_REGION) || (pmpaddr[k] == `SPECIAL_NON_STANDARD_REGION);
   end
 
   PMPZaamo_cg.sample(ins, pmpcfg, pmp_hit);

--- a/coverpoints/priv/PMPZicbo_coverage.svh
+++ b/coverpoints/priv/PMPZicbo_coverage.svh
@@ -18,13 +18,13 @@ covergroup PMPZicbo_cg with function sample(ins_t ins, logic [7:0] pmpcfg [63:0]
         bins configuration = {4'b1111}; //menvcfg.CBIE, CBCFE, CBZE = 1
     }
 
-    pmpaddr_region: coverpoint  ((pmpaddr[0] == (`PMP_REGION_START>>2)) &&
-                                 (pmpaddr[1] == ((`PMP_REGION_START + 16'h1000) >>2))) {
+    pmpaddr_region: coverpoint  ((pmpaddr[0] == (`PMP_SPECIAL_REGION_START>>2)) &&
+                                 (pmpaddr[1] == ((`PMP_SPECIAL_REGION_START + 16'h1000) >>2))) {
         bins region = {1};
     }
 
     addr_in_region: coverpoint ins.current.rs1_val {
-        bins address = {`PMP_REGION_START};
+        bins address = {`PMP_SPECIAL_REGION_START};
     }
 
     cbo_clean_instr: coverpoint ins.current.insn {
@@ -117,7 +117,7 @@ function void pmpzicbo_sample(int hart, int issue, ins_t ins);
   end
 
   for (int k = 0; k < 15; k++) begin  // Check for first 15 PMP regions
-    pmp_hit[k] = (pmpaddr[k] == `STANDARD_REGION) || (pmpaddr[k] == `NON_STANDARD_REGION);
+    pmp_hit[k] = (pmpaddr[k] == `SPECIAL_STANDARD_REGION) || (pmpaddr[k] == `SPECIAL_NON_STANDARD_REGION);
   end
 
   PMPZicbo_cg.sample(ins, pmpcfg, pmp_hit, pmpaddr);

--- a/framework/src/act/fcov/coverage/RISCV_coverage_common.svh
+++ b/framework/src/act/fcov/coverage/RISCV_coverage_common.svh
@@ -41,7 +41,8 @@
             which has been fixed at 4 KB. PMP region starts at 80005004, because there is a return instruction at
             80005000, which is there to make sure we fetch a proper inrtuction from the background region.
  */
-`define PMP_REGION_START   32'h80005004
+`define PMP_REGION_START   32'h80005004 // generic tests
+`define PMP_SPECIAL_REGION_START 32'h80005000 // Zicbo + Zaamo tests
 
 // Calculate region size g in bytes.
 `define g_tor       (2 ** (`G + 2))
@@ -54,9 +55,11 @@
 
 // TOR or NA4 region: directly right-shifted
 `define NON_STANDARD_REGION  (`PMP_REGION_START >> 2)              // TOR/NA4 format: yyyyy...
+`define SPECIAL_NON_STANDARD_REGION  (`PMP_SPECIAL_REGION_START >> 2)              // TOR/NA4 format: yyyyy...
 
 // NAPOT region: add trailing 1s per `k` to form mask
 `define STANDARD_REGION      ((`PMP_REGION_START >> 2) | ((2 ** `k) - 1)) // NAPOT format: yyyyy...0111
+`define SPECIAL_STANDARD_REGION      ((`PMP_SPECIAL_REGION_START >> 2) | ((2 ** `k) - 1)) // NAPOT format: yyyyy...0111
 
 // XLEN64 -> [53:0] & XLEN32 -> [31:0]
 `define EFFECTIVE_PMPADDR (`ifdef XLEN64 53 `else 31 `endif)

--- a/tests/priv/pmp/pmp32/PMPF/pmpf_cfg_wr.S
+++ b/tests/priv/pmp/pmp32/PMPF/pmpf_cfg_wr.S
@@ -219,8 +219,11 @@ test_4_str:  .string "\"test: 4;  cp: pmpf_cfg_wr_flh.S\""
 test_5_str:  .string "\"test: 5;  cp: pmpf_cfg_wr_flw.S\""
 test_6_str:  .string "\"test: 6;  cp: pmpf_cfg_wr_fld.S\""
 
-.align 13
+.align 12
 .align (RVMODEL_PMP_GRAIN+2)
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPZaamo/pmpzaamo_cfg_wr.S
+++ b/tests/priv/pmp/pmp32/PMPZaamo/pmpzaamo_cfg_wr.S
@@ -243,8 +243,8 @@ test_9_str:  .string "\"test: 9;  cp: pmpzaamo_cfg_wr_amoswap\""
 
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
-TEST_FOR_EXECUTION_0:
-    jr ra
+//TEST_FOR_EXECUTION_0:
+//    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp32/PMPZaamo/pmpzaamo_cfg_wr.S
+++ b/tests/priv/pmp/pmp32/PMPZaamo/pmpzaamo_cfg_wr.S
@@ -241,8 +241,11 @@ test_7_str:  .string "\"test: 7;  cp: pmpzaamo_cfg_wr_amomin\""
 test_8_str:  .string "\"test: 8;  cp: pmpzaamo_cfg_wr_amominu\""
 test_9_str:  .string "\"test: 9;  cp: pmpzaamo_cfg_wr_amoswap\""
 
-.align 13
+.align 12
 .align (RVMODEL_PMP_GRAIN+2)
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPZalrsc/pmpzalrsc_cfg_wr.S
+++ b/tests/priv/pmp/pmp32/PMPZalrsc/pmpzalrsc_cfg_wr.S
@@ -190,8 +190,11 @@ RVTEST_DATA_BEGIN
 test_1_str:  .string "\"test: 1;  cp: pmpzalrc_cfg_wr_lr_w\""
 test_2_str:  .string "\"test: 2;  cp: pmpzalrc_cfg_wr_sc_w\""
 
-.align 13
+.align 12
 .align (RVMODEL_PMP_GRAIN+2)
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_01.S
+++ b/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_01.S
@@ -129,8 +129,11 @@ test_2_str:  .string "\"test: 2;  cp: pmpzicbo_cbo_clean\""
 test_3_str:  .string "\"test: 3;  cp: pmpzicbo_cbo_flush\""
 test_4_str:  .string "\"test: 4;  cp: pmpzicbo_cbo_inval\""
 
-.align 13
+.align 12
 .align (RVMODEL_PMP_GRAIN+2)
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION_1:
     .rept 1024
     nop

--- a/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_01.S
+++ b/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_01.S
@@ -131,8 +131,6 @@ test_4_str:  .string "\"test: 4;  cp: pmpzicbo_cbo_inval\""
 
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
-TEST_FOR_EXECUTION_0:
-    jr ra
 
 TEST_FOR_EXECUTION_1:
     .rept 1024

--- a/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_02.S
+++ b/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_02.S
@@ -128,8 +128,11 @@ test_2_str:  .string "\"test: 2;  cp: pmpzicbo_cbo_clean\""
 test_3_str:  .string "\"test: 3;  cp: pmpzicbo_cbo_flush\""
 test_4_str:  .string "\"test: 4;  cp: pmpzicbo_cbo_inval\""
 
-.align 13
+.align 12
 .align (RVMODEL_PMP_GRAIN+2)
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION_1:
     .rept 1024
     nop

--- a/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_02.S
+++ b/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_02.S
@@ -130,8 +130,6 @@ test_4_str:  .string "\"test: 4;  cp: pmpzicbo_cbo_inval\""
 
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
-TEST_FOR_EXECUTION_0:
-    jr ra
 
 TEST_FOR_EXECUTION_1:
     .rept 1024

--- a/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_03.S
+++ b/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_03.S
@@ -129,8 +129,11 @@ test_2_str:  .string "\"test: 2;  cp: pmpzicbo_cbo_clean\""
 test_3_str:  .string "\"test: 3;  cp: pmpzicbo_cbo_flush\""
 test_4_str:  .string "\"test: 4;  cp: pmpzicbo_cbo_inval\""
 
-.align 13
+.align 12
 .align (RVMODEL_PMP_GRAIN+2)
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION_1:
     .rept 1024
     nop

--- a/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_03.S
+++ b/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_03.S
@@ -131,8 +131,6 @@ test_4_str:  .string "\"test: 4;  cp: pmpzicbo_cbo_inval\""
 
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
-TEST_FOR_EXECUTION_0:
-    jr ra
 
 TEST_FOR_EXECUTION_1:
     .rept 1024

--- a/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_prefetch.S
+++ b/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_prefetch.S
@@ -208,8 +208,6 @@ test_3_str:  .string "\"test: 3;  cp: pmpzicbo_prefetch_w\""
 
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
-TEST_FOR_EXECUTION_0:
-    jr ra
 
 TEST_FOR_EXECUTION_1:
     .rept 1024

--- a/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_prefetch.S
+++ b/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_prefetch.S
@@ -206,8 +206,11 @@ test_1_str:  .string "\"test: 1;  cp: pmpzicbo_prefetch_i\""
 test_2_str:  .string "\"test: 2;  cp: pmpzicbo_prefetch_r\""
 test_3_str:  .string "\"test: 3;  cp: pmpzicbo_prefetch_w\""
 
-.align 13
+.align 12
 .align (RVMODEL_PMP_GRAIN+2)
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION_1:
     .rept 1024
     nop

--- a/tests/priv/pmp/pmp64/PMPF/pmpf_cfg_wr.S
+++ b/tests/priv/pmp/pmp64/PMPF/pmpf_cfg_wr.S
@@ -219,8 +219,11 @@ test_4_str:  .string "\"test: 4;  cp: pmpf_cfg_wr_flh.S\""
 test_5_str:  .string "\"test: 5;  cp: pmpf_cfg_wr_flw.S\""
 test_6_str:  .string "\"test: 6;  cp: pmpf_cfg_wr_fld.S\""
 
-.align 13
+.align 12
 .align (RVMODEL_PMP_GRAIN+2)
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp64/PMPZaamo/pmpzaamo_cfg_wr.S
+++ b/tests/priv/pmp/pmp64/PMPZaamo/pmpzaamo_cfg_wr.S
@@ -331,8 +331,8 @@ test_18_str: .string "\"test: 18; cp: pmpzaamo_cfg_wr_amoswap_d\""
 
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
-TEST_FOR_EXECUTION_0:
-    jr ra
+//TEST_FOR_EXECUTION_0:
+//    jr ra
 
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))

--- a/tests/priv/pmp/pmp64/PMPZaamo/pmpzaamo_cfg_wr.S
+++ b/tests/priv/pmp/pmp64/PMPZaamo/pmpzaamo_cfg_wr.S
@@ -329,8 +329,11 @@ test_16_str: .string "\"test: 16; cp: pmpzaamo_cfg_wr_amominu_d\""
 test_17_str: .string "\"test: 17; cp: pmpzaamo_cfg_wr_amoswap_w\""
 test_18_str: .string "\"test: 18; cp: pmpzaamo_cfg_wr_amoswap_d\""
 
-.align 13
+.align 12
 .align (RVMODEL_PMP_GRAIN+2)
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp64/PMPZalrsc/pmpzalrsc_cfg_wr.S
+++ b/tests/priv/pmp/pmp64/PMPZalrsc/pmpzalrsc_cfg_wr.S
@@ -206,8 +206,11 @@ test_2_str:  .string "\"test: 2;  cp: pmpzalrc_cfg_wr_sc_w\""
 test_3_str:  .string "\"test: 3;  cp: pmpzalrc_cfg_wr_lr_f\""
 test_4_str:  .string "\"test: 4;  cp: pmpzalrc_cfg_wr_sc_d\""
 
-.align 13
+.align 12
 .align (RVMODEL_PMP_GRAIN+2)
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION:
     .rept (1<<(RVMODEL_PMP_GRAIN+2))
     nop

--- a/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_01.S
+++ b/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_01.S
@@ -129,8 +129,11 @@ test_2_str:  .string "\"test: 2;  cp: pmpzicbo_cbo_clean\""
 test_3_str:  .string "\"test: 3;  cp: pmpzicbo_cbo_flush\""
 test_4_str:  .string "\"test: 4;  cp: pmpzicbo_cbo_inval\""
 
-.align 13
+.align 12
 .align (RVMODEL_PMP_GRAIN+2)
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION_1:
     .rept 1024
     nop

--- a/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_01.S
+++ b/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_01.S
@@ -131,8 +131,6 @@ test_4_str:  .string "\"test: 4;  cp: pmpzicbo_cbo_inval\""
 
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
-TEST_FOR_EXECUTION_0:
-    jr ra
 
 TEST_FOR_EXECUTION_1:
     .rept 1024

--- a/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_02.S
+++ b/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_02.S
@@ -130,8 +130,11 @@ test_2_str:  .string "\"test: 2;  cp: pmpzicbo_cbo_clean\""
 test_3_str:  .string "\"test: 3;  cp: pmpzicbo_cbo_flush\""
 test_4_str:  .string "\"test: 4;  cp: pmpzicbo_cbo_inval\""
 
-.align 13
+.align 12
 .align (RVMODEL_PMP_GRAIN+2)
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION_1:
     .rept 1024
     nop

--- a/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_02.S
+++ b/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_02.S
@@ -132,8 +132,6 @@ test_4_str:  .string "\"test: 4;  cp: pmpzicbo_cbo_inval\""
 
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
-TEST_FOR_EXECUTION_0:
-    jr ra
 
 TEST_FOR_EXECUTION_1:
     .rept 1024

--- a/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_03.S
+++ b/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_03.S
@@ -130,8 +130,11 @@ test_2_str:  .string "\"test: 2;  cp: pmpzicbo_cbo_clean\""
 test_3_str:  .string "\"test: 3;  cp: pmpzicbo_cbo_flush\""
 test_4_str:  .string "\"test: 4;  cp: pmpzicbo_cbo_inval\""
 
-.align 13
+.align 12
 .align (RVMODEL_PMP_GRAIN+2)
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION_1:
     .rept 1024
     nop

--- a/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_03.S
+++ b/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_03.S
@@ -132,8 +132,6 @@ test_4_str:  .string "\"test: 4;  cp: pmpzicbo_cbo_inval\""
 
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
-TEST_FOR_EXECUTION_0:
-    jr ra
 
 TEST_FOR_EXECUTION_1:
     .rept 1024

--- a/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_prefetch.S
+++ b/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_prefetch.S
@@ -208,8 +208,6 @@ test_3_str:  .string "\"test: 3;  cp: pmpzicbo_prefetch_w\""
 
 .align 12
 .align (RVMODEL_PMP_GRAIN+2)
-TEST_FOR_EXECUTION_0:
-    jr ra
 
 TEST_FOR_EXECUTION_1:
     .rept 1024

--- a/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_prefetch.S
+++ b/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_prefetch.S
@@ -206,8 +206,11 @@ test_1_str:  .string "\"test: 1;  cp: pmpzicbo_prefetch_i\""
 test_2_str:  .string "\"test: 2;  cp: pmpzicbo_prefetch_r\""
 test_3_str:  .string "\"test: 3;  cp: pmpzicbo_prefetch_w\""
 
-.align 13
+.align 12
 .align (RVMODEL_PMP_GRAIN+2)
+TEST_FOR_EXECUTION_0:
+    jr ra
+
 TEST_FOR_EXECUTION_1:
     .rept 1024
     nop


### PR DESCRIPTION
-Fixed coverage for pmpf,pmpzicbo,pmpzaamo,pmpzalrsc.(100%).
-Removed pmpf from excluded extenions from ci.

EDIT: PMPzalrsc is failing for qemu, due to lr sc bug in qemu