### PR TITLE
fix(testgen): add _frm support to cp_fs2_edges and cp_fs3_edges

### DIFF
--- a/generators/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py
@@ -16,76 +16,60 @@ from testgen.formatters import format_single_testcase
 from testgen.formatters.params import generate_random_params
 
 
+def _select_edges(coverpoint: str) -> tuple:
+    if coverpoint.endswith("_D"):
+        return FLOAT_EDGES.double
+    elif coverpoint.endswith("_H"):
+        return FLOAT_EDGES.half
+    elif coverpoint.endswith("_BF16"):
+        return FLOAT_EDGES.bf16
+    return FLOAT_EDGES.single
+
+
+def _frm_modes(coverpoint: str) -> tuple:
+    return ("dyn", "rdn", "rmm", "rne", "rtz", "rup") if "_frm" in coverpoint else (None,)
+
+
 @add_coverpoint_generator("cp_fs1_edges")
 def make_fs1_edges(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[TestChunk]:
     """Generate tests for fs1 edge values."""
-    if coverpoint.endswith("_D"):
-        edges = FLOAT_EDGES.double
-    elif coverpoint.endswith("_H"):
-        edges = FLOAT_EDGES.half
-    elif coverpoint.endswith("_BF16"):
-        edges = FLOAT_EDGES.bf16
-    else:
-        edges = FLOAT_EDGES.single
-
-    cross_frm = "_frm" in coverpoint
-
-    frm_modes = ("dyn", "rdn", "rmm", "rne", "rtz", "rup") if cross_frm else [None]
-
     test_chunks: list[TestChunk] = []
-    for edge_val in edges:
-        for frm_mode in frm_modes:
+    for edge_val in _select_edges(coverpoint):
+        for frm_mode in _frm_modes(coverpoint):
             params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs1val=edge_val, frm=frm_mode)
             bin_name = f"b{edge_val:#x}{f'_{frm_mode}' if frm_mode is not None else ''}"
             desc = f"{coverpoint} (Test source fs1 value = {test_data.flen_format_str.format(edge_val)}{f', frm = {frm_mode}' if frm_mode is not None else ''})"
             tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, bin_name, coverpoint)
             test_chunks.append(tc)
             return_test_regs(test_data, params)
-
     return test_chunks
 
 
 @add_coverpoint_generator("cp_fs2_edges")
 def make_fs2_edges(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[TestChunk]:
     """Generate tests for fs2 edge values."""
-    if coverpoint.endswith("_D"):
-        edges = FLOAT_EDGES.double
-    elif coverpoint.endswith("_H"):
-        edges = FLOAT_EDGES.half
-    elif coverpoint.endswith("_BF16"):
-        edges = FLOAT_EDGES.bf16
-    else:
-        edges = FLOAT_EDGES.single
-
     test_chunks: list[TestChunk] = []
-    for edge_val in edges:
-        params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs2val=edge_val)
-        desc = f"{coverpoint} (Test source fs2 value = {test_data.flen_format_str.format(edge_val)})"
-        tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, f"b{edge_val:#x}", coverpoint)
-        test_chunks.append(tc)
-        return_test_regs(test_data, params)
-
+    for edge_val in _select_edges(coverpoint):
+        for frm_mode in _frm_modes(coverpoint):
+            params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs2val=edge_val, frm=frm_mode)
+            bin_name = f"b{edge_val:#x}{f'_{frm_mode}' if frm_mode is not None else ''}"
+            desc = f"{coverpoint} (Test source fs2 value = {test_data.flen_format_str.format(edge_val)}{f', frm = {frm_mode}' if frm_mode is not None else ''})"
+            tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, bin_name, coverpoint)
+            test_chunks.append(tc)
+            return_test_regs(test_data, params)
     return test_chunks
 
 
 @add_coverpoint_generator("cp_fs3_edges")
 def make_fs3_edges(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[TestChunk]:
     """Generate tests for fs3 edge values."""
-    if coverpoint.endswith("_D"):
-        edges = FLOAT_EDGES.double
-    elif coverpoint.endswith("_H"):
-        edges = FLOAT_EDGES.half
-    elif coverpoint.endswith("_BF16"):
-        edges = FLOAT_EDGES.bf16
-    else:
-        edges = FLOAT_EDGES.single
-
     test_chunks: list[TestChunk] = []
-    for edge_val in edges:
-        params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs3val=edge_val)
-        desc = f"{coverpoint} (Test source fs3 value = {test_data.flen_format_str.format(edge_val)})"
-        tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, f"b{edge_val:#x}", coverpoint)
-        test_chunks.append(tc)
-        return_test_regs(test_data, params)
-
+    for edge_val in _select_edges(coverpoint):
+        for frm_mode in _frm_modes(coverpoint):
+            params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs3val=edge_val, frm=frm_mode)
+            bin_name = f"b{edge_val:#x}{f'_{frm_mode}' if frm_mode is not None else ''}"
+            desc = f"{coverpoint} (Test source fs3 value = {test_data.flen_format_str.format(edge_val)}{f', frm = {frm_mode}' if frm_mode is not None else ''})"
+            tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, bin_name, coverpoint)
+            test_chunks.append(tc)
+            return_test_regs(test_data, params)
     return test_chunks


### PR DESCRIPTION
## Bug Description

`cp_fs2_edges` and `cp_fs3_edges` in `cp_fp_reg_edges.py` both silently ignore the `_frm` suffix in the coverpoint name. When a testplan requests `cp_fs2_edges_frm_S` or `cp_fs3_edges_frm_D`, the generators produce tests with `frm=None` for every edge value instead of iterating over all six rounding modes. The `_frm` suffix is simply never checked.

The sibling generator `cp_fs1_edges` already has the correct behavior — it checks `"_frm" in coverpoint` and iterates `("dyn", "rdn", "rmm", "rne", "rtz", "rup")` when the suffix is present. `make_fs2_edges` and `make_fs3_edges` were never updated to match.

## Impact

- Any testplan coverpoint of the form `cp_fs2_edges_frm*` or `cp_fs3_edges_frm*` generates tests with the rounding mode dimension completely absent
- A DUT that mishandles the `frm` field in instructions where `fs2` or `fs3` is a source operand would silently pass — the tests that should catch it are never generated
- No error or warning is raised; the generator matches the coverpoint name via prefix and proceeds without the frm loop

## Affected Code

| File | Function | Issue |
|------|----------|-------|
| `generators/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py` | `make_fs2_edges` | No `_frm` check, no frm mode iteration |
| `generators/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py` | `make_fs3_edges` | No `_frm` check, no frm mode iteration |

`make_fs1_edges` in the same file already handles `_frm` correctly and serves as the reference.

## Fix

Added `_frm` detection and frm mode iteration to both `make_fs2_edges` and `make_fs3_edges`, matching the logic already present in `make_fs1_edges`.

Also extracted the repeated edge-type selection (`_D` / `_H` / `_BF16` / default) and frm-mode selection into two small module-level helpers — `_select_edges` and `_frm_modes` — so all three generators share identical loop structure and only differ by source register name (`fs1val` / `fs2val` / `fs3val`). This makes the symmetry explicit and ensures any future fix to one generator is trivially visible for the others.

The non-frm path (`cp_fs2_edges`, `cp_fs2_edges_D`, etc.) is unchanged in behavior — `_frm_modes` returns `(None,)` when `_frm` is absent, which collapses the inner loop to a single iteration with `frm=None`, identical to the original.