### PR TITLE
fix(testgen): remove duplicate sigupd_count increment in fs_type formatter

### DIFF
--- a/generators/testgen/src/testgen/formatters/types/fs_type.py
+++ b/generators/testgen/src/testgen/formatters/types/fs_type.py
@@ -76,6 +76,5 @@ def format_fs_type(
         "#endif",
     ]
     assert test_data.test_chunk is not None
-    test_data.test_chunk.sigupd_count += 1
     check.append(write_sigupd(None, test_data, "fflags"))
     return (setup, test, check)

--- a/tests/rv32i/D/D-fsd-00.S
+++ b/tests/rv32i/D/D-fsd-00.S
@@ -17,7 +17,7 @@
 
 // Define the name of this test file for reporting and the size of the signature region
 #define TEST_FILE "D-fsd-00.S"
-#define SIGUPD_COUNT 343
+#define SIGUPD_COUNT 232
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 

--- a/tests/rv32i/D/D-fsw-00.S
+++ b/tests/rv32i/D/D-fsw-00.S
@@ -17,7 +17,7 @@
 
 // Define the name of this test file for reporting and the size of the signature region
 #define TEST_FILE "D-fsw-00.S"
-#define SIGUPD_COUNT 52
+#define SIGUPD_COUNT 38
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 

--- a/tests/rv32i/F/F-fsw-00.S
+++ b/tests/rv32i/F/F-fsw-00.S
@@ -17,7 +17,7 @@
 
 // Define the name of this test file for reporting and the size of the signature region
 #define TEST_FILE "F-fsw-00.S"
-#define SIGUPD_COUNT 343
+#define SIGUPD_COUNT 232
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 

--- a/tests/rv32i/Zfbfmin/Zfbfmin-fsh-00.S
+++ b/tests/rv32i/Zfbfmin/Zfbfmin-fsh-00.S
@@ -17,7 +17,7 @@
 
 // Define the name of this test file for reporting and the size of the signature region
 #define TEST_FILE "Zfbfmin-fsh-00.S"
-#define SIGUPD_COUNT 385
+#define SIGUPD_COUNT 260
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 

--- a/tests/rv32i/Zfh/Zfh-fsh-00.S
+++ b/tests/rv32i/Zfh/Zfh-fsh-00.S
@@ -17,7 +17,7 @@
 
 // Define the name of this test file for reporting and the size of the signature region
 #define TEST_FILE "Zfh-fsh-00.S"
-#define SIGUPD_COUNT 385
+#define SIGUPD_COUNT 260
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 

--- a/tests/rv32i/ZfhD/ZfhD-fsh-00.S
+++ b/tests/rv32i/ZfhD/ZfhD-fsh-00.S
@@ -17,7 +17,7 @@
 
 // Define the name of this test file for reporting and the size of the signature region
 #define TEST_FILE "ZfhD-fsh-00.S"
-#define SIGUPD_COUNT 52
+#define SIGUPD_COUNT 38
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 

--- a/tests/rv32i/Zfhmin/Zfhmin-fsh-00.S
+++ b/tests/rv32i/Zfhmin/Zfhmin-fsh-00.S
@@ -17,7 +17,7 @@
 
 // Define the name of this test file for reporting and the size of the signature region
 #define TEST_FILE "Zfhmin-fsh-00.S"
-#define SIGUPD_COUNT 385
+#define SIGUPD_COUNT 260
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 

--- a/tests/rv32i/ZfhminD/ZfhminD-fsh-00.S
+++ b/tests/rv32i/ZfhminD/ZfhminD-fsh-00.S
@@ -17,7 +17,7 @@
 
 // Define the name of this test file for reporting and the size of the signature region
 #define TEST_FILE "ZfhminD-fsh-00.S"
-#define SIGUPD_COUNT 52
+#define SIGUPD_COUNT 38
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 

--- a/tests/rv64i/D/D-fsd-00.S
+++ b/tests/rv64i/D/D-fsd-00.S
@@ -17,7 +17,7 @@
 
 // Define the name of this test file for reporting and the size of the signature region
 #define TEST_FILE "D-fsd-00.S"
-#define SIGUPD_COUNT 343
+#define SIGUPD_COUNT 232
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 

--- a/tests/rv64i/D/D-fsw-00.S
+++ b/tests/rv64i/D/D-fsw-00.S
@@ -17,7 +17,7 @@
 
 // Define the name of this test file for reporting and the size of the signature region
 #define TEST_FILE "D-fsw-00.S"
-#define SIGUPD_COUNT 52
+#define SIGUPD_COUNT 38
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 

--- a/tests/rv64i/F/F-fsw-00.S
+++ b/tests/rv64i/F/F-fsw-00.S
@@ -17,7 +17,7 @@
 
 // Define the name of this test file for reporting and the size of the signature region
 #define TEST_FILE "F-fsw-00.S"
-#define SIGUPD_COUNT 343
+#define SIGUPD_COUNT 232
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 

--- a/tests/rv64i/Zfbfmin/Zfbfmin-fsh-00.S
+++ b/tests/rv64i/Zfbfmin/Zfbfmin-fsh-00.S
@@ -17,7 +17,7 @@
 
 // Define the name of this test file for reporting and the size of the signature region
 #define TEST_FILE "Zfbfmin-fsh-00.S"
-#define SIGUPD_COUNT 385
+#define SIGUPD_COUNT 260
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 

--- a/tests/rv64i/Zfh/Zfh-fsh-00.S
+++ b/tests/rv64i/Zfh/Zfh-fsh-00.S
@@ -17,7 +17,7 @@
 
 // Define the name of this test file for reporting and the size of the signature region
 #define TEST_FILE "Zfh-fsh-00.S"
-#define SIGUPD_COUNT 385
+#define SIGUPD_COUNT 260
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 

--- a/tests/rv64i/ZfhD/ZfhD-fsh-00.S
+++ b/tests/rv64i/ZfhD/ZfhD-fsh-00.S
@@ -17,7 +17,7 @@
 
 // Define the name of this test file for reporting and the size of the signature region
 #define TEST_FILE "ZfhD-fsh-00.S"
-#define SIGUPD_COUNT 52
+#define SIGUPD_COUNT 38
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 

--- a/tests/rv64i/Zfhmin/Zfhmin-fsh-00.S
+++ b/tests/rv64i/Zfhmin/Zfhmin-fsh-00.S
@@ -17,7 +17,7 @@
 
 // Define the name of this test file for reporting and the size of the signature region
 #define TEST_FILE "Zfhmin-fsh-00.S"
-#define SIGUPD_COUNT 385
+#define SIGUPD_COUNT 260
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 

--- a/tests/rv64i/ZfhminD/ZfhminD-fsh-00.S
+++ b/tests/rv64i/ZfhminD/ZfhminD-fsh-00.S
@@ -17,7 +17,7 @@
 
 // Define the name of this test file for reporting and the size of the signature region
 #define TEST_FILE "ZfhminD-fsh-00.S"
-#define SIGUPD_COUNT 52
+#define SIGUPD_COUNT 38
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 


### PR DESCRIPTION
## Summary

The `fs_type` formatter was incrementing `test_data.test_chunk.sigupd_count` manually on the line immediately before calling `write_sigupd` for fflags capture. `write_sigupd` already increments `sigupd_count` internally, so the explicit increment was a duplicate that left the counter one ahead of the actual number of SIGUPD entries written. This caused the signature buffer to be over-allocated by one slot for every float store test case.

## Fix

Remove the redundant manual `sigupd_count += 1`. The `write_sigupd` call on the next line handles the count correctly on its own, consistent with every other formatter in the codebase.

## Files Changed

- `formatters/types/fs_type.py` — remove duplicate `test_data.test_chunk.sigupd_count += 1`

## Test plan

- [x] Float store test cases now produce a `sigupd_count` that matches the number of actual `write_sigupd` calls in the generated check sequence
- [x] Behavior for all other formatter types is unaffected since none of them had this manual pre-increment pattern