### PR TITLE
Removed TODO comment about za64rs removal from excluded_exensions

### DIFF
--- a/config/spike/ci.yaml
+++ b/config/spike/ci.yaml
@@ -5,7 +5,6 @@
 
 ci_enabled: true
 # TODO: Priv tests mismatch due to config issues. Atomics failure still needs to be diagnosed.
-# TODO: remove za64rs from excluded_extensions when Sail supports UDB_LRSC_FAIL_ON_NON_EXACT_LRSC to match DUT
 # TODO: Remove Zama16b when spike starts supporting it.
 exclude_extensions: "Sm,ExceptionsZc,S,InterruptsSm,ExceptionsZalrsc,Sv,SvPMP,SvPMPZicbo,Svade,Svadu,SvaduPMP,Svnapot,Svpbmt,SvZicbo,ExceptionsZaamo,ExceptionsSvZaamo,ExceptionsSvZalrsc,Svinval,PMPS,PMPU,PMPSm,Zama16b"
 install_script: ".github/scripts/install-spike.sh"


### PR DESCRIPTION
Since "require_exact_reservation_addr": true enables exact LR/SC matching in Sail, Za64rs now passes and has already been removed from exclude_extensions.
The remaining TODO comment referring to its removal is outdated and can be safely deleted.