### PR TITLE
fix(testgen): add frm cross-product support to cp_fs2_edges and cp_fs3_edges

### DIFF
--- a/generators/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py
@@ -57,13 +57,19 @@ def make_fs2_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
     else:
         edges = FLOAT_EDGES.single
 
+    cross_frm = "_frm" in coverpoint
+
+    frm_modes = ("dyn", "rdn", "rmm", "rne", "rtz", "rup") if cross_frm else [None]
+
     test_chunks: list[TestChunk] = []
     for edge_val in edges:
-        params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs2val=edge_val)
-        desc = f"{coverpoint} (Test source fs2 value = {test_data.flen_format_str.format(edge_val)})"
-        tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, f"b{edge_val:#x}", coverpoint)
-        test_chunks.append(tc)
-        return_test_regs(test_data, params)
+        for frm_mode in frm_modes:
+            params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs2val=edge_val, frm=frm_mode)
+            bin_name = f"b{edge_val:#x}{f'_{frm_mode}' if frm_mode is not None else ''}"
+            desc = f"{coverpoint} (Test source fs2 value = {test_data.flen_format_str.format(edge_val)}{f', frm = {frm_mode}' if frm_mode is not None else ''})"
+            tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, bin_name, coverpoint)
+            test_chunks.append(tc)
+            return_test_regs(test_data, params)
 
     return test_chunks
 
@@ -80,12 +86,18 @@ def make_fs3_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
     else:
         edges = FLOAT_EDGES.single
 
+    cross_frm = "_frm" in coverpoint
+
+    frm_modes = ("dyn", "rdn", "rmm", "rne", "rtz", "rup") if cross_frm else [None]
+
     test_chunks: list[TestChunk] = []
     for edge_val in edges:
-        params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs3val=edge_val)
-        desc = f"{coverpoint} (Test source fs3 value = {test_data.flen_format_str.format(edge_val)})"
-        tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, f"b{edge_val:#x}", coverpoint)
-        test_chunks.append(tc)
-        return_test_regs(test_data, params)
+        for frm_mode in frm_modes:
+            params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs3val=edge_val, frm=frm_mode)
+            bin_name = f"b{edge_val:#x}{f'_{frm_mode}' if frm_mode is not None else ''}"
+            desc = f"{coverpoint} (Test source fs3 value = {test_data.flen_format_str.format(edge_val)}{f', frm = {frm_mode}' if frm_mode is not None else ''})"
+            tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, bin_name, coverpoint)
+            test_chunks.append(tc)
+            return_test_regs(test_data, params)
 
     return test_chunks


### PR DESCRIPTION
## Summary

`cp_fs2_edges` and `cp_fs3_edges` were missing the frm cross-product logic that `cp_fs1_edges` already has. When a coverpoint name contains `_frm`, the generator is expected to iterate over all six rounding modes (`dyn`, `rdn`, `rmm`, `rne`, `rtz`, `rup`) and emit one test bin per edge value per mode.

Without this, any test plan referencing `cp_fs2_edges_frm` or `cp_fs3_edges_frm` would silently produce tests with `frm=None`. The assembler defaults to DYN in that case, and since `fcsr.frm` is at its reset value of RNE, a DUT that hardwires RNE computes the correct result and passes every bin without being asked to use any other rounding mode.

## Fix

Added `cross_frm = "_frm" in coverpoint` and the inner `for frm_mode in frm_modes` loop to both `cp_fs2_edges` and `cp_fs3_edges`, matching the structure already present in `cp_fs1_edges`. Bin names and description strings now include the frm suffix when a rounding mode is active, consistent with the existing pattern.

## Files Changed

- `coverpoints/cp_fp_reg_edges.py` — add frm cross-product logic to `make_fs2_edges` and `make_fs3_edges`

## Test plan

- [x] Coverpoints containing `_frm` now produce six bins per edge value from `cp_fs2_edges` and `cp_fs3_edges`, matching the output of `cp_fs1_edges` for the same input
- [x] Coverpoints without `_frm` still produce one bin per edge value with `frm=None`, identical to the previous behavior
- [x] Existing YAML test plans that use `cp_fs2_edges` without the `_frm` suffix are unaffected