### PR TITLE
fix: cmp_fd_fs1_fs2 uses int_regs.reg_count instead of float_regs.reg_count

### DIFF
--- a/generators/testgen/src/testgen/coverpoints/cmp_fp_regs.py
+++ b/generators/testgen/src/testgen/coverpoints/cmp_fp_regs.py
@@ -92,7 +92,7 @@ def make_cmp_fd_fs3(instr_name: str, instr_type: str, coverpoint: str, test_data
 
 @add_coverpoint_generator("cmp_fs1_fs2")
 def make_cmp_fs1_fs2(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[TestChunk]:
-    """Generate tests where fd = fs2."""
+    """Generate tests where fs1 = fs2."""
     # Determine which fd registers to test based on coverpoint variant
     if coverpoint == "cmp_fs1_fs2":
         regs = range(test_data.float_regs.reg_count)
@@ -118,11 +118,11 @@ def make_cmp_fs1_fs2(instr_name: str, instr_type: str, coverpoint: str, test_dat
 @add_coverpoint_generator("cmp_fd_fs1_fs2")
 def make_cmp_fd_fs1_fs2(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[TestChunk]:
     """Generate tests where fd = fs1 = fs2."""
-    # Determine which rd registers to test based on coverpoint variant
+    # Determine which fd registers to test based on coverpoint variant
     if coverpoint == "cmp_fd_fs1_fs2":
-        regs = range(test_data.int_regs.reg_count)
+        regs = range(test_data.float_regs.reg_count)
     elif coverpoint.endswith("_nx0"):
-        regs = range(1, test_data.int_regs.reg_count)  # Exclude x0
+        regs = range(1, test_data.float_regs.reg_count)  # Exclude f0
     else:
         raise ValueError(f"Unknown cmp_fd_fs1_fs2 coverpoint variant: {coverpoint} for {instr_name}")
 


### PR DESCRIPTION
## Bug Description

`make_cmp_fd_fs1_fs2` in `coverpoints/cmp_fp_regs.py` was iterating over registers using `test_data.int_regs.reg_count` instead of `test_data.float_regs.reg_count`. This is a copy-paste error from the integer register equivalent — the loop consumes float registers, not integer registers.

## Impact

On standard RV32I/RV64I machines, both register files have 32 registers so the bug is invisible. On **RV32E** machines, `int_regs.reg_count = 16` while `float_regs.reg_count = 32`, meaning the generator would only test `f0–f15` and silently skip `f16–f31` — a 50% coverage hole in the `fd = fs1 = fs2` aliasing tests.

The `_nx0` variant carried the same bug plus a wrong comment ("Exclude x0") copied from integer register code. For floating-point registers, `f0` is a valid writable destination unlike the hardwired-zero `x0`.

## Affected Code

`generators/testgen/src/testgen/coverpoints/cmp_fp_regs.py` — `make_cmp_fd_fs1_fs2`, lines 123 and 125.

## Fix

Replace both `test_data.int_regs.reg_count` with `test_data.float_regs.reg_count` and update the stale comment from "Exclude x0" to "Exclude f0".