### PR TITLE
fix(testgen): allow cp_csr_frm variants in make_frm generator

### DIFF
--- a/generators/testgen/src/testgen/coverpoints/cp_csr_frm.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_csr_frm.py
@@ -18,9 +18,6 @@ from testgen.formatters.params import generate_random_params
 @add_coverpoint_generator("cp_csr_frm")
 def make_frm(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[TestChunk]:
     """Generate tests for frm values."""
-    if coverpoint != "cp_csr_frm":
-        raise ValueError(f"Unknown cp_csr_frm coverpoint variant: {coverpoint} for {instr_name}")
-
     # Test each valid fcsr.frm value (0-4) via dynamic rounding mode (rm=111 in the encoding).
     frm_modes = (("rne", 0), ("rtz", 1), ("rdn", 2), ("rup", 3), ("rmm", 4))
     test_chunks: list[TestChunk] = []


### PR DESCRIPTION
## Bug Description

`make_frm` in `cp_csr_frm.py` contains a strict equality check that rejects any coverpoint name that is not exactly `"cp_csr_frm"`:

```python
if coverpoint != "cp_csr_frm":
    raise ValueError(f"Unknown cp_csr_frm coverpoint variant: {coverpoint} for {instr_name}")
```

The vector floating-point testplan (`Vf.csv`) uses the variant `cp_csr_frm_v` for all 66 vector FP instructions that have a rounding mode field (`vfadd.vv`, `vfmul.vf`, `vfdiv.vv`, `vfmacc.vv`, etc.). When the vector testgen exclusion gate is removed (see the `TODO: Remove once vector testgen is merged` comment in `testplans.py`), every one of those instructions will crash with a `ValueError` during test generation — producing zero conformance tests for `fcsr.frm` coverage across the entire vector FP instruction set.

## Impact

- 66 vector FP instructions across 4 testplans (`Vf`, `Zvfbfmin`, `Zvfbfwma`, `Zvfhmin`) are blocked
- The crash happens at generation time, so no tests are produced at all — a DUT with a broken dynamic rounding mode implementation would pass by default (no test to fail)
- The check is redundant: the coverpoint registry already uses longest-prefix matching, so only coverpoints starting with `"cp_csr_frm"` ever reach this function

## Affected Code

| File | Issue |
|------|-------|
| `generators/testgen/src/testgen/coverpoints/cp_csr_frm.py` | Strict `coverpoint != "cp_csr_frm"` check raises `ValueError` for valid variant `cp_csr_frm_v` |

## Fix

Removed the overly strict validation check. The registry's prefix matching already ensures only `cp_csr_frm*` coverpoints reach this generator. Both `cp_csr_frm` (scalar FP) and `cp_csr_frm_v` (vector FP) should generate the same 5 test cases — one for each valid `fcsr.frm` value (0–4) exercised via the dynamic rounding mode path (`rm=111`) — which is exactly what the remaining loop produces.