### PR TITLE
frm coverpoints: sweep all 5 fcsr.frm values for dyn rounding mode

### DIFF
--- a/generators/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py
@@ -30,14 +30,28 @@ def make_fs1_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
 
     cross_frm = "_frm" in coverpoint
 
-    frm_modes = ("dyn", "rdn", "rmm", "rne", "rtz", "rup") if cross_frm else [None]
+    # For dyn we sweep all 5 legal fcsr.frm values explicitly; relying on a random pick
+    # lands on rne 20% of the time and hides a DUT that ignores fcsr.frm.
+    if cross_frm:
+        frm_variants: list[tuple[str | None, int | None]] = [("dyn", v) for v in range(5)]
+        frm_variants += [(m, None) for m in ("rdn", "rmm", "rne", "rtz", "rup")]
+    else:
+        frm_variants = [(None, None)]
 
     test_chunks: list[TestChunk] = []
     for edge_val in edges:
-        for frm_mode in frm_modes:
-            params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs1val=edge_val, frm=frm_mode)
-            bin_name = f"b{edge_val:#x}{f'_{frm_mode}' if frm_mode is not None else ''}"
-            desc = f"{coverpoint} (Test source fs1 value = {test_data.flen_format_str.format(edge_val)}{f', frm = {frm_mode}' if frm_mode is not None else ''})"
+        for frm_mode, csr_val in frm_variants:
+            params = generate_random_params(
+                test_data, instr_type, exclude_regs=[0], fs1val=edge_val, frm=frm_mode, csr_frm_val=csr_val
+            )
+            frm_tag = ""
+            if frm_mode is not None:
+                frm_tag = f"_{frm_mode}{csr_val}" if csr_val is not None else f"_{frm_mode}"
+            bin_name = f"b{edge_val:#x}{frm_tag}"
+            desc_tag = ""
+            if frm_mode is not None:
+                desc_tag = f", frm = {frm_mode}" + (f", fcsr.frm = {csr_val}" if csr_val is not None else "")
+            desc = f"{coverpoint} (Test source fs1 value = {test_data.flen_format_str.format(edge_val)}{desc_tag})"
             tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, bin_name, coverpoint)
             test_chunks.append(tc)
             return_test_regs(test_data, params)

--- a/generators/testgen/src/testgen/coverpoints/cp_frm.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_frm.py
@@ -21,12 +21,22 @@ def make_frm(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
     if coverpoint not in ["cp_frm_2", "cp_frm_3", "cp_frm_4"]:  # TODO: Why are these variants needed?
         raise ValueError(f"Unknown cp_frm coverpoint variant: {coverpoint} for {instr_name}")
 
-    frm_modes = ("dyn", "rdn", "rmm", "rne", "rtz", "rup")
+    # Static modes encode rm in the instruction. For dyn, rm=111 in the encoding and the
+    # actual rounding comes from fcsr.frm, so we sweep all 5 legal frm values explicitly
+    # rather than relying on a random pick that lands on rne (the power-on default) 20% of
+    # the time and silently agrees with a DUT that ignores fcsr.frm.
+    frm_variants: list[tuple[str, int | None]] = [("dyn", v) for v in range(5)]
+    frm_variants += [(m, None) for m in ("rdn", "rmm", "rne", "rtz", "rup")]
+
     test_chunks: list[TestChunk] = []
-    for frm_mode in frm_modes:
-        params = generate_random_params(test_data, instr_type, exclude_regs=[0], frm=frm_mode)
-        desc = f"{coverpoint} (Test frm, mode = {frm_mode})"
-        tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, f"b{frm_mode}", coverpoint)
+    for frm_mode, csr_val in frm_variants:
+        params = generate_random_params(
+            test_data, instr_type, exclude_regs=[0], frm=frm_mode, csr_frm_val=csr_val
+        )
+        bin_name = f"b{frm_mode}{csr_val}" if csr_val is not None else f"b{frm_mode}"
+        desc_suffix = f", fcsr.frm = {csr_val}" if csr_val is not None else ""
+        desc = f"{coverpoint} (Test frm, mode = {frm_mode}{desc_suffix})"
+        tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, bin_name, coverpoint)
         test_chunks.append(tc)
         return_test_regs(test_data, params)
 

--- a/generators/testgen/src/testgen/coverpoints/cr_fp_reg_edges.py
+++ b/generators/testgen/src/testgen/coverpoints/cr_fp_reg_edges.py
@@ -34,18 +34,29 @@ def make_cr_fs1_fs2_edges(instr_name: str, instr_type: str, coverpoint: str, tes
 
     cross_frm = "_frm" in coverpoint
 
-    frm_modes = ("dyn", "rdn", "rmm", "rne", "rtz", "rup") if cross_frm else [None]
+    # For dyn we sweep all 5 legal fcsr.frm values explicitly rather than picking one
+    # randomly, so a DUT that ignores fcsr.frm can't slip past on the rne case.
+    if cross_frm:
+        frm_variants: list[tuple[str | None, int | None]] = [("dyn", v) for v in range(5)]
+        frm_variants += [(m, None) for m in ("rdn", "rmm", "rne", "rtz", "rup")]
+    else:
+        frm_variants = [(None, None)]
 
     test_chunks: list[TestChunk] = []
     for edge_val1 in edges1:
         for edge_val2 in edges2:
-            # Explicit rounding modes (if needed)
-            for frm_mode in frm_modes:
+            for frm_mode, csr_val in frm_variants:
                 params = generate_random_params(
-                    test_data, instr_type, exclude_regs=[0], fs1val=edge_val1, fs2val=edge_val2, frm=frm_mode
+                    test_data, instr_type, exclude_regs=[0],
+                    fs1val=edge_val1, fs2val=edge_val2,
+                    frm=frm_mode, csr_frm_val=csr_val,
                 )
-                bin_name = f"fs1val={edge_val1:#x}, fs2val={edge_val2:#x}, frm={frm_mode}"
-                desc = f"{coverpoint} (Test source fs1 = {test_data.flen_format_str.format(edge_val1)} fs2 = {test_data.flen_format_str.format(edge_val2)}{f', frm = {frm_mode}' if frm_mode is not None else ''})"
+                frm_label = "none" if frm_mode is None else (f"{frm_mode}{csr_val}" if csr_val is not None else frm_mode)
+                bin_name = f"fs1val={edge_val1:#x}, fs2val={edge_val2:#x}, frm={frm_label}"
+                desc_tag = ""
+                if frm_mode is not None:
+                    desc_tag = f", frm = {frm_mode}" + (f", fcsr.frm = {csr_val}" if csr_val is not None else "")
+                desc = f"{coverpoint} (Test source fs1 = {test_data.flen_format_str.format(edge_val1)} fs2 = {test_data.flen_format_str.format(edge_val2)}{desc_tag})"
                 tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, bin_name, coverpoint)
                 test_chunks.append(tc)
                 return_test_regs(test_data, params)
@@ -71,18 +82,28 @@ def make_cr_fs1_fs3_edges(instr_name: str, instr_type: str, coverpoint: str, tes
 
     cross_frm = "_frm" in coverpoint
 
-    frm_modes = ("dyn", "rdn", "rmm", "rne", "rtz", "rup") if cross_frm else [None]
+    # See note in make_cr_fs1_fs2_edges — dyn is expanded into 5 explicit fcsr.frm values.
+    if cross_frm:
+        frm_variants: list[tuple[str | None, int | None]] = [("dyn", v) for v in range(5)]
+        frm_variants += [(m, None) for m in ("rdn", "rmm", "rne", "rtz", "rup")]
+    else:
+        frm_variants = [(None, None)]
 
     test_chunks: list[TestChunk] = []
     for edge_val1 in edges1:
         for edge_val2 in edges2:
-            # Explicit rounding modes (if needed)
-            for frm_mode in frm_modes:
+            for frm_mode, csr_val in frm_variants:
                 params = generate_random_params(
-                    test_data, instr_type, exclude_regs=[0], fs1val=edge_val1, fs3val=edge_val2, frm=frm_mode
+                    test_data, instr_type, exclude_regs=[0],
+                    fs1val=edge_val1, fs3val=edge_val2,
+                    frm=frm_mode, csr_frm_val=csr_val,
                 )
-                desc = f"{coverpoint} (Test source fs1 = {test_data.flen_format_str.format(edge_val1)} fs3 = {test_data.flen_format_str.format(edge_val2)}{f', frm = {frm_mode}' if frm_mode is not None else ''})"
-                bin_name = f"fs1val={edge_val1:#x}, fs3val={edge_val2:#x}, frm={frm_mode}"
+                frm_label = "none" if frm_mode is None else (f"{frm_mode}{csr_val}" if csr_val is not None else frm_mode)
+                bin_name = f"fs1val={edge_val1:#x}, fs3val={edge_val2:#x}, frm={frm_label}"
+                desc_tag = ""
+                if frm_mode is not None:
+                    desc_tag = f", frm = {frm_mode}" + (f", fcsr.frm = {csr_val}" if csr_val is not None else "")
+                desc = f"{coverpoint} (Test source fs1 = {test_data.flen_format_str.format(edge_val1)} fs3 = {test_data.flen_format_str.format(edge_val2)}{desc_tag})"
                 tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, bin_name, coverpoint)
                 test_chunks.append(tc)
                 return_test_regs(test_data, params)


### PR DESCRIPTION
## Summary

For the `dyn` rounding-mode case, the four frm-bearing coverpoint generators previously called `generate_random_params(..., frm=\"dyn\")` without specifying `csr_frm_val`. `formatters/params.py` then filled it in with `random_range(0, 4)`. That meant any individual instruction got exactly one randomly-chosen `fcsr.frm` value, and 1-in-5 of those landed on `rne` — which is also the power-on default — so a DUT that ignores `fcsr.frm` entirely would silently pass.

This PR replaces the single random pick with an explicit sweep of all five legal `fcsr.frm` values (0..4) for the `dyn` mode. Static modes are unchanged — `csr_frm_val` is left as `None` for them, which is identical to the old behavior since the formatter only consults it when `frm == \"dyn\"`.

## Change shape

The `frm_modes` tuple is replaced with a `frm_variants` list of `(frm_mode, csr_frm_val)` pairs:

- 5 dyn variants — one per legal `fcsr.frm` value
- 5 static variants — `rdn`, `rmm`, `rne`, `rtz`, `rup`, each with `csr_frm_val=None`

Bin names and descriptions include the `fcsr.frm` value when present, so the dyn entries stay distinct in the signature region.

Touched call sites:

- `cp_frm.py` — `make_frm`
- `cp_fp_reg_edges.py` — `make_fs1_edges`
- `cr_fp_reg_edges.py` — `make_cr_fs1_fs2_edges` and `make_cr_fs1_fs3_edges`

## What this replaces

The earlier revision of this PR pinned `csr_frm_val=4` to defeat the rne-default collision. @jordancarlin pointed out that this gave up coverage of the other four legal values for the sake of catching one bug class. This revision keeps that bug class caught and restores deterministic coverage of all five values.

## Cost

For each affected coverpoint, the dyn case grows from 1 testcase to 5. Static modes are unchanged. Net effect per coverpoint invocation: +4 testcases. The cross-product generators (`cr_fs1_fs2_edges_frm`, `cr_fs1_fs3_edges_frm`) feel this most, since the `+4` multiplies through the edge × edge cross. If that growth is a concern, happy to gate the dyn-expansion behind a flag or trim the static-mode set.

## Risk

- For non-`dyn` modes, `csr_frm_val=None` is passed; identical to the prior behavior.
- For `dyn`, the formatter now emits a deterministic `fsrmi <csr_val>` per testcase rather than a random one.
- No changes to `params.py` or other shared infrastructure.