### PR TITLE
fix(tests): replacing nop with with a 100-iteration retry loop

### DIFF
--- a/generators/testgen/src/testgen/coverpoints/special/cp_custom_sc.py
+++ b/generators/testgen/src/testgen/coverpoints/special/cp_custom_sc.py
@@ -37,14 +37,24 @@ def make_custom_sc(instr_name: str, instr_type: str, coverpoint: str, test_data:
             and params.rs2val is not None
             and params.temp_reg is not None
         )
+        label_line = test_data.add_testcase(suffix, "cp_custom_aqrl")
+        label = test_data.current_testcase_label
+        retry_label = f"{label}_retry"
+        success_label = f"{label}_success"
         test_lines.extend(
             [
                 f"# Testcase: cp_custom_aqrl with suffix '{suffix}'",
                 load_int_reg("rs2", params.rs2, params.rs2val, test_data),
                 f"LA(x{params.rs1}, scratch) # rs1 = base address",
+                f"LI(x{params.temp_reg}, 100) # retry counter for constrained LR/SC loop",
+                f"{retry_label}:",
                 f"{lr_insn} x0, (x{params.rs1}) # establish reservation",
-                test_data.add_testcase(suffix, "cp_custom_aqrl"),
+                label_line,
                 f"{instr_name}{suffix} x{params.rd}, x{params.rs2}, (x{params.rs1}) # perform operation",
+                f"beqz x{params.rd}, {success_label} # SC succeeded, skip retry",
+                f"addi x{params.temp_reg}, x{params.temp_reg}, -1 # decrement retry count",
+                f"bnez x{params.temp_reg}, {retry_label} # retry LR/SC if not exhausted",
+                f"{success_label}:",
                 write_sigupd(params.rd, test_data),
                 f"LA(x{params.rs1}, scratch) # reload base address",
                 f"LREG x{params.temp_reg}, 0(x{params.rs1}) # load stored value",
@@ -66,14 +76,24 @@ def make_custom_sc(instr_name: str, instr_type: str, coverpoint: str, test_data:
         and params.rs2val is not None
         and params.temp_reg is not None
     )
+    sc_lr_label_line = test_data.add_testcase(f"prev_lr_{lr_insn}", "cp_custom_sc_lr")
+    sc_lr_label = test_data.current_testcase_label
+    sc_lr_retry_label = f"{sc_lr_label}_retry"
+    sc_lr_success_label = f"{sc_lr_label}_success"
     test_lines.extend(
         [
             f"# Testcase: cp_custom_sc_lr with prev {lr_insn}",
             load_int_reg("rs2", params.rs2, params.rs2val, test_data),
             f"LA(x{params.rs1}, scratch) # rs1 = base address",
+            f"LI(x{params.temp_reg}, 100) # retry counter for constrained LR/SC loop",
+            f"{sc_lr_retry_label}:",
             f"{lr_insn} x0, (x{params.rs1}) # establish reservation",
-            test_data.add_testcase(f"prev_lr_{lr_insn}", "cp_custom_sc_lr"),
+            sc_lr_label_line,
             f"{instr_name} x{params.rd}, x{params.rs2}, (x{params.rs1}) # perform operation",
+            f"beqz x{params.rd}, {sc_lr_success_label} # SC succeeded, skip retry",
+            f"addi x{params.temp_reg}, x{params.temp_reg}, -1 # decrement retry count",
+            f"bnez x{params.temp_reg}, {sc_lr_retry_label} # retry LR/SC if not exhausted",
+            f"{sc_lr_success_label}:",
             write_sigupd(params.rd, test_data),
             f"LA(x{params.rs1}, scratch) # reload base address",
             f"LREG x{params.temp_reg}, 0(x{params.rs1}) # load stored value",

--- a/generators/testgen/src/testgen/formatters/types/sc_type.py
+++ b/generators/testgen/src/testgen/formatters/types/sc_type.py
@@ -33,16 +33,24 @@ def format_sc_type(
 
     lr_insr = "lr.w" if instr_name.endswith(".w") else "lr.d"
 
-    # load test value
+    label = test_data.current_testcase_label
+    retry_label = f"{label}_retry"
+    success_label = f"{label}_success"
+
     setup = [
         load_int_reg("rs2", params.rs2, params.rs2val, test_data),
         f"LA(x{params.rs1}, scratch) # rs1 = base address",
-        "nop",  # Test fails on spike without this nop; nop is a temp fix; TODO: Link to issue after opening it
+        f"LI(x{params.temp_reg}, 100) # retry counter for constrained LR/SC loop",
+        f"{retry_label}:",
         f"{lr_insr} x0, (x{params.rs1}) # establish reservation",
     ]
 
     test = [f"{instr_name} x{params.rd}, x{params.rs2}, (x{params.rs1}) # perform operation"]
     check = [
+        f"beqz x{params.rd}, {success_label} # SC succeeded, skip retry",
+        f"addi x{params.temp_reg}, x{params.temp_reg}, -1 # decrement retry count",
+        f"bnez x{params.temp_reg}, {retry_label} # retry LR/SC if not exhausted",
+        f"{success_label}:",
         write_sigupd(params.rd, test_data),
         f"LA(x{params.rs1}, scratch) # reload base address",
         f"LREG x{params.temp_reg}, 0(x{params.rs1}) # load stored value",

--- a/tests/rv32i/Zalrsc/Zalrsc-sc.w-00.S
+++ b/tests/rv32i/Zalrsc/Zalrsc-sc.w-00.S
@@ -37,10 +37,15 @@ RVTEST_BEGIN
 # Testcase cp_rs1_nx0 (Test source rs1 = x1)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x3c04a50f
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b1_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b1:
   sc.w x26, x12, (x1) # perform operation
+  beqz x26, Zalrsc_sc_w_cg_cp_rs1_nx0_b1_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_w_cg_cp_rs1_nx0_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b1_success:
   # Check if x26 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x26, Zalrsc_sc_w_cg_cp_rs1_nx0_b1, Zalrsc_sc_w_cg_cp_rs1_nx0_b1_str)
   LA(x1, scratch) # reload base address
@@ -52,10 +57,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b1:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x3a688fc5
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b2_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b2:
   sc.w x13, x11, (x2) # perform operation
+  beqz x13, Zalrsc_sc_w_cg_cp_rs1_nx0_b2_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_w_cg_cp_rs1_nx0_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b2_success:
   # Check if x13 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x13, Zalrsc_sc_w_cg_cp_rs1_nx0_b2, Zalrsc_sc_w_cg_cp_rs1_nx0_b2_str)
   LA(x2, scratch) # reload base address
@@ -67,10 +77,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b2:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
   RVTEST_TESTDATA_LOAD_INT(x14, x29) # load rs2: x29 = 0x0c7d3f57
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b3_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b3:
   sc.w x31, x29, (x3) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cp_rs1_nx0_b3_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_w_cg_cp_rs1_nx0_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b3_success:
   # Check if x31 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x31, Zalrsc_sc_w_cg_cp_rs1_nx0_b3, Zalrsc_sc_w_cg_cp_rs1_nx0_b3_str)
   LA(x3, scratch) # reload base address
@@ -83,10 +98,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b3:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4)
   RVTEST_TESTDATA_LOAD_INT(x14, x27) # load rs2: x27 = 0x0a29683d
   LA(x4, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b4_retry:
   lr.w x0, (x4) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b4:
   sc.w x16, x27, (x4) # perform operation
+  beqz x16, Zalrsc_sc_w_cg_cp_rs1_nx0_b4_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_w_cg_cp_rs1_nx0_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b4_success:
   # Check if x16 contains the expected result. x17 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x17, x13, x12, x16, Zalrsc_sc_w_cg_cp_rs1_nx0_b4, Zalrsc_sc_w_cg_cp_rs1_nx0_b4_str)
   LA(x4, scratch) # reload base address
@@ -97,10 +117,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b4:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x14, x18) # load rs2: x18 = 0x946e396e
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x4, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b5_retry:
   lr.w x0, (x5) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b5:
   sc.w x3, x18, (x5) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cp_rs1_nx0_b5_success # SC succeeded, skip retry
+  addi x4, x4, -1 # decrement retry count
+  bnez x4, Zalrsc_sc_w_cg_cp_rs1_nx0_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b5_success:
   # Check if x3 contains the expected result. x17 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x17, x13, x12, x3, Zalrsc_sc_w_cg_cp_rs1_nx0_b5, Zalrsc_sc_w_cg_cp_rs1_nx0_b5_str)
   LA(x5, scratch) # reload base address
@@ -111,10 +136,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b5:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x14, x1) # load rs2: x1 = 0x967d1bfc
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b6_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b6:
   sc.w x16, x1, (x6) # perform operation
+  beqz x16, Zalrsc_sc_w_cg_cp_rs1_nx0_b6_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cp_rs1_nx0_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b6_success:
   # Check if x16 contains the expected result. x17 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x17, x13, x12, x16, Zalrsc_sc_w_cg_cp_rs1_nx0_b6, Zalrsc_sc_w_cg_cp_rs1_nx0_b6_str)
   LA(x6, scratch) # reload base address
@@ -125,10 +155,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b6:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7)
   RVTEST_TESTDATA_LOAD_INT(x14, x18) # load rs2: x18 = 0xd0a4e4c4
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x5, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b7_retry:
   lr.w x0, (x7) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b7:
   sc.w x21, x18, (x7) # perform operation
+  beqz x21, Zalrsc_sc_w_cg_cp_rs1_nx0_b7_success # SC succeeded, skip retry
+  addi x5, x5, -1 # decrement retry count
+  bnez x5, Zalrsc_sc_w_cg_cp_rs1_nx0_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b7_success:
   # Check if x21 contains the expected result. x17 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x17, x13, x12, x21, Zalrsc_sc_w_cg_cp_rs1_nx0_b7, Zalrsc_sc_w_cg_cp_rs1_nx0_b7_str)
   LA(x7, scratch) # reload base address
@@ -139,10 +174,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b7:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x14, x15) # load rs2: x15 = 0xf7787538
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b8_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b8:
   sc.w x21, x15, (x8) # perform operation
+  beqz x21, Zalrsc_sc_w_cg_cp_rs1_nx0_b8_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cp_rs1_nx0_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b8_success:
   # Check if x21 contains the expected result. x17 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x17, x13, x12, x21, Zalrsc_sc_w_cg_cp_rs1_nx0_b8, Zalrsc_sc_w_cg_cp_rs1_nx0_b8_str)
   LA(x8, scratch) # reload base address
@@ -153,10 +193,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b8:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x14, x4) # load rs2: x4 = 0x6fb5eacd
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b9_retry:
   lr.w x0, (x9) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b9:
   sc.w x26, x4, (x9) # perform operation
+  beqz x26, Zalrsc_sc_w_cg_cp_rs1_nx0_b9_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cp_rs1_nx0_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b9_success:
   # Check if x26 contains the expected result. x17 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x17, x13, x12, x26, Zalrsc_sc_w_cg_cp_rs1_nx0_b9, Zalrsc_sc_w_cg_cp_rs1_nx0_b9_str)
   LA(x9, scratch) # reload base address
@@ -167,10 +212,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b9:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x14, x21) # load rs2: x21 = 0x0ffdd443
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b10_retry:
   lr.w x0, (x10) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b10:
   sc.w x31, x21, (x10) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cp_rs1_nx0_b10_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_w_cg_cp_rs1_nx0_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b10_success:
   # Check if x31 contains the expected result. x17 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x17, x13, x12, x31, Zalrsc_sc_w_cg_cp_rs1_nx0_b10, Zalrsc_sc_w_cg_cp_rs1_nx0_b10_str)
   LA(x10, scratch) # reload base address
@@ -181,10 +231,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b10:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x14, x28) # load rs2: x28 = 0xbe0a69aa
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b11_retry:
   lr.w x0, (x11) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b11:
   sc.w x20, x28, (x11) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cp_rs1_nx0_b11_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cp_rs1_nx0_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b11_success:
   # Check if x20 contains the expected result. x17 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x17, x13, x12, x20, Zalrsc_sc_w_cg_cp_rs1_nx0_b11, Zalrsc_sc_w_cg_cp_rs1_nx0_b11_str)
   LA(x11, scratch) # reload base address
@@ -197,10 +252,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b11:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x14, x1) # load rs2: x1 = 0x81d24338
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b12_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b12:
   sc.w x27, x1, (x12) # perform operation
+  beqz x27, Zalrsc_sc_w_cg_cp_rs1_nx0_b12_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_w_cg_cp_rs1_nx0_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b12_success:
   # Check if x27 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x27, Zalrsc_sc_w_cg_cp_rs1_nx0_b12, Zalrsc_sc_w_cg_cp_rs1_nx0_b12_str)
   LA(x12, scratch) # reload base address
@@ -211,10 +271,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b12:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x14, x21) # load rs2: x21 = 0x06073620
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b13_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b13:
   sc.w x1, x21, (x13) # perform operation
+  beqz x1, Zalrsc_sc_w_cg_cp_rs1_nx0_b13_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cp_rs1_nx0_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b13_success:
   # Check if x1 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x1, Zalrsc_sc_w_cg_cp_rs1_nx0_b13, Zalrsc_sc_w_cg_cp_rs1_nx0_b13_str)
   LA(x13, scratch) # reload base address
@@ -226,10 +291,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b13:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x25, x18) # load rs2: x18 = 0x0ce7a106
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b14_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b14:
   sc.w x10, x18, (x14) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cp_rs1_nx0_b14_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cp_rs1_nx0_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b14_success:
   # Check if x10 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x10, Zalrsc_sc_w_cg_cp_rs1_nx0_b14, Zalrsc_sc_w_cg_cp_rs1_nx0_b14_str)
   LA(x14, scratch) # reload base address
@@ -240,10 +310,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b14:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x25, x13) # load rs2: x13 = 0x573548a9
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b15_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b15:
   sc.w x3, x13, (x15) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cp_rs1_nx0_b15_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_w_cg_cp_rs1_nx0_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b15_success:
   # Check if x3 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x3, Zalrsc_sc_w_cg_cp_rs1_nx0_b15, Zalrsc_sc_w_cg_cp_rs1_nx0_b15_str)
   LA(x15, scratch) # reload base address
@@ -254,10 +329,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b15:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16)
   RVTEST_TESTDATA_LOAD_INT(x25, x11) # load rs2: x11 = 0xab08b234
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b16_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b16:
   sc.w x20, x11, (x16) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cp_rs1_nx0_b16_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_w_cg_cp_rs1_nx0_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b16_success:
   # Check if x20 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x20, Zalrsc_sc_w_cg_cp_rs1_nx0_b16, Zalrsc_sc_w_cg_cp_rs1_nx0_b16_str)
   LA(x16, scratch) # reload base address
@@ -269,10 +349,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b16:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17)
   RVTEST_TESTDATA_LOAD_INT(x25, x13) # load rs2: x13 = 0xdd4d51bc
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b17_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b17:
   sc.w x10, x13, (x17) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cp_rs1_nx0_b17_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cp_rs1_nx0_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b17_success:
   # Check if x10 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x10, Zalrsc_sc_w_cg_cp_rs1_nx0_b17, Zalrsc_sc_w_cg_cp_rs1_nx0_b17_str)
   LA(x17, scratch) # reload base address
@@ -283,10 +368,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b17:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18)
   RVTEST_TESTDATA_LOAD_INT(x25, x8) # load rs2: x8 = 0xb51b31ea
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b18_retry:
   lr.w x0, (x18) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b18:
   sc.w x23, x8, (x18) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cp_rs1_nx0_b18_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rs1_nx0_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b18_success:
   # Check if x23 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x23, Zalrsc_sc_w_cg_cp_rs1_nx0_b18, Zalrsc_sc_w_cg_cp_rs1_nx0_b18_str)
   LA(x18, scratch) # reload base address
@@ -297,10 +387,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b18:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19)
   RVTEST_TESTDATA_LOAD_INT(x25, x22) # load rs2: x22 = 0x9a763128
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b19_retry:
   lr.w x0, (x19) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b19:
   sc.w x6, x22, (x19) # perform operation
+  beqz x6, Zalrsc_sc_w_cg_cp_rs1_nx0_b19_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_w_cg_cp_rs1_nx0_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b19_success:
   # Check if x6 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x6, Zalrsc_sc_w_cg_cp_rs1_nx0_b19, Zalrsc_sc_w_cg_cp_rs1_nx0_b19_str)
   LA(x19, scratch) # reload base address
@@ -311,10 +406,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b19:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20)
   RVTEST_TESTDATA_LOAD_INT(x25, x21) # load rs2: x21 = 0xe983c413
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b20_retry:
   lr.w x0, (x20) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b20:
   sc.w x10, x21, (x20) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cp_rs1_nx0_b20_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cp_rs1_nx0_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b20_success:
   # Check if x10 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x10, Zalrsc_sc_w_cg_cp_rs1_nx0_b20, Zalrsc_sc_w_cg_cp_rs1_nx0_b20_str)
   LA(x20, scratch) # reload base address
@@ -325,10 +425,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b20:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21)
   RVTEST_TESTDATA_LOAD_INT(x25, x26) # load rs2: x26 = 0x3cd76893
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b21_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b21:
   sc.w x14, x26, (x21) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cp_rs1_nx0_b21_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cp_rs1_nx0_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b21_success:
   # Check if x14 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x14, Zalrsc_sc_w_cg_cp_rs1_nx0_b21, Zalrsc_sc_w_cg_cp_rs1_nx0_b21_str)
   LA(x21, scratch) # reload base address
@@ -339,10 +444,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b21:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22)
   RVTEST_TESTDATA_LOAD_INT(x25, x2) # load rs2: x2 = 0xa0f99e85
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b22_retry:
   lr.w x0, (x22) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b22:
   sc.w x10, x2, (x22) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cp_rs1_nx0_b22_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_w_cg_cp_rs1_nx0_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b22_success:
   # Check if x10 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x10, Zalrsc_sc_w_cg_cp_rs1_nx0_b22, Zalrsc_sc_w_cg_cp_rs1_nx0_b22_str)
   LA(x22, scratch) # reload base address
@@ -353,10 +463,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b22:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23)
   RVTEST_TESTDATA_LOAD_INT(x25, x14) # load rs2: x14 = 0x06cd8a17
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b23_retry:
   lr.w x0, (x23) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b23:
   sc.w x16, x14, (x23) # perform operation
+  beqz x16, Zalrsc_sc_w_cg_cp_rs1_nx0_b23_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_w_cg_cp_rs1_nx0_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b23_success:
   # Check if x16 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x16, Zalrsc_sc_w_cg_cp_rs1_nx0_b23, Zalrsc_sc_w_cg_cp_rs1_nx0_b23_str)
   LA(x23, scratch) # reload base address
@@ -367,10 +482,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b23:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24)
   RVTEST_TESTDATA_LOAD_INT(x25, x29) # load rs2: x29 = 0x98d96dbc
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b24_retry:
   lr.w x0, (x24) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b24:
   sc.w x15, x29, (x24) # perform operation
+  beqz x15, Zalrsc_sc_w_cg_cp_rs1_nx0_b24_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_w_cg_cp_rs1_nx0_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b24_success:
   # Check if x15 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x15, Zalrsc_sc_w_cg_cp_rs1_nx0_b24, Zalrsc_sc_w_cg_cp_rs1_nx0_b24_str)
   LA(x24, scratch) # reload base address
@@ -382,10 +502,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b24:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25)
   RVTEST_TESTDATA_LOAD_INT(x6, x23) # load rs2: x23 = 0x31e3de1d
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b25_retry:
   lr.w x0, (x25) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b25:
   sc.w x9, x23, (x25) # perform operation
+  beqz x9, Zalrsc_sc_w_cg_cp_rs1_nx0_b25_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_w_cg_cp_rs1_nx0_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b25_success:
   # Check if x9 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x9, Zalrsc_sc_w_cg_cp_rs1_nx0_b25, Zalrsc_sc_w_cg_cp_rs1_nx0_b25_str)
   LA(x25, scratch) # reload base address
@@ -396,10 +521,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b25:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26)
   RVTEST_TESTDATA_LOAD_INT(x6, x31) # load rs2: x31 = 0x63f2c135
   LA(x26, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b26_retry:
   lr.w x0, (x26) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b26:
   sc.w x17, x31, (x26) # perform operation
+  beqz x17, Zalrsc_sc_w_cg_cp_rs1_nx0_b26_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_w_cg_cp_rs1_nx0_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b26_success:
   # Check if x17 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x17, Zalrsc_sc_w_cg_cp_rs1_nx0_b26, Zalrsc_sc_w_cg_cp_rs1_nx0_b26_str)
   LA(x26, scratch) # reload base address
@@ -410,10 +540,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b26:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27)
   RVTEST_TESTDATA_LOAD_INT(x6, x26) # load rs2: x26 = 0x3649f411
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b27_retry:
   lr.w x0, (x27) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b27:
   sc.w x29, x26, (x27) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cp_rs1_nx0_b27_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cp_rs1_nx0_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b27_success:
   # Check if x29 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x29, Zalrsc_sc_w_cg_cp_rs1_nx0_b27, Zalrsc_sc_w_cg_cp_rs1_nx0_b27_str)
   LA(x27, scratch) # reload base address
@@ -424,10 +559,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b27:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28)
   RVTEST_TESTDATA_LOAD_INT(x6, x24) # load rs2: x24 = 0x5ceceef2
   LA(x28, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b28_retry:
   lr.w x0, (x28) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b28:
   sc.w x12, x24, (x28) # perform operation
+  beqz x12, Zalrsc_sc_w_cg_cp_rs1_nx0_b28_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_w_cg_cp_rs1_nx0_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b28_success:
   # Check if x12 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x12, Zalrsc_sc_w_cg_cp_rs1_nx0_b28, Zalrsc_sc_w_cg_cp_rs1_nx0_b28_str)
   LA(x28, scratch) # reload base address
@@ -438,10 +578,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b28:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29)
   RVTEST_TESTDATA_LOAD_INT(x6, x26) # load rs2: x26 = 0x973277eb
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b29_retry:
   lr.w x0, (x29) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b29:
   sc.w x16, x26, (x29) # perform operation
+  beqz x16, Zalrsc_sc_w_cg_cp_rs1_nx0_b29_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_w_cg_cp_rs1_nx0_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b29_success:
   # Check if x16 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x16, Zalrsc_sc_w_cg_cp_rs1_nx0_b29, Zalrsc_sc_w_cg_cp_rs1_nx0_b29_str)
   LA(x29, scratch) # reload base address
@@ -453,10 +598,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b29:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30)
   RVTEST_TESTDATA_LOAD_INT(x6, x0) # load rs2: x0 = 0xd331f959
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b30_retry:
   lr.w x0, (x30) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b30:
   sc.w x28, x0, (x30) # perform operation
+  beqz x28, Zalrsc_sc_w_cg_cp_rs1_nx0_b30_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cp_rs1_nx0_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b30_success:
   # Check if x28 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x28, Zalrsc_sc_w_cg_cp_rs1_nx0_b30, Zalrsc_sc_w_cg_cp_rs1_nx0_b30_str)
   LA(x30, scratch) # reload base address
@@ -467,10 +617,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b30:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31)
   RVTEST_TESTDATA_LOAD_INT(x6, x27) # load rs2: x27 = 0x833c6170
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b31_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b31:
   sc.w x3, x27, (x31) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cp_rs1_nx0_b31_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_w_cg_cp_rs1_nx0_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b31_success:
   # Check if x3 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x3, Zalrsc_sc_w_cg_cp_rs1_nx0_b31, Zalrsc_sc_w_cg_cp_rs1_nx0_b31_str)
   LA(x31, scratch) # reload base address
@@ -485,10 +640,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b31:
 # Testcase cp_rs2 (Test source rs2 = x0)
   RVTEST_TESTDATA_LOAD_INT(x6, x0) # load rs2: x0 = 0xdf4825ef
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b0_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b0:
   sc.w x21, x0, (x17) # perform operation
+  beqz x21, Zalrsc_sc_w_cg_cp_rs2_b0_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_w_cg_cp_rs2_b0_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b0_success:
   # Check if x21 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x21, Zalrsc_sc_w_cg_cp_rs2_b0, Zalrsc_sc_w_cg_cp_rs2_b0_str)
   LA(x17, scratch) # reload base address
@@ -499,10 +659,15 @@ Zalrsc_sc_w_cg_cp_rs2_b0:
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x6, x1) # load rs2: x1 = 0xa1bcc179
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b1_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b1:
   sc.w x11, x1, (x17) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cp_rs2_b1_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rs2_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b1_success:
   # Check if x11 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x11, Zalrsc_sc_w_cg_cp_rs2_b1, Zalrsc_sc_w_cg_cp_rs2_b1_str)
   LA(x17, scratch) # reload base address
@@ -513,10 +678,15 @@ Zalrsc_sc_w_cg_cp_rs2_b1:
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x6, x2) # load rs2: x2 = 0x935b1f22
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b2_retry:
   lr.w x0, (x11) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b2:
   sc.w x18, x2, (x11) # perform operation
+  beqz x18, Zalrsc_sc_w_cg_cp_rs2_b2_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rs2_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b2_success:
   # Check if x18 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x18, Zalrsc_sc_w_cg_cp_rs2_b2, Zalrsc_sc_w_cg_cp_rs2_b2_str)
   LA(x11, scratch) # reload base address
@@ -527,10 +697,15 @@ Zalrsc_sc_w_cg_cp_rs2_b2:
 # Testcase cp_rs2 (Test source rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x6, x3) # load rs2: x3 = 0xf9121a22
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b3_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b3:
   sc.w x31, x3, (x13) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cp_rs2_b3_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_w_cg_cp_rs2_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b3_success:
   # Check if x31 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x31, Zalrsc_sc_w_cg_cp_rs2_b3, Zalrsc_sc_w_cg_cp_rs2_b3_str)
   LA(x13, scratch) # reload base address
@@ -543,10 +718,15 @@ Zalrsc_sc_w_cg_cp_rs2_b3:
 # Testcase cp_rs2 (Test source rs2 = x4)
   RVTEST_TESTDATA_LOAD_INT(x6, x4) # load rs2: x4 = 0x0ef68605
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b4_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b4:
   sc.w x1, x4, (x15) # perform operation
+  beqz x1, Zalrsc_sc_w_cg_cp_rs2_b4_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_w_cg_cp_rs2_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b4_success:
   # Check if x1 contains the expected result. x26 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x26, x13, x12, x1, Zalrsc_sc_w_cg_cp_rs2_b4, Zalrsc_sc_w_cg_cp_rs2_b4_str)
   LA(x15, scratch) # reload base address
@@ -557,10 +737,15 @@ Zalrsc_sc_w_cg_cp_rs2_b4:
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x6, x5) # load rs2: x5 = 0x5c366289
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b5_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b5:
   sc.w x8, x5, (x14) # perform operation
+  beqz x8, Zalrsc_sc_w_cg_cp_rs2_b5_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cp_rs2_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b5_success:
   # Check if x8 contains the expected result. x26 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x26, x13, x12, x8, Zalrsc_sc_w_cg_cp_rs2_b5, Zalrsc_sc_w_cg_cp_rs2_b5_str)
   LA(x14, scratch) # reload base address
@@ -572,10 +757,15 @@ Zalrsc_sc_w_cg_cp_rs2_b5:
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x19, x6) # load rs2: x6 = 0xd2976272
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b6_retry:
   lr.w x0, (x20) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b6:
   sc.w x14, x6, (x20) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cp_rs2_b6_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cp_rs2_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b6_success:
   # Check if x14 contains the expected result. x26 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x26, x13, x12, x14, Zalrsc_sc_w_cg_cp_rs2_b6, Zalrsc_sc_w_cg_cp_rs2_b6_str)
   LA(x20, scratch) # reload base address
@@ -586,10 +776,15 @@ Zalrsc_sc_w_cg_cp_rs2_b6:
 # Testcase cp_rs2 (Test source rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x19, x7) # load rs2: x7 = 0x1193ef9b
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x5, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b7_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b7:
   sc.w x23, x7, (x17) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cp_rs2_b7_success # SC succeeded, skip retry
+  addi x5, x5, -1 # decrement retry count
+  bnez x5, Zalrsc_sc_w_cg_cp_rs2_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b7_success:
   # Check if x23 contains the expected result. x26 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x26, x13, x12, x23, Zalrsc_sc_w_cg_cp_rs2_b7, Zalrsc_sc_w_cg_cp_rs2_b7_str)
   LA(x17, scratch) # reload base address
@@ -600,10 +795,15 @@ Zalrsc_sc_w_cg_cp_rs2_b7:
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x19, x8) # load rs2: x8 = 0x03c2fb4e
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b8_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b8:
   sc.w x27, x8, (x31) # perform operation
+  beqz x27, Zalrsc_sc_w_cg_cp_rs2_b8_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_w_cg_cp_rs2_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b8_success:
   # Check if x27 contains the expected result. x26 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x26, x13, x12, x27, Zalrsc_sc_w_cg_cp_rs2_b8, Zalrsc_sc_w_cg_cp_rs2_b8_str)
   LA(x31, scratch) # reload base address
@@ -614,10 +814,15 @@ Zalrsc_sc_w_cg_cp_rs2_b8:
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x19, x9) # load rs2: x9 = 0xd810920e
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x4, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b9_retry:
   lr.w x0, (x7) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b9:
   sc.w x21, x9, (x7) # perform operation
+  beqz x21, Zalrsc_sc_w_cg_cp_rs2_b9_success # SC succeeded, skip retry
+  addi x4, x4, -1 # decrement retry count
+  bnez x4, Zalrsc_sc_w_cg_cp_rs2_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b9_success:
   # Check if x21 contains the expected result. x26 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x26, x13, x12, x21, Zalrsc_sc_w_cg_cp_rs2_b9, Zalrsc_sc_w_cg_cp_rs2_b9_str)
   LA(x7, scratch) # reload base address
@@ -628,10 +833,15 @@ Zalrsc_sc_w_cg_cp_rs2_b9:
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x19, x10) # load rs2: x10 = 0x63cce3aa
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b10_retry:
   lr.w x0, (x22) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b10:
   sc.w x4, x10, (x22) # perform operation
+  beqz x4, Zalrsc_sc_w_cg_cp_rs2_b10_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cp_rs2_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b10_success:
   # Check if x4 contains the expected result. x26 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x26, x13, x12, x4, Zalrsc_sc_w_cg_cp_rs2_b10, Zalrsc_sc_w_cg_cp_rs2_b10_str)
   LA(x22, scratch) # reload base address
@@ -642,10 +852,15 @@ Zalrsc_sc_w_cg_cp_rs2_b10:
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x19, x11) # load rs2: x11 = 0x408725c5
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b11_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b11:
   sc.w x10, x11, (x8) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cp_rs2_b11_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cp_rs2_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b11_success:
   # Check if x10 contains the expected result. x26 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x26, x13, x12, x10, Zalrsc_sc_w_cg_cp_rs2_b11, Zalrsc_sc_w_cg_cp_rs2_b11_str)
   LA(x8, scratch) # reload base address
@@ -658,10 +873,15 @@ Zalrsc_sc_w_cg_cp_rs2_b11:
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x19, x12) # load rs2: x12 = 0x2a83a214
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b12_retry:
   lr.w x0, (x7) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b12:
   sc.w x24, x12, (x7) # perform operation
+  beqz x24, Zalrsc_sc_w_cg_cp_rs2_b12_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cp_rs2_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b12_success:
   # Check if x24 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x24, Zalrsc_sc_w_cg_cp_rs2_b12, Zalrsc_sc_w_cg_cp_rs2_b12_str)
   LA(x7, scratch) # reload base address
@@ -672,10 +892,15 @@ Zalrsc_sc_w_cg_cp_rs2_b12:
 # Testcase cp_rs2 (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x19, x13) # load rs2: x13 = 0xc6ab916f
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x30, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b13_retry:
   lr.w x0, (x25) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b13:
   sc.w x0, x13, (x25) # perform operation
+  beqz x0, Zalrsc_sc_w_cg_cp_rs2_b13_success # SC succeeded, skip retry
+  addi x30, x30, -1 # decrement retry count
+  bnez x30, Zalrsc_sc_w_cg_cp_rs2_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b13_success:
   # Check if x0 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x0, Zalrsc_sc_w_cg_cp_rs2_b13, Zalrsc_sc_w_cg_cp_rs2_b13_str)
   LA(x25, scratch) # reload base address
@@ -686,10 +911,15 @@ Zalrsc_sc_w_cg_cp_rs2_b13:
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x19, x14) # load rs2: x14 = 0x7c5efb71
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b14_retry:
   lr.w x0, (x20) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b14:
   sc.w x10, x14, (x20) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cp_rs2_b14_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_w_cg_cp_rs2_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b14_success:
   # Check if x10 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x10, Zalrsc_sc_w_cg_cp_rs2_b14, Zalrsc_sc_w_cg_cp_rs2_b14_str)
   LA(x20, scratch) # reload base address
@@ -700,10 +930,15 @@ Zalrsc_sc_w_cg_cp_rs2_b14:
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x19, x15) # load rs2: x15 = 0x87df1078
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b15_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b15:
   sc.w x20, x15, (x8) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cp_rs2_b15_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cp_rs2_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b15_success:
   # Check if x20 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x20, Zalrsc_sc_w_cg_cp_rs2_b15, Zalrsc_sc_w_cg_cp_rs2_b15_str)
   LA(x8, scratch) # reload base address
@@ -714,10 +949,15 @@ Zalrsc_sc_w_cg_cp_rs2_b15:
 # Testcase cp_rs2 (Test source rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x19, x16) # load rs2: x16 = 0x11768da6
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b16_retry:
   lr.w x0, (x25) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b16:
   sc.w x6, x16, (x25) # perform operation
+  beqz x6, Zalrsc_sc_w_cg_cp_rs2_b16_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_w_cg_cp_rs2_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b16_success:
   # Check if x6 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x6, Zalrsc_sc_w_cg_cp_rs2_b16, Zalrsc_sc_w_cg_cp_rs2_b16_str)
   LA(x25, scratch) # reload base address
@@ -728,10 +968,15 @@ Zalrsc_sc_w_cg_cp_rs2_b16:
 # Testcase cp_rs2 (Test source rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x19, x17) # load rs2: x17 = 0xff4e2593
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b17_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b17:
   sc.w x2, x17, (x8) # perform operation
+  beqz x2, Zalrsc_sc_w_cg_cp_rs2_b17_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cp_rs2_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b17_success:
   # Check if x2 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x2, Zalrsc_sc_w_cg_cp_rs2_b17, Zalrsc_sc_w_cg_cp_rs2_b17_str)
   LA(x8, scratch) # reload base address
@@ -742,10 +987,15 @@ Zalrsc_sc_w_cg_cp_rs2_b17:
 # Testcase cp_rs2 (Test source rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x19, x18) # load rs2: x18 = 0xd8e31131
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b18_retry:
   lr.w x0, (x29) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b18:
   sc.w x27, x18, (x29) # perform operation
+  beqz x27, Zalrsc_sc_w_cg_cp_rs2_b18_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cp_rs2_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b18_success:
   # Check if x27 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x27, Zalrsc_sc_w_cg_cp_rs2_b18, Zalrsc_sc_w_cg_cp_rs2_b18_str)
   LA(x29, scratch) # reload base address
@@ -757,10 +1007,15 @@ Zalrsc_sc_w_cg_cp_rs2_b18:
 # Testcase cp_rs2 (Test source rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x3, x19) # load rs2: x19 = 0xa2a6cf79
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b19_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b19:
   sc.w x8, x19, (x6) # perform operation
+  beqz x8, Zalrsc_sc_w_cg_cp_rs2_b19_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_w_cg_cp_rs2_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b19_success:
   # Check if x8 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x8, Zalrsc_sc_w_cg_cp_rs2_b19, Zalrsc_sc_w_cg_cp_rs2_b19_str)
   LA(x6, scratch) # reload base address
@@ -771,10 +1026,15 @@ Zalrsc_sc_w_cg_cp_rs2_b19:
 # Testcase cp_rs2 (Test source rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x3, x20) # load rs2: x20 = 0x545c41d6
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b20_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b20:
   sc.w x29, x20, (x14) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cp_rs2_b20_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cp_rs2_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b20_success:
   # Check if x29 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x29, Zalrsc_sc_w_cg_cp_rs2_b20, Zalrsc_sc_w_cg_cp_rs2_b20_str)
   LA(x14, scratch) # reload base address
@@ -785,10 +1045,15 @@ Zalrsc_sc_w_cg_cp_rs2_b20:
 # Testcase cp_rs2 (Test source rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x3, x21) # load rs2: x21 = 0x69b08ecb
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b21_retry:
   lr.w x0, (x23) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b21:
   sc.w x2, x21, (x23) # perform operation
+  beqz x2, Zalrsc_sc_w_cg_cp_rs2_b21_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cp_rs2_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b21_success:
   # Check if x2 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x2, Zalrsc_sc_w_cg_cp_rs2_b21, Zalrsc_sc_w_cg_cp_rs2_b21_str)
   LA(x23, scratch) # reload base address
@@ -799,10 +1064,15 @@ Zalrsc_sc_w_cg_cp_rs2_b21:
 # Testcase cp_rs2 (Test source rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x3, x22) # load rs2: x22 = 0x392816d8
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b22_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b22:
   sc.w x30, x22, (x1) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cp_rs2_b22_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_w_cg_cp_rs2_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b22_success:
   # Check if x30 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x30, Zalrsc_sc_w_cg_cp_rs2_b22, Zalrsc_sc_w_cg_cp_rs2_b22_str)
   LA(x1, scratch) # reload base address
@@ -813,10 +1083,15 @@ Zalrsc_sc_w_cg_cp_rs2_b22:
 # Testcase cp_rs2 (Test source rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x3, x23) # load rs2: x23 = 0xab16f8ec
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b23_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b23:
   sc.w x7, x23, (x17) # perform operation
+  beqz x7, Zalrsc_sc_w_cg_cp_rs2_b23_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cp_rs2_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b23_success:
   # Check if x7 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x7, Zalrsc_sc_w_cg_cp_rs2_b23, Zalrsc_sc_w_cg_cp_rs2_b23_str)
   LA(x17, scratch) # reload base address
@@ -827,10 +1102,15 @@ Zalrsc_sc_w_cg_cp_rs2_b23:
 # Testcase cp_rs2 (Test source rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x3, x24) # load rs2: x24 = 0xf89a2c53
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b24_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b24:
   sc.w x22, x24, (x1) # perform operation
+  beqz x22, Zalrsc_sc_w_cg_cp_rs2_b24_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_w_cg_cp_rs2_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b24_success:
   # Check if x22 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x22, Zalrsc_sc_w_cg_cp_rs2_b24, Zalrsc_sc_w_cg_cp_rs2_b24_str)
   LA(x1, scratch) # reload base address
@@ -841,10 +1121,15 @@ Zalrsc_sc_w_cg_cp_rs2_b24:
 # Testcase cp_rs2 (Test source rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x3, x25) # load rs2: x25 = 0x5f55d9c6
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b25_retry:
   lr.w x0, (x11) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b25:
   sc.w x20, x25, (x11) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cp_rs2_b25_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cp_rs2_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b25_success:
   # Check if x20 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x20, Zalrsc_sc_w_cg_cp_rs2_b25, Zalrsc_sc_w_cg_cp_rs2_b25_str)
   LA(x11, scratch) # reload base address
@@ -856,10 +1141,15 @@ Zalrsc_sc_w_cg_cp_rs2_b25:
 # Testcase cp_rs2 (Test source rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x3, x26) # load rs2: x26 = 0xf064596e
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b26_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b26:
   sc.w x7, x26, (x14) # perform operation
+  beqz x7, Zalrsc_sc_w_cg_cp_rs2_b26_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cp_rs2_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b26_success:
   # Check if x7 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x7, Zalrsc_sc_w_cg_cp_rs2_b26, Zalrsc_sc_w_cg_cp_rs2_b26_str)
   LA(x14, scratch) # reload base address
@@ -870,10 +1160,15 @@ Zalrsc_sc_w_cg_cp_rs2_b26:
 # Testcase cp_rs2 (Test source rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x3, x27) # load rs2: x27 = 0xc93a7a48
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b27_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b27:
   sc.w x20, x27, (x2) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cp_rs2_b27_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cp_rs2_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b27_success:
   # Check if x20 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x20, Zalrsc_sc_w_cg_cp_rs2_b27, Zalrsc_sc_w_cg_cp_rs2_b27_str)
   LA(x2, scratch) # reload base address
@@ -884,10 +1179,15 @@ Zalrsc_sc_w_cg_cp_rs2_b27:
 # Testcase cp_rs2 (Test source rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x3, x28) # load rs2: x28 = 0xb8e6a41b
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b28_retry:
   lr.w x0, (x30) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b28:
   sc.w x8, x28, (x30) # perform operation
+  beqz x8, Zalrsc_sc_w_cg_cp_rs2_b28_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_w_cg_cp_rs2_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b28_success:
   # Check if x8 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x8, Zalrsc_sc_w_cg_cp_rs2_b28, Zalrsc_sc_w_cg_cp_rs2_b28_str)
   LA(x30, scratch) # reload base address
@@ -898,10 +1198,15 @@ Zalrsc_sc_w_cg_cp_rs2_b28:
 # Testcase cp_rs2 (Test source rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x3, x29) # load rs2: x29 = 0x8be4ea67
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b29_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b29:
   sc.w x15, x29, (x31) # perform operation
+  beqz x15, Zalrsc_sc_w_cg_cp_rs2_b29_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_w_cg_cp_rs2_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b29_success:
   # Check if x15 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x15, Zalrsc_sc_w_cg_cp_rs2_b29, Zalrsc_sc_w_cg_cp_rs2_b29_str)
   LA(x31, scratch) # reload base address
@@ -912,10 +1217,15 @@ Zalrsc_sc_w_cg_cp_rs2_b29:
 # Testcase cp_rs2 (Test source rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x3, x30) # load rs2: x30 = 0x89bbea97
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b30_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b30:
   sc.w x24, x30, (x2) # perform operation
+  beqz x24, Zalrsc_sc_w_cg_cp_rs2_b30_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cp_rs2_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b30_success:
   # Check if x24 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x24, Zalrsc_sc_w_cg_cp_rs2_b30, Zalrsc_sc_w_cg_cp_rs2_b30_str)
   LA(x2, scratch) # reload base address
@@ -926,10 +1236,15 @@ Zalrsc_sc_w_cg_cp_rs2_b30:
 # Testcase cp_rs2 (Test source rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x3, x31) # load rs2: x31 = 0xd86244ce
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b31_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b31:
   sc.w x2, x31, (x1) # perform operation
+  beqz x2, Zalrsc_sc_w_cg_cp_rs2_b31_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rs2_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b31_success:
   # Check if x2 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x2, Zalrsc_sc_w_cg_cp_rs2_b31, Zalrsc_sc_w_cg_cp_rs2_b31_str)
   LA(x1, scratch) # reload base address
@@ -944,10 +1259,15 @@ Zalrsc_sc_w_cg_cp_rs2_b31:
 # Testcase cp_rd (Test destination rd = x0)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x0b490366
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b0_retry:
   lr.w x0, (x18) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b0:
   sc.w x0, x8, (x18) # perform operation
+  beqz x0, Zalrsc_sc_w_cg_cp_rd_b0_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cp_rd_b0_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b0_success:
   # Check if x0 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x0, Zalrsc_sc_w_cg_cp_rd_b0, Zalrsc_sc_w_cg_cp_rd_b0_str)
   LA(x18, scratch) # reload base address
@@ -958,10 +1278,15 @@ Zalrsc_sc_w_cg_cp_rd_b0:
 # Testcase cp_rd (Test destination rd = x1)
   RVTEST_TESTDATA_LOAD_INT(x3, x28) # load rs2: x28 = 0x1f46ff48
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b1_retry:
   lr.w x0, (x30) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b1:
   sc.w x1, x28, (x30) # perform operation
+  beqz x1, Zalrsc_sc_w_cg_cp_rd_b1_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_w_cg_cp_rd_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b1_success:
   # Check if x1 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x1, Zalrsc_sc_w_cg_cp_rd_b1, Zalrsc_sc_w_cg_cp_rd_b1_str)
   LA(x30, scratch) # reload base address
@@ -972,10 +1297,15 @@ Zalrsc_sc_w_cg_cp_rd_b1:
 # Testcase cp_rd (Test destination rd = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0x38de6121
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b2_retry:
   lr.w x0, (x18) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b2:
   sc.w x2, x1, (x18) # perform operation
+  beqz x2, Zalrsc_sc_w_cg_cp_rd_b2_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rd_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b2_success:
   # Check if x2 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x2, Zalrsc_sc_w_cg_cp_rd_b2, Zalrsc_sc_w_cg_cp_rd_b2_str)
   LA(x18, scratch) # reload base address
@@ -987,10 +1317,15 @@ Zalrsc_sc_w_cg_cp_rd_b2:
 # Testcase cp_rd (Test destination rd = x3)
   RVTEST_TESTDATA_LOAD_INT(x15, x8) # load rs2: x8 = 0xfb0f1804
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b3_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b3:
   sc.w x3, x8, (x14) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cp_rd_b3_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_w_cg_cp_rd_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b3_success:
   # Check if x3 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x3, Zalrsc_sc_w_cg_cp_rd_b3, Zalrsc_sc_w_cg_cp_rd_b3_str)
   LA(x14, scratch) # reload base address
@@ -1003,10 +1338,15 @@ Zalrsc_sc_w_cg_cp_rd_b3:
 # Testcase cp_rd (Test destination rd = x4)
   RVTEST_TESTDATA_LOAD_INT(x15, x10) # load rs2: x10 = 0x58d1657e
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b4_retry:
   lr.w x0, (x25) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b4:
   sc.w x4, x10, (x25) # perform operation
+  beqz x4, Zalrsc_sc_w_cg_cp_rd_b4_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cp_rd_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b4_success:
   # Check if x4 contains the expected result. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x17, x8, x7, x4, Zalrsc_sc_w_cg_cp_rd_b4, Zalrsc_sc_w_cg_cp_rd_b4_str)
   LA(x25, scratch) # reload base address
@@ -1017,10 +1357,15 @@ Zalrsc_sc_w_cg_cp_rd_b4:
 # Testcase cp_rd (Test destination rd = x5)
   RVTEST_TESTDATA_LOAD_INT(x15, x6) # load rs2: x6 = 0x4ca701da
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b5_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b5:
   sc.w x5, x6, (x13) # perform operation
+  beqz x5, Zalrsc_sc_w_cg_cp_rd_b5_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cp_rd_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b5_success:
   # Check if x5 contains the expected result. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x17, x8, x7, x5, Zalrsc_sc_w_cg_cp_rd_b5, Zalrsc_sc_w_cg_cp_rd_b5_str)
   LA(x13, scratch) # reload base address
@@ -1031,10 +1376,15 @@ Zalrsc_sc_w_cg_cp_rd_b5:
 # Testcase cp_rd (Test destination rd = x6)
   RVTEST_TESTDATA_LOAD_INT(x15, x21) # load rs2: x21 = 0xcf200224
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b6_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b6:
   sc.w x6, x21, (x14) # perform operation
+  beqz x6, Zalrsc_sc_w_cg_cp_rd_b6_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_w_cg_cp_rd_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b6_success:
   # Check if x6 contains the expected result. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x17, x8, x7, x6, Zalrsc_sc_w_cg_cp_rd_b6, Zalrsc_sc_w_cg_cp_rd_b6_str)
   LA(x14, scratch) # reload base address
@@ -1047,10 +1397,15 @@ Zalrsc_sc_w_cg_cp_rd_b6:
 # Testcase cp_rd (Test destination rd = x7)
   RVTEST_TESTDATA_LOAD_INT(x15, x14) # load rs2: x14 = 0xf1021867
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b7_retry:
   lr.w x0, (x20) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b7:
   sc.w x7, x14, (x20) # perform operation
+  beqz x7, Zalrsc_sc_w_cg_cp_rd_b7_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rd_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b7_success:
   # Check if x7 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x7, Zalrsc_sc_w_cg_cp_rd_b7, Zalrsc_sc_w_cg_cp_rd_b7_str)
   LA(x20, scratch) # reload base address
@@ -1061,10 +1416,15 @@ Zalrsc_sc_w_cg_cp_rd_b7:
 # Testcase cp_rd (Test destination rd = x8)
   RVTEST_TESTDATA_LOAD_INT(x15, x14) # load rs2: x14 = 0x425e7aff
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b8_retry:
   lr.w x0, (x22) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b8:
   sc.w x8, x14, (x22) # perform operation
+  beqz x8, Zalrsc_sc_w_cg_cp_rd_b8_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rd_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b8_success:
   # Check if x8 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x8, Zalrsc_sc_w_cg_cp_rd_b8, Zalrsc_sc_w_cg_cp_rd_b8_str)
   LA(x22, scratch) # reload base address
@@ -1075,10 +1435,15 @@ Zalrsc_sc_w_cg_cp_rd_b8:
 # Testcase cp_rd (Test destination rd = x9)
   RVTEST_TESTDATA_LOAD_INT(x15, x13) # load rs2: x13 = 0x1112fd6b
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b9_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b9:
   sc.w x9, x13, (x6) # perform operation
+  beqz x9, Zalrsc_sc_w_cg_cp_rd_b9_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cp_rd_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b9_success:
   # Check if x9 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x9, Zalrsc_sc_w_cg_cp_rd_b9, Zalrsc_sc_w_cg_cp_rd_b9_str)
   LA(x6, scratch) # reload base address
@@ -1089,10 +1454,15 @@ Zalrsc_sc_w_cg_cp_rd_b9:
 # Testcase cp_rd (Test destination rd = x10)
   RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rs2: x9 = 0x32f86d89
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b10_retry:
   lr.w x0, (x30) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b10:
   sc.w x10, x9, (x30) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cp_rd_b10_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cp_rd_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b10_success:
   # Check if x10 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x10, Zalrsc_sc_w_cg_cp_rd_b10, Zalrsc_sc_w_cg_cp_rd_b10_str)
   LA(x30, scratch) # reload base address
@@ -1103,10 +1473,15 @@ Zalrsc_sc_w_cg_cp_rd_b10:
 # Testcase cp_rd (Test destination rd = x11)
   RVTEST_TESTDATA_LOAD_INT(x15, x14) # load rs2: x14 = 0x264a6619
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b11_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b11:
   sc.w x11, x14, (x16) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cp_rd_b11_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_w_cg_cp_rd_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b11_success:
   # Check if x11 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x11, Zalrsc_sc_w_cg_cp_rd_b11, Zalrsc_sc_w_cg_cp_rd_b11_str)
   LA(x16, scratch) # reload base address
@@ -1117,10 +1492,15 @@ Zalrsc_sc_w_cg_cp_rd_b11:
 # Testcase cp_rd (Test destination rd = x12)
   RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rs2: x9 = 0x7054534d
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b12_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b12:
   sc.w x12, x9, (x2) # perform operation
+  beqz x12, Zalrsc_sc_w_cg_cp_rd_b12_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cp_rd_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b12_success:
   # Check if x12 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x12, Zalrsc_sc_w_cg_cp_rd_b12, Zalrsc_sc_w_cg_cp_rd_b12_str)
   LA(x2, scratch) # reload base address
@@ -1131,10 +1511,15 @@ Zalrsc_sc_w_cg_cp_rd_b12:
 # Testcase cp_rd (Test destination rd = x13)
   RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rs2: x9 = 0x78b5ed43
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b13_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b13:
   sc.w x13, x9, (x12) # perform operation
+  beqz x13, Zalrsc_sc_w_cg_cp_rd_b13_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_w_cg_cp_rd_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b13_success:
   # Check if x13 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x13, Zalrsc_sc_w_cg_cp_rd_b13, Zalrsc_sc_w_cg_cp_rd_b13_str)
   LA(x12, scratch) # reload base address
@@ -1145,10 +1530,15 @@ Zalrsc_sc_w_cg_cp_rd_b13:
 # Testcase cp_rd (Test destination rd = x14)
   RVTEST_TESTDATA_LOAD_INT(x15, x2) # load rs2: x2 = 0xc910a3c0
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b14_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b14:
   sc.w x14, x2, (x3) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cp_rd_b14_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rd_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b14_success:
   # Check if x14 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x14, Zalrsc_sc_w_cg_cp_rd_b14, Zalrsc_sc_w_cg_cp_rd_b14_str)
   LA(x3, scratch) # reload base address
@@ -1160,10 +1550,15 @@ Zalrsc_sc_w_cg_cp_rd_b14:
 # Testcase cp_rd (Test destination rd = x15)
   RVTEST_TESTDATA_LOAD_INT(x23, x7) # load rs2: x7 = 0x7c48f1dd
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b15_retry:
   lr.w x0, (x22) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b15:
   sc.w x15, x7, (x22) # perform operation
+  beqz x15, Zalrsc_sc_w_cg_cp_rd_b15_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cp_rd_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b15_success:
   # Check if x15 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x15, Zalrsc_sc_w_cg_cp_rd_b15, Zalrsc_sc_w_cg_cp_rd_b15_str)
   LA(x22, scratch) # reload base address
@@ -1174,10 +1569,15 @@ Zalrsc_sc_w_cg_cp_rd_b15:
 # Testcase cp_rd (Test destination rd = x16)
   RVTEST_TESTDATA_LOAD_INT(x23, x18) # load rs2: x18 = 0x688b6a41
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b16_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b16:
   sc.w x16, x18, (x21) # perform operation
+  beqz x16, Zalrsc_sc_w_cg_cp_rd_b16_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_w_cg_cp_rd_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b16_success:
   # Check if x16 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x16, Zalrsc_sc_w_cg_cp_rd_b16, Zalrsc_sc_w_cg_cp_rd_b16_str)
   LA(x21, scratch) # reload base address
@@ -1189,10 +1589,15 @@ Zalrsc_sc_w_cg_cp_rd_b16:
 # Testcase cp_rd (Test destination rd = x17)
   RVTEST_TESTDATA_LOAD_INT(x23, x22) # load rs2: x22 = 0x93295166
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b17_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b17:
   sc.w x17, x22, (x21) # perform operation
+  beqz x17, Zalrsc_sc_w_cg_cp_rd_b17_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cp_rd_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b17_success:
   # Check if x17 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x17, Zalrsc_sc_w_cg_cp_rd_b17, Zalrsc_sc_w_cg_cp_rd_b17_str)
   LA(x21, scratch) # reload base address
@@ -1203,10 +1608,15 @@ Zalrsc_sc_w_cg_cp_rd_b17:
 # Testcase cp_rd (Test destination rd = x18)
   RVTEST_TESTDATA_LOAD_INT(x23, x6) # load rs2: x6 = 0x078f66f1
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b18_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b18:
   sc.w x18, x6, (x13) # perform operation
+  beqz x18, Zalrsc_sc_w_cg_cp_rd_b18_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_w_cg_cp_rd_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b18_success:
   # Check if x18 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x18, Zalrsc_sc_w_cg_cp_rd_b18, Zalrsc_sc_w_cg_cp_rd_b18_str)
   LA(x13, scratch) # reload base address
@@ -1217,10 +1627,15 @@ Zalrsc_sc_w_cg_cp_rd_b18:
 # Testcase cp_rd (Test destination rd = x19)
   RVTEST_TESTDATA_LOAD_INT(x23, x18) # load rs2: x18 = 0xff5195b5
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b19_retry:
   lr.w x0, (x7) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b19:
   sc.w x19, x18, (x7) # perform operation
+  beqz x19, Zalrsc_sc_w_cg_cp_rd_b19_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cp_rd_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b19_success:
   # Check if x19 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x19, Zalrsc_sc_w_cg_cp_rd_b19, Zalrsc_sc_w_cg_cp_rd_b19_str)
   LA(x7, scratch) # reload base address
@@ -1231,10 +1646,15 @@ Zalrsc_sc_w_cg_cp_rd_b19:
 # Testcase cp_rd (Test destination rd = x20)
   RVTEST_TESTDATA_LOAD_INT(x23, x16) # load rs2: x16 = 0xa373d869
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b20_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b20:
   sc.w x20, x16, (x2) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cp_rd_b20_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_w_cg_cp_rd_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b20_success:
   # Check if x20 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x20, Zalrsc_sc_w_cg_cp_rd_b20, Zalrsc_sc_w_cg_cp_rd_b20_str)
   LA(x2, scratch) # reload base address
@@ -1245,10 +1665,15 @@ Zalrsc_sc_w_cg_cp_rd_b20:
 # Testcase cp_rd (Test destination rd = x21)
   RVTEST_TESTDATA_LOAD_INT(x23, x18) # load rs2: x18 = 0xe8dc98d8
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b21_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b21:
   sc.w x21, x18, (x14) # perform operation
+  beqz x21, Zalrsc_sc_w_cg_cp_rd_b21_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_w_cg_cp_rd_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b21_success:
   # Check if x21 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x21, Zalrsc_sc_w_cg_cp_rd_b21, Zalrsc_sc_w_cg_cp_rd_b21_str)
   LA(x14, scratch) # reload base address
@@ -1259,10 +1684,15 @@ Zalrsc_sc_w_cg_cp_rd_b21:
 # Testcase cp_rd (Test destination rd = x22)
   RVTEST_TESTDATA_LOAD_INT(x23, x1) # load rs2: x1 = 0x10a6f38d
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b22_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b22:
   sc.w x22, x1, (x2) # perform operation
+  beqz x22, Zalrsc_sc_w_cg_cp_rd_b22_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_w_cg_cp_rd_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b22_success:
   # Check if x22 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x22, Zalrsc_sc_w_cg_cp_rd_b22, Zalrsc_sc_w_cg_cp_rd_b22_str)
   LA(x2, scratch) # reload base address
@@ -1274,10 +1704,15 @@ Zalrsc_sc_w_cg_cp_rd_b22:
 # Testcase cp_rd (Test destination rd = x23)
   RVTEST_TESTDATA_LOAD_INT(x26, x30) # load rs2: x30 = 0x893a732e
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b23_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b23:
   sc.w x23, x30, (x13) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cp_rd_b23_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_w_cg_cp_rd_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b23_success:
   # Check if x23 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x23, Zalrsc_sc_w_cg_cp_rd_b23, Zalrsc_sc_w_cg_cp_rd_b23_str)
   LA(x13, scratch) # reload base address
@@ -1288,10 +1723,15 @@ Zalrsc_sc_w_cg_cp_rd_b23:
 # Testcase cp_rd (Test destination rd = x24)
   RVTEST_TESTDATA_LOAD_INT(x26, x23) # load rs2: x23 = 0xaa53aa8c
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b24_retry:
   lr.w x0, (x20) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b24:
   sc.w x24, x23, (x20) # perform operation
+  beqz x24, Zalrsc_sc_w_cg_cp_rd_b24_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rd_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b24_success:
   # Check if x24 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x24, Zalrsc_sc_w_cg_cp_rd_b24, Zalrsc_sc_w_cg_cp_rd_b24_str)
   LA(x20, scratch) # reload base address
@@ -1302,10 +1742,15 @@ Zalrsc_sc_w_cg_cp_rd_b24:
 # Testcase cp_rd (Test destination rd = x25)
   RVTEST_TESTDATA_LOAD_INT(x26, x0) # load rs2: x0 = 0x3cbe1969
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b25_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b25:
   sc.w x25, x0, (x17) # perform operation
+  beqz x25, Zalrsc_sc_w_cg_cp_rd_b25_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cp_rd_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b25_success:
   # Check if x25 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x25, Zalrsc_sc_w_cg_cp_rd_b25, Zalrsc_sc_w_cg_cp_rd_b25_str)
   LA(x17, scratch) # reload base address
@@ -1317,10 +1762,15 @@ Zalrsc_sc_w_cg_cp_rd_b25:
 # Testcase cp_rd (Test destination rd = x26)
   RVTEST_TESTDATA_LOAD_INT(x30, x21) # load rs2: x21 = 0xe1bc0f84
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b26_retry:
   lr.w x0, (x23) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b26:
   sc.w x26, x21, (x23) # perform operation
+  beqz x26, Zalrsc_sc_w_cg_cp_rd_b26_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_w_cg_cp_rd_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b26_success:
   # Check if x26 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x26, Zalrsc_sc_w_cg_cp_rd_b26, Zalrsc_sc_w_cg_cp_rd_b26_str)
   LA(x23, scratch) # reload base address
@@ -1331,10 +1781,15 @@ Zalrsc_sc_w_cg_cp_rd_b26:
 # Testcase cp_rd (Test destination rd = x27)
   RVTEST_TESTDATA_LOAD_INT(x30, x19) # load rs2: x19 = 0x924f29a8
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b27_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b27:
   sc.w x27, x19, (x13) # perform operation
+  beqz x27, Zalrsc_sc_w_cg_cp_rd_b27_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_w_cg_cp_rd_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b27_success:
   # Check if x27 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x27, Zalrsc_sc_w_cg_cp_rd_b27, Zalrsc_sc_w_cg_cp_rd_b27_str)
   LA(x13, scratch) # reload base address
@@ -1346,10 +1801,15 @@ Zalrsc_sc_w_cg_cp_rd_b27:
 # Testcase cp_rd (Test destination rd = x28)
   RVTEST_TESTDATA_LOAD_INT(x30, x13) # load rs2: x13 = 0xcebaa994
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b28_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b28:
   sc.w x28, x13, (x3) # perform operation
+  beqz x28, Zalrsc_sc_w_cg_cp_rd_b28_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rd_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b28_success:
   # Check if x28 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x28, Zalrsc_sc_w_cg_cp_rd_b28, Zalrsc_sc_w_cg_cp_rd_b28_str)
   LA(x3, scratch) # reload base address
@@ -1360,10 +1820,15 @@ Zalrsc_sc_w_cg_cp_rd_b28:
 # Testcase cp_rd (Test destination rd = x29)
   RVTEST_TESTDATA_LOAD_INT(x30, x7) # load rs2: x7 = 0x6c659716
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b29_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b29:
   sc.w x29, x7, (x6) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cp_rd_b29_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_w_cg_cp_rd_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b29_success:
   # Check if x29 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x29, Zalrsc_sc_w_cg_cp_rd_b29, Zalrsc_sc_w_cg_cp_rd_b29_str)
   LA(x6, scratch) # reload base address
@@ -1375,10 +1840,15 @@ Zalrsc_sc_w_cg_cp_rd_b29:
 # Testcase cp_rd (Test destination rd = x30)
   RVTEST_TESTDATA_LOAD_INT(x27, x15) # load rs2: x15 = 0xc9253559
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b30_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b30:
   sc.w x30, x15, (x21) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cp_rd_b30_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cp_rd_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b30_success:
   # Check if x30 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x30, Zalrsc_sc_w_cg_cp_rd_b30, Zalrsc_sc_w_cg_cp_rd_b30_str)
   LA(x21, scratch) # reload base address
@@ -1389,10 +1859,15 @@ Zalrsc_sc_w_cg_cp_rd_b30:
 # Testcase cp_rd (Test destination rd = x31)
   RVTEST_TESTDATA_LOAD_INT(x27, x11) # load rs2: x11 = 0xe99524de
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b31_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b31:
   sc.w x31, x11, (x6) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cp_rd_b31_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_w_cg_cp_rd_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b31_success:
   # Check if x31 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x31, Zalrsc_sc_w_cg_cp_rd_b31, Zalrsc_sc_w_cg_cp_rd_b31_str)
   LA(x6, scratch) # reload base address
@@ -1407,10 +1882,15 @@ Zalrsc_sc_w_cg_cp_rd_b31:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000)
   RVTEST_TESTDATA_LOAD_INT(x27, x28) # load rs2: x28 = 0x00000000
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x0_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x0:
   sc.w x14, x28, (x17) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cp_rs2_edges_0x0_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cp_rs2_edges_0x0_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x0_success:
   # Check if x14 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x14, Zalrsc_sc_w_cg_cp_rs2_edges_0x0, Zalrsc_sc_w_cg_cp_rs2_edges_0x0_str)
   LA(x17, scratch) # reload base address
@@ -1421,10 +1901,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x0:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
   RVTEST_TESTDATA_LOAD_INT(x27, x30) # load rs2: x30 = 0x00000001
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x1_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x1:
   sc.w x23, x30, (x31) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cp_rs2_edges_0x1_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cp_rs2_edges_0x1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x1_success:
   # Check if x23 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x23, Zalrsc_sc_w_cg_cp_rs2_edges_0x1, Zalrsc_sc_w_cg_cp_rs2_edges_0x1_str)
   LA(x31, scratch) # reload base address
@@ -1435,10 +1920,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x1:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
   RVTEST_TESTDATA_LOAD_INT(x27, x2) # load rs2: x2 = 0x00000002
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x2_retry:
   lr.w x0, (x24) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x2:
   sc.w x23, x2, (x24) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cp_rs2_edges_0x2_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_w_cg_cp_rs2_edges_0x2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x2_success:
   # Check if x23 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x23, Zalrsc_sc_w_cg_cp_rs2_edges_0x2, Zalrsc_sc_w_cg_cp_rs2_edges_0x2_str)
   LA(x24, scratch) # reload base address
@@ -1449,10 +1939,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x2:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
   RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rs2: x21 = 0x80000000
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x24, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x80000000_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x80000000:
   sc.w x3, x21, (x14) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cp_rs2_edges_0x80000000_success # SC succeeded, skip retry
+  addi x24, x24, -1 # decrement retry count
+  bnez x24, Zalrsc_sc_w_cg_cp_rs2_edges_0x80000000_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x80000000_success:
   # Check if x3 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x3, Zalrsc_sc_w_cg_cp_rs2_edges_0x80000000, Zalrsc_sc_w_cg_cp_rs2_edges_0x80000000_str)
   LA(x14, scratch) # reload base address
@@ -1463,10 +1958,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x80000000:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
   RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rs2: x20 = 0x80000001
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x80000001_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x80000001:
   sc.w x16, x20, (x2) # perform operation
+  beqz x16, Zalrsc_sc_w_cg_cp_rs2_edges_0x80000001_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rs2_edges_0x80000001_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x80000001_success:
   # Check if x16 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x16, Zalrsc_sc_w_cg_cp_rs2_edges_0x80000001, Zalrsc_sc_w_cg_cp_rs2_edges_0x80000001_str)
   LA(x2, scratch) # reload base address
@@ -1477,10 +1977,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x80000001:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rs2: x10 = 0x7fffffff
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x7fffffff_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x7fffffff:
   sc.w x1, x10, (x2) # perform operation
+  beqz x1, Zalrsc_sc_w_cg_cp_rs2_edges_0x7fffffff_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cp_rs2_edges_0x7fffffff_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x7fffffff_success:
   # Check if x1 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x1, Zalrsc_sc_w_cg_cp_rs2_edges_0x7fffffff, Zalrsc_sc_w_cg_cp_rs2_edges_0x7fffffff_str)
   LA(x2, scratch) # reload base address
@@ -1491,10 +1996,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x7fffffff:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
   RVTEST_TESTDATA_LOAD_INT(x27, x30) # load rs2: x30 = 0x7ffffffe
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x7ffffffe_retry:
   lr.w x0, (x11) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x7ffffffe:
   sc.w x28, x30, (x11) # perform operation
+  beqz x28, Zalrsc_sc_w_cg_cp_rs2_edges_0x7ffffffe_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cp_rs2_edges_0x7ffffffe_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x7ffffffe_success:
   # Check if x28 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x28, Zalrsc_sc_w_cg_cp_rs2_edges_0x7ffffffe, Zalrsc_sc_w_cg_cp_rs2_edges_0x7ffffffe_str)
   LA(x11, scratch) # reload base address
@@ -1505,10 +2015,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x7ffffffe:
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
   RVTEST_TESTDATA_LOAD_INT(x27, x3) # load rs2: x3 = 0xffffffff
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffff_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffff:
   sc.w x11, x3, (x15) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffff_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffff_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffff_success:
   # Check if x11 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x11, Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffff, Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffff_str)
   LA(x15, scratch) # reload base address
@@ -1519,10 +2034,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffff:
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
   RVTEST_TESTDATA_LOAD_INT(x27, x9) # load rs2: x9 = 0xfffffffe
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffe_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffe:
   sc.w x30, x9, (x14) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffe_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffe_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffe_success:
   # Check if x30 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x30, Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffe, Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffe_str)
   LA(x14, scratch) # reload base address
@@ -1533,10 +2053,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffe:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
   RVTEST_TESTDATA_LOAD_INT(x27, x3) # load rs2: x3 = 0x5bbc8872
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x5bbc8872_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x5bbc8872:
   sc.w x31, x3, (x17) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cp_rs2_edges_0x5bbc8872_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cp_rs2_edges_0x5bbc8872_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x5bbc8872_success:
   # Check if x31 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x31, Zalrsc_sc_w_cg_cp_rs2_edges_0x5bbc8872, Zalrsc_sc_w_cg_cp_rs2_edges_0x5bbc8872_str)
   LA(x17, scratch) # reload base address
@@ -1547,10 +2072,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x5bbc8872:
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x27, x24) # load rs2: x24 = 0xaaaaaaaa
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0xaaaaaaaa_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0xaaaaaaaa:
   sc.w x15, x24, (x31) # perform operation
+  beqz x15, Zalrsc_sc_w_cg_cp_rs2_edges_0xaaaaaaaa_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_w_cg_cp_rs2_edges_0xaaaaaaaa_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0xaaaaaaaa_success:
   # Check if x15 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x15, Zalrsc_sc_w_cg_cp_rs2_edges_0xaaaaaaaa, Zalrsc_sc_w_cg_cp_rs2_edges_0xaaaaaaaa_str)
   LA(x31, scratch) # reload base address
@@ -1561,10 +2091,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0xaaaaaaaa:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load rs2: x31 = 0x55555555
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x55555555_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x55555555:
   sc.w x3, x31, (x1) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cp_rs2_edges_0x55555555_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_w_cg_cp_rs2_edges_0x55555555_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x55555555_success:
   # Check if x3 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x3, Zalrsc_sc_w_cg_cp_rs2_edges_0x55555555, Zalrsc_sc_w_cg_cp_rs2_edges_0x55555555_str)
   LA(x1, scratch) # reload base address
@@ -1579,10 +2114,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x55555555:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rs2: x1 = 0x8d4809bb
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b1_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b1:
   sc.w x11, x1, (x1) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b1_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b1_success:
   # Check if x11 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x11, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b1, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b1_str)
   LA(x1, scratch) # reload base address
@@ -1593,10 +2133,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b1:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x27, x2) # load rs2: x2 = 0xcc228067
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b2_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b2:
   sc.w x9, x2, (x2) # perform operation
+  beqz x9, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b2_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b2_success:
   # Check if x9 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x9, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b2, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b2_str)
   LA(x2, scratch) # reload base address
@@ -1607,10 +2152,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b2:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x27, x3) # load rs2: x3 = 0xc50c4bf8
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b3_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b3:
   sc.w x10, x3, (x3) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b3_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b3_success:
   # Check if x10 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x10, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b3_str)
   LA(x3, scratch) # reload base address
@@ -1623,10 +2173,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b3:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x4)
   RVTEST_TESTDATA_LOAD_INT(x27, x4) # load rs2: x4 = 0x33b39afe
   LA(x4, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b4_retry:
   lr.w x0, (x4) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b4:
   sc.w x0, x4, (x4) # perform operation
+  beqz x0, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b4_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b4_success:
   # Check if x0 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x0, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b4, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b4_str)
   LA(x4, scratch) # reload base address
@@ -1637,10 +2192,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b4:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x27, x5) # load rs2: x5 = 0xcc0e3c21
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b5_retry:
   lr.w x0, (x5) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b5:
   sc.w x4, x5, (x5) # perform operation
+  beqz x4, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b5_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b5_success:
   # Check if x4 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x4, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b5, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b5_str)
   LA(x5, scratch) # reload base address
@@ -1651,10 +2211,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b5:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x27, x6) # load rs2: x6 = 0xb8fc7987
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b6_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b6:
   sc.w x10, x6, (x6) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b6_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b6_success:
   # Check if x10 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x10, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b6, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b6_str)
   LA(x6, scratch) # reload base address
@@ -1665,10 +2230,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b6:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x27, x7) # load rs2: x7 = 0xf24fb747
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b7_retry:
   lr.w x0, (x7) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b7:
   sc.w x3, x7, (x7) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b7_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b7_success:
   # Check if x3 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b7, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b7_str)
   LA(x7, scratch) # reload base address
@@ -1679,10 +2249,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b7:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load rs2: x8 = 0x17f33091
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b8_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b8:
   sc.w x25, x8, (x8) # perform operation
+  beqz x25, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b8_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b8_success:
   # Check if x25 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x25, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b8, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b8_str)
   LA(x8, scratch) # reload base address
@@ -1693,10 +2268,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b8:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x27, x9) # load rs2: x9 = 0xffc8a80a
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x5, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b9_retry:
   lr.w x0, (x9) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b9:
   sc.w x17, x9, (x9) # perform operation
+  beqz x17, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b9_success # SC succeeded, skip retry
+  addi x5, x5, -1 # decrement retry count
+  bnez x5, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b9_success:
   # Check if x17 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x17, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b9, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b9_str)
   LA(x9, scratch) # reload base address
@@ -1707,10 +2287,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b9:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rs2: x10 = 0xb5acd3d6
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b10_retry:
   lr.w x0, (x10) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b10:
   sc.w x0, x10, (x10) # perform operation
+  beqz x0, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b10_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b10_success:
   # Check if x0 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x0, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b10, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b10_str)
   LA(x10, scratch) # reload base address
@@ -1721,10 +2306,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b10:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x27, x11) # load rs2: x11 = 0x6a9e0a11
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b11_retry:
   lr.w x0, (x11) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b11:
   sc.w x1, x11, (x11) # perform operation
+  beqz x1, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b11_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b11_success:
   # Check if x1 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x1, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b11, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b11_str)
   LA(x11, scratch) # reload base address
@@ -1737,10 +2327,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b11:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rs2: x12 = 0xae650066
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b12_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b12:
   sc.w x3, x12, (x12) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b12_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b12_success:
   # Check if x3 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b12, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b12_str)
   LA(x12, scratch) # reload base address
@@ -1751,10 +2346,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b12:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rs2: x13 = 0x3b270215
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b13_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b13:
   sc.w x31, x13, (x13) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b13_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b13_success:
   # Check if x31 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x31, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b13, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b13_str)
   LA(x13, scratch) # reload base address
@@ -1765,10 +2365,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b13:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x27, x14) # load rs2: x14 = 0x67d6cf3d
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b14_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b14:
   sc.w x18, x14, (x14) # perform operation
+  beqz x18, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b14_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b14_success:
   # Check if x18 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x18, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b14, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b14_str)
   LA(x14, scratch) # reload base address
@@ -1779,10 +2384,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b14:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x27, x15) # load rs2: x15 = 0xe5343ed7
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b15_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b15:
   sc.w x3, x15, (x15) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b15_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b15_success:
   # Check if x3 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b15, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b15_str)
   LA(x15, scratch) # reload base address
@@ -1793,10 +2403,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b15:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rs2: x16 = 0xdc35236e
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b16_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b16:
   sc.w x12, x16, (x16) # perform operation
+  beqz x12, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b16_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b16_success:
   # Check if x12 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x12, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b16, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b16_str)
   LA(x16, scratch) # reload base address
@@ -1807,10 +2422,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b16:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x27, x17) # load rs2: x17 = 0x90a3a92b
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b17_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b17:
   sc.w x9, x17, (x17) # perform operation
+  beqz x9, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b17_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b17_success:
   # Check if x9 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x9, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b17, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b17_str)
   LA(x17, scratch) # reload base address
@@ -1821,10 +2441,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b17:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x27, x18) # load rs2: x18 = 0x34fd9294
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b18_retry:
   lr.w x0, (x18) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b18:
   sc.w x5, x18, (x18) # perform operation
+  beqz x5, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b18_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b18_success:
   # Check if x5 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x5, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b18, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b18_str)
   LA(x18, scratch) # reload base address
@@ -1835,10 +2460,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b18:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x27, x19) # load rs2: x19 = 0x02ece3be
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b19_retry:
   lr.w x0, (x19) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b19:
   sc.w x9, x19, (x19) # perform operation
+  beqz x9, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b19_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b19_success:
   # Check if x9 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x9, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b19, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b19_str)
   LA(x19, scratch) # reload base address
@@ -1849,10 +2479,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b19:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rs2: x20 = 0xa2dfe244
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b20_retry:
   lr.w x0, (x20) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b20:
   sc.w x14, x20, (x20) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b20_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b20_success:
   # Check if x14 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x14, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b20, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b20_str)
   LA(x20, scratch) # reload base address
@@ -1863,10 +2498,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b20:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rs2: x21 = 0x3ea67f83
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x5, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b21_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b21:
   sc.w x11, x21, (x21) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b21_success # SC succeeded, skip retry
+  addi x5, x5, -1 # decrement retry count
+  bnez x5, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b21_success:
   # Check if x11 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x11, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b21, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b21_str)
   LA(x21, scratch) # reload base address
@@ -1878,10 +2518,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b21:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x27, x22) # load rs2: x22 = 0x822f443c
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b22_retry:
   lr.w x0, (x22) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b22:
   sc.w x23, x22, (x22) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b22_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b22_success:
   # Check if x23 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x23, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b22, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b22_str)
   LA(x22, scratch) # reload base address
@@ -1892,10 +2537,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b22:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x27, x23) # load rs2: x23 = 0x46268128
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b23_retry:
   lr.w x0, (x23) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b23:
   sc.w x0, x23, (x23) # perform operation
+  beqz x0, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b23_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b23_success:
   # Check if x0 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x0, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b23, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b23_str)
   LA(x23, scratch) # reload base address
@@ -1906,10 +2556,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b23:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x27, x24) # load rs2: x24 = 0x7ac1e602
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b24_retry:
   lr.w x0, (x24) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b24:
   sc.w x4, x24, (x24) # perform operation
+  beqz x4, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b24_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b24_success:
   # Check if x4 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x4, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b24, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b24_str)
   LA(x24, scratch) # reload base address
@@ -1920,10 +2575,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b24:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x27, x25) # load rs2: x25 = 0x8fc02b72
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x4, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b25_retry:
   lr.w x0, (x25) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b25:
   sc.w x15, x25, (x25) # perform operation
+  beqz x15, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b25_success # SC succeeded, skip retry
+  addi x4, x4, -1 # decrement retry count
+  bnez x4, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b25_success:
   # Check if x15 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x15, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b25, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b25_str)
   LA(x25, scratch) # reload base address
@@ -1934,10 +2594,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b25:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x27, x26) # load rs2: x26 = 0x7ea2ffa2
   LA(x26, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b26_retry:
   lr.w x0, (x26) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b26:
   sc.w x5, x26, (x26) # perform operation
+  beqz x5, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b26_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b26_success:
   # Check if x5 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x5, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b26, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b26_str)
   LA(x26, scratch) # reload base address
@@ -1949,10 +2614,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b26:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x17, x27) # load rs2: x27 = 0x17c28439
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b27_retry:
   lr.w x0, (x27) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b27:
   sc.w x28, x27, (x27) # perform operation
+  beqz x28, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b27_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b27_success:
   # Check if x28 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x28, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b27, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b27_str)
   LA(x27, scratch) # reload base address
@@ -1963,10 +2633,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b27:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x17, x28) # load rs2: x28 = 0x11a68d91
   LA(x28, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b28_retry:
   lr.w x0, (x28) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b28:
   sc.w x30, x28, (x28) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b28_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b28_success:
   # Check if x30 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x30, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b28, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b28_str)
   LA(x28, scratch) # reload base address
@@ -1977,10 +2652,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b28:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x17, x29) # load rs2: x29 = 0x8ef15ad8
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b29_retry:
   lr.w x0, (x29) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b29:
   sc.w x13, x29, (x29) # perform operation
+  beqz x13, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b29_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b29_success:
   # Check if x13 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x13, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b29, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b29_str)
   LA(x29, scratch) # reload base address
@@ -1991,10 +2671,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b29:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x17, x30) # load rs2: x30 = 0x6fa05cff
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b30_retry:
   lr.w x0, (x30) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b30:
   sc.w x20, x30, (x30) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b30_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b30_success:
   # Check if x20 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x20, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b30, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b30_str)
   LA(x30, scratch) # reload base address
@@ -2005,10 +2690,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b30:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x17, x31) # load rs2: x31 = 0xfb6249aa
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b31_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b31:
   sc.w x10, x31, (x31) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b31_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b31_success:
   # Check if x10 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x10, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b31, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b31_str)
   LA(x31, scratch) # reload base address
@@ -2023,10 +2713,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b31:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x1)
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load rs2: x6 = 0xb9c47741
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x4, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b1_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b1:
   sc.w x1, x6, (x1) # perform operation
+  beqz x1, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b1_success # SC succeeded, skip retry
+  addi x4, x4, -1 # decrement retry count
+  bnez x4, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b1_success:
   # Check if x1 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x1, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b1, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b1_str)
   LA(x1, scratch) # reload base address
@@ -2037,10 +2732,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b1:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load rs2: x6 = 0x99a71874
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b2_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b2:
   sc.w x2, x6, (x2) # perform operation
+  beqz x2, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b2_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b2_success:
   # Check if x2 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x2, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b2, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b2_str)
   LA(x2, scratch) # reload base address
@@ -2051,10 +2751,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b2:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x3)
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load rs2: x13 = 0xadce5e99
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x30, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b3_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b3:
   sc.w x3, x13, (x3) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b3_success # SC succeeded, skip retry
+  addi x30, x30, -1 # decrement retry count
+  bnez x30, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b3_success:
   # Check if x3 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x3, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b3, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b3_str)
   LA(x3, scratch) # reload base address
@@ -2065,10 +2770,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b3:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x4)
   RVTEST_TESTDATA_LOAD_INT(x17, x20) # load rs2: x20 = 0xe4531a37
   LA(x4, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b4_retry:
   lr.w x0, (x4) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b4:
   sc.w x4, x20, (x4) # perform operation
+  beqz x4, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b4_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b4_success:
   # Check if x4 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x4, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b4, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b4_str)
   LA(x4, scratch) # reload base address
@@ -2079,10 +2789,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b4:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x17, x25) # load rs2: x25 = 0x63fe8675
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b5_retry:
   lr.w x0, (x5) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b5:
   sc.w x5, x25, (x5) # perform operation
+  beqz x5, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b5_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b5_success:
   # Check if x5 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x5, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b5, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b5_str)
   LA(x5, scratch) # reload base address
@@ -2093,10 +2808,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b5:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x17, x11) # load rs2: x11 = 0xdf7030d4
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b6_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b6:
   sc.w x6, x11, (x6) # perform operation
+  beqz x6, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b6_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b6_success:
   # Check if x6 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x6, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b6, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b6_str)
   LA(x6, scratch) # reload base address
@@ -2109,10 +2829,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b6:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x7)
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load rs2: x1 = 0x93d3bef4
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b7_retry:
   lr.w x0, (x7) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b7:
   sc.w x7, x1, (x7) # perform operation
+  beqz x7, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b7_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b7_success:
   # Check if x7 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x7, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b7, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b7_str)
   LA(x7, scratch) # reload base address
@@ -2123,10 +2848,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b7:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x17, x29) # load rs2: x29 = 0x5014c2e5
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x30, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b8_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b8:
   sc.w x8, x29, (x8) # perform operation
+  beqz x8, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b8_success # SC succeeded, skip retry
+  addi x30, x30, -1 # decrement retry count
+  bnez x30, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b8_success:
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b8, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b8_str)
   LA(x8, scratch) # reload base address
@@ -2137,10 +2867,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b8:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x17, x8) # load rs2: x8 = 0xb7ed8831
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b9_retry:
   lr.w x0, (x9) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b9:
   sc.w x9, x8, (x9) # perform operation
+  beqz x9, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b9_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b9_success:
   # Check if x9 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x9, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b9, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b9_str)
   LA(x9, scratch) # reload base address
@@ -2151,10 +2886,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b9:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x17, x26) # load rs2: x26 = 0x6c9e688c
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b10_retry:
   lr.w x0, (x10) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b10:
   sc.w x10, x26, (x10) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b10_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b10_success:
   # Check if x10 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x10, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b10, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b10_str)
   LA(x10, scratch) # reload base address
@@ -2165,10 +2905,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b10:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x17, x27) # load rs2: x27 = 0x54bc394c
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b11_retry:
   lr.w x0, (x11) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b11:
   sc.w x11, x27, (x11) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b11_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b11_success:
   # Check if x11 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x11, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b11, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b11_str)
   LA(x11, scratch) # reload base address
@@ -2179,10 +2924,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b11:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rs2: x2 = 0xe1e35f95
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b12_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b12:
   sc.w x12, x2, (x12) # perform operation
+  beqz x12, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b12_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b12_success:
   # Check if x12 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x12, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b12, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b12_str)
   LA(x12, scratch) # reload base address
@@ -2193,10 +2943,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b12:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x17, x22) # load rs2: x22 = 0x83f2ff01
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b13_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b13:
   sc.w x13, x22, (x13) # perform operation
+  beqz x13, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b13_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b13_success:
   # Check if x13 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x13, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b13, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b13_str)
   LA(x13, scratch) # reload base address
@@ -2207,10 +2962,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b13:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rs2: x0 = 0x5858810d
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b14_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b14:
   sc.w x14, x0, (x14) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b14_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b14_success:
   # Check if x14 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x14, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b14, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b14_str)
   LA(x14, scratch) # reload base address
@@ -2221,10 +2981,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b14:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x17, x22) # load rs2: x22 = 0xf57ef0ac
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b15_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b15:
   sc.w x15, x22, (x15) # perform operation
+  beqz x15, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b15_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b15_success:
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b15, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b15_str)
   LA(x15, scratch) # reload base address
@@ -2235,10 +3000,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b15:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x16)
   RVTEST_TESTDATA_LOAD_INT(x17, x25) # load rs2: x25 = 0xcad218c8
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b16_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b16:
   sc.w x16, x25, (x16) # perform operation
+  beqz x16, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b16_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b16_success:
   # Check if x16 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x16, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b16, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b16_str)
   LA(x16, scratch) # reload base address
@@ -2250,10 +3020,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b16:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x17)
   RVTEST_TESTDATA_LOAD_INT(x22, x9) # load rs2: x9 = 0xb77370be
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x30, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b17_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b17:
   sc.w x17, x9, (x17) # perform operation
+  beqz x17, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b17_success # SC succeeded, skip retry
+  addi x30, x30, -1 # decrement retry count
+  bnez x30, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b17_success:
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b17, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b17_str)
   LA(x17, scratch) # reload base address
@@ -2265,10 +3040,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b17:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x18)
   RVTEST_TESTDATA_LOAD_INT(x22, x19) # load rs2: x19 = 0x67d46c06
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b18_retry:
   lr.w x0, (x18) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b18:
   sc.w x18, x19, (x18) # perform operation
+  beqz x18, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b18_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b18_success:
   # Check if x18 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x18, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b18, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b18_str)
   LA(x18, scratch) # reload base address
@@ -2279,10 +3059,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b18:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x19)
   RVTEST_TESTDATA_LOAD_INT(x22, x13) # load rs2: x13 = 0x0e83b3ec
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b19_retry:
   lr.w x0, (x19) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b19:
   sc.w x19, x13, (x19) # perform operation
+  beqz x19, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b19_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b19_success:
   # Check if x19 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x19, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b19, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b19_str)
   LA(x19, scratch) # reload base address
@@ -2293,10 +3078,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b19:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x20)
   RVTEST_TESTDATA_LOAD_INT(x22, x24) # load rs2: x24 = 0x452e807b
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b20_retry:
   lr.w x0, (x20) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b20:
   sc.w x20, x24, (x20) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b20_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b20_success:
   # Check if x20 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x20, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b20, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b20_str)
   LA(x20, scratch) # reload base address
@@ -2307,10 +3097,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b20:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x21)
   RVTEST_TESTDATA_LOAD_INT(x22, x27) # load rs2: x27 = 0x373ec43c
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b21_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b21:
   sc.w x21, x27, (x21) # perform operation
+  beqz x21, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b21_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b21_success:
   # Check if x21 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x21, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b21, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b21_str)
   LA(x21, scratch) # reload base address
@@ -2322,10 +3117,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b21:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x22)
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0xf0772d19
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b22_retry:
   lr.w x0, (x22) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b22:
   sc.w x22, x29, (x22) # perform operation
+  beqz x22, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b22_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b22_success:
   # Check if x22 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x22, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b22, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b22_str)
   LA(x22, scratch) # reload base address
@@ -2336,10 +3136,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b22:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x23)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xfec42bda
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b23_retry:
   lr.w x0, (x23) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b23:
   sc.w x23, x12, (x23) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b23_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b23_success:
   # Check if x23 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x23, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b23, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b23_str)
   LA(x23, scratch) # reload base address
@@ -2350,10 +3155,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b23:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x24)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xad84ccce
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b24_retry:
   lr.w x0, (x24) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b24:
   sc.w x24, x6, (x24) # perform operation
+  beqz x24, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b24_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b24_success:
   # Check if x24 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x24, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b24, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b24_str)
   LA(x24, scratch) # reload base address
@@ -2364,10 +3174,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b24:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x25)
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x0ba0820d
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b25_retry:
   lr.w x0, (x25) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b25:
   sc.w x25, x29, (x25) # perform operation
+  beqz x25, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b25_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b25_success:
   # Check if x25 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x25, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b25, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b25_str)
   LA(x25, scratch) # reload base address
@@ -2379,10 +3194,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b25:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x26)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x05bfc0ab
   LA(x26, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b26_retry:
   lr.w x0, (x26) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b26:
   sc.w x26, x6, (x26) # perform operation
+  beqz x26, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b26_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b26_success:
   # Check if x26 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x26, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b26, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b26_str)
   LA(x26, scratch) # reload base address
@@ -2393,10 +3213,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b26:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x27)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x528607e1
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b27_retry:
   lr.w x0, (x27) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b27:
   sc.w x27, x15, (x27) # perform operation
+  beqz x27, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b27_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b27_success:
   # Check if x27 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x27, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b27, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b27_str)
   LA(x27, scratch) # reload base address
@@ -2407,10 +3232,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b27:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x28)
   RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x3a61a991
   LA(x28, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b28_retry:
   lr.w x0, (x28) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b28:
   sc.w x28, x16, (x28) # perform operation
+  beqz x28, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b28_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b28_success:
   # Check if x28 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x28, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b28, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b28_str)
   LA(x28, scratch) # reload base address
@@ -2421,10 +3251,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b28:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x29)
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0xccee4b0a
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x24, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b29_retry:
   lr.w x0, (x29) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b29:
   sc.w x29, x25, (x29) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b29_success # SC succeeded, skip retry
+  addi x24, x24, -1 # decrement retry count
+  bnez x24, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b29_success:
   # Check if x29 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x29, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b29, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b29_str)
   LA(x29, scratch) # reload base address
@@ -2435,10 +3270,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b29:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x30)
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0xac923084
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b30_retry:
   lr.w x0, (x30) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b30:
   sc.w x30, x19, (x30) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b30_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b30_success:
   # Check if x30 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x30, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b30, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b30_str)
   LA(x30, scratch) # reload base address
@@ -2449,10 +3289,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b30:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x31)
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x2b48820c
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b31_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b31:
   sc.w x31, x20, (x31) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b31_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b31_success:
   # Check if x31 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x31, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b31, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b31_str)
   LA(x31, scratch) # reload base address
@@ -2467,10 +3312,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b31:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x0)
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0xf4a665d4
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b0_retry:
   lr.w x0, (x27) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b0:
   sc.w x0, x0, (x27) # perform operation
+  beqz x0, Zalrsc_sc_w_cg_cmp_rd_rs2_b0_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cmp_rd_rs2_b0_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b0_success:
   # Check if x0 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x0, Zalrsc_sc_w_cg_cmp_rd_rs2_b0, Zalrsc_sc_w_cg_cmp_rd_rs2_b0_str)
   LA(x27, scratch) # reload base address
@@ -2482,10 +3332,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b0:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load rs2: x1 = 0xf914877a
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b1_retry:
   lr.w x0, (x25) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b1:
   sc.w x1, x1, (x25) # perform operation
+  beqz x1, Zalrsc_sc_w_cg_cmp_rd_rs2_b1_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rd_rs2_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b1_success:
   # Check if x1 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x1, Zalrsc_sc_w_cg_cmp_rd_rs2_b1, Zalrsc_sc_w_cg_cmp_rd_rs2_b1_str)
   LA(x25, scratch) # reload base address
@@ -2496,10 +3351,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b1:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x24, x2) # load rs2: x2 = 0x75ab8d10
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b2_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b2:
   sc.w x2, x2, (x12) # perform operation
+  beqz x2, Zalrsc_sc_w_cg_cmp_rd_rs2_b2_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_w_cg_cmp_rd_rs2_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b2_success:
   # Check if x2 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x2, Zalrsc_sc_w_cg_cmp_rd_rs2_b2, Zalrsc_sc_w_cg_cmp_rd_rs2_b2_str)
   LA(x12, scratch) # reload base address
@@ -2510,10 +3370,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b2:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load rs2: x3 = 0xde42bb1c
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b3_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b3:
   sc.w x3, x3, (x21) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cmp_rd_rs2_b3_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_w_cg_cmp_rd_rs2_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b3_success:
   # Check if x3 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x3, Zalrsc_sc_w_cg_cmp_rd_rs2_b3, Zalrsc_sc_w_cg_cmp_rd_rs2_b3_str)
   LA(x21, scratch) # reload base address
@@ -2526,10 +3391,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b3:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x4)
   RVTEST_TESTDATA_LOAD_INT(x24, x4) # load rs2: x4 = 0x655238b3
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b4_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b4:
   sc.w x4, x4, (x12) # perform operation
+  beqz x4, Zalrsc_sc_w_cg_cmp_rd_rs2_b4_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cmp_rd_rs2_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b4_success:
   # Check if x4 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x4, Zalrsc_sc_w_cg_cmp_rd_rs2_b4, Zalrsc_sc_w_cg_cmp_rd_rs2_b4_str)
   LA(x12, scratch) # reload base address
@@ -2540,10 +3410,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b4:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x24, x5) # load rs2: x5 = 0x26710596
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b5_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b5:
   sc.w x5, x5, (x6) # perform operation
+  beqz x5, Zalrsc_sc_w_cg_cmp_rd_rs2_b5_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_w_cg_cmp_rd_rs2_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b5_success:
   # Check if x5 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x5, Zalrsc_sc_w_cg_cmp_rd_rs2_b5, Zalrsc_sc_w_cg_cmp_rd_rs2_b5_str)
   LA(x6, scratch) # reload base address
@@ -2554,10 +3429,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b5:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x24, x6) # load rs2: x6 = 0xc757628b
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b6_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b6:
   sc.w x6, x6, (x21) # perform operation
+  beqz x6, Zalrsc_sc_w_cg_cmp_rd_rs2_b6_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_w_cg_cmp_rd_rs2_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b6_success:
   # Check if x6 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x6, Zalrsc_sc_w_cg_cmp_rd_rs2_b6, Zalrsc_sc_w_cg_cmp_rd_rs2_b6_str)
   LA(x21, scratch) # reload base address
@@ -2570,10 +3450,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b6:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x24, x7) # load rs2: x7 = 0xe770db9f
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b7_retry:
   lr.w x0, (x27) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b7:
   sc.w x7, x7, (x27) # perform operation
+  beqz x7, Zalrsc_sc_w_cg_cmp_rd_rs2_b7_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cmp_rd_rs2_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b7_success:
   # Check if x7 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x7, Zalrsc_sc_w_cg_cmp_rd_rs2_b7, Zalrsc_sc_w_cg_cmp_rd_rs2_b7_str)
   LA(x27, scratch) # reload base address
@@ -2584,10 +3469,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b7:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x24, x8) # load rs2: x8 = 0x1969dea1
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b8_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b8:
   sc.w x8, x8, (x31) # perform operation
+  beqz x8, Zalrsc_sc_w_cg_cmp_rd_rs2_b8_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cmp_rd_rs2_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b8_success:
   # Check if x8 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x8, Zalrsc_sc_w_cg_cmp_rd_rs2_b8, Zalrsc_sc_w_cg_cmp_rd_rs2_b8_str)
   LA(x31, scratch) # reload base address
@@ -2598,10 +3488,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b8:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x24, x9) # load rs2: x9 = 0xeea09489
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b9_retry:
   lr.w x0, (x11) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b9:
   sc.w x9, x9, (x11) # perform operation
+  beqz x9, Zalrsc_sc_w_cg_cmp_rd_rs2_b9_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cmp_rd_rs2_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b9_success:
   # Check if x9 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x9, Zalrsc_sc_w_cg_cmp_rd_rs2_b9, Zalrsc_sc_w_cg_cmp_rd_rs2_b9_str)
   LA(x11, scratch) # reload base address
@@ -2612,10 +3507,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b9:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x24, x10) # load rs2: x10 = 0x34269207
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b10_retry:
   lr.w x0, (x5) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b10:
   sc.w x10, x10, (x5) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cmp_rd_rs2_b10_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_w_cg_cmp_rd_rs2_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b10_success:
   # Check if x10 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x10, Zalrsc_sc_w_cg_cmp_rd_rs2_b10, Zalrsc_sc_w_cg_cmp_rd_rs2_b10_str)
   LA(x5, scratch) # reload base address
@@ -2626,10 +3526,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b10:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x24, x11) # load rs2: x11 = 0xa1ee428e
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b11_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b11:
   sc.w x11, x11, (x1) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cmp_rd_rs2_b11_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cmp_rd_rs2_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b11_success:
   # Check if x11 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x11, Zalrsc_sc_w_cg_cmp_rd_rs2_b11, Zalrsc_sc_w_cg_cmp_rd_rs2_b11_str)
   LA(x1, scratch) # reload base address
@@ -2642,10 +3547,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b11:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x24, x12) # load rs2: x12 = 0x713226bc
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b12_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b12:
   sc.w x12, x12, (x2) # perform operation
+  beqz x12, Zalrsc_sc_w_cg_cmp_rd_rs2_b12_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cmp_rd_rs2_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b12_success:
   # Check if x12 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x12, Zalrsc_sc_w_cg_cmp_rd_rs2_b12, Zalrsc_sc_w_cg_cmp_rd_rs2_b12_str)
   LA(x2, scratch) # reload base address
@@ -2656,10 +3566,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b12:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x24, x13) # load rs2: x13 = 0x3a460211
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b13_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b13:
   sc.w x13, x13, (x1) # perform operation
+  beqz x13, Zalrsc_sc_w_cg_cmp_rd_rs2_b13_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cmp_rd_rs2_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b13_success:
   # Check if x13 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x13, Zalrsc_sc_w_cg_cmp_rd_rs2_b13, Zalrsc_sc_w_cg_cmp_rd_rs2_b13_str)
   LA(x1, scratch) # reload base address
@@ -2670,10 +3585,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b13:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x24, x14) # load rs2: x14 = 0x5727be8d
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b14_retry:
   lr.w x0, (x10) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b14:
   sc.w x14, x14, (x10) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cmp_rd_rs2_b14_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cmp_rd_rs2_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b14_success:
   # Check if x14 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x14, Zalrsc_sc_w_cg_cmp_rd_rs2_b14, Zalrsc_sc_w_cg_cmp_rd_rs2_b14_str)
   LA(x10, scratch) # reload base address
@@ -2684,10 +3604,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b14:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x24, x15) # load rs2: x15 = 0xda504906
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b15_retry:
   lr.w x0, (x19) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b15:
   sc.w x15, x15, (x19) # perform operation
+  beqz x15, Zalrsc_sc_w_cg_cmp_rd_rs2_b15_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cmp_rd_rs2_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b15_success:
   # Check if x15 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x15, Zalrsc_sc_w_cg_cmp_rd_rs2_b15, Zalrsc_sc_w_cg_cmp_rd_rs2_b15_str)
   LA(x19, scratch) # reload base address
@@ -2698,10 +3623,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b15:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x24, x16) # load rs2: x16 = 0x2b13dfea
   LA(x26, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b16_retry:
   lr.w x0, (x26) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b16:
   sc.w x16, x16, (x26) # perform operation
+  beqz x16, Zalrsc_sc_w_cg_cmp_rd_rs2_b16_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cmp_rd_rs2_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b16_success:
   # Check if x16 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x16, Zalrsc_sc_w_cg_cmp_rd_rs2_b16, Zalrsc_sc_w_cg_cmp_rd_rs2_b16_str)
   LA(x26, scratch) # reload base address
@@ -2712,10 +3642,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b16:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load rs2: x17 = 0x0b715f30
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b17_retry:
   lr.w x0, (x19) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b17:
   sc.w x17, x17, (x19) # perform operation
+  beqz x17, Zalrsc_sc_w_cg_cmp_rd_rs2_b17_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_w_cg_cmp_rd_rs2_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b17_success:
   # Check if x17 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x17, Zalrsc_sc_w_cg_cmp_rd_rs2_b17, Zalrsc_sc_w_cg_cmp_rd_rs2_b17_str)
   LA(x19, scratch) # reload base address
@@ -2726,10 +3661,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b17:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x24, x18) # load rs2: x18 = 0x193c5d09
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b18_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b18:
   sc.w x18, x18, (x3) # perform operation
+  beqz x18, Zalrsc_sc_w_cg_cmp_rd_rs2_b18_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cmp_rd_rs2_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b18_success:
   # Check if x18 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x18, Zalrsc_sc_w_cg_cmp_rd_rs2_b18, Zalrsc_sc_w_cg_cmp_rd_rs2_b18_str)
   LA(x3, scratch) # reload base address
@@ -2740,10 +3680,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b18:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rs2: x19 = 0x153eaa36
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b19_retry:
   lr.w x0, (x29) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b19:
   sc.w x19, x19, (x29) # perform operation
+  beqz x19, Zalrsc_sc_w_cg_cmp_rd_rs2_b19_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cmp_rd_rs2_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b19_success:
   # Check if x19 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x19, Zalrsc_sc_w_cg_cmp_rd_rs2_b19, Zalrsc_sc_w_cg_cmp_rd_rs2_b19_str)
   LA(x29, scratch) # reload base address
@@ -2754,10 +3699,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b19:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load rs2: x20 = 0xe602c57c
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b20_retry:
   lr.w x0, (x10) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b20:
   sc.w x20, x20, (x10) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cmp_rd_rs2_b20_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cmp_rd_rs2_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b20_success:
   # Check if x20 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x20, Zalrsc_sc_w_cg_cmp_rd_rs2_b20, Zalrsc_sc_w_cg_cmp_rd_rs2_b20_str)
   LA(x10, scratch) # reload base address
@@ -2768,10 +3718,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b20:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rs2: x21 = 0xa26c9dc6
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b21_retry:
   lr.w x0, (x11) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b21:
   sc.w x21, x21, (x11) # perform operation
+  beqz x21, Zalrsc_sc_w_cg_cmp_rd_rs2_b21_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cmp_rd_rs2_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b21_success:
   # Check if x21 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x21, Zalrsc_sc_w_cg_cmp_rd_rs2_b21, Zalrsc_sc_w_cg_cmp_rd_rs2_b21_str)
   LA(x11, scratch) # reload base address
@@ -2783,10 +3738,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b21:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rs2: x22 = 0x6e8d0fd5
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b22_retry:
   lr.w x0, (x30) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b22:
   sc.w x22, x22, (x30) # perform operation
+  beqz x22, Zalrsc_sc_w_cg_cmp_rd_rs2_b22_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cmp_rd_rs2_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b22_success:
   # Check if x22 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x22, Zalrsc_sc_w_cg_cmp_rd_rs2_b22, Zalrsc_sc_w_cg_cmp_rd_rs2_b22_str)
   LA(x30, scratch) # reload base address
@@ -2797,10 +3757,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b22:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rs2: x23 = 0xb34ca431
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b23_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b23:
   sc.w x23, x23, (x6) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cmp_rd_rs2_b23_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_w_cg_cmp_rd_rs2_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b23_success:
   # Check if x23 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x23, Zalrsc_sc_w_cg_cmp_rd_rs2_b23, Zalrsc_sc_w_cg_cmp_rd_rs2_b23_str)
   LA(x6, scratch) # reload base address
@@ -2812,10 +3777,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b23:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x19, x24) # load rs2: x24 = 0x482f7a6a
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b24_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b24:
   sc.w x24, x24, (x2) # perform operation
+  beqz x24, Zalrsc_sc_w_cg_cmp_rd_rs2_b24_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cmp_rd_rs2_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b24_success:
   # Check if x24 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x24, Zalrsc_sc_w_cg_cmp_rd_rs2_b24, Zalrsc_sc_w_cg_cmp_rd_rs2_b24_str)
   LA(x2, scratch) # reload base address
@@ -2826,10 +3796,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b24:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x19, x25) # load rs2: x25 = 0xc72efb26
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b25_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b25:
   sc.w x25, x25, (x8) # perform operation
+  beqz x25, Zalrsc_sc_w_cg_cmp_rd_rs2_b25_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cmp_rd_rs2_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b25_success:
   # Check if x25 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x25, Zalrsc_sc_w_cg_cmp_rd_rs2_b25, Zalrsc_sc_w_cg_cmp_rd_rs2_b25_str)
   LA(x8, scratch) # reload base address
@@ -2840,10 +3815,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b25:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x19, x26) # load rs2: x26 = 0xa8af600b
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b26_retry:
   lr.w x0, (x27) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b26:
   sc.w x26, x26, (x27) # perform operation
+  beqz x26, Zalrsc_sc_w_cg_cmp_rd_rs2_b26_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_w_cg_cmp_rd_rs2_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b26_success:
   # Check if x26 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x26, Zalrsc_sc_w_cg_cmp_rd_rs2_b26, Zalrsc_sc_w_cg_cmp_rd_rs2_b26_str)
   LA(x27, scratch) # reload base address
@@ -2854,10 +3834,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b26:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x19, x27) # load rs2: x27 = 0x1c2b1acd
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b27_retry:
   lr.w x0, (x11) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b27:
   sc.w x27, x27, (x11) # perform operation
+  beqz x27, Zalrsc_sc_w_cg_cmp_rd_rs2_b27_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_w_cg_cmp_rd_rs2_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b27_success:
   # Check if x27 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x27, Zalrsc_sc_w_cg_cmp_rd_rs2_b27, Zalrsc_sc_w_cg_cmp_rd_rs2_b27_str)
   LA(x11, scratch) # reload base address
@@ -2868,10 +3853,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b27:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x19, x28) # load rs2: x28 = 0xdaf31a9a
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b28_retry:
   lr.w x0, (x18) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b28:
   sc.w x28, x28, (x18) # perform operation
+  beqz x28, Zalrsc_sc_w_cg_cmp_rd_rs2_b28_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_w_cg_cmp_rd_rs2_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b28_success:
   # Check if x28 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x28, Zalrsc_sc_w_cg_cmp_rd_rs2_b28, Zalrsc_sc_w_cg_cmp_rd_rs2_b28_str)
   LA(x18, scratch) # reload base address
@@ -2883,10 +3873,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b28:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x19, x29) # load rs2: x29 = 0x68bb2d57
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b29_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b29:
   sc.w x29, x29, (x12) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cmp_rd_rs2_b29_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_w_cg_cmp_rd_rs2_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b29_success:
   # Check if x29 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x29, Zalrsc_sc_w_cg_cmp_rd_rs2_b29, Zalrsc_sc_w_cg_cmp_rd_rs2_b29_str)
   LA(x12, scratch) # reload base address
@@ -2897,10 +3892,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b29:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x19, x30) # load rs2: x30 = 0x5250bca9
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x24, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b30_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b30:
   sc.w x30, x30, (x2) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cmp_rd_rs2_b30_success # SC succeeded, skip retry
+  addi x24, x24, -1 # decrement retry count
+  bnez x24, Zalrsc_sc_w_cg_cmp_rd_rs2_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b30_success:
   # Check if x30 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x30, Zalrsc_sc_w_cg_cmp_rd_rs2_b30, Zalrsc_sc_w_cg_cmp_rd_rs2_b30_str)
   LA(x2, scratch) # reload base address
@@ -2911,10 +3911,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b30:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x19, x31) # load rs2: x31 = 0x81839657
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b31_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b31:
   sc.w x31, x31, (x16) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cmp_rd_rs2_b31_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cmp_rd_rs2_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b31_success:
   # Check if x31 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x31, Zalrsc_sc_w_cg_cmp_rd_rs2_b31, Zalrsc_sc_w_cg_cmp_rd_rs2_b31_str)
   LA(x16, scratch) # reload base address
@@ -2929,10 +3934,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b31:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x19, x1) # load rs2: x1 = 0x519fdac8
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b1_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b1:
   sc.w x1, x1, (x1) # perform operation
+  beqz x1, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b1_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b1_success:
   # Check if x1 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x1, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b1, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b1_str)
   LA(x1, scratch) # reload base address
@@ -2943,10 +3953,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b1:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x19, x2) # load rs2: x2 = 0xf3e68478
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b2_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b2:
   sc.w x2, x2, (x2) # perform operation
+  beqz x2, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b2_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b2_success:
   # Check if x2 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x2, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b2, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b2_str)
   LA(x2, scratch) # reload base address
@@ -2957,10 +3972,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b2:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x19, x3) # load rs2: x3 = 0xa320df94
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b3_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b3:
   sc.w x3, x3, (x3) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b3_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b3_success:
   # Check if x3 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x3, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b3, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b3_str)
   LA(x3, scratch) # reload base address
@@ -2973,10 +3993,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b3:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x4)
   RVTEST_TESTDATA_LOAD_INT(x19, x4) # load rs2: x4 = 0x702cc08d
   LA(x4, scratch) # rs1 = base address
-  nop
+  LI(x5, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b4_retry:
   lr.w x0, (x4) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b4:
   sc.w x4, x4, (x4) # perform operation
+  beqz x4, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b4_success # SC succeeded, skip retry
+  addi x5, x5, -1 # decrement retry count
+  bnez x5, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b4_success:
   # Check if x4 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x4, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b4, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b4_str)
   LA(x4, scratch) # reload base address
@@ -2987,10 +4012,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b4:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x19, x5) # load rs2: x5 = 0xbd23d64e
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b5_retry:
   lr.w x0, (x5) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b5:
   sc.w x5, x5, (x5) # perform operation
+  beqz x5, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b5_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b5_success:
   # Check if x5 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x5, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b5, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b5_str)
   LA(x5, scratch) # reload base address
@@ -3001,10 +4031,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b5:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x19, x6) # load rs2: x6 = 0x33dd01a4
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x4, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b6_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b6:
   sc.w x6, x6, (x6) # perform operation
+  beqz x6, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b6_success # SC succeeded, skip retry
+  addi x4, x4, -1 # decrement retry count
+  bnez x4, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b6_success:
   # Check if x6 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x6, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b6, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b6_str)
   LA(x6, scratch) # reload base address
@@ -3017,10 +4052,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b6:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x19, x7) # load rs2: x7 = 0x39d3b1ca
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b7_retry:
   lr.w x0, (x7) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b7:
   sc.w x7, x7, (x7) # perform operation
+  beqz x7, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b7_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b7_success:
   # Check if x7 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x7, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b7, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b7_str)
   LA(x7, scratch) # reload base address
@@ -3031,10 +4071,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b7:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x19, x8) # load rs2: x8 = 0x47b4ae5a
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x30, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b8_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b8:
   sc.w x8, x8, (x8) # perform operation
+  beqz x8, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b8_success # SC succeeded, skip retry
+  addi x30, x30, -1 # decrement retry count
+  bnez x30, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b8_success:
   # Check if x8 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x8, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b8, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b8_str)
   LA(x8, scratch) # reload base address
@@ -3045,10 +4090,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b8:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x19, x9) # load rs2: x9 = 0x63413451
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b9_retry:
   lr.w x0, (x9) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b9:
   sc.w x9, x9, (x9) # perform operation
+  beqz x9, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b9_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b9_success:
   # Check if x9 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x9, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b9, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b9_str)
   LA(x9, scratch) # reload base address
@@ -3059,10 +4109,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b9:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x19, x10) # load rs2: x10 = 0x98fb261a
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b10_retry:
   lr.w x0, (x10) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b10:
   sc.w x10, x10, (x10) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b10_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b10_success:
   # Check if x10 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x10, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b10, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b10_str)
   LA(x10, scratch) # reload base address
@@ -3073,10 +4128,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b10:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x19, x11) # load rs2: x11 = 0x8467aa17
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b11_retry:
   lr.w x0, (x11) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b11:
   sc.w x11, x11, (x11) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b11_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b11_success:
   # Check if x11 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x11, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b11, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b11_str)
   LA(x11, scratch) # reload base address
@@ -3087,10 +4147,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b11:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x19, x12) # load rs2: x12 = 0xffcfe09f
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b12_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b12:
   sc.w x12, x12, (x12) # perform operation
+  beqz x12, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b12_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b12_success:
   # Check if x12 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x12, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b12, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b12_str)
   LA(x12, scratch) # reload base address
@@ -3101,10 +4166,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b12:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x19, x13) # load rs2: x13 = 0xf55c4ff0
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b13_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b13:
   sc.w x13, x13, (x13) # perform operation
+  beqz x13, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b13_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b13_success:
   # Check if x13 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x13, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b13, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b13_str)
   LA(x13, scratch) # reload base address
@@ -3115,10 +4185,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b13:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x19, x14) # load rs2: x14 = 0x453e86bd
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b14_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b14:
   sc.w x14, x14, (x14) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b14_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b14_success:
   # Check if x14 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x14, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b14, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b14_str)
   LA(x14, scratch) # reload base address
@@ -3129,10 +4204,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b14:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x19, x15) # load rs2: x15 = 0xf0a82363
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b15_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b15:
   sc.w x15, x15, (x15) # perform operation
+  beqz x15, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b15_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b15_success:
   # Check if x15 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x15, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b15, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b15_str)
   LA(x15, scratch) # reload base address
@@ -3143,10 +4223,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b15:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x19, x16) # load rs2: x16 = 0x363e702d
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b16_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b16:
   sc.w x16, x16, (x16) # perform operation
+  beqz x16, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b16_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b16_success:
   # Check if x16 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x16, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b16, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b16_str)
   LA(x16, scratch) # reload base address
@@ -3157,10 +4242,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b16:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x19, x17) # load rs2: x17 = 0x41f6efb3
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b17_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b17:
   sc.w x17, x17, (x17) # perform operation
+  beqz x17, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b17_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b17_success:
   # Check if x17 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x17, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b17, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b17_str)
   LA(x17, scratch) # reload base address
@@ -3171,10 +4261,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b17:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x19, x18) # load rs2: x18 = 0x18a0a636
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b18_retry:
   lr.w x0, (x18) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b18:
   sc.w x18, x18, (x18) # perform operation
+  beqz x18, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b18_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b18_success:
   # Check if x18 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x18, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b18, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b18_str)
   LA(x18, scratch) # reload base address
@@ -3186,10 +4281,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b18:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x18, x19) # load rs2: x19 = 0x80d5c275
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b19_retry:
   lr.w x0, (x19) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b19:
   sc.w x19, x19, (x19) # perform operation
+  beqz x19, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b19_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b19_success:
   # Check if x19 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x19, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b19, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b19_str)
   LA(x19, scratch) # reload base address
@@ -3200,10 +4300,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b19:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x18, x20) # load rs2: x20 = 0x94e2bc2c
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b20_retry:
   lr.w x0, (x20) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b20:
   sc.w x20, x20, (x20) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b20_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b20_success:
   # Check if x20 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x20, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b20, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b20_str)
   LA(x20, scratch) # reload base address
@@ -3214,10 +4319,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b20:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x18, x21) # load rs2: x21 = 0x8f0a7ecf
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b21_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b21:
   sc.w x21, x21, (x21) # perform operation
+  beqz x21, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b21_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b21_success:
   # Check if x21 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x21, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b21, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b21_str)
   LA(x21, scratch) # reload base address
@@ -3228,10 +4338,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b21:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x18, x22) # load rs2: x22 = 0xccca2109
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b22_retry:
   lr.w x0, (x22) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b22:
   sc.w x22, x22, (x22) # perform operation
+  beqz x22, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b22_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b22_success:
   # Check if x22 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x22, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b22, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b22_str)
   LA(x22, scratch) # reload base address
@@ -3243,10 +4358,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b22:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x18, x23) # load rs2: x23 = 0x62a1c743
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b23_retry:
   lr.w x0, (x23) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b23:
   sc.w x23, x23, (x23) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b23_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b23_success:
   # Check if x23 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x23, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b23, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b23_str)
   LA(x23, scratch) # reload base address
@@ -3257,10 +4377,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b23:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x18, x24) # load rs2: x24 = 0x94b0c47c
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b24_retry:
   lr.w x0, (x24) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b24:
   sc.w x24, x24, (x24) # perform operation
+  beqz x24, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b24_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b24_success:
   # Check if x24 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x24, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b24, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b24_str)
   LA(x24, scratch) # reload base address
@@ -3271,10 +4396,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b24:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x18, x25) # load rs2: x25 = 0xfc010b5f
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b25_retry:
   lr.w x0, (x25) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b25:
   sc.w x25, x25, (x25) # perform operation
+  beqz x25, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b25_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b25_success:
   # Check if x25 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x25, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b25, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b25_str)
   LA(x25, scratch) # reload base address
@@ -3285,10 +4415,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b25:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x18, x26) # load rs2: x26 = 0xdedf2761
   LA(x26, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b26_retry:
   lr.w x0, (x26) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b26:
   sc.w x26, x26, (x26) # perform operation
+  beqz x26, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b26_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b26_success:
   # Check if x26 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x26, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b26, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b26_str)
   LA(x26, scratch) # reload base address
@@ -3299,10 +4434,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b26:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x18, x27) # load rs2: x27 = 0x44f7f301
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b27_retry:
   lr.w x0, (x27) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b27:
   sc.w x27, x27, (x27) # perform operation
+  beqz x27, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b27_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b27_success:
   # Check if x27 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x27, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b27, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b27_str)
   LA(x27, scratch) # reload base address
@@ -3313,10 +4453,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b27:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x18, x28) # load rs2: x28 = 0x7e0ee604
   LA(x28, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b28_retry:
   lr.w x0, (x28) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b28:
   sc.w x28, x28, (x28) # perform operation
+  beqz x28, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b28_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b28_success:
   # Check if x28 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x28, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b28, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b28_str)
   LA(x28, scratch) # reload base address
@@ -3328,10 +4473,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b28:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x18, x29) # load rs2: x29 = 0x4d42f562
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b29_retry:
   lr.w x0, (x29) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b29:
   sc.w x29, x29, (x29) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b29_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b29_success:
   # Check if x29 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x29, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b29, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b29_str)
   LA(x29, scratch) # reload base address
@@ -3342,10 +4492,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b29:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x18, x30) # load rs2: x30 = 0xa18a3b65
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b30_retry:
   lr.w x0, (x30) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b30:
   sc.w x30, x30, (x30) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b30_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b30_success:
   # Check if x30 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x30, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b30, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b30_str)
   LA(x30, scratch) # reload base address
@@ -3356,10 +4511,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b30:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x18, x31) # load rs2: x31 = 0x6ec036ed
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b31_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b31:
   sc.w x31, x31, (x31) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b31_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b31_success:
   # Check if x31 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x31, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b31, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b31_str)
   LA(x31, scratch) # reload base address
@@ -3374,9 +4534,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b31:
 # Testcase: cp_custom_aqrl with suffix ''
   RVTEST_TESTDATA_LOAD_INT(x18, x2) # load rs2: x2 = 0xe179b362
   LA(x3, scratch) # rs1 = base address
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_custom_aqrl_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cp_custom_aqrl:
   sc.w x29, x2, (x3) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cp_custom_aqrl_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cp_custom_aqrl_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_custom_aqrl_success:
   # Check if x29 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x29, Zalrsc_sc_w_cg_cp_custom_aqrl, Zalrsc_sc_w_cg_cp_custom_aqrl_str)
   LA(x3, scratch) # reload base address
@@ -3387,9 +4553,15 @@ Zalrsc_sc_w_cg_cp_custom_aqrl:
 # Testcase: cp_custom_aqrl with suffix '.rl'
   RVTEST_TESTDATA_LOAD_INT(x18, x3) # load rs2: x3 = 0xd0955a66
   LA(x26, scratch) # rs1 = base address
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_custom_aqrl_rl_retry:
   lr.w x0, (x26) # establish reservation
 Zalrsc_sc_w_cg_cp_custom_aqrl_rl:
   sc.w.rl x9, x3, (x26) # perform operation
+  beqz x9, Zalrsc_sc_w_cg_cp_custom_aqrl_rl_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_w_cg_cp_custom_aqrl_rl_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_custom_aqrl_rl_success:
   # Check if x9 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x9, Zalrsc_sc_w_cg_cp_custom_aqrl_rl, Zalrsc_sc_w_cg_cp_custom_aqrl_rl_str)
   LA(x26, scratch) # reload base address
@@ -3400,9 +4572,15 @@ Zalrsc_sc_w_cg_cp_custom_aqrl_rl:
 # Testcase: cp_custom_aqrl with suffix '.aqrl'
   RVTEST_TESTDATA_LOAD_INT(x18, x8) # load rs2: x8 = 0x383ff64e
   LA(x25, scratch) # rs1 = base address
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_custom_aqrl_aqrl_retry:
   lr.w x0, (x25) # establish reservation
 Zalrsc_sc_w_cg_cp_custom_aqrl_aqrl:
   sc.w.aqrl x10, x8, (x25) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cp_custom_aqrl_aqrl_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_custom_aqrl_aqrl_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_custom_aqrl_aqrl_success:
   # Check if x10 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x10, Zalrsc_sc_w_cg_cp_custom_aqrl_aqrl, Zalrsc_sc_w_cg_cp_custom_aqrl_aqrl_str)
   LA(x25, scratch) # reload base address
@@ -3413,9 +4591,15 @@ Zalrsc_sc_w_cg_cp_custom_aqrl_aqrl:
 # Testcase: cp_custom_sc_lr with prev lr.w
   RVTEST_TESTDATA_LOAD_INT(x18, x2) # load rs2: x2 = 0xd02cc3e1
   LA(x8, scratch) # rs1 = base address
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_custom_sc_lr_prev_lr_lr_w_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cp_custom_sc_lr_prev_lr_lr_w:
   sc.w x11, x2, (x8) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cp_custom_sc_lr_prev_lr_lr_w_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cp_custom_sc_lr_prev_lr_lr_w_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_custom_sc_lr_prev_lr_lr_w_success:
   # Check if x11 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x11, Zalrsc_sc_w_cg_cp_custom_sc_lr_prev_lr_lr_w, Zalrsc_sc_w_cg_cp_custom_sc_lr_prev_lr_lr_w_str)
   LA(x8, scratch) # reload base address

--- a/tests/rv64i/Zalrsc/Zalrsc-sc.d-00.S
+++ b/tests/rv64i/Zalrsc/Zalrsc-sc.d-00.S
@@ -37,10 +37,15 @@ RVTEST_BEGIN
 # Testcase cp_rs1_nx0 (Test source rs1 = x1)
   RVTEST_TESTDATA_LOAD_INT(x3, x19) # load rs2: x19 = 0x5152b4be87b49fde
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b1_retry:
   lr.d x0, (x1) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b1:
   sc.d x17, x19, (x1) # perform operation
+  beqz x17, Zalrsc_sc_d_cg_cp_rs1_nx0_b1_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_d_cg_cp_rs1_nx0_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b1_success:
   # Check if x17 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x17, Zalrsc_sc_d_cg_cp_rs1_nx0_b1, Zalrsc_sc_d_cg_cp_rs1_nx0_b1_str)
   LA(x1, scratch) # reload base address
@@ -52,10 +57,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b1:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x730dc8ec6a8832d2
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b2_retry:
   lr.d x0, (x2) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b2:
   sc.d x8, x10, (x2) # perform operation
+  beqz x8, Zalrsc_sc_d_cg_cp_rs1_nx0_b2_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_d_cg_cp_rs1_nx0_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b2_success:
   # Check if x8 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x8, Zalrsc_sc_d_cg_cp_rs1_nx0_b2, Zalrsc_sc_d_cg_cp_rs1_nx0_b2_str)
   LA(x2, scratch) # reload base address
@@ -67,10 +77,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b2:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
   RVTEST_TESTDATA_LOAD_INT(x14, x15) # load rs2: x15 = 0xb786419cd2f06c67
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b3_retry:
   lr.d x0, (x3) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b3:
   sc.d x0, x15, (x3) # perform operation
+  beqz x0, Zalrsc_sc_d_cg_cp_rs1_nx0_b3_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_d_cg_cp_rs1_nx0_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b3_success:
   # Check if x0 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x0, Zalrsc_sc_d_cg_cp_rs1_nx0_b3, Zalrsc_sc_d_cg_cp_rs1_nx0_b3_str)
   LA(x3, scratch) # reload base address
@@ -83,10 +98,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b3:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4)
   RVTEST_TESTDATA_LOAD_INT(x14, x0) # load rs2: x0 = 0x12ed21a692ac349f
   LA(x4, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b4_retry:
   lr.d x0, (x4) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b4:
   sc.d x22, x0, (x4) # perform operation
+  beqz x22, Zalrsc_sc_d_cg_cp_rs1_nx0_b4_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_d_cg_cp_rs1_nx0_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b4_success:
   # Check if x22 contains the expected result. x31 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x31, x8, x7, x22, Zalrsc_sc_d_cg_cp_rs1_nx0_b4, Zalrsc_sc_d_cg_cp_rs1_nx0_b4_str)
   LA(x4, scratch) # reload base address
@@ -97,10 +117,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b4:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x14, x17) # load rs2: x17 = 0x5ff69d09106f0742
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x4, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b5_retry:
   lr.d x0, (x5) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b5:
   sc.d x28, x17, (x5) # perform operation
+  beqz x28, Zalrsc_sc_d_cg_cp_rs1_nx0_b5_success # SC succeeded, skip retry
+  addi x4, x4, -1 # decrement retry count
+  bnez x4, Zalrsc_sc_d_cg_cp_rs1_nx0_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b5_success:
   # Check if x28 contains the expected result. x31 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x31, x8, x7, x28, Zalrsc_sc_d_cg_cp_rs1_nx0_b5, Zalrsc_sc_d_cg_cp_rs1_nx0_b5_str)
   LA(x5, scratch) # reload base address
@@ -111,10 +136,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b5:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x14, x16) # load rs2: x16 = 0x946fb8366a69ad9a
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b6_retry:
   lr.d x0, (x6) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b6:
   sc.d x29, x16, (x6) # perform operation
+  beqz x29, Zalrsc_sc_d_cg_cp_rs1_nx0_b6_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_d_cg_cp_rs1_nx0_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b6_success:
   # Check if x29 contains the expected result. x31 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x31, x8, x7, x29, Zalrsc_sc_d_cg_cp_rs1_nx0_b6, Zalrsc_sc_d_cg_cp_rs1_nx0_b6_str)
   LA(x6, scratch) # reload base address
@@ -127,10 +157,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b6:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7)
   RVTEST_TESTDATA_LOAD_INT(x14, x27) # load rs2: x27 = 0x3dd56d6c8e5d5199
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b7_retry:
   lr.d x0, (x7) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b7:
   sc.d x30, x27, (x7) # perform operation
+  beqz x30, Zalrsc_sc_d_cg_cp_rs1_nx0_b7_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_d_cg_cp_rs1_nx0_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b7_success:
   # Check if x30 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x30, Zalrsc_sc_d_cg_cp_rs1_nx0_b7, Zalrsc_sc_d_cg_cp_rs1_nx0_b7_str)
   LA(x7, scratch) # reload base address
@@ -141,10 +176,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b7:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x14, x11) # load rs2: x11 = 0xc4f9e724bf20a186
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b8_retry:
   lr.d x0, (x8) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b8:
   sc.d x9, x11, (x8) # perform operation
+  beqz x9, Zalrsc_sc_d_cg_cp_rs1_nx0_b8_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_d_cg_cp_rs1_nx0_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b8_success:
   # Check if x9 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x9, Zalrsc_sc_d_cg_cp_rs1_nx0_b8, Zalrsc_sc_d_cg_cp_rs1_nx0_b8_str)
   LA(x8, scratch) # reload base address
@@ -155,10 +195,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b8:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x14, x26) # load rs2: x26 = 0xa7017a6d0825a410
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x30, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b9_retry:
   lr.d x0, (x9) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b9:
   sc.d x20, x26, (x9) # perform operation
+  beqz x20, Zalrsc_sc_d_cg_cp_rs1_nx0_b9_success # SC succeeded, skip retry
+  addi x30, x30, -1 # decrement retry count
+  bnez x30, Zalrsc_sc_d_cg_cp_rs1_nx0_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b9_success:
   # Check if x20 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x20, Zalrsc_sc_d_cg_cp_rs1_nx0_b9, Zalrsc_sc_d_cg_cp_rs1_nx0_b9_str)
   LA(x9, scratch) # reload base address
@@ -169,10 +214,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b9:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x14, x12) # load rs2: x12 = 0xf47c60ea31ff55de
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b10_retry:
   lr.d x0, (x10) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b10:
   sc.d x9, x12, (x10) # perform operation
+  beqz x9, Zalrsc_sc_d_cg_cp_rs1_nx0_b10_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_d_cg_cp_rs1_nx0_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b10_success:
   # Check if x9 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x9, Zalrsc_sc_d_cg_cp_rs1_nx0_b10, Zalrsc_sc_d_cg_cp_rs1_nx0_b10_str)
   LA(x10, scratch) # reload base address
@@ -183,10 +233,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b10:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x14, x24) # load rs2: x24 = 0x73aefddfc3372888
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b11_retry:
   lr.d x0, (x11) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b11:
   sc.d x6, x24, (x11) # perform operation
+  beqz x6, Zalrsc_sc_d_cg_cp_rs1_nx0_b11_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_d_cg_cp_rs1_nx0_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b11_success:
   # Check if x6 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x6, Zalrsc_sc_d_cg_cp_rs1_nx0_b11, Zalrsc_sc_d_cg_cp_rs1_nx0_b11_str)
   LA(x11, scratch) # reload base address
@@ -197,10 +252,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b11:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x14, x27) # load rs2: x27 = 0xb3092b49996695d5
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b12_retry:
   lr.d x0, (x12) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b12:
   sc.d x28, x27, (x12) # perform operation
+  beqz x28, Zalrsc_sc_d_cg_cp_rs1_nx0_b12_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_d_cg_cp_rs1_nx0_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b12_success:
   # Check if x28 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x28, Zalrsc_sc_d_cg_cp_rs1_nx0_b12, Zalrsc_sc_d_cg_cp_rs1_nx0_b12_str)
   LA(x12, scratch) # reload base address
@@ -211,10 +271,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b12:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x14, x7) # load rs2: x7 = 0x25edc55e3355f5f3
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x24, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b13_retry:
   lr.d x0, (x13) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b13:
   sc.d x30, x7, (x13) # perform operation
+  beqz x30, Zalrsc_sc_d_cg_cp_rs1_nx0_b13_success # SC succeeded, skip retry
+  addi x24, x24, -1 # decrement retry count
+  bnez x24, Zalrsc_sc_d_cg_cp_rs1_nx0_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b13_success:
   # Check if x30 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x30, Zalrsc_sc_d_cg_cp_rs1_nx0_b13, Zalrsc_sc_d_cg_cp_rs1_nx0_b13_str)
   LA(x13, scratch) # reload base address
@@ -226,10 +291,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b13:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x10, x17) # load rs2: x17 = 0x8dc17cd2bfff7f95
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b14_retry:
   lr.d x0, (x14) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b14:
   sc.d x2, x17, (x14) # perform operation
+  beqz x2, Zalrsc_sc_d_cg_cp_rs1_nx0_b14_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_d_cg_cp_rs1_nx0_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b14_success:
   # Check if x2 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x2, Zalrsc_sc_d_cg_cp_rs1_nx0_b14, Zalrsc_sc_d_cg_cp_rs1_nx0_b14_str)
   LA(x14, scratch) # reload base address
@@ -240,10 +310,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b14:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x10, x7) # load rs2: x7 = 0x8d6cfc4cb24b3554
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b15_retry:
   lr.d x0, (x15) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b15:
   sc.d x13, x7, (x15) # perform operation
+  beqz x13, Zalrsc_sc_d_cg_cp_rs1_nx0_b15_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_d_cg_cp_rs1_nx0_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b15_success:
   # Check if x13 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x13, Zalrsc_sc_d_cg_cp_rs1_nx0_b15, Zalrsc_sc_d_cg_cp_rs1_nx0_b15_str)
   LA(x15, scratch) # reload base address
@@ -254,10 +329,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b15:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16)
   RVTEST_TESTDATA_LOAD_INT(x10, x23) # load rs2: x23 = 0xc1fe008bdb030a3c
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b16_retry:
   lr.d x0, (x16) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b16:
   sc.d x25, x23, (x16) # perform operation
+  beqz x25, Zalrsc_sc_d_cg_cp_rs1_nx0_b16_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_d_cg_cp_rs1_nx0_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b16_success:
   # Check if x25 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x25, Zalrsc_sc_d_cg_cp_rs1_nx0_b16, Zalrsc_sc_d_cg_cp_rs1_nx0_b16_str)
   LA(x16, scratch) # reload base address
@@ -268,10 +348,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b16:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17)
   RVTEST_TESTDATA_LOAD_INT(x10, x21) # load rs2: x21 = 0x8f6242abe67f01b1
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b17_retry:
   lr.d x0, (x17) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b17:
   sc.d x11, x21, (x17) # perform operation
+  beqz x11, Zalrsc_sc_d_cg_cp_rs1_nx0_b17_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_d_cg_cp_rs1_nx0_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b17_success:
   # Check if x11 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x11, Zalrsc_sc_d_cg_cp_rs1_nx0_b17, Zalrsc_sc_d_cg_cp_rs1_nx0_b17_str)
   LA(x17, scratch) # reload base address
@@ -282,10 +367,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b17:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18)
   RVTEST_TESTDATA_LOAD_INT(x10, x28) # load rs2: x28 = 0xc29567c59fde8995
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b18_retry:
   lr.d x0, (x18) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b18:
   sc.d x22, x28, (x18) # perform operation
+  beqz x22, Zalrsc_sc_d_cg_cp_rs1_nx0_b18_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_d_cg_cp_rs1_nx0_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b18_success:
   # Check if x22 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x22, Zalrsc_sc_d_cg_cp_rs1_nx0_b18, Zalrsc_sc_d_cg_cp_rs1_nx0_b18_str)
   LA(x18, scratch) # reload base address
@@ -296,10 +386,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b18:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19)
   RVTEST_TESTDATA_LOAD_INT(x10, x14) # load rs2: x14 = 0x5321dad5b2b4592c
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b19_retry:
   lr.d x0, (x19) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b19:
   sc.d x24, x14, (x19) # perform operation
+  beqz x24, Zalrsc_sc_d_cg_cp_rs1_nx0_b19_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_d_cg_cp_rs1_nx0_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b19_success:
   # Check if x24 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x24, Zalrsc_sc_d_cg_cp_rs1_nx0_b19, Zalrsc_sc_d_cg_cp_rs1_nx0_b19_str)
   LA(x19, scratch) # reload base address
@@ -310,10 +405,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b19:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20)
   RVTEST_TESTDATA_LOAD_INT(x10, x3) # load rs2: x3 = 0x6aba8cfbdc8bf01b
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b20_retry:
   lr.d x0, (x20) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b20:
   sc.d x29, x3, (x20) # perform operation
+  beqz x29, Zalrsc_sc_d_cg_cp_rs1_nx0_b20_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_d_cg_cp_rs1_nx0_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b20_success:
   # Check if x29 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x29, Zalrsc_sc_d_cg_cp_rs1_nx0_b20, Zalrsc_sc_d_cg_cp_rs1_nx0_b20_str)
   LA(x20, scratch) # reload base address
@@ -324,10 +424,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b20:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21)
   RVTEST_TESTDATA_LOAD_INT(x10, x13) # load rs2: x13 = 0x5abde3453543d5ef
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b21_retry:
   lr.d x0, (x21) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b21:
   sc.d x9, x13, (x21) # perform operation
+  beqz x9, Zalrsc_sc_d_cg_cp_rs1_nx0_b21_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_d_cg_cp_rs1_nx0_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b21_success:
   # Check if x9 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x9, Zalrsc_sc_d_cg_cp_rs1_nx0_b21, Zalrsc_sc_d_cg_cp_rs1_nx0_b21_str)
   LA(x21, scratch) # reload base address
@@ -338,10 +443,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b21:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22)
   RVTEST_TESTDATA_LOAD_INT(x10, x25) # load rs2: x25 = 0x5a86e4f36fd824f5
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x24, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b22_retry:
   lr.d x0, (x22) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b22:
   sc.d x7, x25, (x22) # perform operation
+  beqz x7, Zalrsc_sc_d_cg_cp_rs1_nx0_b22_success # SC succeeded, skip retry
+  addi x24, x24, -1 # decrement retry count
+  bnez x24, Zalrsc_sc_d_cg_cp_rs1_nx0_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b22_success:
   # Check if x7 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x7, Zalrsc_sc_d_cg_cp_rs1_nx0_b22, Zalrsc_sc_d_cg_cp_rs1_nx0_b22_str)
   LA(x22, scratch) # reload base address
@@ -352,10 +462,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b22:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23)
   RVTEST_TESTDATA_LOAD_INT(x10, x26) # load rs2: x26 = 0x9f0f648fe138a202
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b23_retry:
   lr.d x0, (x23) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b23:
   sc.d x7, x26, (x23) # perform operation
+  beqz x7, Zalrsc_sc_d_cg_cp_rs1_nx0_b23_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_d_cg_cp_rs1_nx0_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b23_success:
   # Check if x7 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x7, Zalrsc_sc_d_cg_cp_rs1_nx0_b23, Zalrsc_sc_d_cg_cp_rs1_nx0_b23_str)
   LA(x23, scratch) # reload base address
@@ -366,10 +481,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b23:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24)
   RVTEST_TESTDATA_LOAD_INT(x10, x7) # load rs2: x7 = 0xdb67b5e74d49d4c2
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b24_retry:
   lr.d x0, (x24) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b24:
   sc.d x15, x7, (x24) # perform operation
+  beqz x15, Zalrsc_sc_d_cg_cp_rs1_nx0_b24_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_d_cg_cp_rs1_nx0_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b24_success:
   # Check if x15 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x15, Zalrsc_sc_d_cg_cp_rs1_nx0_b24, Zalrsc_sc_d_cg_cp_rs1_nx0_b24_str)
   LA(x24, scratch) # reload base address
@@ -380,10 +500,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b24:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25)
   RVTEST_TESTDATA_LOAD_INT(x10, x23) # load rs2: x23 = 0x592dd1ed2a1ed52e
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x24, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b25_retry:
   lr.d x0, (x25) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b25:
   sc.d x6, x23, (x25) # perform operation
+  beqz x6, Zalrsc_sc_d_cg_cp_rs1_nx0_b25_success # SC succeeded, skip retry
+  addi x24, x24, -1 # decrement retry count
+  bnez x24, Zalrsc_sc_d_cg_cp_rs1_nx0_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b25_success:
   # Check if x6 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x6, Zalrsc_sc_d_cg_cp_rs1_nx0_b25, Zalrsc_sc_d_cg_cp_rs1_nx0_b25_str)
   LA(x25, scratch) # reload base address
@@ -394,10 +519,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b25:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26)
   RVTEST_TESTDATA_LOAD_INT(x10, x24) # load rs2: x24 = 0xaed681c0f016ff32
   LA(x26, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b26_retry:
   lr.d x0, (x26) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b26:
   sc.d x12, x24, (x26) # perform operation
+  beqz x12, Zalrsc_sc_d_cg_cp_rs1_nx0_b26_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_d_cg_cp_rs1_nx0_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b26_success:
   # Check if x12 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x12, Zalrsc_sc_d_cg_cp_rs1_nx0_b26, Zalrsc_sc_d_cg_cp_rs1_nx0_b26_str)
   LA(x26, scratch) # reload base address
@@ -408,10 +538,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b26:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27)
   RVTEST_TESTDATA_LOAD_INT(x10, x2) # load rs2: x2 = 0x66869b505c266496
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b27_retry:
   lr.d x0, (x27) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b27:
   sc.d x25, x2, (x27) # perform operation
+  beqz x25, Zalrsc_sc_d_cg_cp_rs1_nx0_b27_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_d_cg_cp_rs1_nx0_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b27_success:
   # Check if x25 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x25, Zalrsc_sc_d_cg_cp_rs1_nx0_b27, Zalrsc_sc_d_cg_cp_rs1_nx0_b27_str)
   LA(x27, scratch) # reload base address
@@ -422,10 +557,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b27:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28)
   RVTEST_TESTDATA_LOAD_INT(x10, x20) # load rs2: x20 = 0x4dc69a80fa510c55
   LA(x28, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b28_retry:
   lr.d x0, (x28) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b28:
   sc.d x12, x20, (x28) # perform operation
+  beqz x12, Zalrsc_sc_d_cg_cp_rs1_nx0_b28_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_d_cg_cp_rs1_nx0_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b28_success:
   # Check if x12 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x12, Zalrsc_sc_d_cg_cp_rs1_nx0_b28, Zalrsc_sc_d_cg_cp_rs1_nx0_b28_str)
   LA(x28, scratch) # reload base address
@@ -436,10 +576,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b28:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29)
   RVTEST_TESTDATA_LOAD_INT(x10, x9) # load rs2: x9 = 0xb6ba3aa24c0e7a5c
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b29_retry:
   lr.d x0, (x29) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b29:
   sc.d x2, x9, (x29) # perform operation
+  beqz x2, Zalrsc_sc_d_cg_cp_rs1_nx0_b29_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_d_cg_cp_rs1_nx0_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b29_success:
   # Check if x2 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x2, Zalrsc_sc_d_cg_cp_rs1_nx0_b29, Zalrsc_sc_d_cg_cp_rs1_nx0_b29_str)
   LA(x29, scratch) # reload base address
@@ -450,10 +595,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b29:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30)
   RVTEST_TESTDATA_LOAD_INT(x10, x6) # load rs2: x6 = 0x3b0f90e35b7926ab
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b30_retry:
   lr.d x0, (x30) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b30:
   sc.d x23, x6, (x30) # perform operation
+  beqz x23, Zalrsc_sc_d_cg_cp_rs1_nx0_b30_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_d_cg_cp_rs1_nx0_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b30_success:
   # Check if x23 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x23, Zalrsc_sc_d_cg_cp_rs1_nx0_b30, Zalrsc_sc_d_cg_cp_rs1_nx0_b30_str)
   LA(x30, scratch) # reload base address
@@ -465,10 +615,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b30:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31)
   RVTEST_TESTDATA_LOAD_INT(x10, x6) # load rs2: x6 = 0xcae385bb4a5a890e
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs1_nx0_b31_retry:
   lr.d x0, (x31) # establish reservation
 Zalrsc_sc_d_cg_cp_rs1_nx0_b31:
   sc.d x11, x6, (x31) # perform operation
+  beqz x11, Zalrsc_sc_d_cg_cp_rs1_nx0_b31_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_d_cg_cp_rs1_nx0_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs1_nx0_b31_success:
   # Check if x11 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x11, Zalrsc_sc_d_cg_cp_rs1_nx0_b31, Zalrsc_sc_d_cg_cp_rs1_nx0_b31_str)
   LA(x31, scratch) # reload base address
@@ -483,10 +638,15 @@ Zalrsc_sc_d_cg_cp_rs1_nx0_b31:
 # Testcase cp_rs2 (Test source rs2 = x0)
   RVTEST_TESTDATA_LOAD_INT(x10, x0) # load rs2: x0 = 0x363e2cf037699aa4
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x24, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b0_retry:
   lr.d x0, (x19) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b0:
   sc.d x16, x0, (x19) # perform operation
+  beqz x16, Zalrsc_sc_d_cg_cp_rs2_b0_success # SC succeeded, skip retry
+  addi x24, x24, -1 # decrement retry count
+  bnez x24, Zalrsc_sc_d_cg_cp_rs2_b0_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b0_success:
   # Check if x16 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x16, Zalrsc_sc_d_cg_cp_rs2_b0, Zalrsc_sc_d_cg_cp_rs2_b0_str)
   LA(x19, scratch) # reload base address
@@ -497,10 +657,15 @@ Zalrsc_sc_d_cg_cp_rs2_b0:
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x10, x1) # load rs2: x1 = 0x9925f2c86e82a4d4
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b1_retry:
   lr.d x0, (x20) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b1:
   sc.d x30, x1, (x20) # perform operation
+  beqz x30, Zalrsc_sc_d_cg_cp_rs2_b1_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_d_cg_cp_rs2_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b1_success:
   # Check if x30 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x30, Zalrsc_sc_d_cg_cp_rs2_b1, Zalrsc_sc_d_cg_cp_rs2_b1_str)
   LA(x20, scratch) # reload base address
@@ -511,10 +676,15 @@ Zalrsc_sc_d_cg_cp_rs2_b1:
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x10, x2) # load rs2: x2 = 0xdef7cf02beb1572d
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b2_retry:
   lr.d x0, (x27) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b2:
   sc.d x29, x2, (x27) # perform operation
+  beqz x29, Zalrsc_sc_d_cg_cp_rs2_b2_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_d_cg_cp_rs2_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b2_success:
   # Check if x29 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x29, Zalrsc_sc_d_cg_cp_rs2_b2, Zalrsc_sc_d_cg_cp_rs2_b2_str)
   LA(x27, scratch) # reload base address
@@ -525,10 +695,15 @@ Zalrsc_sc_d_cg_cp_rs2_b2:
 # Testcase cp_rs2 (Test source rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x10, x3) # load rs2: x3 = 0x9a6c2c49e8b6da37
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b3_retry:
   lr.d x0, (x9) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b3:
   sc.d x2, x3, (x9) # perform operation
+  beqz x2, Zalrsc_sc_d_cg_cp_rs2_b3_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_d_cg_cp_rs2_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b3_success:
   # Check if x2 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x2, Zalrsc_sc_d_cg_cp_rs2_b3, Zalrsc_sc_d_cg_cp_rs2_b3_str)
   LA(x9, scratch) # reload base address
@@ -541,10 +716,15 @@ Zalrsc_sc_d_cg_cp_rs2_b3:
 # Testcase cp_rs2 (Test source rs2 = x4)
   RVTEST_TESTDATA_LOAD_INT(x10, x4) # load rs2: x4 = 0x9fa5362f33fdabaf
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b4_retry:
   lr.d x0, (x21) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b4:
   sc.d x15, x4, (x21) # perform operation
+  beqz x15, Zalrsc_sc_d_cg_cp_rs2_b4_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_d_cg_cp_rs2_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b4_success:
   # Check if x15 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x15, Zalrsc_sc_d_cg_cp_rs2_b4, Zalrsc_sc_d_cg_cp_rs2_b4_str)
   LA(x21, scratch) # reload base address
@@ -555,10 +735,15 @@ Zalrsc_sc_d_cg_cp_rs2_b4:
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x10, x5) # load rs2: x5 = 0x4ca2c7a6bbc1bcf8
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b5_retry:
   lr.d x0, (x25) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b5:
   sc.d x14, x5, (x25) # perform operation
+  beqz x14, Zalrsc_sc_d_cg_cp_rs2_b5_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_d_cg_cp_rs2_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b5_success:
   # Check if x14 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x14, Zalrsc_sc_d_cg_cp_rs2_b5, Zalrsc_sc_d_cg_cp_rs2_b5_str)
   LA(x25, scratch) # reload base address
@@ -569,10 +754,15 @@ Zalrsc_sc_d_cg_cp_rs2_b5:
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x10, x6) # load rs2: x6 = 0xd53dbf444f1b5b50
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b6_retry:
   lr.d x0, (x23) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b6:
   sc.d x3, x6, (x23) # perform operation
+  beqz x3, Zalrsc_sc_d_cg_cp_rs2_b6_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_d_cg_cp_rs2_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b6_success:
   # Check if x3 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x3, Zalrsc_sc_d_cg_cp_rs2_b6, Zalrsc_sc_d_cg_cp_rs2_b6_str)
   LA(x23, scratch) # reload base address
@@ -585,10 +775,15 @@ Zalrsc_sc_d_cg_cp_rs2_b6:
 # Testcase cp_rs2 (Test source rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x10, x7) # load rs2: x7 = 0xf3b48fc5dc5b23b2
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b7_retry:
   lr.d x0, (x9) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b7:
   sc.d x2, x7, (x9) # perform operation
+  beqz x2, Zalrsc_sc_d_cg_cp_rs2_b7_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_d_cg_cp_rs2_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b7_success:
   # Check if x2 contains the expected result. x26 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x26, x13, x12, x2, Zalrsc_sc_d_cg_cp_rs2_b7, Zalrsc_sc_d_cg_cp_rs2_b7_str)
   LA(x9, scratch) # reload base address
@@ -599,10 +794,15 @@ Zalrsc_sc_d_cg_cp_rs2_b7:
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x10, x8) # load rs2: x8 = 0x54369a7fc2d8fb74
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b8_retry:
   lr.d x0, (x3) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b8:
   sc.d x25, x8, (x3) # perform operation
+  beqz x25, Zalrsc_sc_d_cg_cp_rs2_b8_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_d_cg_cp_rs2_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b8_success:
   # Check if x25 contains the expected result. x26 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x26, x13, x12, x25, Zalrsc_sc_d_cg_cp_rs2_b8, Zalrsc_sc_d_cg_cp_rs2_b8_str)
   LA(x3, scratch) # reload base address
@@ -613,10 +813,15 @@ Zalrsc_sc_d_cg_cp_rs2_b8:
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x10, x9) # load rs2: x9 = 0x1befde52c181eabe
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b9_retry:
   lr.d x0, (x18) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b9:
   sc.d x4, x9, (x18) # perform operation
+  beqz x4, Zalrsc_sc_d_cg_cp_rs2_b9_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_d_cg_cp_rs2_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b9_success:
   # Check if x4 contains the expected result. x26 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x26, x13, x12, x4, Zalrsc_sc_d_cg_cp_rs2_b9, Zalrsc_sc_d_cg_cp_rs2_b9_str)
   LA(x18, scratch) # reload base address
@@ -628,10 +833,15 @@ Zalrsc_sc_d_cg_cp_rs2_b9:
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x30, x10) # load rs2: x10 = 0xc7ef6580177a5616
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b10_retry:
   lr.d x0, (x9) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b10:
   sc.d x22, x10, (x9) # perform operation
+  beqz x22, Zalrsc_sc_d_cg_cp_rs2_b10_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_d_cg_cp_rs2_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b10_success:
   # Check if x22 contains the expected result. x26 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x26, x13, x12, x22, Zalrsc_sc_d_cg_cp_rs2_b10, Zalrsc_sc_d_cg_cp_rs2_b10_str)
   LA(x9, scratch) # reload base address
@@ -642,10 +852,15 @@ Zalrsc_sc_d_cg_cp_rs2_b10:
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x30, x11) # load rs2: x11 = 0xb334460edeb98168
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b11_retry:
   lr.d x0, (x10) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b11:
   sc.d x9, x11, (x10) # perform operation
+  beqz x9, Zalrsc_sc_d_cg_cp_rs2_b11_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_d_cg_cp_rs2_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b11_success:
   # Check if x9 contains the expected result. x26 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x26, x13, x12, x9, Zalrsc_sc_d_cg_cp_rs2_b11, Zalrsc_sc_d_cg_cp_rs2_b11_str)
   LA(x10, scratch) # reload base address
@@ -658,10 +873,15 @@ Zalrsc_sc_d_cg_cp_rs2_b11:
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x30, x12) # load rs2: x12 = 0x40b3906a689b24f7
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b12_retry:
   lr.d x0, (x27) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b12:
   sc.d x10, x12, (x27) # perform operation
+  beqz x10, Zalrsc_sc_d_cg_cp_rs2_b12_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_d_cg_cp_rs2_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b12_success:
   # Check if x10 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x10, Zalrsc_sc_d_cg_cp_rs2_b12, Zalrsc_sc_d_cg_cp_rs2_b12_str)
   LA(x27, scratch) # reload base address
@@ -672,10 +892,15 @@ Zalrsc_sc_d_cg_cp_rs2_b12:
 # Testcase cp_rs2 (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x30, x13) # load rs2: x13 = 0xf544be85cba23538
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b13_retry:
   lr.d x0, (x29) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b13:
   sc.d x27, x13, (x29) # perform operation
+  beqz x27, Zalrsc_sc_d_cg_cp_rs2_b13_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_d_cg_cp_rs2_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b13_success:
   # Check if x27 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x27, Zalrsc_sc_d_cg_cp_rs2_b13, Zalrsc_sc_d_cg_cp_rs2_b13_str)
   LA(x29, scratch) # reload base address
@@ -686,10 +911,15 @@ Zalrsc_sc_d_cg_cp_rs2_b13:
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x30, x14) # load rs2: x14 = 0xb9eedf6567a0e569
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x4, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b14_retry:
   lr.d x0, (x22) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b14:
   sc.d x16, x14, (x22) # perform operation
+  beqz x16, Zalrsc_sc_d_cg_cp_rs2_b14_success # SC succeeded, skip retry
+  addi x4, x4, -1 # decrement retry count
+  bnez x4, Zalrsc_sc_d_cg_cp_rs2_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b14_success:
   # Check if x16 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x16, Zalrsc_sc_d_cg_cp_rs2_b14, Zalrsc_sc_d_cg_cp_rs2_b14_str)
   LA(x22, scratch) # reload base address
@@ -700,10 +930,15 @@ Zalrsc_sc_d_cg_cp_rs2_b14:
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x30, x15) # load rs2: x15 = 0x71775f723c5c5c24
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b15_retry:
   lr.d x0, (x31) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b15:
   sc.d x16, x15, (x31) # perform operation
+  beqz x16, Zalrsc_sc_d_cg_cp_rs2_b15_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_d_cg_cp_rs2_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b15_success:
   # Check if x16 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x16, Zalrsc_sc_d_cg_cp_rs2_b15, Zalrsc_sc_d_cg_cp_rs2_b15_str)
   LA(x31, scratch) # reload base address
@@ -714,10 +949,15 @@ Zalrsc_sc_d_cg_cp_rs2_b15:
 # Testcase cp_rs2 (Test source rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x30, x16) # load rs2: x16 = 0x24a4a6f058f4a098
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b16_retry:
   lr.d x0, (x25) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b16:
   sc.d x12, x16, (x25) # perform operation
+  beqz x12, Zalrsc_sc_d_cg_cp_rs2_b16_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_d_cg_cp_rs2_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b16_success:
   # Check if x12 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x12, Zalrsc_sc_d_cg_cp_rs2_b16, Zalrsc_sc_d_cg_cp_rs2_b16_str)
   LA(x25, scratch) # reload base address
@@ -728,10 +968,15 @@ Zalrsc_sc_d_cg_cp_rs2_b16:
 # Testcase cp_rs2 (Test source rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x30, x17) # load rs2: x17 = 0xe52f524f8b54bf16
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b17_retry:
   lr.d x0, (x29) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b17:
   sc.d x19, x17, (x29) # perform operation
+  beqz x19, Zalrsc_sc_d_cg_cp_rs2_b17_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_d_cg_cp_rs2_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b17_success:
   # Check if x19 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x19, Zalrsc_sc_d_cg_cp_rs2_b17, Zalrsc_sc_d_cg_cp_rs2_b17_str)
   LA(x29, scratch) # reload base address
@@ -742,10 +987,15 @@ Zalrsc_sc_d_cg_cp_rs2_b17:
 # Testcase cp_rs2 (Test source rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x30, x18) # load rs2: x18 = 0x7da375f5fbcb0dae
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b18_retry:
   lr.d x0, (x23) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b18:
   sc.d x14, x18, (x23) # perform operation
+  beqz x14, Zalrsc_sc_d_cg_cp_rs2_b18_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_d_cg_cp_rs2_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b18_success:
   # Check if x14 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x14, Zalrsc_sc_d_cg_cp_rs2_b18, Zalrsc_sc_d_cg_cp_rs2_b18_str)
   LA(x23, scratch) # reload base address
@@ -756,10 +1006,15 @@ Zalrsc_sc_d_cg_cp_rs2_b18:
 # Testcase cp_rs2 (Test source rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x30, x19) # load rs2: x19 = 0xe745847d75278bd8
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b19_retry:
   lr.d x0, (x5) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b19:
   sc.d x2, x19, (x5) # perform operation
+  beqz x2, Zalrsc_sc_d_cg_cp_rs2_b19_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_d_cg_cp_rs2_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b19_success:
   # Check if x2 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x2, Zalrsc_sc_d_cg_cp_rs2_b19, Zalrsc_sc_d_cg_cp_rs2_b19_str)
   LA(x5, scratch) # reload base address
@@ -770,10 +1025,15 @@ Zalrsc_sc_d_cg_cp_rs2_b19:
 # Testcase cp_rs2 (Test source rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x30, x20) # load rs2: x20 = 0xbcf21fff0b6f6197
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b20_retry:
   lr.d x0, (x13) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b20:
   sc.d x25, x20, (x13) # perform operation
+  beqz x25, Zalrsc_sc_d_cg_cp_rs2_b20_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_d_cg_cp_rs2_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b20_success:
   # Check if x25 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x25, Zalrsc_sc_d_cg_cp_rs2_b20, Zalrsc_sc_d_cg_cp_rs2_b20_str)
   LA(x13, scratch) # reload base address
@@ -784,10 +1044,15 @@ Zalrsc_sc_d_cg_cp_rs2_b20:
 # Testcase cp_rs2 (Test source rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x30, x21) # load rs2: x21 = 0x7bf7be613f9ab751
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b21_retry:
   lr.d x0, (x16) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b21:
   sc.d x11, x21, (x16) # perform operation
+  beqz x11, Zalrsc_sc_d_cg_cp_rs2_b21_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_d_cg_cp_rs2_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b21_success:
   # Check if x11 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x11, Zalrsc_sc_d_cg_cp_rs2_b21, Zalrsc_sc_d_cg_cp_rs2_b21_str)
   LA(x16, scratch) # reload base address
@@ -798,10 +1063,15 @@ Zalrsc_sc_d_cg_cp_rs2_b21:
 # Testcase cp_rs2 (Test source rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x30, x22) # load rs2: x22 = 0xcce3ac021c4eb8f6
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b22_retry:
   lr.d x0, (x19) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b22:
   sc.d x5, x22, (x19) # perform operation
+  beqz x5, Zalrsc_sc_d_cg_cp_rs2_b22_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_d_cg_cp_rs2_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b22_success:
   # Check if x5 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x5, Zalrsc_sc_d_cg_cp_rs2_b22, Zalrsc_sc_d_cg_cp_rs2_b22_str)
   LA(x19, scratch) # reload base address
@@ -812,10 +1082,15 @@ Zalrsc_sc_d_cg_cp_rs2_b22:
 # Testcase cp_rs2 (Test source rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x30, x23) # load rs2: x23 = 0xc9873ddc110e0c39
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b23_retry:
   lr.d x0, (x15) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b23:
   sc.d x14, x23, (x15) # perform operation
+  beqz x14, Zalrsc_sc_d_cg_cp_rs2_b23_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_d_cg_cp_rs2_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b23_success:
   # Check if x14 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x14, Zalrsc_sc_d_cg_cp_rs2_b23, Zalrsc_sc_d_cg_cp_rs2_b23_str)
   LA(x15, scratch) # reload base address
@@ -826,10 +1101,15 @@ Zalrsc_sc_d_cg_cp_rs2_b23:
 # Testcase cp_rs2 (Test source rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x30, x24) # load rs2: x24 = 0x46cdc27d9a7416ba
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b24_retry:
   lr.d x0, (x1) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b24:
   sc.d x27, x24, (x1) # perform operation
+  beqz x27, Zalrsc_sc_d_cg_cp_rs2_b24_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_d_cg_cp_rs2_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b24_success:
   # Check if x27 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x27, Zalrsc_sc_d_cg_cp_rs2_b24, Zalrsc_sc_d_cg_cp_rs2_b24_str)
   LA(x1, scratch) # reload base address
@@ -840,10 +1120,15 @@ Zalrsc_sc_d_cg_cp_rs2_b24:
 # Testcase cp_rs2 (Test source rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x30, x25) # load rs2: x25 = 0x2a76f791c2f57d10
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x5, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b25_retry:
   lr.d x0, (x12) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b25:
   sc.d x3, x25, (x12) # perform operation
+  beqz x3, Zalrsc_sc_d_cg_cp_rs2_b25_success # SC succeeded, skip retry
+  addi x5, x5, -1 # decrement retry count
+  bnez x5, Zalrsc_sc_d_cg_cp_rs2_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b25_success:
   # Check if x3 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x3, Zalrsc_sc_d_cg_cp_rs2_b25, Zalrsc_sc_d_cg_cp_rs2_b25_str)
   LA(x12, scratch) # reload base address
@@ -855,10 +1140,15 @@ Zalrsc_sc_d_cg_cp_rs2_b25:
 # Testcase cp_rs2 (Test source rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x30, x26) # load rs2: x26 = 0x993ed405091446cc
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b26_retry:
   lr.d x0, (x5) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b26:
   sc.d x17, x26, (x5) # perform operation
+  beqz x17, Zalrsc_sc_d_cg_cp_rs2_b26_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_d_cg_cp_rs2_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b26_success:
   # Check if x17 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x17, Zalrsc_sc_d_cg_cp_rs2_b26, Zalrsc_sc_d_cg_cp_rs2_b26_str)
   LA(x5, scratch) # reload base address
@@ -869,10 +1159,15 @@ Zalrsc_sc_d_cg_cp_rs2_b26:
 # Testcase cp_rs2 (Test source rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x30, x27) # load rs2: x27 = 0x58876ce09fd01908
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b27_retry:
   lr.d x0, (x19) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b27:
   sc.d x17, x27, (x19) # perform operation
+  beqz x17, Zalrsc_sc_d_cg_cp_rs2_b27_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_d_cg_cp_rs2_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b27_success:
   # Check if x17 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x17, Zalrsc_sc_d_cg_cp_rs2_b27, Zalrsc_sc_d_cg_cp_rs2_b27_str)
   LA(x19, scratch) # reload base address
@@ -883,10 +1178,15 @@ Zalrsc_sc_d_cg_cp_rs2_b27:
 # Testcase cp_rs2 (Test source rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x30, x28) # load rs2: x28 = 0x9a1000ace59f924f
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b28_retry:
   lr.d x0, (x23) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b28:
   sc.d x2, x28, (x23) # perform operation
+  beqz x2, Zalrsc_sc_d_cg_cp_rs2_b28_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_d_cg_cp_rs2_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b28_success:
   # Check if x2 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x2, Zalrsc_sc_d_cg_cp_rs2_b28, Zalrsc_sc_d_cg_cp_rs2_b28_str)
   LA(x23, scratch) # reload base address
@@ -897,10 +1197,15 @@ Zalrsc_sc_d_cg_cp_rs2_b28:
 # Testcase cp_rs2 (Test source rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x30, x29) # load rs2: x29 = 0x59d720d83328b55d
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b29_retry:
   lr.d x0, (x5) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b29:
   sc.d x3, x29, (x5) # perform operation
+  beqz x3, Zalrsc_sc_d_cg_cp_rs2_b29_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_d_cg_cp_rs2_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b29_success:
   # Check if x3 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x3, Zalrsc_sc_d_cg_cp_rs2_b29, Zalrsc_sc_d_cg_cp_rs2_b29_str)
   LA(x5, scratch) # reload base address
@@ -912,10 +1217,15 @@ Zalrsc_sc_d_cg_cp_rs2_b29:
 # Testcase cp_rs2 (Test source rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x19, x30) # load rs2: x30 = 0xff5547228ed1ba54
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b30_retry:
   lr.d x0, (x20) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b30:
   sc.d x3, x30, (x20) # perform operation
+  beqz x3, Zalrsc_sc_d_cg_cp_rs2_b30_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_d_cg_cp_rs2_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b30_success:
   # Check if x3 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x3, Zalrsc_sc_d_cg_cp_rs2_b30, Zalrsc_sc_d_cg_cp_rs2_b30_str)
   LA(x20, scratch) # reload base address
@@ -926,10 +1236,15 @@ Zalrsc_sc_d_cg_cp_rs2_b30:
 # Testcase cp_rs2 (Test source rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x19, x31) # load rs2: x31 = 0x3683654ac239e3e0
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_b31_retry:
   lr.d x0, (x25) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_b31:
   sc.d x22, x31, (x25) # perform operation
+  beqz x22, Zalrsc_sc_d_cg_cp_rs2_b31_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_d_cg_cp_rs2_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_b31_success:
   # Check if x22 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x22, Zalrsc_sc_d_cg_cp_rs2_b31, Zalrsc_sc_d_cg_cp_rs2_b31_str)
   LA(x25, scratch) # reload base address
@@ -944,10 +1259,15 @@ Zalrsc_sc_d_cg_cp_rs2_b31:
 # Testcase cp_rd (Test destination rd = x0)
   RVTEST_TESTDATA_LOAD_INT(x19, x5) # load rs2: x5 = 0x510b7401fbb755e2
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x24, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b0_retry:
   lr.d x0, (x30) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b0:
   sc.d x0, x5, (x30) # perform operation
+  beqz x0, Zalrsc_sc_d_cg_cp_rd_b0_success # SC succeeded, skip retry
+  addi x24, x24, -1 # decrement retry count
+  bnez x24, Zalrsc_sc_d_cg_cp_rd_b0_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b0_success:
   # Check if x0 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x0, Zalrsc_sc_d_cg_cp_rd_b0, Zalrsc_sc_d_cg_cp_rd_b0_str)
   LA(x30, scratch) # reload base address
@@ -958,10 +1278,15 @@ Zalrsc_sc_d_cg_cp_rd_b0:
 # Testcase cp_rd (Test destination rd = x1)
   RVTEST_TESTDATA_LOAD_INT(x19, x23) # load rs2: x23 = 0xba39100422c2347b
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b1_retry:
   lr.d x0, (x12) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b1:
   sc.d x1, x23, (x12) # perform operation
+  beqz x1, Zalrsc_sc_d_cg_cp_rd_b1_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_d_cg_cp_rd_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b1_success:
   # Check if x1 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x1, Zalrsc_sc_d_cg_cp_rd_b1, Zalrsc_sc_d_cg_cp_rd_b1_str)
   LA(x12, scratch) # reload base address
@@ -972,10 +1297,15 @@ Zalrsc_sc_d_cg_cp_rd_b1:
 # Testcase cp_rd (Test destination rd = x2)
   RVTEST_TESTDATA_LOAD_INT(x19, x5) # load rs2: x5 = 0xdc187d2b66501842
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b2_retry:
   lr.d x0, (x24) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b2:
   sc.d x2, x5, (x24) # perform operation
+  beqz x2, Zalrsc_sc_d_cg_cp_rd_b2_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_d_cg_cp_rd_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b2_success:
   # Check if x2 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x2, Zalrsc_sc_d_cg_cp_rd_b2, Zalrsc_sc_d_cg_cp_rd_b2_str)
   LA(x24, scratch) # reload base address
@@ -986,10 +1316,15 @@ Zalrsc_sc_d_cg_cp_rd_b2:
 # Testcase cp_rd (Test destination rd = x3)
   RVTEST_TESTDATA_LOAD_INT(x19, x6) # load rs2: x6 = 0xaaed4fb2fec26f20
   LA(x26, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b3_retry:
   lr.d x0, (x26) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b3:
   sc.d x3, x6, (x26) # perform operation
+  beqz x3, Zalrsc_sc_d_cg_cp_rd_b3_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_d_cg_cp_rd_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b3_success:
   # Check if x3 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x3, Zalrsc_sc_d_cg_cp_rd_b3, Zalrsc_sc_d_cg_cp_rd_b3_str)
   LA(x26, scratch) # reload base address
@@ -1000,10 +1335,15 @@ Zalrsc_sc_d_cg_cp_rd_b3:
 # Testcase cp_rd (Test destination rd = x4)
   RVTEST_TESTDATA_LOAD_INT(x19, x5) # load rs2: x5 = 0x3b394ade372a2e71
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b4_retry:
   lr.d x0, (x17) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b4:
   sc.d x4, x5, (x17) # perform operation
+  beqz x4, Zalrsc_sc_d_cg_cp_rd_b4_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_d_cg_cp_rd_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b4_success:
   # Check if x4 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x4, Zalrsc_sc_d_cg_cp_rd_b4, Zalrsc_sc_d_cg_cp_rd_b4_str)
   LA(x17, scratch) # reload base address
@@ -1014,10 +1354,15 @@ Zalrsc_sc_d_cg_cp_rd_b4:
 # Testcase cp_rd (Test destination rd = x5)
   RVTEST_TESTDATA_LOAD_INT(x19, x0) # load rs2: x0 = 0x6c9f2eda9c20f42d
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x24, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b5_retry:
   lr.d x0, (x9) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b5:
   sc.d x5, x0, (x9) # perform operation
+  beqz x5, Zalrsc_sc_d_cg_cp_rd_b5_success # SC succeeded, skip retry
+  addi x24, x24, -1 # decrement retry count
+  bnez x24, Zalrsc_sc_d_cg_cp_rd_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b5_success:
   # Check if x5 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x5, Zalrsc_sc_d_cg_cp_rd_b5, Zalrsc_sc_d_cg_cp_rd_b5_str)
   LA(x9, scratch) # reload base address
@@ -1028,10 +1373,15 @@ Zalrsc_sc_d_cg_cp_rd_b5:
 # Testcase cp_rd (Test destination rd = x6)
   RVTEST_TESTDATA_LOAD_INT(x19, x29) # load rs2: x29 = 0x068e54b71cebf196
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b6_retry:
   lr.d x0, (x17) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b6:
   sc.d x6, x29, (x17) # perform operation
+  beqz x6, Zalrsc_sc_d_cg_cp_rd_b6_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_d_cg_cp_rd_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b6_success:
   # Check if x6 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x6, Zalrsc_sc_d_cg_cp_rd_b6, Zalrsc_sc_d_cg_cp_rd_b6_str)
   LA(x17, scratch) # reload base address
@@ -1044,10 +1394,15 @@ Zalrsc_sc_d_cg_cp_rd_b6:
 # Testcase cp_rd (Test destination rd = x7)
   RVTEST_TESTDATA_LOAD_INT(x19, x26) # load rs2: x26 = 0x2291ed004fda4ab4
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b7_retry:
   lr.d x0, (x24) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b7:
   sc.d x7, x26, (x24) # perform operation
+  beqz x7, Zalrsc_sc_d_cg_cp_rd_b7_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_d_cg_cp_rd_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b7_success:
   # Check if x7 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x7, Zalrsc_sc_d_cg_cp_rd_b7, Zalrsc_sc_d_cg_cp_rd_b7_str)
   LA(x24, scratch) # reload base address
@@ -1058,10 +1413,15 @@ Zalrsc_sc_d_cg_cp_rd_b7:
 # Testcase cp_rd (Test destination rd = x8)
   RVTEST_TESTDATA_LOAD_INT(x19, x26) # load rs2: x26 = 0x54f66e95fbaa5f4f
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b8_retry:
   lr.d x0, (x9) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b8:
   sc.d x8, x26, (x9) # perform operation
+  beqz x8, Zalrsc_sc_d_cg_cp_rd_b8_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_d_cg_cp_rd_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b8_success:
   # Check if x8 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x8, Zalrsc_sc_d_cg_cp_rd_b8, Zalrsc_sc_d_cg_cp_rd_b8_str)
   LA(x9, scratch) # reload base address
@@ -1072,10 +1432,15 @@ Zalrsc_sc_d_cg_cp_rd_b8:
 # Testcase cp_rd (Test destination rd = x9)
   RVTEST_TESTDATA_LOAD_INT(x19, x25) # load rs2: x25 = 0xc94d834bb84a4a53
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b9_retry:
   lr.d x0, (x31) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b9:
   sc.d x9, x25, (x31) # perform operation
+  beqz x9, Zalrsc_sc_d_cg_cp_rd_b9_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_d_cg_cp_rd_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b9_success:
   # Check if x9 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x9, Zalrsc_sc_d_cg_cp_rd_b9, Zalrsc_sc_d_cg_cp_rd_b9_str)
   LA(x31, scratch) # reload base address
@@ -1087,10 +1452,15 @@ Zalrsc_sc_d_cg_cp_rd_b9:
 # Testcase cp_rd (Test destination rd = x10)
   RVTEST_TESTDATA_LOAD_INT(x19, x11) # load rs2: x11 = 0x715c400c947cb9cf
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b10_retry:
   lr.d x0, (x1) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b10:
   sc.d x10, x11, (x1) # perform operation
+  beqz x10, Zalrsc_sc_d_cg_cp_rd_b10_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_d_cg_cp_rd_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b10_success:
   # Check if x10 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x10, Zalrsc_sc_d_cg_cp_rd_b10, Zalrsc_sc_d_cg_cp_rd_b10_str)
   LA(x1, scratch) # reload base address
@@ -1101,10 +1471,15 @@ Zalrsc_sc_d_cg_cp_rd_b10:
 # Testcase cp_rd (Test destination rd = x11)
   RVTEST_TESTDATA_LOAD_INT(x19, x23) # load rs2: x23 = 0x9e2e88bc39cbab87
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b11_retry:
   lr.d x0, (x6) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b11:
   sc.d x11, x23, (x6) # perform operation
+  beqz x11, Zalrsc_sc_d_cg_cp_rd_b11_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_d_cg_cp_rd_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b11_success:
   # Check if x11 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x11, Zalrsc_sc_d_cg_cp_rd_b11, Zalrsc_sc_d_cg_cp_rd_b11_str)
   LA(x6, scratch) # reload base address
@@ -1115,10 +1490,15 @@ Zalrsc_sc_d_cg_cp_rd_b11:
 # Testcase cp_rd (Test destination rd = x12)
   RVTEST_TESTDATA_LOAD_INT(x19, x9) # load rs2: x9 = 0x10e3747e72b28ad1
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b12_retry:
   lr.d x0, (x10) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b12:
   sc.d x12, x9, (x10) # perform operation
+  beqz x12, Zalrsc_sc_d_cg_cp_rd_b12_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_d_cg_cp_rd_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b12_success:
   # Check if x12 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x12, Zalrsc_sc_d_cg_cp_rd_b12, Zalrsc_sc_d_cg_cp_rd_b12_str)
   LA(x10, scratch) # reload base address
@@ -1129,10 +1509,15 @@ Zalrsc_sc_d_cg_cp_rd_b12:
 # Testcase cp_rd (Test destination rd = x13)
   RVTEST_TESTDATA_LOAD_INT(x19, x2) # load rs2: x2 = 0x34fd50f7529775fe
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b13_retry:
   lr.d x0, (x7) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b13:
   sc.d x13, x2, (x7) # perform operation
+  beqz x13, Zalrsc_sc_d_cg_cp_rd_b13_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_d_cg_cp_rd_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b13_success:
   # Check if x13 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x13, Zalrsc_sc_d_cg_cp_rd_b13, Zalrsc_sc_d_cg_cp_rd_b13_str)
   LA(x7, scratch) # reload base address
@@ -1143,10 +1528,15 @@ Zalrsc_sc_d_cg_cp_rd_b13:
 # Testcase cp_rd (Test destination rd = x14)
   RVTEST_TESTDATA_LOAD_INT(x19, x21) # load rs2: x21 = 0x107e7ab6f44ee501
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b14_retry:
   lr.d x0, (x7) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b14:
   sc.d x14, x21, (x7) # perform operation
+  beqz x14, Zalrsc_sc_d_cg_cp_rd_b14_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_d_cg_cp_rd_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b14_success:
   # Check if x14 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x14, Zalrsc_sc_d_cg_cp_rd_b14, Zalrsc_sc_d_cg_cp_rd_b14_str)
   LA(x7, scratch) # reload base address
@@ -1157,10 +1547,15 @@ Zalrsc_sc_d_cg_cp_rd_b14:
 # Testcase cp_rd (Test destination rd = x15)
   RVTEST_TESTDATA_LOAD_INT(x19, x8) # load rs2: x8 = 0x9b02c030dded9160
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b15_retry:
   lr.d x0, (x10) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b15:
   sc.d x15, x8, (x10) # perform operation
+  beqz x15, Zalrsc_sc_d_cg_cp_rd_b15_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_d_cg_cp_rd_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b15_success:
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zalrsc_sc_d_cg_cp_rd_b15, Zalrsc_sc_d_cg_cp_rd_b15_str)
   LA(x10, scratch) # reload base address
@@ -1171,10 +1566,15 @@ Zalrsc_sc_d_cg_cp_rd_b15:
 # Testcase cp_rd (Test destination rd = x16)
   RVTEST_TESTDATA_LOAD_INT(x19, x26) # load rs2: x26 = 0x75792305e99fbdae
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b16_retry:
   lr.d x0, (x29) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b16:
   sc.d x16, x26, (x29) # perform operation
+  beqz x16, Zalrsc_sc_d_cg_cp_rd_b16_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_d_cg_cp_rd_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b16_success:
   # Check if x16 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x16, Zalrsc_sc_d_cg_cp_rd_b16, Zalrsc_sc_d_cg_cp_rd_b16_str)
   LA(x29, scratch) # reload base address
@@ -1185,10 +1585,15 @@ Zalrsc_sc_d_cg_cp_rd_b16:
 # Testcase cp_rd (Test destination rd = x17)
   RVTEST_TESTDATA_LOAD_INT(x19, x2) # load rs2: x2 = 0xb56693a6228c17fb
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b17_retry:
   lr.d x0, (x25) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b17:
   sc.d x17, x2, (x25) # perform operation
+  beqz x17, Zalrsc_sc_d_cg_cp_rd_b17_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_d_cg_cp_rd_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b17_success:
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zalrsc_sc_d_cg_cp_rd_b17, Zalrsc_sc_d_cg_cp_rd_b17_str)
   LA(x25, scratch) # reload base address
@@ -1200,10 +1605,15 @@ Zalrsc_sc_d_cg_cp_rd_b17:
 # Testcase cp_rd (Test destination rd = x18)
   RVTEST_TESTDATA_LOAD_INT(x19, x10) # load rs2: x10 = 0x404a73ccd1acd17f
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b18_retry:
   lr.d x0, (x30) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b18:
   sc.d x18, x10, (x30) # perform operation
+  beqz x18, Zalrsc_sc_d_cg_cp_rd_b18_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_d_cg_cp_rd_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b18_success:
   # Check if x18 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x18, Zalrsc_sc_d_cg_cp_rd_b18, Zalrsc_sc_d_cg_cp_rd_b18_str)
   LA(x30, scratch) # reload base address
@@ -1215,10 +1625,15 @@ Zalrsc_sc_d_cg_cp_rd_b18:
 # Testcase cp_rd (Test destination rd = x19)
   RVTEST_TESTDATA_LOAD_INT(x21, x25) # load rs2: x25 = 0xab2878b3024a22a2
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b19_retry:
   lr.d x0, (x1) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b19:
   sc.d x19, x25, (x1) # perform operation
+  beqz x19, Zalrsc_sc_d_cg_cp_rd_b19_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_d_cg_cp_rd_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b19_success:
   # Check if x19 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x19, Zalrsc_sc_d_cg_cp_rd_b19, Zalrsc_sc_d_cg_cp_rd_b19_str)
   LA(x1, scratch) # reload base address
@@ -1229,10 +1644,15 @@ Zalrsc_sc_d_cg_cp_rd_b19:
 # Testcase cp_rd (Test destination rd = x20)
   RVTEST_TESTDATA_LOAD_INT(x21, x18) # load rs2: x18 = 0xa3d4ae1b81654324
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b20_retry:
   lr.d x0, (x15) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b20:
   sc.d x20, x18, (x15) # perform operation
+  beqz x20, Zalrsc_sc_d_cg_cp_rd_b20_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_d_cg_cp_rd_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b20_success:
   # Check if x20 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x20, Zalrsc_sc_d_cg_cp_rd_b20, Zalrsc_sc_d_cg_cp_rd_b20_str)
   LA(x15, scratch) # reload base address
@@ -1244,10 +1664,15 @@ Zalrsc_sc_d_cg_cp_rd_b20:
 # Testcase cp_rd (Test destination rd = x21)
   RVTEST_TESTDATA_LOAD_INT(x28, x26) # load rs2: x26 = 0xe74279175b54a94a
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b21_retry:
   lr.d x0, (x20) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b21:
   sc.d x21, x26, (x20) # perform operation
+  beqz x21, Zalrsc_sc_d_cg_cp_rd_b21_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_d_cg_cp_rd_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b21_success:
   # Check if x21 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x21, Zalrsc_sc_d_cg_cp_rd_b21, Zalrsc_sc_d_cg_cp_rd_b21_str)
   LA(x20, scratch) # reload base address
@@ -1258,10 +1683,15 @@ Zalrsc_sc_d_cg_cp_rd_b21:
 # Testcase cp_rd (Test destination rd = x22)
   RVTEST_TESTDATA_LOAD_INT(x28, x7) # load rs2: x7 = 0x888d7eb01f0527a8
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b22_retry:
   lr.d x0, (x10) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b22:
   sc.d x22, x7, (x10) # perform operation
+  beqz x22, Zalrsc_sc_d_cg_cp_rd_b22_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_d_cg_cp_rd_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b22_success:
   # Check if x22 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x22, Zalrsc_sc_d_cg_cp_rd_b22, Zalrsc_sc_d_cg_cp_rd_b22_str)
   LA(x10, scratch) # reload base address
@@ -1272,10 +1702,15 @@ Zalrsc_sc_d_cg_cp_rd_b22:
 # Testcase cp_rd (Test destination rd = x23)
   RVTEST_TESTDATA_LOAD_INT(x28, x26) # load rs2: x26 = 0xa825d42fbeb7f01e
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b23_retry:
   lr.d x0, (x11) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b23:
   sc.d x23, x26, (x11) # perform operation
+  beqz x23, Zalrsc_sc_d_cg_cp_rd_b23_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_d_cg_cp_rd_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b23_success:
   # Check if x23 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x23, Zalrsc_sc_d_cg_cp_rd_b23, Zalrsc_sc_d_cg_cp_rd_b23_str)
   LA(x11, scratch) # reload base address
@@ -1286,10 +1721,15 @@ Zalrsc_sc_d_cg_cp_rd_b23:
 # Testcase cp_rd (Test destination rd = x24)
   RVTEST_TESTDATA_LOAD_INT(x28, x20) # load rs2: x20 = 0x23f5a3b5be490fde
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b24_retry:
   lr.d x0, (x21) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b24:
   sc.d x24, x20, (x21) # perform operation
+  beqz x24, Zalrsc_sc_d_cg_cp_rd_b24_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_d_cg_cp_rd_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b24_success:
   # Check if x24 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x24, Zalrsc_sc_d_cg_cp_rd_b24, Zalrsc_sc_d_cg_cp_rd_b24_str)
   LA(x21, scratch) # reload base address
@@ -1300,10 +1740,15 @@ Zalrsc_sc_d_cg_cp_rd_b24:
 # Testcase cp_rd (Test destination rd = x25)
   RVTEST_TESTDATA_LOAD_INT(x28, x8) # load rs2: x8 = 0x035e284a53d0f708
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b25_retry:
   lr.d x0, (x24) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b25:
   sc.d x25, x8, (x24) # perform operation
+  beqz x25, Zalrsc_sc_d_cg_cp_rd_b25_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_d_cg_cp_rd_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b25_success:
   # Check if x25 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x25, Zalrsc_sc_d_cg_cp_rd_b25, Zalrsc_sc_d_cg_cp_rd_b25_str)
   LA(x24, scratch) # reload base address
@@ -1314,10 +1759,15 @@ Zalrsc_sc_d_cg_cp_rd_b25:
 # Testcase cp_rd (Test destination rd = x26)
   RVTEST_TESTDATA_LOAD_INT(x28, x7) # load rs2: x7 = 0xc3916e07816602fc
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b26_retry:
   lr.d x0, (x30) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b26:
   sc.d x26, x7, (x30) # perform operation
+  beqz x26, Zalrsc_sc_d_cg_cp_rd_b26_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_d_cg_cp_rd_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b26_success:
   # Check if x26 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x26, Zalrsc_sc_d_cg_cp_rd_b26, Zalrsc_sc_d_cg_cp_rd_b26_str)
   LA(x30, scratch) # reload base address
@@ -1328,10 +1778,15 @@ Zalrsc_sc_d_cg_cp_rd_b26:
 # Testcase cp_rd (Test destination rd = x27)
   RVTEST_TESTDATA_LOAD_INT(x28, x2) # load rs2: x2 = 0x0ea557fef901d237
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b27_retry:
   lr.d x0, (x25) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b27:
   sc.d x27, x2, (x25) # perform operation
+  beqz x27, Zalrsc_sc_d_cg_cp_rd_b27_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_d_cg_cp_rd_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b27_success:
   # Check if x27 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x27, Zalrsc_sc_d_cg_cp_rd_b27, Zalrsc_sc_d_cg_cp_rd_b27_str)
   LA(x25, scratch) # reload base address
@@ -1343,10 +1798,15 @@ Zalrsc_sc_d_cg_cp_rd_b27:
 # Testcase cp_rd (Test destination rd = x28)
   RVTEST_TESTDATA_LOAD_INT(x9, x2) # load rs2: x2 = 0x53dfe3d67d28f82f
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b28_retry:
   lr.d x0, (x24) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b28:
   sc.d x28, x2, (x24) # perform operation
+  beqz x28, Zalrsc_sc_d_cg_cp_rd_b28_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_d_cg_cp_rd_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b28_success:
   # Check if x28 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x28, Zalrsc_sc_d_cg_cp_rd_b28, Zalrsc_sc_d_cg_cp_rd_b28_str)
   LA(x24, scratch) # reload base address
@@ -1357,10 +1817,15 @@ Zalrsc_sc_d_cg_cp_rd_b28:
 # Testcase cp_rd (Test destination rd = x29)
   RVTEST_TESTDATA_LOAD_INT(x9, x31) # load rs2: x31 = 0x73b978648cf2356a
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b29_retry:
   lr.d x0, (x7) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b29:
   sc.d x29, x31, (x7) # perform operation
+  beqz x29, Zalrsc_sc_d_cg_cp_rd_b29_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_d_cg_cp_rd_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b29_success:
   # Check if x29 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x29, Zalrsc_sc_d_cg_cp_rd_b29, Zalrsc_sc_d_cg_cp_rd_b29_str)
   LA(x7, scratch) # reload base address
@@ -1371,10 +1836,15 @@ Zalrsc_sc_d_cg_cp_rd_b29:
 # Testcase cp_rd (Test destination rd = x30)
   RVTEST_TESTDATA_LOAD_INT(x9, x20) # load rs2: x20 = 0x2e72eaba50fb6937
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b30_retry:
   lr.d x0, (x29) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b30:
   sc.d x30, x20, (x29) # perform operation
+  beqz x30, Zalrsc_sc_d_cg_cp_rd_b30_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_d_cg_cp_rd_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b30_success:
   # Check if x30 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x30, Zalrsc_sc_d_cg_cp_rd_b30, Zalrsc_sc_d_cg_cp_rd_b30_str)
   LA(x29, scratch) # reload base address
@@ -1385,10 +1855,15 @@ Zalrsc_sc_d_cg_cp_rd_b30:
 # Testcase cp_rd (Test destination rd = x31)
   RVTEST_TESTDATA_LOAD_INT(x9, x17) # load rs2: x17 = 0x56e2752d91f7deca
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rd_b31_retry:
   lr.d x0, (x21) # establish reservation
 Zalrsc_sc_d_cg_cp_rd_b31:
   sc.d x31, x17, (x21) # perform operation
+  beqz x31, Zalrsc_sc_d_cg_cp_rd_b31_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_d_cg_cp_rd_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rd_b31_success:
   # Check if x31 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x31, Zalrsc_sc_d_cg_cp_rd_b31, Zalrsc_sc_d_cg_cp_rd_b31_str)
   LA(x21, scratch) # reload base address
@@ -1403,10 +1878,15 @@ Zalrsc_sc_d_cg_cp_rd_b31:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x9, x29) # load rs2: x29 = 0x0000000000000000
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_edges_0x0_retry:
   lr.d x0, (x21) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_edges_0x0:
   sc.d x12, x29, (x21) # perform operation
+  beqz x12, Zalrsc_sc_d_cg_cp_rs2_edges_0x0_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_d_cg_cp_rs2_edges_0x0_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_edges_0x0_success:
   # Check if x12 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x12, Zalrsc_sc_d_cg_cp_rs2_edges_0x0, Zalrsc_sc_d_cg_cp_rs2_edges_0x0_str)
   LA(x21, scratch) # reload base address
@@ -1417,10 +1897,15 @@ Zalrsc_sc_d_cg_cp_rs2_edges_0x0:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x9, x19) # load rs2: x19 = 0x0000000000000001
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_edges_0x1_retry:
   lr.d x0, (x14) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_edges_0x1:
   sc.d x12, x19, (x14) # perform operation
+  beqz x12, Zalrsc_sc_d_cg_cp_rs2_edges_0x1_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_d_cg_cp_rs2_edges_0x1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_edges_0x1_success:
   # Check if x12 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x12, Zalrsc_sc_d_cg_cp_rs2_edges_0x1, Zalrsc_sc_d_cg_cp_rs2_edges_0x1_str)
   LA(x14, scratch) # reload base address
@@ -1431,10 +1916,15 @@ Zalrsc_sc_d_cg_cp_rs2_edges_0x1:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x9, x16) # load rs2: x16 = 0x0000000000000002
   LA(x28, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_edges_0x2_retry:
   lr.d x0, (x28) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_edges_0x2:
   sc.d x14, x16, (x28) # perform operation
+  beqz x14, Zalrsc_sc_d_cg_cp_rs2_edges_0x2_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_d_cg_cp_rs2_edges_0x2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_edges_0x2_success:
   # Check if x14 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x14, Zalrsc_sc_d_cg_cp_rs2_edges_0x2, Zalrsc_sc_d_cg_cp_rs2_edges_0x2_str)
   LA(x28, scratch) # reload base address
@@ -1445,10 +1935,15 @@ Zalrsc_sc_d_cg_cp_rs2_edges_0x2:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x9, x22) # load rs2: x22 = 0x8000000000000000
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_edges_0x8000000000000000_retry:
   lr.d x0, (x18) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_edges_0x8000000000000000:
   sc.d x2, x22, (x18) # perform operation
+  beqz x2, Zalrsc_sc_d_cg_cp_rs2_edges_0x8000000000000000_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_d_cg_cp_rs2_edges_0x8000000000000000_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_edges_0x8000000000000000_success:
   # Check if x2 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x2, Zalrsc_sc_d_cg_cp_rs2_edges_0x8000000000000000, Zalrsc_sc_d_cg_cp_rs2_edges_0x8000000000000000_str)
   LA(x18, scratch) # reload base address
@@ -1459,10 +1954,15 @@ Zalrsc_sc_d_cg_cp_rs2_edges_0x8000000000000000:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x9, x18) # load rs2: x18 = 0x8000000000000001
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_edges_0x8000000000000001_retry:
   lr.d x0, (x10) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_edges_0x8000000000000001:
   sc.d x2, x18, (x10) # perform operation
+  beqz x2, Zalrsc_sc_d_cg_cp_rs2_edges_0x8000000000000001_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_d_cg_cp_rs2_edges_0x8000000000000001_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_edges_0x8000000000000001_success:
   # Check if x2 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x2, Zalrsc_sc_d_cg_cp_rs2_edges_0x8000000000000001, Zalrsc_sc_d_cg_cp_rs2_edges_0x8000000000000001_str)
   LA(x10, scratch) # reload base address
@@ -1473,10 +1973,15 @@ Zalrsc_sc_d_cg_cp_rs2_edges_0x8000000000000001:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x9, x28) # load rs2: x28 = 0x7fffffffffffffff
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_edges_0x7fffffffffffffff_retry:
   lr.d x0, (x24) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_edges_0x7fffffffffffffff:
   sc.d x3, x28, (x24) # perform operation
+  beqz x3, Zalrsc_sc_d_cg_cp_rs2_edges_0x7fffffffffffffff_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_d_cg_cp_rs2_edges_0x7fffffffffffffff_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_edges_0x7fffffffffffffff_success:
   # Check if x3 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x3, Zalrsc_sc_d_cg_cp_rs2_edges_0x7fffffffffffffff, Zalrsc_sc_d_cg_cp_rs2_edges_0x7fffffffffffffff_str)
   LA(x24, scratch) # reload base address
@@ -1487,10 +1992,15 @@ Zalrsc_sc_d_cg_cp_rs2_edges_0x7fffffffffffffff:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x9, x24) # load rs2: x24 = 0x7ffffffffffffffe
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_edges_0x7ffffffffffffffe_retry:
   lr.d x0, (x16) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_edges_0x7ffffffffffffffe:
   sc.d x13, x24, (x16) # perform operation
+  beqz x13, Zalrsc_sc_d_cg_cp_rs2_edges_0x7ffffffffffffffe_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_d_cg_cp_rs2_edges_0x7ffffffffffffffe_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_edges_0x7ffffffffffffffe_success:
   # Check if x13 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x13, Zalrsc_sc_d_cg_cp_rs2_edges_0x7ffffffffffffffe, Zalrsc_sc_d_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
   LA(x16, scratch) # reload base address
@@ -1501,10 +2011,15 @@ Zalrsc_sc_d_cg_cp_rs2_edges_0x7ffffffffffffffe:
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x9, x15) # load rs2: x15 = 0xffffffffffffffff
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_edges_0xffffffffffffffff_retry:
   lr.d x0, (x13) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_edges_0xffffffffffffffff:
   sc.d x27, x15, (x13) # perform operation
+  beqz x27, Zalrsc_sc_d_cg_cp_rs2_edges_0xffffffffffffffff_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_d_cg_cp_rs2_edges_0xffffffffffffffff_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_edges_0xffffffffffffffff_success:
   # Check if x27 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x27, Zalrsc_sc_d_cg_cp_rs2_edges_0xffffffffffffffff, Zalrsc_sc_d_cg_cp_rs2_edges_0xffffffffffffffff_str)
   LA(x13, scratch) # reload base address
@@ -1515,10 +2030,15 @@ Zalrsc_sc_d_cg_cp_rs2_edges_0xffffffffffffffff:
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x9, x24) # load rs2: x24 = 0xfffffffffffffffe
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_edges_0xfffffffffffffffe_retry:
   lr.d x0, (x21) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_edges_0xfffffffffffffffe:
   sc.d x18, x24, (x21) # perform operation
+  beqz x18, Zalrsc_sc_d_cg_cp_rs2_edges_0xfffffffffffffffe_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_d_cg_cp_rs2_edges_0xfffffffffffffffe_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_edges_0xfffffffffffffffe_success:
   # Check if x18 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x18, Zalrsc_sc_d_cg_cp_rs2_edges_0xfffffffffffffffe, Zalrsc_sc_d_cg_cp_rs2_edges_0xfffffffffffffffe_str)
   LA(x21, scratch) # reload base address
@@ -1529,10 +2049,15 @@ Zalrsc_sc_d_cg_cp_rs2_edges_0xfffffffffffffffe:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x9, x10) # load rs2: x10 = 0x5bbc887763ae86f2
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_edges_0x5bbc887763ae86f2_retry:
   lr.d x0, (x21) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   sc.d x15, x10, (x21) # perform operation
+  beqz x15, Zalrsc_sc_d_cg_cp_rs2_edges_0x5bbc887763ae86f2_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_d_cg_cp_rs2_edges_0x5bbc887763ae86f2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_edges_0x5bbc887763ae86f2_success:
   # Check if x15 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x15, Zalrsc_sc_d_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zalrsc_sc_d_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
   LA(x21, scratch) # reload base address
@@ -1543,10 +2068,15 @@ Zalrsc_sc_d_cg_cp_rs2_edges_0x5bbc887763ae86f2:
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x9, x17) # load rs2: x17 = 0xaaaaaaaaaaaaaaaa
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_retry:
   lr.d x0, (x10) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   sc.d x26, x17, (x10) # perform operation
+  beqz x26, Zalrsc_sc_d_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_d_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_success:
   # Check if x26 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x26, Zalrsc_sc_d_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zalrsc_sc_d_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
   LA(x10, scratch) # reload base address
@@ -1557,10 +2087,15 @@ Zalrsc_sc_d_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x9, x30) # load rs2: x30 = 0x5555555555555555
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_edges_0x5555555555555555_retry:
   lr.d x0, (x19) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_edges_0x5555555555555555:
   sc.d x18, x30, (x19) # perform operation
+  beqz x18, Zalrsc_sc_d_cg_cp_rs2_edges_0x5555555555555555_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_d_cg_cp_rs2_edges_0x5555555555555555_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_edges_0x5555555555555555_success:
   # Check if x18 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x18, Zalrsc_sc_d_cg_cp_rs2_edges_0x5555555555555555, Zalrsc_sc_d_cg_cp_rs2_edges_0x5555555555555555_str)
   LA(x19, scratch) # reload base address
@@ -1571,10 +2106,15 @@ Zalrsc_sc_d_cg_cp_rs2_edges_0x5555555555555555:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x9, x12) # load rs2: x12 = 0x00000000ffffffff
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_edges_0xffffffff_retry:
   lr.d x0, (x22) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_edges_0xffffffff:
   sc.d x10, x12, (x22) # perform operation
+  beqz x10, Zalrsc_sc_d_cg_cp_rs2_edges_0xffffffff_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_d_cg_cp_rs2_edges_0xffffffff_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_edges_0xffffffff_success:
   # Check if x10 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x10, Zalrsc_sc_d_cg_cp_rs2_edges_0xffffffff, Zalrsc_sc_d_cg_cp_rs2_edges_0xffffffff_str)
   LA(x22, scratch) # reload base address
@@ -1585,10 +2125,15 @@ Zalrsc_sc_d_cg_cp_rs2_edges_0xffffffff:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x9, x18) # load rs2: x18 = 0x00000000fffffffe
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_edges_0xfffffffe_retry:
   lr.d x0, (x24) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_edges_0xfffffffe:
   sc.d x10, x18, (x24) # perform operation
+  beqz x10, Zalrsc_sc_d_cg_cp_rs2_edges_0xfffffffe_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_d_cg_cp_rs2_edges_0xfffffffe_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_edges_0xfffffffe_success:
   # Check if x10 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x10, Zalrsc_sc_d_cg_cp_rs2_edges_0xfffffffe, Zalrsc_sc_d_cg_cp_rs2_edges_0xfffffffe_str)
   LA(x24, scratch) # reload base address
@@ -1599,10 +2144,15 @@ Zalrsc_sc_d_cg_cp_rs2_edges_0xfffffffe:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x9, x28) # load rs2: x28 = 0x0000000100000000
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_edges_0x100000000_retry:
   lr.d x0, (x30) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_edges_0x100000000:
   sc.d x7, x28, (x30) # perform operation
+  beqz x7, Zalrsc_sc_d_cg_cp_rs2_edges_0x100000000_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_d_cg_cp_rs2_edges_0x100000000_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_edges_0x100000000_success:
   # Check if x7 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x7, Zalrsc_sc_d_cg_cp_rs2_edges_0x100000000, Zalrsc_sc_d_cg_cp_rs2_edges_0x100000000_str)
   LA(x30, scratch) # reload base address
@@ -1613,10 +2163,15 @@ Zalrsc_sc_d_cg_cp_rs2_edges_0x100000000:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x9, x16) # load rs2: x16 = 0x0000000100000001
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_rs2_edges_0x100000001_retry:
   lr.d x0, (x19) # establish reservation
 Zalrsc_sc_d_cg_cp_rs2_edges_0x100000001:
   sc.d x25, x16, (x19) # perform operation
+  beqz x25, Zalrsc_sc_d_cg_cp_rs2_edges_0x100000001_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_d_cg_cp_rs2_edges_0x100000001_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_rs2_edges_0x100000001_success:
   # Check if x25 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x25, Zalrsc_sc_d_cg_cp_rs2_edges_0x100000001, Zalrsc_sc_d_cg_cp_rs2_edges_0x100000001_str)
   LA(x19, scratch) # reload base address
@@ -1631,10 +2186,15 @@ Zalrsc_sc_d_cg_cp_rs2_edges_0x100000001:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x9, x1) # load rs2: x1 = 0x57128b633f960d4e
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b1_retry:
   lr.d x0, (x1) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b1:
   sc.d x23, x1, (x1) # perform operation
+  beqz x23, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b1_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b1_success:
   # Check if x23 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x23, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b1, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b1_str)
   LA(x1, scratch) # reload base address
@@ -1645,10 +2205,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b1:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x9, x2) # load rs2: x2 = 0x1cbc97aad98619a3
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b2_retry:
   lr.d x0, (x2) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b2:
   sc.d x15, x2, (x2) # perform operation
+  beqz x15, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b2_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b2_success:
   # Check if x15 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x15, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b2, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b2_str)
   LA(x2, scratch) # reload base address
@@ -1659,10 +2224,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b2:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x9, x3) # load rs2: x3 = 0x2d2f6d9410344499
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b3_retry:
   lr.d x0, (x3) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b3:
   sc.d x1, x3, (x3) # perform operation
+  beqz x1, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b3_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b3_success:
   # Check if x1 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x1, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b3, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b3_str)
   LA(x3, scratch) # reload base address
@@ -1675,10 +2245,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b3:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x4)
   RVTEST_TESTDATA_LOAD_INT(x9, x4) # load rs2: x4 = 0x1136a2eea76937ea
   LA(x4, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b4_retry:
   lr.d x0, (x4) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b4:
   sc.d x15, x4, (x4) # perform operation
+  beqz x15, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b4_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b4_success:
   # Check if x15 contains the expected result. x6 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x6, x13, x12, x15, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b4, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b4_str)
   LA(x4, scratch) # reload base address
@@ -1689,10 +2264,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b4:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x9, x5) # load rs2: x5 = 0x6c675bd38388d265
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b5_retry:
   lr.d x0, (x5) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b5:
   sc.d x21, x5, (x5) # perform operation
+  beqz x21, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b5_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b5_success:
   # Check if x21 contains the expected result. x6 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x6, x13, x12, x21, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b5, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b5_str)
   LA(x5, scratch) # reload base address
@@ -1704,10 +2284,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b5:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x9, x6) # load rs2: x6 = 0x2c5edad967213e99
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b6_retry:
   lr.d x0, (x6) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b6:
   sc.d x30, x6, (x6) # perform operation
+  beqz x30, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b6_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b6_success:
   # Check if x30 contains the expected result. x27 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x27, x13, x12, x30, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b6, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b6_str)
   LA(x6, scratch) # reload base address
@@ -1718,10 +2303,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b6:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x9, x7) # load rs2: x7 = 0xc233d16e23e7c879
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b7_retry:
   lr.d x0, (x7) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b7:
   sc.d x2, x7, (x7) # perform operation
+  beqz x2, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b7_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b7_success:
   # Check if x2 contains the expected result. x27 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x27, x13, x12, x2, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b7, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b7_str)
   LA(x7, scratch) # reload base address
@@ -1732,10 +2322,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b7:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x9, x8) # load rs2: x8 = 0x6e681c18dae4fffe
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b8_retry:
   lr.d x0, (x8) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b8:
   sc.d x11, x8, (x8) # perform operation
+  beqz x11, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b8_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b8_success:
   # Check if x11 contains the expected result. x27 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x27, x13, x12, x11, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b8, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b8_str)
   LA(x8, scratch) # reload base address
@@ -1747,10 +2342,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b8:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x6, x9) # load rs2: x9 = 0xf11b5a90f50e07d8
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b9_retry:
   lr.d x0, (x9) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b9:
   sc.d x15, x9, (x9) # perform operation
+  beqz x15, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b9_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b9_success:
   # Check if x15 contains the expected result. x27 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x27, x13, x12, x15, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b9, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b9_str)
   LA(x9, scratch) # reload base address
@@ -1761,10 +2361,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b9:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x6, x10) # load rs2: x10 = 0x15c48a918cdde9d6
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x5, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b10_retry:
   lr.d x0, (x10) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b10:
   sc.d x3, x10, (x10) # perform operation
+  beqz x3, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b10_success # SC succeeded, skip retry
+  addi x5, x5, -1 # decrement retry count
+  bnez x5, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b10_success:
   # Check if x3 contains the expected result. x27 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x27, x13, x12, x3, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b10, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b10_str)
   LA(x10, scratch) # reload base address
@@ -1775,10 +2380,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b10:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x6, x11) # load rs2: x11 = 0x622b92a27701d812
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b11_retry:
   lr.d x0, (x11) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b11:
   sc.d x5, x11, (x11) # perform operation
+  beqz x5, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b11_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b11_success:
   # Check if x5 contains the expected result. x27 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x27, x13, x12, x5, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b11, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b11_str)
   LA(x11, scratch) # reload base address
@@ -1791,10 +2401,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b11:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x6, x12) # load rs2: x12 = 0xf9b2ea2a980b9b6d
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b12_retry:
   lr.d x0, (x12) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b12:
   sc.d x25, x12, (x12) # perform operation
+  beqz x25, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b12_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b12_success:
   # Check if x25 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x25, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b12, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b12_str)
   LA(x12, scratch) # reload base address
@@ -1805,10 +2420,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b12:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x6, x13) # load rs2: x13 = 0x8a6005af40f7633a
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b13_retry:
   lr.d x0, (x13) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b13:
   sc.d x18, x13, (x13) # perform operation
+  beqz x18, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b13_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b13_success:
   # Check if x18 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x18, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b13, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b13_str)
   LA(x13, scratch) # reload base address
@@ -1819,10 +2439,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b13:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x6, x14) # load rs2: x14 = 0xb375c56cf1f37d38
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x24, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b14_retry:
   lr.d x0, (x14) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b14:
   sc.d x15, x14, (x14) # perform operation
+  beqz x15, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b14_success # SC succeeded, skip retry
+  addi x24, x24, -1 # decrement retry count
+  bnez x24, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b14_success:
   # Check if x15 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x15, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b14, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b14_str)
   LA(x14, scratch) # reload base address
@@ -1833,10 +2458,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b14:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x6, x15) # load rs2: x15 = 0xfc0c98b1b3f3c5ed
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b15_retry:
   lr.d x0, (x15) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b15:
   sc.d x25, x15, (x15) # perform operation
+  beqz x25, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b15_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b15_success:
   # Check if x25 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x25, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b15, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b15_str)
   LA(x15, scratch) # reload base address
@@ -1847,10 +2477,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b15:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x6, x16) # load rs2: x16 = 0x23484b9ee4769d6a
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b16_retry:
   lr.d x0, (x16) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b16:
   sc.d x3, x16, (x16) # perform operation
+  beqz x3, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b16_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b16_success:
   # Check if x3 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x3, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b16, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b16_str)
   LA(x16, scratch) # reload base address
@@ -1861,10 +2496,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b16:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x6, x17) # load rs2: x17 = 0x30d8718975bcaeba
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b17_retry:
   lr.d x0, (x17) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b17:
   sc.d x12, x17, (x17) # perform operation
+  beqz x12, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b17_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b17_success:
   # Check if x12 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x12, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b17, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b17_str)
   LA(x17, scratch) # reload base address
@@ -1875,10 +2515,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b17:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x6, x18) # load rs2: x18 = 0x09b5d1f9684929fb
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x30, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b18_retry:
   lr.d x0, (x18) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b18:
   sc.d x22, x18, (x18) # perform operation
+  beqz x22, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b18_success # SC succeeded, skip retry
+  addi x30, x30, -1 # decrement retry count
+  bnez x30, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b18_success:
   # Check if x22 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x22, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b18, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b18_str)
   LA(x18, scratch) # reload base address
@@ -1889,10 +2534,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b18:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x6, x19) # load rs2: x19 = 0xf19f470aafb62b13
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b19_retry:
   lr.d x0, (x19) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b19:
   sc.d x3, x19, (x19) # perform operation
+  beqz x3, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b19_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b19_success:
   # Check if x3 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x3, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b19, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b19_str)
   LA(x19, scratch) # reload base address
@@ -1903,10 +2553,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b19:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x6, x20) # load rs2: x20 = 0x3529fc9f1d1b8a29
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b20_retry:
   lr.d x0, (x20) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b20:
   sc.d x3, x20, (x20) # perform operation
+  beqz x3, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b20_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b20_success:
   # Check if x3 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x3, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b20, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b20_str)
   LA(x20, scratch) # reload base address
@@ -1917,10 +2572,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b20:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x6, x21) # load rs2: x21 = 0x8b7337a3abac1258
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b21_retry:
   lr.d x0, (x21) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b21:
   sc.d x14, x21, (x21) # perform operation
+  beqz x14, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b21_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b21_success:
   # Check if x14 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x14, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b21, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b21_str)
   LA(x21, scratch) # reload base address
@@ -1931,10 +2591,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b21:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x6, x22) # load rs2: x22 = 0x8124bd9b2600145e
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b22_retry:
   lr.d x0, (x22) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b22:
   sc.d x10, x22, (x22) # perform operation
+  beqz x10, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b22_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b22_success:
   # Check if x10 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x10, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b22, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b22_str)
   LA(x22, scratch) # reload base address
@@ -1945,10 +2610,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b22:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x6, x23) # load rs2: x23 = 0x5d97cc3c3d3e9f68
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x30, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b23_retry:
   lr.d x0, (x23) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b23:
   sc.d x19, x23, (x23) # perform operation
+  beqz x19, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b23_success # SC succeeded, skip retry
+  addi x30, x30, -1 # decrement retry count
+  bnez x30, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b23_success:
   # Check if x19 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x19, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b23, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b23_str)
   LA(x23, scratch) # reload base address
@@ -1959,10 +2629,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b23:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x6, x24) # load rs2: x24 = 0x3ef700538eb8b25f
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b24_retry:
   lr.d x0, (x24) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b24:
   sc.d x9, x24, (x24) # perform operation
+  beqz x9, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b24_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b24_success:
   # Check if x9 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x9, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b24, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b24_str)
   LA(x24, scratch) # reload base address
@@ -1973,10 +2648,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b24:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x6, x25) # load rs2: x25 = 0xd51d93203bca54ec
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b25_retry:
   lr.d x0, (x25) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b25:
   sc.d x10, x25, (x25) # perform operation
+  beqz x10, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b25_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b25_success:
   # Check if x10 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x10, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b25, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b25_str)
   LA(x25, scratch) # reload base address
@@ -1987,10 +2667,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b25:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x6, x26) # load rs2: x26 = 0x270b20e5dead7d0c
   LA(x26, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b26_retry:
   lr.d x0, (x26) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b26:
   sc.d x11, x26, (x26) # perform operation
+  beqz x11, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b26_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b26_success:
   # Check if x11 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x11, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b26, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b26_str)
   LA(x26, scratch) # reload base address
@@ -2002,10 +2687,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b26:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x6, x27) # load rs2: x27 = 0xade9b4be1bc87ddc
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b27_retry:
   lr.d x0, (x27) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b27:
   sc.d x29, x27, (x27) # perform operation
+  beqz x29, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b27_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b27_success:
   # Check if x29 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x29, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b27, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b27_str)
   LA(x27, scratch) # reload base address
@@ -2016,10 +2706,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b27:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x6, x28) # load rs2: x28 = 0xa592a730bd136f77
   LA(x28, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b28_retry:
   lr.d x0, (x28) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b28:
   sc.d x24, x28, (x28) # perform operation
+  beqz x24, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b28_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b28_success:
   # Check if x24 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x24, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b28, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b28_str)
   LA(x28, scratch) # reload base address
@@ -2030,10 +2725,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b28:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x6, x29) # load rs2: x29 = 0xe1a1eda4c09dd88d
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b29_retry:
   lr.d x0, (x29) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b29:
   sc.d x15, x29, (x29) # perform operation
+  beqz x15, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b29_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b29_success:
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b29, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b29_str)
   LA(x29, scratch) # reload base address
@@ -2044,10 +2744,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b29:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x6, x30) # load rs2: x30 = 0xf36cbd637475b0be
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b30_retry:
   lr.d x0, (x30) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b30:
   sc.d x22, x30, (x30) # perform operation
+  beqz x22, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b30_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b30_success:
   # Check if x22 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x22, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b30, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b30_str)
   LA(x30, scratch) # reload base address
@@ -2058,10 +2763,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b30:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x6, x31) # load rs2: x31 = 0xc21fff80bfecad11
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b31_retry:
   lr.d x0, (x31) # establish reservation
 Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b31:
   sc.d x8, x31, (x31) # perform operation
+  beqz x8, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b31_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b31_success:
   # Check if x8 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x8, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b31, Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b31_str)
   LA(x31, scratch) # reload base address
@@ -2076,10 +2786,15 @@ Zalrsc_sc_d_cg_cmp_rs1_rs2_nx0_b31:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x1)
   RVTEST_TESTDATA_LOAD_INT(x6, x27) # load rs2: x27 = 0x8d5f7e913153d5c3
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b1_retry:
   lr.d x0, (x1) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b1:
   sc.d x1, x27, (x1) # perform operation
+  beqz x1, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b1_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b1_success:
   # Check if x1 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x1, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b1, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b1_str)
   LA(x1, scratch) # reload base address
@@ -2090,10 +2805,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b1:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x6, x24) # load rs2: x24 = 0x3c0bc6e7eef14261
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b2_retry:
   lr.d x0, (x2) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b2:
   sc.d x2, x24, (x2) # perform operation
+  beqz x2, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b2_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b2_success:
   # Check if x2 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x2, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b2, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b2_str)
   LA(x2, scratch) # reload base address
@@ -2104,10 +2824,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b2:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x3)
   RVTEST_TESTDATA_LOAD_INT(x6, x8) # load rs2: x8 = 0xaf7132e671de5649
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b3_retry:
   lr.d x0, (x3) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b3:
   sc.d x3, x8, (x3) # perform operation
+  beqz x3, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b3_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b3_success:
   # Check if x3 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x3, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b3, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b3_str)
   LA(x3, scratch) # reload base address
@@ -2120,10 +2845,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b3:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x4)
   RVTEST_TESTDATA_LOAD_INT(x6, x28) # load rs2: x28 = 0x8a22cf0910e7dac9
   LA(x4, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b4_retry:
   lr.d x0, (x4) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b4:
   sc.d x4, x28, (x4) # perform operation
+  beqz x4, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b4_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b4_success:
   # Check if x4 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x4, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b4, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b4_str)
   LA(x4, scratch) # reload base address
@@ -2134,10 +2864,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b4:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x6, x3) # load rs2: x3 = 0xfa31b9aff94e35fb
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b5_retry:
   lr.d x0, (x5) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b5:
   sc.d x5, x3, (x5) # perform operation
+  beqz x5, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b5_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b5_success:
   # Check if x5 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x5, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b5, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b5_str)
   LA(x5, scratch) # reload base address
@@ -2149,10 +2884,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b5:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x22, x18) # load rs2: x18 = 0x4e845febaf1a89ed
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x4, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b6_retry:
   lr.d x0, (x6) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b6:
   sc.d x6, x18, (x6) # perform operation
+  beqz x6, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b6_success # SC succeeded, skip retry
+  addi x4, x4, -1 # decrement retry count
+  bnez x4, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b6_success:
   # Check if x6 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x6, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b6, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b6_str)
   LA(x6, scratch) # reload base address
@@ -2165,10 +2905,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b6:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x7)
   RVTEST_TESTDATA_LOAD_INT(x22, x16) # load rs2: x16 = 0xc6bb33f6bd21fb57
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b7_retry:
   lr.d x0, (x7) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b7:
   sc.d x7, x16, (x7) # perform operation
+  beqz x7, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b7_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b7_success:
   # Check if x7 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x7, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b7, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b7_str)
   LA(x7, scratch) # reload base address
@@ -2179,10 +2924,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b7:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x22, x3) # load rs2: x3 = 0x8a5f1f947ff7e73c
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b8_retry:
   lr.d x0, (x8) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b8:
   sc.d x8, x3, (x8) # perform operation
+  beqz x8, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b8_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b8_success:
   # Check if x8 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x8, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b8, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b8_str)
   LA(x8, scratch) # reload base address
@@ -2193,10 +2943,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b8:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x22, x8) # load rs2: x8 = 0xdbb8acded701a4a7
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b9_retry:
   lr.d x0, (x9) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b9:
   sc.d x9, x8, (x9) # perform operation
+  beqz x9, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b9_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b9_success:
   # Check if x9 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x9, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b9, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b9_str)
   LA(x9, scratch) # reload base address
@@ -2208,10 +2963,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b9:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x22, x8) # load rs2: x8 = 0xa19da95d6c76cc67
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b10_retry:
   lr.d x0, (x10) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b10:
   sc.d x10, x8, (x10) # perform operation
+  beqz x10, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b10_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b10_success:
   # Check if x10 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x10, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b10, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b10_str)
   LA(x10, scratch) # reload base address
@@ -2222,10 +2982,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b10:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x22, x3) # load rs2: x3 = 0x322596df1bc431cd
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b11_retry:
   lr.d x0, (x11) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b11:
   sc.d x11, x3, (x11) # perform operation
+  beqz x11, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b11_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b11_success:
   # Check if x11 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x11, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b11, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b11_str)
   LA(x11, scratch) # reload base address
@@ -2236,10 +3001,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b11:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x22, x21) # load rs2: x21 = 0xcfde3284c6dabd6e
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b12_retry:
   lr.d x0, (x12) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b12:
   sc.d x12, x21, (x12) # perform operation
+  beqz x12, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b12_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b12_success:
   # Check if x12 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x12, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b12, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b12_str)
   LA(x12, scratch) # reload base address
@@ -2250,10 +3020,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b12:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x22, x2) # load rs2: x2 = 0x3b56b51b94b39fc9
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b13_retry:
   lr.d x0, (x13) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b13:
   sc.d x13, x2, (x13) # perform operation
+  beqz x13, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b13_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b13_success:
   # Check if x13 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x13, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b13, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b13_str)
   LA(x13, scratch) # reload base address
@@ -2264,10 +3039,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b13:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x22, x3) # load rs2: x3 = 0x72cc1a2e396fd127
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b14_retry:
   lr.d x0, (x14) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b14:
   sc.d x14, x3, (x14) # perform operation
+  beqz x14, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b14_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b14_success:
   # Check if x14 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x14, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b14, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b14_str)
   LA(x14, scratch) # reload base address
@@ -2278,10 +3058,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b14:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x22, x11) # load rs2: x11 = 0x40145f7f3f329b3b
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b15_retry:
   lr.d x0, (x15) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b15:
   sc.d x15, x11, (x15) # perform operation
+  beqz x15, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b15_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b15_success:
   # Check if x15 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x15, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b15, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b15_str)
   LA(x15, scratch) # reload base address
@@ -2292,10 +3077,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b15:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x16)
   RVTEST_TESTDATA_LOAD_INT(x22, x31) # load rs2: x31 = 0x094ba28cea2f8324
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b16_retry:
   lr.d x0, (x16) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b16:
   sc.d x16, x31, (x16) # perform operation
+  beqz x16, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b16_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b16_success:
   # Check if x16 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x16, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b16, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b16_str)
   LA(x16, scratch) # reload base address
@@ -2306,10 +3096,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b16:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x17)
   RVTEST_TESTDATA_LOAD_INT(x22, x31) # load rs2: x31 = 0x82a4134bbea5412d
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b17_retry:
   lr.d x0, (x17) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b17:
   sc.d x17, x31, (x17) # perform operation
+  beqz x17, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b17_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b17_success:
   # Check if x17 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x17, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b17, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b17_str)
   LA(x17, scratch) # reload base address
@@ -2320,10 +3115,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b17:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x18)
   RVTEST_TESTDATA_LOAD_INT(x22, x12) # load rs2: x12 = 0xfa0511d3b4c38cef
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b18_retry:
   lr.d x0, (x18) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b18:
   sc.d x18, x12, (x18) # perform operation
+  beqz x18, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b18_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b18_success:
   # Check if x18 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x18, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b18, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b18_str)
   LA(x18, scratch) # reload base address
@@ -2334,10 +3134,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b18:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x19)
   RVTEST_TESTDATA_LOAD_INT(x22, x25) # load rs2: x25 = 0xf26d075fe007c96d
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b19_retry:
   lr.d x0, (x19) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b19:
   sc.d x19, x25, (x19) # perform operation
+  beqz x19, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b19_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b19_success:
   # Check if x19 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x19, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b19, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b19_str)
   LA(x19, scratch) # reload base address
@@ -2348,10 +3153,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b19:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x20)
   RVTEST_TESTDATA_LOAD_INT(x22, x16) # load rs2: x16 = 0x80417ca30d42fb53
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b20_retry:
   lr.d x0, (x20) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b20:
   sc.d x20, x16, (x20) # perform operation
+  beqz x20, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b20_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b20_success:
   # Check if x20 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x20, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b20, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b20_str)
   LA(x20, scratch) # reload base address
@@ -2362,10 +3172,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b20:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x21)
   RVTEST_TESTDATA_LOAD_INT(x22, x1) # load rs2: x1 = 0xaedc7d90edec056b
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b21_retry:
   lr.d x0, (x21) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b21:
   sc.d x21, x1, (x21) # perform operation
+  beqz x21, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b21_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b21_success:
   # Check if x21 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x21, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b21, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b21_str)
   LA(x21, scratch) # reload base address
@@ -2377,10 +3192,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b21:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x22)
   RVTEST_TESTDATA_LOAD_INT(x23, x26) # load rs2: x26 = 0xd4f3e928d65c6c9e
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b22_retry:
   lr.d x0, (x22) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b22:
   sc.d x22, x26, (x22) # perform operation
+  beqz x22, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b22_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b22_success:
   # Check if x22 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x22, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b22, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b22_str)
   LA(x22, scratch) # reload base address
@@ -2392,10 +3212,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b22:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x23)
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load rs2: x31 = 0xacf1b13a9fad178e
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b23_retry:
   lr.d x0, (x23) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b23:
   sc.d x23, x31, (x23) # perform operation
+  beqz x23, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b23_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b23_success:
   # Check if x23 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x23, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b23, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b23_str)
   LA(x23, scratch) # reload base address
@@ -2406,10 +3231,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b23:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x24)
   RVTEST_TESTDATA_LOAD_INT(x27, x7) # load rs2: x7 = 0x928ffe7753e11631
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b24_retry:
   lr.d x0, (x24) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b24:
   sc.d x24, x7, (x24) # perform operation
+  beqz x24, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b24_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b24_success:
   # Check if x24 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x24, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b24, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b24_str)
   LA(x24, scratch) # reload base address
@@ -2420,10 +3250,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b24:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x25)
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rs2: x10 = 0x63273b1757844ec4
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b25_retry:
   lr.d x0, (x25) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b25:
   sc.d x25, x10, (x25) # perform operation
+  beqz x25, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b25_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b25_success:
   # Check if x25 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x25, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b25, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b25_str)
   LA(x25, scratch) # reload base address
@@ -2434,10 +3269,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b25:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x26)
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load rs2: x31 = 0x876418ff946e1247
   LA(x26, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b26_retry:
   lr.d x0, (x26) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b26:
   sc.d x26, x31, (x26) # perform operation
+  beqz x26, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b26_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b26_success:
   # Check if x26 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x26, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b26, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b26_str)
   LA(x26, scratch) # reload base address
@@ -2449,10 +3289,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b26:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x27)
   RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rs2: x0 = 0x0236c0d568fe1907
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b27_retry:
   lr.d x0, (x27) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b27:
   sc.d x27, x0, (x27) # perform operation
+  beqz x27, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b27_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b27_success:
   # Check if x27 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x27, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b27, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b27_str)
   LA(x27, scratch) # reload base address
@@ -2463,10 +3308,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b27:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x28)
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load rs2: x1 = 0xd702c90cc6491904
   LA(x28, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b28_retry:
   lr.d x0, (x28) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b28:
   sc.d x28, x1, (x28) # perform operation
+  beqz x28, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b28_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b28_success:
   # Check if x28 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x28, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b28, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b28_str)
   LA(x28, scratch) # reload base address
@@ -2477,10 +3327,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b28:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x29)
   RVTEST_TESTDATA_LOAD_INT(x17, x3) # load rs2: x3 = 0x08ee1d1211763da0
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b29_retry:
   lr.d x0, (x29) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b29:
   sc.d x29, x3, (x29) # perform operation
+  beqz x29, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b29_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b29_success:
   # Check if x29 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x29, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b29, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b29_str)
   LA(x29, scratch) # reload base address
@@ -2492,10 +3347,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b29:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x30)
   RVTEST_TESTDATA_LOAD_INT(x17, x19) # load rs2: x19 = 0xc16e2fd9268f7bc6
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b30_retry:
   lr.d x0, (x30) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b30:
   sc.d x30, x19, (x30) # perform operation
+  beqz x30, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b30_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b30_success:
   # Check if x30 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x30, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b30, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b30_str)
   LA(x30, scratch) # reload base address
@@ -2506,10 +3366,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b30:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x31)
   RVTEST_TESTDATA_LOAD_INT(x17, x18) # load rs2: x18 = 0xb03188342e007bdf
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b31_retry:
   lr.d x0, (x31) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b31:
   sc.d x31, x18, (x31) # perform operation
+  beqz x31, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b31_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b31_success:
   # Check if x31 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x31, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b31, Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b31_str)
   LA(x31, scratch) # reload base address
@@ -2524,10 +3389,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_nx0_b31:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x0)
   RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rs2: x0 = 0xe760e15629132a53
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b0_retry:
   lr.d x0, (x19) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b0:
   sc.d x0, x0, (x19) # perform operation
+  beqz x0, Zalrsc_sc_d_cg_cmp_rd_rs2_b0_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_d_cg_cmp_rd_rs2_b0_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b0_success:
   # Check if x0 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x0, Zalrsc_sc_d_cg_cmp_rd_rs2_b0, Zalrsc_sc_d_cg_cmp_rd_rs2_b0_str)
   LA(x19, scratch) # reload base address
@@ -2538,10 +3408,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b0:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load rs2: x1 = 0xf3174892e59a9bb9
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b1_retry:
   lr.d x0, (x14) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b1:
   sc.d x1, x1, (x14) # perform operation
+  beqz x1, Zalrsc_sc_d_cg_cmp_rd_rs2_b1_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_d_cg_cmp_rd_rs2_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b1_success:
   # Check if x1 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x1, Zalrsc_sc_d_cg_cmp_rd_rs2_b1, Zalrsc_sc_d_cg_cmp_rd_rs2_b1_str)
   LA(x14, scratch) # reload base address
@@ -2552,10 +3427,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b1:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rs2: x2 = 0x4d1a2d93897a0f84
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b2_retry:
   lr.d x0, (x31) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b2:
   sc.d x2, x2, (x31) # perform operation
+  beqz x2, Zalrsc_sc_d_cg_cmp_rd_rs2_b2_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_d_cg_cmp_rd_rs2_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b2_success:
   # Check if x2 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x2, Zalrsc_sc_d_cg_cmp_rd_rs2_b2, Zalrsc_sc_d_cg_cmp_rd_rs2_b2_str)
   LA(x31, scratch) # reload base address
@@ -2566,10 +3446,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b2:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x17, x3) # load rs2: x3 = 0xdef339a4c2a2ae1d
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b3_retry:
   lr.d x0, (x12) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b3:
   sc.d x3, x3, (x12) # perform operation
+  beqz x3, Zalrsc_sc_d_cg_cmp_rd_rs2_b3_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_d_cg_cmp_rd_rs2_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b3_success:
   # Check if x3 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x3, Zalrsc_sc_d_cg_cmp_rd_rs2_b3, Zalrsc_sc_d_cg_cmp_rd_rs2_b3_str)
   LA(x12, scratch) # reload base address
@@ -2582,10 +3467,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b3:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x4)
   RVTEST_TESTDATA_LOAD_INT(x17, x4) # load rs2: x4 = 0xc6afc6dde78ece12
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b4_retry:
   lr.d x0, (x27) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b4:
   sc.d x4, x4, (x27) # perform operation
+  beqz x4, Zalrsc_sc_d_cg_cmp_rd_rs2_b4_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_d_cg_cmp_rd_rs2_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b4_success:
   # Check if x4 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x4, Zalrsc_sc_d_cg_cmp_rd_rs2_b4, Zalrsc_sc_d_cg_cmp_rd_rs2_b4_str)
   LA(x27, scratch) # reload base address
@@ -2596,10 +3486,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b4:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x17, x5) # load rs2: x5 = 0x452692456c23f642
   LA(x28, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b5_retry:
   lr.d x0, (x28) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b5:
   sc.d x5, x5, (x28) # perform operation
+  beqz x5, Zalrsc_sc_d_cg_cmp_rd_rs2_b5_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_d_cg_cmp_rd_rs2_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b5_success:
   # Check if x5 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x5, Zalrsc_sc_d_cg_cmp_rd_rs2_b5, Zalrsc_sc_d_cg_cmp_rd_rs2_b5_str)
   LA(x28, scratch) # reload base address
@@ -2610,10 +3505,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b5:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load rs2: x6 = 0x95ba861929338470
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b6_retry:
   lr.d x0, (x20) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b6:
   sc.d x6, x6, (x20) # perform operation
+  beqz x6, Zalrsc_sc_d_cg_cmp_rd_rs2_b6_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_d_cg_cmp_rd_rs2_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b6_success:
   # Check if x6 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x6, Zalrsc_sc_d_cg_cmp_rd_rs2_b6, Zalrsc_sc_d_cg_cmp_rd_rs2_b6_str)
   LA(x20, scratch) # reload base address
@@ -2626,10 +3526,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b6:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x17, x7) # load rs2: x7 = 0x1cebc085b8017f34
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b7_retry:
   lr.d x0, (x1) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b7:
   sc.d x7, x7, (x1) # perform operation
+  beqz x7, Zalrsc_sc_d_cg_cmp_rd_rs2_b7_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_d_cg_cmp_rd_rs2_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b7_success:
   # Check if x7 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x7, Zalrsc_sc_d_cg_cmp_rd_rs2_b7, Zalrsc_sc_d_cg_cmp_rd_rs2_b7_str)
   LA(x1, scratch) # reload base address
@@ -2640,10 +3545,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b7:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x17, x8) # load rs2: x8 = 0xb356534ba0772a80
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b8_retry:
   lr.d x0, (x30) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b8:
   sc.d x8, x8, (x30) # perform operation
+  beqz x8, Zalrsc_sc_d_cg_cmp_rd_rs2_b8_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_d_cg_cmp_rd_rs2_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b8_success:
   # Check if x8 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x8, Zalrsc_sc_d_cg_cmp_rd_rs2_b8, Zalrsc_sc_d_cg_cmp_rd_rs2_b8_str)
   LA(x30, scratch) # reload base address
@@ -2654,10 +3564,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b8:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rs2: x9 = 0xd1c0f1029d85800f
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b9_retry:
   lr.d x0, (x25) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b9:
   sc.d x9, x9, (x25) # perform operation
+  beqz x9, Zalrsc_sc_d_cg_cmp_rd_rs2_b9_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_d_cg_cmp_rd_rs2_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b9_success:
   # Check if x9 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x9, Zalrsc_sc_d_cg_cmp_rd_rs2_b9, Zalrsc_sc_d_cg_cmp_rd_rs2_b9_str)
   LA(x25, scratch) # reload base address
@@ -2668,10 +3583,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b9:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x17, x10) # load rs2: x10 = 0x90debfda281174f3
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b10_retry:
   lr.d x0, (x31) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b10:
   sc.d x10, x10, (x31) # perform operation
+  beqz x10, Zalrsc_sc_d_cg_cmp_rd_rs2_b10_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_d_cg_cmp_rd_rs2_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b10_success:
   # Check if x10 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x10, Zalrsc_sc_d_cg_cmp_rd_rs2_b10, Zalrsc_sc_d_cg_cmp_rd_rs2_b10_str)
   LA(x31, scratch) # reload base address
@@ -2682,10 +3602,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b10:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x17, x11) # load rs2: x11 = 0xaa72ae11991d3c39
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b11_retry:
   lr.d x0, (x10) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b11:
   sc.d x11, x11, (x10) # perform operation
+  beqz x11, Zalrsc_sc_d_cg_cmp_rd_rs2_b11_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_d_cg_cmp_rd_rs2_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b11_success:
   # Check if x11 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x11, Zalrsc_sc_d_cg_cmp_rd_rs2_b11, Zalrsc_sc_d_cg_cmp_rd_rs2_b11_str)
   LA(x10, scratch) # reload base address
@@ -2696,10 +3621,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b11:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x17, x12) # load rs2: x12 = 0xa54c5bd584bb0dba
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b12_retry:
   lr.d x0, (x6) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b12:
   sc.d x12, x12, (x6) # perform operation
+  beqz x12, Zalrsc_sc_d_cg_cmp_rd_rs2_b12_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_d_cg_cmp_rd_rs2_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b12_success:
   # Check if x12 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x12, Zalrsc_sc_d_cg_cmp_rd_rs2_b12, Zalrsc_sc_d_cg_cmp_rd_rs2_b12_str)
   LA(x6, scratch) # reload base address
@@ -2710,10 +3640,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b12:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load rs2: x13 = 0x9b085ebc9bf26de6
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b13_retry:
   lr.d x0, (x6) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b13:
   sc.d x13, x13, (x6) # perform operation
+  beqz x13, Zalrsc_sc_d_cg_cmp_rd_rs2_b13_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_d_cg_cmp_rd_rs2_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b13_success:
   # Check if x13 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x13, Zalrsc_sc_d_cg_cmp_rd_rs2_b13, Zalrsc_sc_d_cg_cmp_rd_rs2_b13_str)
   LA(x6, scratch) # reload base address
@@ -2724,10 +3659,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b13:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rs2: x14 = 0xe580514b4df7857a
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b14_retry:
   lr.d x0, (x6) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b14:
   sc.d x14, x14, (x6) # perform operation
+  beqz x14, Zalrsc_sc_d_cg_cmp_rd_rs2_b14_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_d_cg_cmp_rd_rs2_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b14_success:
   # Check if x14 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x14, Zalrsc_sc_d_cg_cmp_rd_rs2_b14, Zalrsc_sc_d_cg_cmp_rd_rs2_b14_str)
   LA(x6, scratch) # reload base address
@@ -2738,10 +3678,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b14:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load rs2: x15 = 0x51499f2a37cdcfba
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b15_retry:
   lr.d x0, (x1) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b15:
   sc.d x15, x15, (x1) # perform operation
+  beqz x15, Zalrsc_sc_d_cg_cmp_rd_rs2_b15_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_d_cg_cmp_rd_rs2_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b15_success:
   # Check if x15 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x15, Zalrsc_sc_d_cg_cmp_rd_rs2_b15, Zalrsc_sc_d_cg_cmp_rd_rs2_b15_str)
   LA(x1, scratch) # reload base address
@@ -2752,10 +3697,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b15:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x17, x16) # load rs2: x16 = 0xe5695de1cbc12729
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b16_retry:
   lr.d x0, (x21) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b16:
   sc.d x16, x16, (x21) # perform operation
+  beqz x16, Zalrsc_sc_d_cg_cmp_rd_rs2_b16_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_d_cg_cmp_rd_rs2_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b16_success:
   # Check if x16 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x16, Zalrsc_sc_d_cg_cmp_rd_rs2_b16, Zalrsc_sc_d_cg_cmp_rd_rs2_b16_str)
   LA(x21, scratch) # reload base address
@@ -2767,10 +3717,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b16:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x11, x17) # load rs2: x17 = 0x247a37acb9cdc875
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b17_retry:
   lr.d x0, (x30) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b17:
   sc.d x17, x17, (x30) # perform operation
+  beqz x17, Zalrsc_sc_d_cg_cmp_rd_rs2_b17_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_d_cg_cmp_rd_rs2_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b17_success:
   # Check if x17 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x17, Zalrsc_sc_d_cg_cmp_rd_rs2_b17, Zalrsc_sc_d_cg_cmp_rd_rs2_b17_str)
   LA(x30, scratch) # reload base address
@@ -2781,10 +3736,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b17:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x11, x18) # load rs2: x18 = 0xa07395b27367c795
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b18_retry:
   lr.d x0, (x24) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b18:
   sc.d x18, x18, (x24) # perform operation
+  beqz x18, Zalrsc_sc_d_cg_cmp_rd_rs2_b18_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_d_cg_cmp_rd_rs2_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b18_success:
   # Check if x18 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x18, Zalrsc_sc_d_cg_cmp_rd_rs2_b18, Zalrsc_sc_d_cg_cmp_rd_rs2_b18_str)
   LA(x24, scratch) # reload base address
@@ -2795,10 +3755,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b18:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x11, x19) # load rs2: x19 = 0xf222a11d7f8cd815
   LA(x26, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b19_retry:
   lr.d x0, (x26) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b19:
   sc.d x19, x19, (x26) # perform operation
+  beqz x19, Zalrsc_sc_d_cg_cmp_rd_rs2_b19_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_d_cg_cmp_rd_rs2_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b19_success:
   # Check if x19 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x19, Zalrsc_sc_d_cg_cmp_rd_rs2_b19, Zalrsc_sc_d_cg_cmp_rd_rs2_b19_str)
   LA(x26, scratch) # reload base address
@@ -2809,10 +3774,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b19:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x11, x20) # load rs2: x20 = 0x03f20339dbd81db3
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b20_retry:
   lr.d x0, (x7) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b20:
   sc.d x20, x20, (x7) # perform operation
+  beqz x20, Zalrsc_sc_d_cg_cmp_rd_rs2_b20_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_d_cg_cmp_rd_rs2_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b20_success:
   # Check if x20 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x20, Zalrsc_sc_d_cg_cmp_rd_rs2_b20, Zalrsc_sc_d_cg_cmp_rd_rs2_b20_str)
   LA(x7, scratch) # reload base address
@@ -2823,10 +3793,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b20:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x11, x21) # load rs2: x21 = 0xea2eb278ccdfed63
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b21_retry:
   lr.d x0, (x23) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b21:
   sc.d x21, x21, (x23) # perform operation
+  beqz x21, Zalrsc_sc_d_cg_cmp_rd_rs2_b21_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_d_cg_cmp_rd_rs2_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b21_success:
   # Check if x21 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x21, Zalrsc_sc_d_cg_cmp_rd_rs2_b21, Zalrsc_sc_d_cg_cmp_rd_rs2_b21_str)
   LA(x23, scratch) # reload base address
@@ -2838,10 +3813,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b21:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x11, x22) # load rs2: x22 = 0xb2e49960a12d1d34
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b22_retry:
   lr.d x0, (x23) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b22:
   sc.d x22, x22, (x23) # perform operation
+  beqz x22, Zalrsc_sc_d_cg_cmp_rd_rs2_b22_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_d_cg_cmp_rd_rs2_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b22_success:
   # Check if x22 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x22, Zalrsc_sc_d_cg_cmp_rd_rs2_b22, Zalrsc_sc_d_cg_cmp_rd_rs2_b22_str)
   LA(x23, scratch) # reload base address
@@ -2852,10 +3832,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b22:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x11, x23) # load rs2: x23 = 0x29a10f64148abed6
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b23_retry:
   lr.d x0, (x21) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b23:
   sc.d x23, x23, (x21) # perform operation
+  beqz x23, Zalrsc_sc_d_cg_cmp_rd_rs2_b23_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_d_cg_cmp_rd_rs2_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b23_success:
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zalrsc_sc_d_cg_cmp_rd_rs2_b23, Zalrsc_sc_d_cg_cmp_rd_rs2_b23_str)
   LA(x21, scratch) # reload base address
@@ -2866,10 +3851,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b23:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x11, x24) # load rs2: x24 = 0x6b6152e584752435
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b24_retry:
   lr.d x0, (x31) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b24:
   sc.d x24, x24, (x31) # perform operation
+  beqz x24, Zalrsc_sc_d_cg_cmp_rd_rs2_b24_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_d_cg_cmp_rd_rs2_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b24_success:
   # Check if x24 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x24, Zalrsc_sc_d_cg_cmp_rd_rs2_b24, Zalrsc_sc_d_cg_cmp_rd_rs2_b24_str)
   LA(x31, scratch) # reload base address
@@ -2880,10 +3870,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b24:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x11, x25) # load rs2: x25 = 0x2158cd7367a7f2c9
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b25_retry:
   lr.d x0, (x13) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b25:
   sc.d x25, x25, (x13) # perform operation
+  beqz x25, Zalrsc_sc_d_cg_cmp_rd_rs2_b25_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_d_cg_cmp_rd_rs2_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b25_success:
   # Check if x25 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x25, Zalrsc_sc_d_cg_cmp_rd_rs2_b25, Zalrsc_sc_d_cg_cmp_rd_rs2_b25_str)
   LA(x13, scratch) # reload base address
@@ -2894,10 +3889,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b25:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x11, x26) # load rs2: x26 = 0x50c7c150e27fc7a7
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b26_retry:
   lr.d x0, (x27) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b26:
   sc.d x26, x26, (x27) # perform operation
+  beqz x26, Zalrsc_sc_d_cg_cmp_rd_rs2_b26_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_d_cg_cmp_rd_rs2_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b26_success:
   # Check if x26 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x26, Zalrsc_sc_d_cg_cmp_rd_rs2_b26, Zalrsc_sc_d_cg_cmp_rd_rs2_b26_str)
   LA(x27, scratch) # reload base address
@@ -2908,10 +3908,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b26:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x11, x27) # load rs2: x27 = 0x71539a7675f25a37
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b27_retry:
   lr.d x0, (x9) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b27:
   sc.d x27, x27, (x9) # perform operation
+  beqz x27, Zalrsc_sc_d_cg_cmp_rd_rs2_b27_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_d_cg_cmp_rd_rs2_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b27_success:
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, Zalrsc_sc_d_cg_cmp_rd_rs2_b27, Zalrsc_sc_d_cg_cmp_rd_rs2_b27_str)
   LA(x9, scratch) # reload base address
@@ -2922,10 +3927,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b27:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x11, x28) # load rs2: x28 = 0x3dd84afbfb2cd277
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b28_retry:
   lr.d x0, (x7) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b28:
   sc.d x28, x28, (x7) # perform operation
+  beqz x28, Zalrsc_sc_d_cg_cmp_rd_rs2_b28_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_d_cg_cmp_rd_rs2_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b28_success:
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zalrsc_sc_d_cg_cmp_rd_rs2_b28, Zalrsc_sc_d_cg_cmp_rd_rs2_b28_str)
   LA(x7, scratch) # reload base address
@@ -2936,10 +3946,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b28:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x11, x29) # load rs2: x29 = 0x07b2d1a468e3328f
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b29_retry:
   lr.d x0, (x31) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b29:
   sc.d x29, x29, (x31) # perform operation
+  beqz x29, Zalrsc_sc_d_cg_cmp_rd_rs2_b29_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_d_cg_cmp_rd_rs2_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b29_success:
   # Check if x29 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x29, Zalrsc_sc_d_cg_cmp_rd_rs2_b29, Zalrsc_sc_d_cg_cmp_rd_rs2_b29_str)
   LA(x31, scratch) # reload base address
@@ -2950,10 +3965,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b29:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x11, x30) # load rs2: x30 = 0x28fd7021f0a69bea
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b30_retry:
   lr.d x0, (x31) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b30:
   sc.d x30, x30, (x31) # perform operation
+  beqz x30, Zalrsc_sc_d_cg_cmp_rd_rs2_b30_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_d_cg_cmp_rd_rs2_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b30_success:
   # Check if x30 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x30, Zalrsc_sc_d_cg_cmp_rd_rs2_b30, Zalrsc_sc_d_cg_cmp_rd_rs2_b30_str)
   LA(x31, scratch) # reload base address
@@ -2964,10 +3984,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b30:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0x1153bd1667e8c133
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs2_b31_retry:
   lr.d x0, (x23) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs2_b31:
   sc.d x31, x31, (x23) # perform operation
+  beqz x31, Zalrsc_sc_d_cg_cmp_rd_rs2_b31_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_d_cg_cmp_rd_rs2_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs2_b31_success:
   # Check if x31 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x31, Zalrsc_sc_d_cg_cmp_rd_rs2_b31, Zalrsc_sc_d_cg_cmp_rd_rs2_b31_str)
   LA(x23, scratch) # reload base address
@@ -2982,10 +4007,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs2_b31:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x11, x1) # load rs2: x1 = 0xc4ebb3aefed1832f
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b1_retry:
   lr.d x0, (x1) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b1:
   sc.d x1, x1, (x1) # perform operation
+  beqz x1, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b1_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b1_success:
   # Check if x1 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x1, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b1, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b1_str)
   LA(x1, scratch) # reload base address
@@ -2996,10 +4026,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b1:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x11, x2) # load rs2: x2 = 0xa9157b6253011b7b
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b2_retry:
   lr.d x0, (x2) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b2:
   sc.d x2, x2, (x2) # perform operation
+  beqz x2, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b2_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b2_success:
   # Check if x2 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x2, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b2, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b2_str)
   LA(x2, scratch) # reload base address
@@ -3010,10 +4045,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b2:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x11, x3) # load rs2: x3 = 0x15ab71f78ed23a31
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b3_retry:
   lr.d x0, (x3) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b3:
   sc.d x3, x3, (x3) # perform operation
+  beqz x3, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b3_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b3_success:
   # Check if x3 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x3, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b3, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b3_str)
   LA(x3, scratch) # reload base address
@@ -3026,10 +4066,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b3:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x4)
   RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0x178ad6a3b22788ba
   LA(x4, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b4_retry:
   lr.d x0, (x4) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b4:
   sc.d x4, x4, (x4) # perform operation
+  beqz x4, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b4_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b4_success:
   # Check if x4 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x4, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b4, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b4_str)
   LA(x4, scratch) # reload base address
@@ -3040,10 +4085,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b4:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0x4f76bb93d0c3c6f8
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b5_retry:
   lr.d x0, (x5) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b5:
   sc.d x5, x5, (x5) # perform operation
+  beqz x5, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b5_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b5_success:
   # Check if x5 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x5, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b5, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b5_str)
   LA(x5, scratch) # reload base address
@@ -3054,10 +4104,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b5:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x11, x6) # load rs2: x6 = 0x27a59724c5885958
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b6_retry:
   lr.d x0, (x6) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b6:
   sc.d x6, x6, (x6) # perform operation
+  beqz x6, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b6_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b6_success:
   # Check if x6 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x6, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b6, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b6_str)
   LA(x6, scratch) # reload base address
@@ -3070,10 +4125,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b6:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x11, x7) # load rs2: x7 = 0xb1f4f9eb1e0ce228
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b7_retry:
   lr.d x0, (x7) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b7:
   sc.d x7, x7, (x7) # perform operation
+  beqz x7, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b7_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b7_success:
   # Check if x7 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x7, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b7, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b7_str)
   LA(x7, scratch) # reload base address
@@ -3084,10 +4144,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b7:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x11, x8) # load rs2: x8 = 0x489c663a9bfd0602
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b8_retry:
   lr.d x0, (x8) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b8:
   sc.d x8, x8, (x8) # perform operation
+  beqz x8, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b8_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b8_success:
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b8, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b8_str)
   LA(x8, scratch) # reload base address
@@ -3098,10 +4163,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b8:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0x04c6297847ffa68c
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b9_retry:
   lr.d x0, (x9) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b9:
   sc.d x9, x9, (x9) # perform operation
+  beqz x9, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b9_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b9_success:
   # Check if x9 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x9, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b9, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b9_str)
   LA(x9, scratch) # reload base address
@@ -3112,10 +4182,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b9:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x11, x10) # load rs2: x10 = 0xc4bcbc7a0fa00345
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b10_retry:
   lr.d x0, (x10) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b10:
   sc.d x10, x10, (x10) # perform operation
+  beqz x10, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b10_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b10_success:
   # Check if x10 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x10, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b10, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b10_str)
   LA(x10, scratch) # reload base address
@@ -3127,10 +4202,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b10:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xf5022744bf0585ff
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b11_retry:
   lr.d x0, (x11) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b11:
   sc.d x11, x11, (x11) # perform operation
+  beqz x11, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b11_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b11_success:
   # Check if x11 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x11, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b11, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b11_str)
   LA(x11, scratch) # reload base address
@@ -3141,10 +4221,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b11:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x52847c979f86f78c
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b12_retry:
   lr.d x0, (x12) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b12:
   sc.d x12, x12, (x12) # perform operation
+  beqz x12, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b12_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b12_success:
   # Check if x12 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x12, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b12, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b12_str)
   LA(x12, scratch) # reload base address
@@ -3155,10 +4240,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b12:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x4e6df99df35bd87f
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b13_retry:
   lr.d x0, (x13) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b13:
   sc.d x13, x13, (x13) # perform operation
+  beqz x13, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b13_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b13_success:
   # Check if x13 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x13, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b13, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b13_str)
   LA(x13, scratch) # reload base address
@@ -3169,10 +4259,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b13:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x0325b7e1bc0fb4a3
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b14_retry:
   lr.d x0, (x14) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b14:
   sc.d x14, x14, (x14) # perform operation
+  beqz x14, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b14_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b14_success:
   # Check if x14 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x14, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b14, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b14_str)
   LA(x14, scratch) # reload base address
@@ -3183,10 +4278,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b14:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xc6fd47bdb913f5a5
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b15_retry:
   lr.d x0, (x15) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b15:
   sc.d x15, x15, (x15) # perform operation
+  beqz x15, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b15_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b15_success:
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b15, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b15_str)
   LA(x15, scratch) # reload base address
@@ -3197,10 +4297,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b15:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x62064eb71ecd0899
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b16_retry:
   lr.d x0, (x16) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b16:
   sc.d x16, x16, (x16) # perform operation
+  beqz x16, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b16_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b16_success:
   # Check if x16 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x16, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b16, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b16_str)
   LA(x16, scratch) # reload base address
@@ -3211,10 +4316,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b16:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0x2925742eeda35f29
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b17_retry:
   lr.d x0, (x17) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b17:
   sc.d x17, x17, (x17) # perform operation
+  beqz x17, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b17_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b17_success:
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b17, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b17_str)
   LA(x17, scratch) # reload base address
@@ -3226,10 +4336,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b17:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rs2: x18 = 0x3069300f25627dad
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b18_retry:
   lr.d x0, (x18) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b18:
   sc.d x18, x18, (x18) # perform operation
+  beqz x18, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b18_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b18_success:
   # Check if x18 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x18, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b18, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b18_str)
   LA(x18, scratch) # reload base address
@@ -3240,10 +4355,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b18:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0x81fea3f8bbc93d39
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b19_retry:
   lr.d x0, (x19) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b19:
   sc.d x19, x19, (x19) # perform operation
+  beqz x19, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b19_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b19_success:
   # Check if x19 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x19, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b19, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b19_str)
   LA(x19, scratch) # reload base address
@@ -3254,10 +4374,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b19:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x5a7d305fd5b95c94
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b20_retry:
   lr.d x0, (x20) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b20:
   sc.d x20, x20, (x20) # perform operation
+  beqz x20, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b20_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b20_success:
   # Check if x20 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x20, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b20, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b20_str)
   LA(x20, scratch) # reload base address
@@ -3268,10 +4393,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b20:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0xf9fae2973e2e2f67
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b21_retry:
   lr.d x0, (x21) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b21:
   sc.d x21, x21, (x21) # perform operation
+  beqz x21, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b21_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b21_success:
   # Check if x21 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x21, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b21, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b21_str)
   LA(x21, scratch) # reload base address
@@ -3282,10 +4412,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b21:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0xac1ff803c841a538
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b22_retry:
   lr.d x0, (x22) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b22:
   sc.d x22, x22, (x22) # perform operation
+  beqz x22, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b22_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b22_success:
   # Check if x22 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x22, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b22, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b22_str)
   LA(x22, scratch) # reload base address
@@ -3296,10 +4431,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b22:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0xd9f71cb612366895
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b23_retry:
   lr.d x0, (x23) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b23:
   sc.d x23, x23, (x23) # perform operation
+  beqz x23, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b23_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b23_success:
   # Check if x23 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x23, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b23, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b23_str)
   LA(x23, scratch) # reload base address
@@ -3310,10 +4450,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b23:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0xc3a85e239a1d0fef
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b24_retry:
   lr.d x0, (x24) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b24:
   sc.d x24, x24, (x24) # perform operation
+  beqz x24, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b24_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b24_success:
   # Check if x24 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x24, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b24, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b24_str)
   LA(x24, scratch) # reload base address
@@ -3324,10 +4469,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b24:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x803ff3ca1212405f
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b25_retry:
   lr.d x0, (x25) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b25:
   sc.d x25, x25, (x25) # perform operation
+  beqz x25, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b25_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b25_success:
   # Check if x25 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x25, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b25, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b25_str)
   LA(x25, scratch) # reload base address
@@ -3338,10 +4488,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b25:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0xa6bc1d1c16ffb700
   LA(x26, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b26_retry:
   lr.d x0, (x26) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b26:
   sc.d x26, x26, (x26) # perform operation
+  beqz x26, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b26_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b26_success:
   # Check if x26 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x26, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b26, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b26_str)
   LA(x26, scratch) # reload base address
@@ -3352,10 +4507,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b26:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x2afef2c6f461490c
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b27_retry:
   lr.d x0, (x27) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b27:
   sc.d x27, x27, (x27) # perform operation
+  beqz x27, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b27_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b27_success:
   # Check if x27 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x27, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b27, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b27_str)
   LA(x27, scratch) # reload base address
@@ -3366,10 +4526,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b27:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x3282c135a64b7817
   LA(x28, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b28_retry:
   lr.d x0, (x28) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b28:
   sc.d x28, x28, (x28) # perform operation
+  beqz x28, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b28_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b28_success:
   # Check if x28 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x28, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b28, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b28_str)
   LA(x28, scratch) # reload base address
@@ -3380,10 +4545,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b28:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x02bf11a86deca749
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b29_retry:
   lr.d x0, (x29) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b29:
   sc.d x29, x29, (x29) # perform operation
+  beqz x29, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b29_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b29_success:
   # Check if x29 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x29, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b29, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b29_str)
   LA(x29, scratch) # reload base address
@@ -3395,10 +4565,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b29:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x8472d96c3ba3f1f1
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b30_retry:
   lr.d x0, (x30) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b30:
   sc.d x30, x30, (x30) # perform operation
+  beqz x30, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b30_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b30_success:
   # Check if x30 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x30, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b30, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b30_str)
   LA(x30, scratch) # reload base address
@@ -3409,10 +4584,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b30:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0xd72e29a9f201ea30
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b31_retry:
   lr.d x0, (x31) # establish reservation
 Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b31:
   sc.d x31, x31, (x31) # perform operation
+  beqz x31, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b31_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b31_success:
   # Check if x31 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x31, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b31, Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b31_str)
   LA(x31, scratch) # reload base address
@@ -3427,9 +4607,15 @@ Zalrsc_sc_d_cg_cmp_rd_rs1_rs2_nx0_b31:
 # Testcase: cp_custom_aqrl with suffix ''
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x09db713058524af3
   LA(x31, scratch) # rs1 = base address
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_custom_aqrl_retry:
   lr.d x0, (x31) # establish reservation
 Zalrsc_sc_d_cg_cp_custom_aqrl:
   sc.d x3, x14, (x31) # perform operation
+  beqz x3, Zalrsc_sc_d_cg_cp_custom_aqrl_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_d_cg_cp_custom_aqrl_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_custom_aqrl_success:
   # Check if x3 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x3, Zalrsc_sc_d_cg_cp_custom_aqrl, Zalrsc_sc_d_cg_cp_custom_aqrl_str)
   LA(x31, scratch) # reload base address
@@ -3440,9 +4626,15 @@ Zalrsc_sc_d_cg_cp_custom_aqrl:
 # Testcase: cp_custom_aqrl with suffix '.rl'
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x4059129d0c79dd93
   LA(x28, scratch) # rs1 = base address
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_custom_aqrl_rl_retry:
   lr.d x0, (x28) # establish reservation
 Zalrsc_sc_d_cg_cp_custom_aqrl_rl:
   sc.d.rl x17, x14, (x28) # perform operation
+  beqz x17, Zalrsc_sc_d_cg_cp_custom_aqrl_rl_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_d_cg_cp_custom_aqrl_rl_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_custom_aqrl_rl_success:
   # Check if x17 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x17, Zalrsc_sc_d_cg_cp_custom_aqrl_rl, Zalrsc_sc_d_cg_cp_custom_aqrl_rl_str)
   LA(x28, scratch) # reload base address
@@ -3453,9 +4645,15 @@ Zalrsc_sc_d_cg_cp_custom_aqrl_rl:
 # Testcase: cp_custom_aqrl with suffix '.aqrl'
   RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0xbe1ceb742117df88
   LA(x22, scratch) # rs1 = base address
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_custom_aqrl_aqrl_retry:
   lr.d x0, (x22) # establish reservation
 Zalrsc_sc_d_cg_cp_custom_aqrl_aqrl:
   sc.d.aqrl x15, x16, (x22) # perform operation
+  beqz x15, Zalrsc_sc_d_cg_cp_custom_aqrl_aqrl_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_d_cg_cp_custom_aqrl_aqrl_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_custom_aqrl_aqrl_success:
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, Zalrsc_sc_d_cg_cp_custom_aqrl_aqrl, Zalrsc_sc_d_cg_cp_custom_aqrl_aqrl_str)
   LA(x22, scratch) # reload base address
@@ -3466,9 +4664,15 @@ Zalrsc_sc_d_cg_cp_custom_aqrl_aqrl:
 # Testcase: cp_custom_sc_lr with prev lr.d
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0x9cadd5ae9e2ac9c5
   LA(x24, scratch) # rs1 = base address
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_d_cg_cp_custom_sc_lr_prev_lr_lr_d_retry:
   lr.d x0, (x24) # establish reservation
 Zalrsc_sc_d_cg_cp_custom_sc_lr_prev_lr_lr_d:
   sc.d x18, x19, (x24) # perform operation
+  beqz x18, Zalrsc_sc_d_cg_cp_custom_sc_lr_prev_lr_lr_d_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_d_cg_cp_custom_sc_lr_prev_lr_lr_d_retry # retry LR/SC if not exhausted
+Zalrsc_sc_d_cg_cp_custom_sc_lr_prev_lr_lr_d_success:
   # Check if x18 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x18, Zalrsc_sc_d_cg_cp_custom_sc_lr_prev_lr_lr_d, Zalrsc_sc_d_cg_cp_custom_sc_lr_prev_lr_lr_d_str)
   LA(x24, scratch) # reload base address

--- a/tests/rv64i/Zalrsc/Zalrsc-sc.w-00.S
+++ b/tests/rv64i/Zalrsc/Zalrsc-sc.w-00.S
@@ -37,10 +37,15 @@ RVTEST_BEGIN
 # Testcase cp_rs1_nx0 (Test source rs1 = x1)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x0f2091f8cdf4dcc0
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b1_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b1:
   sc.w x26, x12, (x1) # perform operation
+  beqz x26, Zalrsc_sc_w_cg_cp_rs1_nx0_b1_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cp_rs1_nx0_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b1_success:
   # Check if x26 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x26, Zalrsc_sc_w_cg_cp_rs1_nx0_b1, Zalrsc_sc_w_cg_cp_rs1_nx0_b1_str)
   LA(x1, scratch) # reload base address
@@ -52,10 +57,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b1:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x16) # load rs2: x16 = 0xbf61a80cba688fc5
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b2_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b2:
   sc.w x29, x16, (x2) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cp_rs1_nx0_b2_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rs1_nx0_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b2_success:
   # Check if x29 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x29, Zalrsc_sc_w_cg_cp_rs1_nx0_b2, Zalrsc_sc_w_cg_cp_rs1_nx0_b2_str)
   LA(x2, scratch) # reload base address
@@ -67,10 +77,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b2:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
   RVTEST_TESTDATA_LOAD_INT(x6, x17) # load rs2: x17 = 0x685f3d494c30ea40
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x30, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b3_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b3:
   sc.w x8, x17, (x3) # perform operation
+  beqz x8, Zalrsc_sc_w_cg_cp_rs1_nx0_b3_success # SC succeeded, skip retry
+  addi x30, x30, -1 # decrement retry count
+  bnez x30, Zalrsc_sc_w_cg_cp_rs1_nx0_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b3_success:
   # Check if x8 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x8, Zalrsc_sc_w_cg_cp_rs1_nx0_b3, Zalrsc_sc_w_cg_cp_rs1_nx0_b3_str)
   LA(x3, scratch) # reload base address
@@ -83,10 +98,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b3:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4)
   RVTEST_TESTDATA_LOAD_INT(x6, x3) # load rs2: x3 = 0x946e396e63d9be9c
   LA(x4, scratch) # rs1 = base address
-  nop
+  LI(x5, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b4_retry:
   lr.w x0, (x4) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b4:
   sc.w x17, x3, (x4) # perform operation
+  beqz x17, Zalrsc_sc_w_cg_cp_rs1_nx0_b4_success # SC succeeded, skip retry
+  addi x5, x5, -1 # decrement retry count
+  bnez x5, Zalrsc_sc_w_cg_cp_rs1_nx0_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b4_success:
   # Check if x17 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x17, Zalrsc_sc_w_cg_cp_rs1_nx0_b4, Zalrsc_sc_w_cg_cp_rs1_nx0_b4_str)
   LA(x4, scratch) # reload base address
@@ -97,10 +117,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b4:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x6, x17) # load rs2: x17 = 0xc4cca04ad537d8ea
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b5_retry:
   lr.w x0, (x5) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b5:
   sc.w x14, x17, (x5) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cp_rs1_nx0_b5_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cp_rs1_nx0_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b5_success:
   # Check if x14 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x14, Zalrsc_sc_w_cg_cp_rs1_nx0_b5, Zalrsc_sc_w_cg_cp_rs1_nx0_b5_str)
   LA(x5, scratch) # reload base address
@@ -112,10 +137,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b5:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x9, x28) # load rs2: x28 = 0xd89273a382c134a7
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x30, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b6_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b6:
   sc.w x5, x28, (x6) # perform operation
+  beqz x5, Zalrsc_sc_w_cg_cp_rs1_nx0_b6_success # SC succeeded, skip retry
+  addi x30, x30, -1 # decrement retry count
+  bnez x30, Zalrsc_sc_w_cg_cp_rs1_nx0_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b6_success:
   # Check if x5 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x5, Zalrsc_sc_w_cg_cp_rs1_nx0_b6, Zalrsc_sc_w_cg_cp_rs1_nx0_b6_str)
   LA(x6, scratch) # reload base address
@@ -128,10 +158,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b6:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7)
   RVTEST_TESTDATA_LOAD_INT(x9, x16) # load rs2: x16 = 0x423195f196451e67
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b7_retry:
   lr.w x0, (x7) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b7:
   sc.w x30, x16, (x7) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cp_rs1_nx0_b7_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cp_rs1_nx0_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b7_success:
   # Check if x30 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x30, Zalrsc_sc_w_cg_cp_rs1_nx0_b7, Zalrsc_sc_w_cg_cp_rs1_nx0_b7_str)
   LA(x7, scratch) # reload base address
@@ -142,10 +177,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b7:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x9, x21) # load rs2: x21 = 0x0ffdd4438146141a
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b8_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b8:
   sc.w x31, x21, (x8) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cp_rs1_nx0_b8_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_w_cg_cp_rs1_nx0_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b8_success:
   # Check if x31 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x31, Zalrsc_sc_w_cg_cp_rs1_nx0_b8, Zalrsc_sc_w_cg_cp_rs1_nx0_b8_str)
   LA(x8, scratch) # reload base address
@@ -157,10 +197,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b8:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x31, x23) # load rs2: x23 = 0x072c8b292580d5f2
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b9_retry:
   lr.w x0, (x9) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b9:
   sc.w x14, x23, (x9) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cp_rs1_nx0_b9_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_w_cg_cp_rs1_nx0_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b9_success:
   # Check if x14 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x14, Zalrsc_sc_w_cg_cp_rs1_nx0_b9, Zalrsc_sc_w_cg_cp_rs1_nx0_b9_str)
   LA(x9, scratch) # reload base address
@@ -171,10 +216,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b9:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x31, x0) # load rs2: x0 = 0x3044c019e4c1e65f
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b10_retry:
   lr.w x0, (x10) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b10:
   sc.w x12, x0, (x10) # perform operation
+  beqz x12, Zalrsc_sc_w_cg_cp_rs1_nx0_b10_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cp_rs1_nx0_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b10_success:
   # Check if x12 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x12, Zalrsc_sc_w_cg_cp_rs1_nx0_b10, Zalrsc_sc_w_cg_cp_rs1_nx0_b10_str)
   LA(x10, scratch) # reload base address
@@ -185,10 +235,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b10:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x31, x14) # load rs2: x14 = 0xc5ab6f84b45d51d0
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x24, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b11_retry:
   lr.w x0, (x11) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b11:
   sc.w x19, x14, (x11) # perform operation
+  beqz x19, Zalrsc_sc_w_cg_cp_rs1_nx0_b11_success # SC succeeded, skip retry
+  addi x24, x24, -1 # decrement retry count
+  bnez x24, Zalrsc_sc_w_cg_cp_rs1_nx0_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b11_success:
   # Check if x19 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x19, Zalrsc_sc_w_cg_cp_rs1_nx0_b11, Zalrsc_sc_w_cg_cp_rs1_nx0_b11_str)
   LA(x11, scratch) # reload base address
@@ -199,10 +254,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b11:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x31, x8) # load rs2: x8 = 0xc06ee537c90bfe5f
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b12_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b12:
   sc.w x21, x8, (x12) # perform operation
+  beqz x21, Zalrsc_sc_w_cg_cp_rs1_nx0_b12_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cp_rs1_nx0_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b12_success:
   # Check if x21 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x21, Zalrsc_sc_w_cg_cp_rs1_nx0_b12, Zalrsc_sc_w_cg_cp_rs1_nx0_b12_str)
   LA(x12, scratch) # reload base address
@@ -213,10 +273,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b12:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x31, x17) # load rs2: x17 = 0x74e5a8e72ab8db15
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b13_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b13:
   sc.w x7, x17, (x13) # perform operation
+  beqz x7, Zalrsc_sc_w_cg_cp_rs1_nx0_b13_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cp_rs1_nx0_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b13_success:
   # Check if x7 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x7, Zalrsc_sc_w_cg_cp_rs1_nx0_b13, Zalrsc_sc_w_cg_cp_rs1_nx0_b13_str)
   LA(x13, scratch) # reload base address
@@ -227,10 +292,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b13:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x31, x19) # load rs2: x19 = 0xb3eb6a875d4d51bc
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b14_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b14:
   sc.w x23, x19, (x14) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cp_rs1_nx0_b14_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cp_rs1_nx0_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b14_success:
   # Check if x23 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x23, Zalrsc_sc_w_cg_cp_rs1_nx0_b14, Zalrsc_sc_w_cg_cp_rs1_nx0_b14_str)
   LA(x14, scratch) # reload base address
@@ -241,10 +311,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b14:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x31, x12) # load rs2: x12 = 0xfae94adc1a763128
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b15_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b15:
   sc.w x6, x12, (x15) # perform operation
+  beqz x6, Zalrsc_sc_w_cg_cp_rs1_nx0_b15_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_w_cg_cp_rs1_nx0_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b15_success:
   # Check if x6 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x6, Zalrsc_sc_w_cg_cp_rs1_nx0_b15, Zalrsc_sc_w_cg_cp_rs1_nx0_b15_str)
   LA(x15, scratch) # reload base address
@@ -255,10 +330,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b15:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16)
   RVTEST_TESTDATA_LOAD_INT(x31, x7) # load rs2: x7 = 0x7a9bcacd88340987
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b16_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b16:
   sc.w x23, x7, (x16) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cp_rs1_nx0_b16_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_w_cg_cp_rs1_nx0_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b16_success:
   # Check if x23 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x23, Zalrsc_sc_w_cg_cp_rs1_nx0_b16, Zalrsc_sc_w_cg_cp_rs1_nx0_b16_str)
   LA(x16, scratch) # reload base address
@@ -269,10 +349,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b16:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17)
   RVTEST_TESTDATA_LOAD_INT(x31, x14) # load rs2: x14 = 0x3cd76893e69b7b06
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b17_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b17:
   sc.w x30, x14, (x17) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cp_rs1_nx0_b17_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cp_rs1_nx0_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b17_success:
   # Check if x30 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x30, Zalrsc_sc_w_cg_cp_rs1_nx0_b17, Zalrsc_sc_w_cg_cp_rs1_nx0_b17_str)
   LA(x17, scratch) # reload base address
@@ -283,10 +368,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b17:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18)
   RVTEST_TESTDATA_LOAD_INT(x31, x10) # load rs2: x10 = 0xbe8b8ab2047f7fb4
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b18_retry:
   lr.w x0, (x18) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b18:
   sc.w x21, x10, (x18) # perform operation
+  beqz x21, Zalrsc_sc_w_cg_cp_rs1_nx0_b18_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cp_rs1_nx0_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b18_success:
   # Check if x21 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x21, Zalrsc_sc_w_cg_cp_rs1_nx0_b18, Zalrsc_sc_w_cg_cp_rs1_nx0_b18_str)
   LA(x18, scratch) # reload base address
@@ -297,10 +387,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b18:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19)
   RVTEST_TESTDATA_LOAD_INT(x31, x16) # load rs2: x16 = 0x06cd8a17bcff84a3
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b19_retry:
   lr.w x0, (x19) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b19:
   sc.w x23, x16, (x19) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cp_rs1_nx0_b19_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_w_cg_cp_rs1_nx0_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b19_success:
   # Check if x23 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x23, Zalrsc_sc_w_cg_cp_rs1_nx0_b19, Zalrsc_sc_w_cg_cp_rs1_nx0_b19_str)
   LA(x19, scratch) # reload base address
@@ -312,10 +407,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b19:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20)
   RVTEST_TESTDATA_LOAD_INT(x31, x29) # load rs2: x29 = 0x98d96dbcb0492b9d
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b20_retry:
   lr.w x0, (x20) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b20:
   sc.w x15, x29, (x20) # perform operation
+  beqz x15, Zalrsc_sc_w_cg_cp_rs1_nx0_b20_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_w_cg_cp_rs1_nx0_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b20_success:
   # Check if x15 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x15, Zalrsc_sc_w_cg_cp_rs1_nx0_b20, Zalrsc_sc_w_cg_cp_rs1_nx0_b20_str)
   LA(x20, scratch) # reload base address
@@ -326,10 +426,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b20:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21)
   RVTEST_TESTDATA_LOAD_INT(x31, x24) # load rs2: x24 = 0x8a088ae3b1e3de1d
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b21_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b21:
   sc.w x8, x24, (x21) # perform operation
+  beqz x8, Zalrsc_sc_w_cg_cp_rs1_nx0_b21_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_w_cg_cp_rs1_nx0_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b21_success:
   # Check if x8 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x8, Zalrsc_sc_w_cg_cp_rs1_nx0_b21, Zalrsc_sc_w_cg_cp_rs1_nx0_b21_str)
   LA(x21, scratch) # reload base address
@@ -341,10 +446,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b21:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22)
   RVTEST_TESTDATA_LOAD_INT(x31, x11) # load rs2: x11 = 0x7a0c10a1254d354a
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b22_retry:
   lr.w x0, (x22) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b22:
   sc.w x14, x11, (x22) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cp_rs1_nx0_b22_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cp_rs1_nx0_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b22_success:
   # Check if x14 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x14, Zalrsc_sc_w_cg_cp_rs1_nx0_b22, Zalrsc_sc_w_cg_cp_rs1_nx0_b22_str)
   LA(x22, scratch) # reload base address
@@ -355,10 +465,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b22:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23)
   RVTEST_TESTDATA_LOAD_INT(x31, x26) # load rs2: x26 = 0x29d16b1901df6bc0
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b23_retry:
   lr.w x0, (x23) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b23:
   sc.w x28, x26, (x23) # perform operation
+  beqz x28, Zalrsc_sc_w_cg_cp_rs1_nx0_b23_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_w_cg_cp_rs1_nx0_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b23_success:
   # Check if x28 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x28, Zalrsc_sc_w_cg_cp_rs1_nx0_b23, Zalrsc_sc_w_cg_cp_rs1_nx0_b23_str)
   LA(x23, scratch) # reload base address
@@ -369,10 +484,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b23:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24)
   RVTEST_TESTDATA_LOAD_INT(x31, x16) # load rs2: x16 = 0x3ae96af8b1aa85d2
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b24_retry:
   lr.w x0, (x24) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b24:
   sc.w x20, x16, (x24) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cp_rs1_nx0_b24_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cp_rs1_nx0_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b24_success:
   # Check if x20 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x20, Zalrsc_sc_w_cg_cp_rs1_nx0_b24, Zalrsc_sc_w_cg_cp_rs1_nx0_b24_str)
   LA(x24, scratch) # reload base address
@@ -383,10 +503,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b24:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25)
   RVTEST_TESTDATA_LOAD_INT(x31, x6) # load rs2: x6 = 0x4d08f83aa6e3d1c4
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b25_retry:
   lr.w x0, (x25) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b25:
   sc.w x24, x6, (x25) # perform operation
+  beqz x24, Zalrsc_sc_w_cg_cp_rs1_nx0_b25_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cp_rs1_nx0_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b25_success:
   # Check if x24 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x24, Zalrsc_sc_w_cg_cp_rs1_nx0_b25, Zalrsc_sc_w_cg_cp_rs1_nx0_b25_str)
   LA(x25, scratch) # reload base address
@@ -397,10 +522,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b25:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26)
   RVTEST_TESTDATA_LOAD_INT(x31, x0) # load rs2: x0 = 0x9436b41154ff8257
   LA(x26, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b26_retry:
   lr.w x0, (x26) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b26:
   sc.w x13, x0, (x26) # perform operation
+  beqz x13, Zalrsc_sc_w_cg_cp_rs1_nx0_b26_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cp_rs1_nx0_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b26_success:
   # Check if x13 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x13, Zalrsc_sc_w_cg_cp_rs1_nx0_b26, Zalrsc_sc_w_cg_cp_rs1_nx0_b26_str)
   LA(x26, scratch) # reload base address
@@ -411,10 +541,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b26:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27)
   RVTEST_TESTDATA_LOAD_INT(x31, x6) # load rs2: x6 = 0x675333062a6f97b6
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b27_retry:
   lr.w x0, (x27) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b27:
   sc.w x17, x6, (x27) # perform operation
+  beqz x17, Zalrsc_sc_w_cg_cp_rs1_nx0_b27_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_w_cg_cp_rs1_nx0_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b27_success:
   # Check if x17 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x17, Zalrsc_sc_w_cg_cp_rs1_nx0_b27, Zalrsc_sc_w_cg_cp_rs1_nx0_b27_str)
   LA(x27, scratch) # reload base address
@@ -425,10 +560,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b27:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28)
   RVTEST_TESTDATA_LOAD_INT(x31, x7) # load rs2: x7 = 0x3e3506bce09c795c
   LA(x28, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b28_retry:
   lr.w x0, (x28) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b28:
   sc.w x23, x7, (x28) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cp_rs1_nx0_b28_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_w_cg_cp_rs1_nx0_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b28_success:
   # Check if x23 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x23, Zalrsc_sc_w_cg_cp_rs1_nx0_b28, Zalrsc_sc_w_cg_cp_rs1_nx0_b28_str)
   LA(x28, scratch) # reload base address
@@ -440,10 +580,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b28:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29)
   RVTEST_TESTDATA_LOAD_INT(x31, x28) # load rs2: x28 = 0xaa1099c1ccd91864
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b29_retry:
   lr.w x0, (x29) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b29:
   sc.w x9, x28, (x29) # perform operation
+  beqz x9, Zalrsc_sc_w_cg_cp_rs1_nx0_b29_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cp_rs1_nx0_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b29_success:
   # Check if x9 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x9, Zalrsc_sc_w_cg_cp_rs1_nx0_b29, Zalrsc_sc_w_cg_cp_rs1_nx0_b29_str)
   LA(x29, scratch) # reload base address
@@ -454,10 +599,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b29:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30)
   RVTEST_TESTDATA_LOAD_INT(x31, x19) # load rs2: x19 = 0xb9f055c955711bdf
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b30_retry:
   lr.w x0, (x30) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b30:
   sc.w x2, x19, (x30) # perform operation
+  beqz x2, Zalrsc_sc_w_cg_cp_rs1_nx0_b30_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_w_cg_cp_rs1_nx0_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b30_success:
   # Check if x2 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x2, Zalrsc_sc_w_cg_cp_rs1_nx0_b30, Zalrsc_sc_w_cg_cp_rs1_nx0_b30_str)
   LA(x30, scratch) # reload base address
@@ -469,10 +619,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b30:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31)
   RVTEST_TESTDATA_LOAD_INT(x30, x1) # load rs2: x1 = 0x4ae3bfc7a23f465a
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs1_nx0_b31_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cp_rs1_nx0_b31:
   sc.w x19, x1, (x31) # perform operation
+  beqz x19, Zalrsc_sc_w_cg_cp_rs1_nx0_b31_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_w_cg_cp_rs1_nx0_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs1_nx0_b31_success:
   # Check if x19 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x19, Zalrsc_sc_w_cg_cp_rs1_nx0_b31, Zalrsc_sc_w_cg_cp_rs1_nx0_b31_str)
   LA(x31, scratch) # reload base address
@@ -487,10 +642,15 @@ Zalrsc_sc_w_cg_cp_rs1_nx0_b31:
 # Testcase cp_rs2 (Test source rs2 = x0)
   RVTEST_TESTDATA_LOAD_INT(x30, x0) # load rs2: x0 = 0x415539f92147f3fc
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b0_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b0:
   sc.w x20, x0, (x16) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cp_rs2_b0_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cp_rs2_b0_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b0_success:
   # Check if x20 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x20, Zalrsc_sc_w_cg_cp_rs2_b0, Zalrsc_sc_w_cg_cp_rs2_b0_str)
   LA(x16, scratch) # reload base address
@@ -501,10 +661,15 @@ Zalrsc_sc_w_cg_cp_rs2_b0:
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x30, x1) # load rs2: x1 = 0xd1871ad4ab66fc77
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b1_retry:
   lr.w x0, (x7) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b1:
   sc.w x0, x1, (x7) # perform operation
+  beqz x0, Zalrsc_sc_w_cg_cp_rs2_b1_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_w_cg_cp_rs2_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b1_success:
   # Check if x0 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x0, Zalrsc_sc_w_cg_cp_rs2_b1, Zalrsc_sc_w_cg_cp_rs2_b1_str)
   LA(x7, scratch) # reload base address
@@ -515,10 +680,15 @@ Zalrsc_sc_w_cg_cp_rs2_b1:
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x30, x2) # load rs2: x2 = 0xf139f7edcf9fb98a
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b2_retry:
   lr.w x0, (x10) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b2:
   sc.w x7, x2, (x10) # perform operation
+  beqz x7, Zalrsc_sc_w_cg_cp_rs2_b2_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cp_rs2_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b2_success:
   # Check if x7 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x7, Zalrsc_sc_w_cg_cp_rs2_b2, Zalrsc_sc_w_cg_cp_rs2_b2_str)
   LA(x10, scratch) # reload base address
@@ -529,10 +699,15 @@ Zalrsc_sc_w_cg_cp_rs2_b2:
 # Testcase cp_rs2 (Test source rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x30, x3) # load rs2: x3 = 0x39c2468e4f4da580
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b3_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b3:
   sc.w x29, x3, (x8) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cp_rs2_b3_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_w_cg_cp_rs2_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b3_success:
   # Check if x29 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x29, Zalrsc_sc_w_cg_cp_rs2_b3, Zalrsc_sc_w_cg_cp_rs2_b3_str)
   LA(x8, scratch) # reload base address
@@ -545,10 +720,15 @@ Zalrsc_sc_w_cg_cp_rs2_b3:
 # Testcase cp_rs2 (Test source rs2 = x4)
   RVTEST_TESTDATA_LOAD_INT(x30, x4) # load rs2: x4 = 0x1193ef9bb12f3747
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b4_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b4:
   sc.w x29, x4, (x31) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cp_rs2_b4_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cp_rs2_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b4_success:
   # Check if x29 contains the expected result. x24 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x24, x13, x12, x29, Zalrsc_sc_w_cg_cp_rs2_b4, Zalrsc_sc_w_cg_cp_rs2_b4_str)
   LA(x31, scratch) # reload base address
@@ -559,10 +739,15 @@ Zalrsc_sc_w_cg_cp_rs2_b4:
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x30, x5) # load rs2: x5 = 0x0e9dc67167678b49
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b5_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b5:
   sc.w x26, x5, (x31) # perform operation
+  beqz x26, Zalrsc_sc_w_cg_cp_rs2_b5_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_w_cg_cp_rs2_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b5_success:
   # Check if x26 contains the expected result. x24 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x24, x13, x12, x26, Zalrsc_sc_w_cg_cp_rs2_b5, Zalrsc_sc_w_cg_cp_rs2_b5_str)
   LA(x31, scratch) # reload base address
@@ -573,10 +758,15 @@ Zalrsc_sc_w_cg_cp_rs2_b5:
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x30, x6) # load rs2: x6 = 0x116fbcae95fbd935
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b6_retry:
   lr.w x0, (x19) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b6:
   sc.w x28, x6, (x19) # perform operation
+  beqz x28, Zalrsc_sc_w_cg_cp_rs2_b6_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cp_rs2_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b6_success:
   # Check if x28 contains the expected result. x24 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x24, x13, x12, x28, Zalrsc_sc_w_cg_cp_rs2_b6, Zalrsc_sc_w_cg_cp_rs2_b6_str)
   LA(x19, scratch) # reload base address
@@ -587,10 +777,15 @@ Zalrsc_sc_w_cg_cp_rs2_b6:
 # Testcase cp_rs2 (Test source rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x30, x7) # load rs2: x7 = 0x96d8ac657e0837b6
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b7_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b7:
   sc.w x20, x7, (x14) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cp_rs2_b7_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_w_cg_cp_rs2_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b7_success:
   # Check if x20 contains the expected result. x24 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x24, x13, x12, x20, Zalrsc_sc_w_cg_cp_rs2_b7, Zalrsc_sc_w_cg_cp_rs2_b7_str)
   LA(x14, scratch) # reload base address
@@ -601,10 +796,15 @@ Zalrsc_sc_w_cg_cp_rs2_b7:
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x30, x8) # load rs2: x8 = 0x408725c546074da3
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b8_retry:
   lr.w x0, (x19) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b8:
   sc.w x15, x8, (x19) # perform operation
+  beqz x15, Zalrsc_sc_w_cg_cp_rs2_b8_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cp_rs2_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b8_success:
   # Check if x15 contains the expected result. x24 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x24, x13, x12, x15, Zalrsc_sc_w_cg_cp_rs2_b8, Zalrsc_sc_w_cg_cp_rs2_b8_str)
   LA(x19, scratch) # reload base address
@@ -615,10 +815,15 @@ Zalrsc_sc_w_cg_cp_rs2_b8:
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x30, x9) # load rs2: x9 = 0xe3dd0f8af8065d0d
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b9_retry:
   lr.w x0, (x25) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b9:
   sc.w x7, x9, (x25) # perform operation
+  beqz x7, Zalrsc_sc_w_cg_cp_rs2_b9_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cp_rs2_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b9_success:
   # Check if x7 contains the expected result. x24 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x24, x13, x12, x7, Zalrsc_sc_w_cg_cp_rs2_b9, Zalrsc_sc_w_cg_cp_rs2_b9_str)
   LA(x25, scratch) # reload base address
@@ -629,10 +834,15 @@ Zalrsc_sc_w_cg_cp_rs2_b9:
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x30, x10) # load rs2: x10 = 0xa5272acd2d95b75d
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b10_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b10:
   sc.w x26, x10, (x1) # perform operation
+  beqz x26, Zalrsc_sc_w_cg_cp_rs2_b10_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cp_rs2_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b10_success:
   # Check if x26 contains the expected result. x24 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x24, x13, x12, x26, Zalrsc_sc_w_cg_cp_rs2_b10, Zalrsc_sc_w_cg_cp_rs2_b10_str)
   LA(x1, scratch) # reload base address
@@ -643,10 +853,15 @@ Zalrsc_sc_w_cg_cp_rs2_b10:
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x30, x11) # load rs2: x11 = 0xd50d125ffbf2f936
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b11_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b11:
   sc.w x9, x11, (x15) # perform operation
+  beqz x9, Zalrsc_sc_w_cg_cp_rs2_b11_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_w_cg_cp_rs2_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b11_success:
   # Check if x9 contains the expected result. x24 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x24, x13, x12, x9, Zalrsc_sc_w_cg_cp_rs2_b11, Zalrsc_sc_w_cg_cp_rs2_b11_str)
   LA(x15, scratch) # reload base address
@@ -659,10 +874,15 @@ Zalrsc_sc_w_cg_cp_rs2_b11:
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x30, x12) # load rs2: x12 = 0x4032cb25fe8d05eb
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b12_retry:
   lr.w x0, (x27) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b12:
   sc.w x6, x12, (x27) # perform operation
+  beqz x6, Zalrsc_sc_w_cg_cp_rs2_b12_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rs2_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b12_success:
   # Check if x6 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x6, Zalrsc_sc_w_cg_cp_rs2_b12, Zalrsc_sc_w_cg_cp_rs2_b12_str)
   LA(x27, scratch) # reload base address
@@ -673,10 +893,15 @@ Zalrsc_sc_w_cg_cp_rs2_b12:
 # Testcase cp_rs2 (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x30, x13) # load rs2: x13 = 0x99ce18d5cf3a3174
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b13_retry:
   lr.w x0, (x27) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b13:
   sc.w x19, x13, (x27) # perform operation
+  beqz x19, Zalrsc_sc_w_cg_cp_rs2_b13_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_w_cg_cp_rs2_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b13_success:
   # Check if x19 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x19, Zalrsc_sc_w_cg_cp_rs2_b13, Zalrsc_sc_w_cg_cp_rs2_b13_str)
   LA(x27, scratch) # reload base address
@@ -687,10 +912,15 @@ Zalrsc_sc_w_cg_cp_rs2_b13:
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x30, x14) # load rs2: x14 = 0x48c54cdf00fe5f01
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b14_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b14:
   sc.w x13, x14, (x21) # perform operation
+  beqz x13, Zalrsc_sc_w_cg_cp_rs2_b14_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rs2_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b14_success:
   # Check if x13 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x13, Zalrsc_sc_w_cg_cp_rs2_b14, Zalrsc_sc_w_cg_cp_rs2_b14_str)
   LA(x21, scratch) # reload base address
@@ -701,10 +931,15 @@ Zalrsc_sc_w_cg_cp_rs2_b14:
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x30, x15) # load rs2: x15 = 0xa175141410167a2a
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b15_retry:
   lr.w x0, (x20) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b15:
   sc.w x14, x15, (x20) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cp_rs2_b15_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_w_cg_cp_rs2_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b15_success:
   # Check if x14 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x14, Zalrsc_sc_w_cg_cp_rs2_b15, Zalrsc_sc_w_cg_cp_rs2_b15_str)
   LA(x20, scratch) # reload base address
@@ -715,10 +950,15 @@ Zalrsc_sc_w_cg_cp_rs2_b15:
 # Testcase cp_rs2 (Test source rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x30, x16) # load rs2: x16 = 0xfd1dcf3ddc62a079
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b16_retry:
   lr.w x0, (x5) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b16:
   sc.w x11, x16, (x5) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cp_rs2_b16_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cp_rs2_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b16_success:
   # Check if x11 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x11, Zalrsc_sc_w_cg_cp_rs2_b16, Zalrsc_sc_w_cg_cp_rs2_b16_str)
   LA(x5, scratch) # reload base address
@@ -729,10 +969,15 @@ Zalrsc_sc_w_cg_cp_rs2_b16:
 # Testcase cp_rs2 (Test source rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x30, x17) # load rs2: x17 = 0x0ed7354d693873a7
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x5, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b17_retry:
   lr.w x0, (x18) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b17:
   sc.w x14, x17, (x18) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cp_rs2_b17_success # SC succeeded, skip retry
+  addi x5, x5, -1 # decrement retry count
+  bnez x5, Zalrsc_sc_w_cg_cp_rs2_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b17_success:
   # Check if x14 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x14, Zalrsc_sc_w_cg_cp_rs2_b17, Zalrsc_sc_w_cg_cp_rs2_b17_str)
   LA(x18, scratch) # reload base address
@@ -743,10 +988,15 @@ Zalrsc_sc_w_cg_cp_rs2_b17:
 # Testcase cp_rs2 (Test source rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x30, x18) # load rs2: x18 = 0xd349471622e5f3bd
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b18_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b18:
   sc.w x4, x18, (x12) # perform operation
+  beqz x4, Zalrsc_sc_w_cg_cp_rs2_b18_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cp_rs2_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b18_success:
   # Check if x4 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x4, Zalrsc_sc_w_cg_cp_rs2_b18, Zalrsc_sc_w_cg_cp_rs2_b18_str)
   LA(x12, scratch) # reload base address
@@ -757,10 +1007,15 @@ Zalrsc_sc_w_cg_cp_rs2_b18:
 # Testcase cp_rs2 (Test source rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x30, x19) # load rs2: x19 = 0x8e5dfe56d5a8a279
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b19_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b19:
   sc.w x21, x19, (x16) # perform operation
+  beqz x21, Zalrsc_sc_w_cg_cp_rs2_b19_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cp_rs2_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b19_success:
   # Check if x21 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x21, Zalrsc_sc_w_cg_cp_rs2_b19, Zalrsc_sc_w_cg_cp_rs2_b19_str)
   LA(x16, scratch) # reload base address
@@ -771,10 +1026,15 @@ Zalrsc_sc_w_cg_cp_rs2_b19:
 # Testcase cp_rs2 (Test source rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x30, x20) # load rs2: x20 = 0x41d44cc4567bf100
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b20_retry:
   lr.w x0, (x11) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b20:
   sc.w x27, x20, (x11) # perform operation
+  beqz x27, Zalrsc_sc_w_cg_cp_rs2_b20_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rs2_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b20_success:
   # Check if x27 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x27, Zalrsc_sc_w_cg_cp_rs2_b20, Zalrsc_sc_w_cg_cp_rs2_b20_str)
   LA(x11, scratch) # reload base address
@@ -785,10 +1045,15 @@ Zalrsc_sc_w_cg_cp_rs2_b20:
 # Testcase cp_rs2 (Test source rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x30, x21) # load rs2: x21 = 0x9b6fdb1a0be4ea67
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b21_retry:
   lr.w x0, (x9) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b21:
   sc.w x20, x21, (x9) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cp_rs2_b21_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cp_rs2_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b21_success:
   # Check if x20 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x20, Zalrsc_sc_w_cg_cp_rs2_b21, Zalrsc_sc_w_cg_cp_rs2_b21_str)
   LA(x9, scratch) # reload base address
@@ -799,10 +1064,15 @@ Zalrsc_sc_w_cg_cp_rs2_b21:
 # Testcase cp_rs2 (Test source rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x30, x22) # load rs2: x22 = 0x96d5d0f61c1d8cf6
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b22_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b22:
   sc.w x1, x22, (x14) # perform operation
+  beqz x1, Zalrsc_sc_w_cg_cp_rs2_b22_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_w_cg_cp_rs2_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b22_success:
   # Check if x1 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x1, Zalrsc_sc_w_cg_cp_rs2_b22, Zalrsc_sc_w_cg_cp_rs2_b22_str)
   LA(x14, scratch) # reload base address
@@ -813,10 +1083,15 @@ Zalrsc_sc_w_cg_cp_rs2_b22:
 # Testcase cp_rs2 (Test source rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x30, x23) # load rs2: x23 = 0x6eb2018dfbf1fb3c
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b23_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b23:
   sc.w x5, x23, (x15) # perform operation
+  beqz x5, Zalrsc_sc_w_cg_cp_rs2_b23_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cp_rs2_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b23_success:
   # Check if x5 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x5, Zalrsc_sc_w_cg_cp_rs2_b23, Zalrsc_sc_w_cg_cp_rs2_b23_str)
   LA(x15, scratch) # reload base address
@@ -828,10 +1103,15 @@ Zalrsc_sc_w_cg_cp_rs2_b23:
 # Testcase cp_rs2 (Test source rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x30, x24) # load rs2: x24 = 0xd5ad855e9073eb7f
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x4, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b24_retry:
   lr.w x0, (x18) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b24:
   sc.w x29, x24, (x18) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cp_rs2_b24_success # SC succeeded, skip retry
+  addi x4, x4, -1 # decrement retry count
+  bnez x4, Zalrsc_sc_w_cg_cp_rs2_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b24_success:
   # Check if x29 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x29, Zalrsc_sc_w_cg_cp_rs2_b24, Zalrsc_sc_w_cg_cp_rs2_b24_str)
   LA(x18, scratch) # reload base address
@@ -842,10 +1122,15 @@ Zalrsc_sc_w_cg_cp_rs2_b24:
 # Testcase cp_rs2 (Test source rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x30, x25) # load rs2: x25 = 0xd474d40149504d85
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b25_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b25:
   sc.w x1, x25, (x3) # perform operation
+  beqz x1, Zalrsc_sc_w_cg_cp_rs2_b25_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_w_cg_cp_rs2_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b25_success:
   # Check if x1 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x1, Zalrsc_sc_w_cg_cp_rs2_b25, Zalrsc_sc_w_cg_cp_rs2_b25_str)
   LA(x3, scratch) # reload base address
@@ -856,10 +1141,15 @@ Zalrsc_sc_w_cg_cp_rs2_b25:
 # Testcase cp_rs2 (Test source rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x30, x26) # load rs2: x26 = 0x50af798881f36837
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b26_retry:
   lr.w x0, (x20) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b26:
   sc.w x5, x26, (x20) # perform operation
+  beqz x5, Zalrsc_sc_w_cg_cp_rs2_b26_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_w_cg_cp_rs2_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b26_success:
   # Check if x5 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x5, Zalrsc_sc_w_cg_cp_rs2_b26, Zalrsc_sc_w_cg_cp_rs2_b26_str)
   LA(x20, scratch) # reload base address
@@ -870,10 +1160,15 @@ Zalrsc_sc_w_cg_cp_rs2_b26:
 # Testcase cp_rs2 (Test source rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x30, x27) # load rs2: x27 = 0xc4edde22c26b4b99
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b27_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b27:
   sc.w x4, x27, (x15) # perform operation
+  beqz x4, Zalrsc_sc_w_cg_cp_rs2_b27_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_w_cg_cp_rs2_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b27_success:
   # Check if x4 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x4, Zalrsc_sc_w_cg_cp_rs2_b27, Zalrsc_sc_w_cg_cp_rs2_b27_str)
   LA(x15, scratch) # reload base address
@@ -884,10 +1179,15 @@ Zalrsc_sc_w_cg_cp_rs2_b27:
 # Testcase cp_rs2 (Test source rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x30, x28) # load rs2: x28 = 0x559f87f469a8e608
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b28_retry:
   lr.w x0, (x19) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b28:
   sc.w x11, x28, (x19) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cp_rs2_b28_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cp_rs2_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b28_success:
   # Check if x11 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x11, Zalrsc_sc_w_cg_cp_rs2_b28, Zalrsc_sc_w_cg_cp_rs2_b28_str)
   LA(x19, scratch) # reload base address
@@ -898,10 +1198,15 @@ Zalrsc_sc_w_cg_cp_rs2_b28:
 # Testcase cp_rs2 (Test source rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x30, x29) # load rs2: x29 = 0x68d657df1470b649
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b29_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b29:
   sc.w x25, x29, (x31) # perform operation
+  beqz x25, Zalrsc_sc_w_cg_cp_rs2_b29_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cp_rs2_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b29_success:
   # Check if x25 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x25, Zalrsc_sc_w_cg_cp_rs2_b29, Zalrsc_sc_w_cg_cp_rs2_b29_str)
   LA(x31, scratch) # reload base address
@@ -913,10 +1218,15 @@ Zalrsc_sc_w_cg_cp_rs2_b29:
 # Testcase cp_rs2 (Test source rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x26, x30) # load rs2: x30 = 0x8337568243f78a96
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b30_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b30:
   sc.w x14, x30, (x16) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cp_rs2_b30_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cp_rs2_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b30_success:
   # Check if x14 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x14, Zalrsc_sc_w_cg_cp_rs2_b30, Zalrsc_sc_w_cg_cp_rs2_b30_str)
   LA(x16, scratch) # reload base address
@@ -927,10 +1237,15 @@ Zalrsc_sc_w_cg_cp_rs2_b30:
 # Testcase cp_rs2 (Test source rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x26, x31) # load rs2: x31 = 0x4331a0659a42e03e
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_b31_retry:
   lr.w x0, (x24) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_b31:
   sc.w x25, x31, (x24) # perform operation
+  beqz x25, Zalrsc_sc_w_cg_cp_rs2_b31_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cp_rs2_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_b31_success:
   # Check if x25 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x25, Zalrsc_sc_w_cg_cp_rs2_b31, Zalrsc_sc_w_cg_cp_rs2_b31_str)
   LA(x24, scratch) # reload base address
@@ -945,10 +1260,15 @@ Zalrsc_sc_w_cg_cp_rs2_b31:
 # Testcase cp_rd (Test destination rd = x0)
   RVTEST_TESTDATA_LOAD_INT(x26, x5) # load rs2: x5 = 0xc4853f7d8b490366
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b0_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b0:
   sc.w x0, x5, (x16) # perform operation
+  beqz x0, Zalrsc_sc_w_cg_cp_rd_b0_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cp_rd_b0_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b0_success:
   # Check if x0 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x0, Zalrsc_sc_w_cg_cp_rd_b0, Zalrsc_sc_w_cg_cp_rd_b0_str)
   LA(x16, scratch) # reload base address
@@ -959,10 +1279,15 @@ Zalrsc_sc_w_cg_cp_rd_b0:
 # Testcase cp_rd (Test destination rd = x1)
   RVTEST_TESTDATA_LOAD_INT(x26, x21) # load rs2: x21 = 0xb8c5ff01a3bd275a
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x4, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b1_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b1:
   sc.w x1, x21, (x16) # perform operation
+  beqz x1, Zalrsc_sc_w_cg_cp_rd_b1_success # SC succeeded, skip retry
+  addi x4, x4, -1 # decrement retry count
+  bnez x4, Zalrsc_sc_w_cg_cp_rd_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b1_success:
   # Check if x1 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x1, Zalrsc_sc_w_cg_cp_rd_b1, Zalrsc_sc_w_cg_cp_rd_b1_str)
   LA(x16, scratch) # reload base address
@@ -973,10 +1298,15 @@ Zalrsc_sc_w_cg_cp_rd_b1:
 # Testcase cp_rd (Test destination rd = x2)
   RVTEST_TESTDATA_LOAD_INT(x26, x28) # load rs2: x28 = 0xa427d44ad2555291
   LA(x4, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b2_retry:
   lr.w x0, (x4) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b2:
   sc.w x2, x28, (x4) # perform operation
+  beqz x2, Zalrsc_sc_w_cg_cp_rd_b2_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_w_cg_cp_rd_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b2_success:
   # Check if x2 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x2, Zalrsc_sc_w_cg_cp_rd_b2, Zalrsc_sc_w_cg_cp_rd_b2_str)
   LA(x4, scratch) # reload base address
@@ -987,10 +1317,15 @@ Zalrsc_sc_w_cg_cp_rd_b2:
 # Testcase cp_rd (Test destination rd = x3)
   RVTEST_TESTDATA_LOAD_INT(x26, x18) # load rs2: x18 = 0x70498171770732a9
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b3_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b3:
   sc.w x3, x18, (x21) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cp_rd_b3_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cp_rd_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b3_success:
   # Check if x3 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x3, Zalrsc_sc_w_cg_cp_rd_b3, Zalrsc_sc_w_cg_cp_rd_b3_str)
   LA(x21, scratch) # reload base address
@@ -1001,10 +1336,15 @@ Zalrsc_sc_w_cg_cp_rd_b3:
 # Testcase cp_rd (Test destination rd = x4)
   RVTEST_TESTDATA_LOAD_INT(x26, x1) # load rs2: x1 = 0x231fdc4a1f690799
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b4_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b4:
   sc.w x4, x1, (x13) # perform operation
+  beqz x4, Zalrsc_sc_w_cg_cp_rd_b4_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_w_cg_cp_rd_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b4_success:
   # Check if x4 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x4, Zalrsc_sc_w_cg_cp_rd_b4, Zalrsc_sc_w_cg_cp_rd_b4_str)
   LA(x13, scratch) # reload base address
@@ -1015,10 +1355,15 @@ Zalrsc_sc_w_cg_cp_rd_b4:
 # Testcase cp_rd (Test destination rd = x5)
   RVTEST_TESTDATA_LOAD_INT(x26, x15) # load rs2: x15 = 0xea0d0a50a0c2351f
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b5_retry:
   lr.w x0, (x30) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b5:
   sc.w x5, x15, (x30) # perform operation
+  beqz x5, Zalrsc_sc_w_cg_cp_rd_b5_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_w_cg_cp_rd_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b5_success:
   # Check if x5 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x5, Zalrsc_sc_w_cg_cp_rd_b5, Zalrsc_sc_w_cg_cp_rd_b5_str)
   LA(x30, scratch) # reload base address
@@ -1029,10 +1374,15 @@ Zalrsc_sc_w_cg_cp_rd_b5:
 # Testcase cp_rd (Test destination rd = x6)
   RVTEST_TESTDATA_LOAD_INT(x26, x20) # load rs2: x20 = 0x8722898b5f7592e0
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b6_retry:
   lr.w x0, (x11) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b6:
   sc.w x6, x20, (x11) # perform operation
+  beqz x6, Zalrsc_sc_w_cg_cp_rd_b6_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_w_cg_cp_rd_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b6_success:
   # Check if x6 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x6, Zalrsc_sc_w_cg_cp_rd_b6, Zalrsc_sc_w_cg_cp_rd_b6_str)
   LA(x11, scratch) # reload base address
@@ -1045,10 +1395,15 @@ Zalrsc_sc_w_cg_cp_rd_b6:
 # Testcase cp_rd (Test destination rd = x7)
   RVTEST_TESTDATA_LOAD_INT(x26, x25) # load rs2: x25 = 0x085550e11af148ea
   LA(x4, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b7_retry:
   lr.w x0, (x4) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b7:
   sc.w x7, x25, (x4) # perform operation
+  beqz x7, Zalrsc_sc_w_cg_cp_rd_b7_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cp_rd_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b7_success:
   # Check if x7 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x7, Zalrsc_sc_w_cg_cp_rd_b7, Zalrsc_sc_w_cg_cp_rd_b7_str)
   LA(x4, scratch) # reload base address
@@ -1059,10 +1414,15 @@ Zalrsc_sc_w_cg_cp_rd_b7:
 # Testcase cp_rd (Test destination rd = x8)
   RVTEST_TESTDATA_LOAD_INT(x26, x27) # load rs2: x27 = 0xca9b65da2571ea95
   LA(x4, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b8_retry:
   lr.w x0, (x4) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b8:
   sc.w x8, x27, (x4) # perform operation
+  beqz x8, Zalrsc_sc_w_cg_cp_rd_b8_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_w_cg_cp_rd_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b8_success:
   # Check if x8 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x8, Zalrsc_sc_w_cg_cp_rd_b8, Zalrsc_sc_w_cg_cp_rd_b8_str)
   LA(x4, scratch) # reload base address
@@ -1073,10 +1433,15 @@ Zalrsc_sc_w_cg_cp_rd_b8:
 # Testcase cp_rd (Test destination rd = x9)
   RVTEST_TESTDATA_LOAD_INT(x26, x31) # load rs2: x31 = 0xba6603c1d484f515
   LA(x4, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b9_retry:
   lr.w x0, (x4) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b9:
   sc.w x9, x31, (x4) # perform operation
+  beqz x9, Zalrsc_sc_w_cg_cp_rd_b9_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cp_rd_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b9_success:
   # Check if x9 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x9, Zalrsc_sc_w_cg_cp_rd_b9, Zalrsc_sc_w_cg_cp_rd_b9_str)
   LA(x4, scratch) # reload base address
@@ -1087,10 +1452,15 @@ Zalrsc_sc_w_cg_cp_rd_b9:
 # Testcase cp_rd (Test destination rd = x10)
   RVTEST_TESTDATA_LOAD_INT(x26, x14) # load rs2: x14 = 0x34f94209e7688e1f
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b10_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b10:
   sc.w x10, x14, (x15) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cp_rd_b10_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cp_rd_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b10_success:
   # Check if x10 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x10, Zalrsc_sc_w_cg_cp_rd_b10, Zalrsc_sc_w_cg_cp_rd_b10_str)
   LA(x15, scratch) # reload base address
@@ -1101,10 +1471,15 @@ Zalrsc_sc_w_cg_cp_rd_b10:
 # Testcase cp_rd (Test destination rd = x11)
   RVTEST_TESTDATA_LOAD_INT(x26, x23) # load rs2: x23 = 0xbdc41e8205a60c94
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b11_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b11:
   sc.w x11, x23, (x6) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cp_rd_b11_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cp_rd_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b11_success:
   # Check if x11 contains the expected result. x22 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x22, x13, x12, x11, Zalrsc_sc_w_cg_cp_rd_b11, Zalrsc_sc_w_cg_cp_rd_b11_str)
   LA(x6, scratch) # reload base address
@@ -1117,10 +1492,15 @@ Zalrsc_sc_w_cg_cp_rd_b11:
 # Testcase cp_rd (Test destination rd = x12)
   RVTEST_TESTDATA_LOAD_INT(x26, x17) # load rs2: x17 = 0xc910a3c08dceed68
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b12_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b12:
   sc.w x12, x17, (x2) # perform operation
+  beqz x12, Zalrsc_sc_w_cg_cp_rd_b12_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_w_cg_cp_rd_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b12_success:
   # Check if x12 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x12, Zalrsc_sc_w_cg_cp_rd_b12, Zalrsc_sc_w_cg_cp_rd_b12_str)
   LA(x2, scratch) # reload base address
@@ -1131,10 +1511,15 @@ Zalrsc_sc_w_cg_cp_rd_b12:
 # Testcase cp_rd (Test destination rd = x13)
   RVTEST_TESTDATA_LOAD_INT(x26, x7) # load rs2: x7 = 0xd2b54ea5fc48f1dd
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b13_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b13:
   sc.w x13, x7, (x21) # perform operation
+  beqz x13, Zalrsc_sc_w_cg_cp_rd_b13_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cp_rd_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b13_success:
   # Check if x13 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x13, Zalrsc_sc_w_cg_cp_rd_b13, Zalrsc_sc_w_cg_cp_rd_b13_str)
   LA(x21, scratch) # reload base address
@@ -1145,10 +1530,15 @@ Zalrsc_sc_w_cg_cp_rd_b13:
 # Testcase cp_rd (Test destination rd = x14)
   RVTEST_TESTDATA_LOAD_INT(x26, x10) # load rs2: x10 = 0xd9b3fa334a938089
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b14_retry:
   lr.w x0, (x23) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b14:
   sc.w x14, x10, (x23) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cp_rd_b14_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cp_rd_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b14_success:
   # Check if x14 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x14, Zalrsc_sc_w_cg_cp_rd_b14, Zalrsc_sc_w_cg_cp_rd_b14_str)
   LA(x23, scratch) # reload base address
@@ -1159,10 +1549,15 @@ Zalrsc_sc_w_cg_cp_rd_b14:
 # Testcase cp_rd (Test destination rd = x15)
   RVTEST_TESTDATA_LOAD_INT(x26, x10) # load rs2: x10 = 0xd1afddf203726cb2
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b15_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b15:
   sc.w x15, x10, (x17) # perform operation
+  beqz x15, Zalrsc_sc_w_cg_cp_rd_b15_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cp_rd_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b15_success:
   # Check if x15 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x15, Zalrsc_sc_w_cg_cp_rd_b15, Zalrsc_sc_w_cg_cp_rd_b15_str)
   LA(x17, scratch) # reload base address
@@ -1173,10 +1568,15 @@ Zalrsc_sc_w_cg_cp_rd_b15:
 # Testcase cp_rd (Test destination rd = x16)
   RVTEST_TESTDATA_LOAD_INT(x26, x17) # load rs2: x17 = 0xe082d1722373d869
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b16_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b16:
   sc.w x16, x17, (x2) # perform operation
+  beqz x16, Zalrsc_sc_w_cg_cp_rd_b16_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_w_cg_cp_rd_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b16_success:
   # Check if x16 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x16, Zalrsc_sc_w_cg_cp_rd_b16, Zalrsc_sc_w_cg_cp_rd_b16_str)
   LA(x2, scratch) # reload base address
@@ -1187,10 +1587,15 @@ Zalrsc_sc_w_cg_cp_rd_b16:
 # Testcase cp_rd (Test destination rd = x17)
   RVTEST_TESTDATA_LOAD_INT(x26, x15) # load rs2: x15 = 0xe8dc98d87c46b189
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b17_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b17:
   sc.w x17, x15, (x6) # perform operation
+  beqz x17, Zalrsc_sc_w_cg_cp_rd_b17_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_w_cg_cp_rd_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b17_success:
   # Check if x17 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x17, Zalrsc_sc_w_cg_cp_rd_b17, Zalrsc_sc_w_cg_cp_rd_b17_str)
   LA(x6, scratch) # reload base address
@@ -1201,10 +1606,15 @@ Zalrsc_sc_w_cg_cp_rd_b17:
 # Testcase cp_rd (Test destination rd = x18)
   RVTEST_TESTDATA_LOAD_INT(x26, x14) # load rs2: x14 = 0x9186f2260e601a24
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x30, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b18_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b18:
   sc.w x18, x14, (x8) # perform operation
+  beqz x18, Zalrsc_sc_w_cg_cp_rd_b18_success # SC succeeded, skip retry
+  addi x30, x30, -1 # decrement retry count
+  bnez x30, Zalrsc_sc_w_cg_cp_rd_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b18_success:
   # Check if x18 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x18, Zalrsc_sc_w_cg_cp_rd_b18, Zalrsc_sc_w_cg_cp_rd_b18_str)
   LA(x8, scratch) # reload base address
@@ -1215,10 +1625,15 @@ Zalrsc_sc_w_cg_cp_rd_b18:
 # Testcase cp_rd (Test destination rd = x19)
   RVTEST_TESTDATA_LOAD_INT(x26, x31) # load rs2: x31 = 0x10c6b0ff00d1a363
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b19_retry:
   lr.w x0, (x7) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b19:
   sc.w x19, x31, (x7) # perform operation
+  beqz x19, Zalrsc_sc_w_cg_cp_rd_b19_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_w_cg_cp_rd_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b19_success:
   # Check if x19 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x19, Zalrsc_sc_w_cg_cp_rd_b19, Zalrsc_sc_w_cg_cp_rd_b19_str)
   LA(x7, scratch) # reload base address
@@ -1229,10 +1644,15 @@ Zalrsc_sc_w_cg_cp_rd_b19:
 # Testcase cp_rd (Test destination rd = x20)
   RVTEST_TESTDATA_LOAD_INT(x26, x23) # load rs2: x23 = 0xaa53aa8ca6eb40a0
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b20_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b20:
   sc.w x20, x23, (x2) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cp_rd_b20_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rd_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b20_success:
   # Check if x20 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x20, Zalrsc_sc_w_cg_cp_rd_b20, Zalrsc_sc_w_cg_cp_rd_b20_str)
   LA(x2, scratch) # reload base address
@@ -1243,10 +1663,15 @@ Zalrsc_sc_w_cg_cp_rd_b20:
 # Testcase cp_rd (Test destination rd = x21)
   RVTEST_TESTDATA_LOAD_INT(x26, x29) # load rs2: x29 = 0xdbe95e393103b093
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b21_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b21:
   sc.w x21, x29, (x13) # perform operation
+  beqz x21, Zalrsc_sc_w_cg_cp_rd_b21_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cp_rd_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b21_success:
   # Check if x21 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x21, Zalrsc_sc_w_cg_cp_rd_b21, Zalrsc_sc_w_cg_cp_rd_b21_str)
   LA(x13, scratch) # reload base address
@@ -1258,10 +1683,15 @@ Zalrsc_sc_w_cg_cp_rd_b21:
 # Testcase cp_rd (Test destination rd = x22)
   RVTEST_TESTDATA_LOAD_INT(x26, x24) # load rs2: x24 = 0x924f29a88537af88
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b22_retry:
   lr.w x0, (x23) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b22:
   sc.w x22, x24, (x23) # perform operation
+  beqz x22, Zalrsc_sc_w_cg_cp_rd_b22_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cp_rd_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b22_success:
   # Check if x22 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x22, Zalrsc_sc_w_cg_cp_rd_b22, Zalrsc_sc_w_cg_cp_rd_b22_str)
   LA(x23, scratch) # reload base address
@@ -1272,10 +1702,15 @@ Zalrsc_sc_w_cg_cp_rd_b22:
 # Testcase cp_rd (Test destination rd = x23)
   RVTEST_TESTDATA_LOAD_INT(x26, x13) # load rs2: x13 = 0x52100b2721a22dee
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b23_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b23:
   sc.w x23, x13, (x3) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cp_rd_b23_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rd_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b23_success:
   # Check if x23 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x23, Zalrsc_sc_w_cg_cp_rd_b23, Zalrsc_sc_w_cg_cp_rd_b23_str)
   LA(x3, scratch) # reload base address
@@ -1286,10 +1721,15 @@ Zalrsc_sc_w_cg_cp_rd_b23:
 # Testcase cp_rd (Test destination rd = x24)
   RVTEST_TESTDATA_LOAD_INT(x26, x30) # load rs2: x30 = 0xc215925d7ddf6376
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b24_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b24:
   sc.w x24, x30, (x15) # perform operation
+  beqz x24, Zalrsc_sc_w_cg_cp_rd_b24_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cp_rd_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b24_success:
   # Check if x24 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x24, Zalrsc_sc_w_cg_cp_rd_b24, Zalrsc_sc_w_cg_cp_rd_b24_str)
   LA(x15, scratch) # reload base address
@@ -1300,10 +1740,15 @@ Zalrsc_sc_w_cg_cp_rd_b24:
 # Testcase cp_rd (Test destination rd = x25)
   RVTEST_TESTDATA_LOAD_INT(x26, x11) # load rs2: x11 = 0xa324a06d63cfa6dc
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b25_retry:
   lr.w x0, (x23) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b25:
   sc.w x25, x11, (x23) # perform operation
+  beqz x25, Zalrsc_sc_w_cg_cp_rd_b25_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_w_cg_cp_rd_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b25_success:
   # Check if x25 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x25, Zalrsc_sc_w_cg_cp_rd_b25, Zalrsc_sc_w_cg_cp_rd_b25_str)
   LA(x23, scratch) # reload base address
@@ -1315,10 +1760,15 @@ Zalrsc_sc_w_cg_cp_rd_b25:
 # Testcase cp_rd (Test destination rd = x26)
   RVTEST_TESTDATA_LOAD_INT(x25, x23) # load rs2: x23 = 0x5c2aa599db258269
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b26_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b26:
   sc.w x26, x23, (x3) # perform operation
+  beqz x26, Zalrsc_sc_w_cg_cp_rd_b26_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rd_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b26_success:
   # Check if x26 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x26, Zalrsc_sc_w_cg_cp_rd_b26, Zalrsc_sc_w_cg_cp_rd_b26_str)
   LA(x3, scratch) # reload base address
@@ -1329,10 +1779,15 @@ Zalrsc_sc_w_cg_cp_rd_b26:
 # Testcase cp_rd (Test destination rd = x27)
   RVTEST_TESTDATA_LOAD_INT(x25, x7) # load rs2: x7 = 0x242d0fc4bdef6d11
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b27_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b27:
   sc.w x27, x7, (x3) # perform operation
+  beqz x27, Zalrsc_sc_w_cg_cp_rd_b27_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cp_rd_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b27_success:
   # Check if x27 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x27, Zalrsc_sc_w_cg_cp_rd_b27, Zalrsc_sc_w_cg_cp_rd_b27_str)
   LA(x3, scratch) # reload base address
@@ -1343,10 +1798,15 @@ Zalrsc_sc_w_cg_cp_rd_b27:
 # Testcase cp_rd (Test destination rd = x28)
   RVTEST_TESTDATA_LOAD_INT(x25, x23) # load rs2: x23 = 0x8c02cce6c5510f69
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b28_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b28:
   sc.w x28, x23, (x1) # perform operation
+  beqz x28, Zalrsc_sc_w_cg_cp_rd_b28_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cp_rd_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b28_success:
   # Check if x28 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x28, Zalrsc_sc_w_cg_cp_rd_b28, Zalrsc_sc_w_cg_cp_rd_b28_str)
   LA(x1, scratch) # reload base address
@@ -1357,10 +1817,15 @@ Zalrsc_sc_w_cg_cp_rd_b28:
 # Testcase cp_rd (Test destination rd = x29)
   RVTEST_TESTDATA_LOAD_INT(x25, x3) # load rs2: x3 = 0x3d1c37a2b2d057ac
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b29_retry:
   lr.w x0, (x7) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b29:
   sc.w x29, x3, (x7) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cp_rd_b29_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cp_rd_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b29_success:
   # Check if x29 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x29, Zalrsc_sc_w_cg_cp_rd_b29, Zalrsc_sc_w_cg_cp_rd_b29_str)
   LA(x7, scratch) # reload base address
@@ -1371,10 +1836,15 @@ Zalrsc_sc_w_cg_cp_rd_b29:
 # Testcase cp_rd (Test destination rd = x30)
   RVTEST_TESTDATA_LOAD_INT(x25, x18) # load rs2: x18 = 0xfcdb636c14065af3
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b30_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b30:
   sc.w x30, x18, (x12) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cp_rd_b30_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cp_rd_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b30_success:
   # Check if x30 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x30, Zalrsc_sc_w_cg_cp_rd_b30, Zalrsc_sc_w_cg_cp_rd_b30_str)
   LA(x12, scratch) # reload base address
@@ -1385,10 +1855,15 @@ Zalrsc_sc_w_cg_cp_rd_b30:
 # Testcase cp_rd (Test destination rd = x31)
   RVTEST_TESTDATA_LOAD_INT(x25, x28) # load rs2: x28 = 0x76471a5d78de1281
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rd_b31_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cp_rd_b31:
   sc.w x31, x28, (x12) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cp_rd_b31_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_w_cg_cp_rd_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rd_b31_success:
   # Check if x31 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x31, Zalrsc_sc_w_cg_cp_rd_b31, Zalrsc_sc_w_cg_cp_rd_b31_str)
   LA(x12, scratch) # reload base address
@@ -1403,10 +1878,15 @@ Zalrsc_sc_w_cg_cp_rd_b31:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x25, x28) # load rs2: x28 = 0x0000000000000000
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x0_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x0:
   sc.w x14, x28, (x17) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cp_rs2_edges_0x0_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cp_rs2_edges_0x0_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x0_success:
   # Check if x14 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x14, Zalrsc_sc_w_cg_cp_rs2_edges_0x0, Zalrsc_sc_w_cg_cp_rs2_edges_0x0_str)
   LA(x17, scratch) # reload base address
@@ -1417,10 +1897,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x0:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x25, x30) # load rs2: x30 = 0x0000000000000001
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x1_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x1:
   sc.w x23, x30, (x31) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cp_rs2_edges_0x1_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cp_rs2_edges_0x1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x1_success:
   # Check if x23 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x23, Zalrsc_sc_w_cg_cp_rs2_edges_0x1, Zalrsc_sc_w_cg_cp_rs2_edges_0x1_str)
   LA(x31, scratch) # reload base address
@@ -1431,10 +1916,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x1:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x25, x8) # load rs2: x8 = 0x0000000000000002
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x2_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x2:
   sc.w x30, x8, (x21) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cp_rs2_edges_0x2_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cp_rs2_edges_0x2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x2_success:
   # Check if x30 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x30, Zalrsc_sc_w_cg_cp_rs2_edges_0x2, Zalrsc_sc_w_cg_cp_rs2_edges_0x2_str)
   LA(x21, scratch) # reload base address
@@ -1445,10 +1935,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x2:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x25, x11) # load rs2: x11 = 0x8000000000000000
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x8000000000000000_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x8000000000000000:
   sc.w x18, x11, (x8) # perform operation
+  beqz x18, Zalrsc_sc_w_cg_cp_rs2_edges_0x8000000000000000_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_w_cg_cp_rs2_edges_0x8000000000000000_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x8000000000000000_success:
   # Check if x18 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x18, Zalrsc_sc_w_cg_cp_rs2_edges_0x8000000000000000, Zalrsc_sc_w_cg_cp_rs2_edges_0x8000000000000000_str)
   LA(x8, scratch) # reload base address
@@ -1459,10 +1954,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x8000000000000000:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x25, x6) # load rs2: x6 = 0x8000000000000001
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x8000000000000001_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x8000000000000001:
   sc.w x24, x6, (x12) # perform operation
+  beqz x24, Zalrsc_sc_w_cg_cp_rs2_edges_0x8000000000000001_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_w_cg_cp_rs2_edges_0x8000000000000001_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x8000000000000001_success:
   # Check if x24 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x24, Zalrsc_sc_w_cg_cp_rs2_edges_0x8000000000000001, Zalrsc_sc_w_cg_cp_rs2_edges_0x8000000000000001_str)
   LA(x12, scratch) # reload base address
@@ -1473,10 +1973,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x8000000000000001:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x25, x18) # load rs2: x18 = 0x7fffffffffffffff
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x7fffffffffffffff_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x7fffffffffffffff:
   sc.w x14, x18, (x3) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cp_rs2_edges_0x7fffffffffffffff_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cp_rs2_edges_0x7fffffffffffffff_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x7fffffffffffffff_success:
   # Check if x14 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x14, Zalrsc_sc_w_cg_cp_rs2_edges_0x7fffffffffffffff, Zalrsc_sc_w_cg_cp_rs2_edges_0x7fffffffffffffff_str)
   LA(x3, scratch) # reload base address
@@ -1487,10 +1992,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x7fffffffffffffff:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x25, x9) # load rs2: x9 = 0x7ffffffffffffffe
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x7ffffffffffffffe_retry:
   lr.w x0, (x24) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x7ffffffffffffffe:
   sc.w x12, x9, (x24) # perform operation
+  beqz x12, Zalrsc_sc_w_cg_cp_rs2_edges_0x7ffffffffffffffe_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_w_cg_cp_rs2_edges_0x7ffffffffffffffe_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x7ffffffffffffffe_success:
   # Check if x12 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x12, Zalrsc_sc_w_cg_cp_rs2_edges_0x7ffffffffffffffe, Zalrsc_sc_w_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
   LA(x24, scratch) # reload base address
@@ -1501,10 +2011,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x7ffffffffffffffe:
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x25, x17) # load rs2: x17 = 0xffffffffffffffff
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffffffffffff_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffffffffffff:
   sc.w x1, x17, (x8) # perform operation
+  beqz x1, Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffffffffffff_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffffffffffff_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffffffffffff_success:
   # Check if x1 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x1, Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffffffffffff, Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffffffffffff_str)
   LA(x8, scratch) # reload base address
@@ -1515,10 +2030,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffffffffffff:
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x25, x31) # load rs2: x31 = 0xfffffffffffffffe
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffffffffffe_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffffffffffe:
   sc.w x3, x31, (x1) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffffffffffe_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffffffffffe_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffffffffffe_success:
   # Check if x3 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x3, Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffffffffffe, Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffffffffffe_str)
   LA(x1, scratch) # reload base address
@@ -1529,10 +2049,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffffffffffe:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x25, x3) # load rs2: x3 = 0x5bbc887763ae86f2
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x5bbc887763ae86f2_retry:
   lr.w x0, (x27) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   sc.w x22, x3, (x27) # perform operation
+  beqz x22, Zalrsc_sc_w_cg_cp_rs2_edges_0x5bbc887763ae86f2_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_w_cg_cp_rs2_edges_0x5bbc887763ae86f2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x5bbc887763ae86f2_success:
   # Check if x22 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x22, Zalrsc_sc_w_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zalrsc_sc_w_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
   LA(x27, scratch) # reload base address
@@ -1543,10 +2068,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x5bbc887763ae86f2:
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x25, x29) # load rs2: x29 = 0xaaaaaaaaaaaaaaaa
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   sc.w x8, x29, (x12) # perform operation
+  beqz x8, Zalrsc_sc_w_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_success:
   # Check if x8 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x8, Zalrsc_sc_w_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zalrsc_sc_w_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
   LA(x12, scratch) # reload base address
@@ -1557,10 +2087,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x25, x6) # load rs2: x6 = 0x5555555555555555
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x5555555555555555_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x5555555555555555:
   sc.w x23, x6, (x8) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cp_rs2_edges_0x5555555555555555_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cp_rs2_edges_0x5555555555555555_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x5555555555555555_success:
   # Check if x23 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x23, Zalrsc_sc_w_cg_cp_rs2_edges_0x5555555555555555, Zalrsc_sc_w_cg_cp_rs2_edges_0x5555555555555555_str)
   LA(x8, scratch) # reload base address
@@ -1571,10 +2106,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x5555555555555555:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x25, x18) # load rs2: x18 = 0x00000000ffffffff
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffff_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffff:
   sc.w x11, x18, (x12) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffff_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffff_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffff_success:
   # Check if x11 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x11, Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffff, Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffff_str)
   LA(x12, scratch) # reload base address
@@ -1585,10 +2125,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0xffffffff:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x25, x19) # load rs2: x19 = 0x00000000fffffffe
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffe_retry:
   lr.w x0, (x10) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffe:
   sc.w x30, x19, (x10) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffe_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffe_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffe_success:
   # Check if x30 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x30, Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffe, Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffe_str)
   LA(x10, scratch) # reload base address
@@ -1599,10 +2144,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0xfffffffe:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x25, x27) # load rs2: x27 = 0x0000000100000000
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x100000000_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x100000000:
   sc.w x17, x27, (x8) # perform operation
+  beqz x17, Zalrsc_sc_w_cg_cp_rs2_edges_0x100000000_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cp_rs2_edges_0x100000000_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x100000000_success:
   # Check if x17 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x17, Zalrsc_sc_w_cg_cp_rs2_edges_0x100000000, Zalrsc_sc_w_cg_cp_rs2_edges_0x100000000_str)
   LA(x8, scratch) # reload base address
@@ -1613,10 +2163,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x100000000:
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x25, x9) # load rs2: x9 = 0x0000000100000001
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_rs2_edges_0x100000001_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cp_rs2_edges_0x100000001:
   sc.w x10, x9, (x13) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cp_rs2_edges_0x100000001_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cp_rs2_edges_0x100000001_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_rs2_edges_0x100000001_success:
   # Check if x10 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x10, Zalrsc_sc_w_cg_cp_rs2_edges_0x100000001, Zalrsc_sc_w_cg_cp_rs2_edges_0x100000001_str)
   LA(x13, scratch) # reload base address
@@ -1631,10 +2186,15 @@ Zalrsc_sc_w_cg_cp_rs2_edges_0x100000001:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x25, x1) # load rs2: x1 = 0xf16b3a17eac63f33
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b1_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b1:
   sc.w x11, x1, (x1) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b1_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b1_success:
   # Check if x11 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x11, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b1, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b1_str)
   LA(x1, scratch) # reload base address
@@ -1645,10 +2205,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b1:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x25, x2) # load rs2: x2 = 0xbaf32bc8dc990846
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b2_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b2:
   sc.w x8, x2, (x2) # perform operation
+  beqz x8, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b2_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b2_success:
   # Check if x8 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x8, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b2, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b2_str)
   LA(x2, scratch) # reload base address
@@ -1659,10 +2224,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b2:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x25, x3) # load rs2: x3 = 0xc50c4bf8fa8955ad
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b3_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b3:
   sc.w x27, x3, (x3) # perform operation
+  beqz x27, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b3_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b3_success:
   # Check if x27 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x27, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b3_str)
   LA(x3, scratch) # reload base address
@@ -1675,10 +2245,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b3:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x4)
   RVTEST_TESTDATA_LOAD_INT(x25, x4) # load rs2: x4 = 0xcc0e3c212625375c
   LA(x4, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b4_retry:
   lr.w x0, (x4) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b4:
   sc.w x23, x4, (x4) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b4_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b4_success:
   # Check if x23 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x23, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b4, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b4_str)
   LA(x4, scratch) # reload base address
@@ -1689,10 +2264,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b4:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x25, x5) # load rs2: x5 = 0x70787e56d2d9f092
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b5_retry:
   lr.w x0, (x5) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b5:
   sc.w x29, x5, (x5) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b5_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b5_success:
   # Check if x29 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x29, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b5, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b5_str)
   LA(x5, scratch) # reload base address
@@ -1703,10 +2283,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b5:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x25, x6) # load rs2: x6 = 0xfb6f79a8724fb747
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b6_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b6:
   sc.w x1, x6, (x6) # perform operation
+  beqz x1, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b6_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b6_success:
   # Check if x1 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x1, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b6, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b6_str)
   LA(x6, scratch) # reload base address
@@ -1719,10 +2304,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b6:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x25, x7) # load rs2: x7 = 0x2f49a971a038198c
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b7_retry:
   lr.w x0, (x7) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b7:
   sc.w x30, x7, (x7) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b7_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b7_success:
   # Check if x30 contains the expected result. x20 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x20, x13, x12, x30, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b7, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b7_str)
   LA(x7, scratch) # reload base address
@@ -1733,10 +2323,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b7:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x25, x8) # load rs2: x8 = 0x69af963b053b37aa
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b8_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b8:
   sc.w x30, x8, (x8) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b8_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b8_success:
   # Check if x30 contains the expected result. x20 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x20, x13, x12, x30, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b8, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b8_str)
   LA(x8, scratch) # reload base address
@@ -1747,10 +2342,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b8:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x25, x9) # load rs2: x9 = 0xc000fe1c223781cc
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b9_retry:
   lr.w x0, (x9) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b9:
   sc.w x3, x9, (x9) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b9_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b9_success:
   # Check if x3 contains the expected result. x20 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x20, x13, x12, x3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b9, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b9_str)
   LA(x9, scratch) # reload base address
@@ -1761,10 +2361,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b9:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x25, x10) # load rs2: x10 = 0xc3aea326ea9e0a11
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b10_retry:
   lr.w x0, (x10) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b10:
   sc.w x0, x10, (x10) # perform operation
+  beqz x0, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b10_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b10_success:
   # Check if x0 contains the expected result. x20 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x20, x13, x12, x0, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b10, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b10_str)
   LA(x10, scratch) # reload base address
@@ -1775,10 +2380,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b10:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x25, x11) # load rs2: x11 = 0xd970b3f8bb270215
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b11_retry:
   lr.w x0, (x11) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b11:
   sc.w x3, x11, (x11) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b11_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b11_success:
   # Check if x3 contains the expected result. x20 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x20, x13, x12, x3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b11, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b11_str)
   LA(x11, scratch) # reload base address
@@ -1791,10 +2401,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b11:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x25, x12) # load rs2: x12 = 0xc7a70a9304d5aefc
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b12_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b12:
   sc.w x17, x12, (x12) # perform operation
+  beqz x17, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b12_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b12_success:
   # Check if x17 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x17, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b12, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b12_str)
   LA(x12, scratch) # reload base address
@@ -1805,10 +2420,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b12:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x25, x13) # load rs2: x13 = 0x661bf409679ce471
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b13_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b13:
   sc.w x9, x13, (x13) # perform operation
+  beqz x9, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b13_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b13_success:
   # Check if x9 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x9, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b13, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b13_str)
   LA(x13, scratch) # reload base address
@@ -1819,10 +2439,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b13:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x25, x14) # load rs2: x14 = 0x9e2fd0b749b5692c
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b14_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b14:
   sc.w x12, x14, (x14) # perform operation
+  beqz x12, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b14_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b14_success:
   # Check if x12 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x12, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b14, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b14_str)
   LA(x14, scratch) # reload base address
@@ -1833,10 +2458,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b14:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x25, x15) # load rs2: x15 = 0x5c2f8826358107ba
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b15_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b15:
   sc.w x19, x15, (x15) # perform operation
+  beqz x19, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b15_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b15_success:
   # Check if x19 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x19, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b15, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b15_str)
   LA(x15, scratch) # reload base address
@@ -1847,10 +2477,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b15:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x25, x16) # load rs2: x16 = 0xac94d5743a38e6d8
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b16_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b16:
   sc.w x3, x16, (x16) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b16_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b16_success:
   # Check if x3 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b16, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b16_str)
   LA(x16, scratch) # reload base address
@@ -1861,10 +2496,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b16:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x25, x17) # load rs2: x17 = 0x1edd36215c2152f8
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b17_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b17:
   sc.w x7, x17, (x17) # perform operation
+  beqz x7, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b17_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b17_success:
   # Check if x7 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x7, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b17, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b17_str)
   LA(x17, scratch) # reload base address
@@ -1875,10 +2515,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b17:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x25, x18) # load rs2: x18 = 0xb582d12cb0bd38a1
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b18_retry:
   lr.w x0, (x18) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b18:
   sc.w x23, x18, (x18) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b18_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b18_success:
   # Check if x23 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x23, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b18, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b18_str)
   LA(x18, scratch) # reload base address
@@ -1889,10 +2534,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b18:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x25, x19) # load rs2: x19 = 0xc2fa654ea0c780f1
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b19_retry:
   lr.w x0, (x19) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b19:
   sc.w x31, x19, (x19) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b19_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b19_success:
   # Check if x31 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x31, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b19, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b19_str)
   LA(x19, scratch) # reload base address
@@ -1904,10 +2554,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b19:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x25, x20) # load rs2: x20 = 0x7ea2ffa228f30bac
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b20_retry:
   lr.w x0, (x20) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b20:
   sc.w x0, x20, (x20) # perform operation
+  beqz x0, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b20_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b20_success:
   # Check if x0 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x0, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b20, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b20_str)
   LA(x20, scratch) # reload base address
@@ -1918,10 +2573,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b20:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x25, x21) # load rs2: x21 = 0xb1d8ee7c97c28439
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b21_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b21:
   sc.w x28, x21, (x21) # perform operation
+  beqz x28, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b21_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b21_success:
   # Check if x28 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x28, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b21, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b21_str)
   LA(x21, scratch) # reload base address
@@ -1932,10 +2592,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b21:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x25, x22) # load rs2: x22 = 0x080d85fcc0cd5d26
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b22_retry:
   lr.w x0, (x22) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b22:
   sc.w x30, x22, (x22) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b22_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b22_success:
   # Check if x30 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x30, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b22, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b22_str)
   LA(x22, scratch) # reload base address
@@ -1946,10 +2611,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b22:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x25, x23) # load rs2: x23 = 0x893bf996e1a65136
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x20, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b23_retry:
   lr.w x0, (x23) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b23:
   sc.w x7, x23, (x23) # perform operation
+  beqz x7, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b23_success # SC succeeded, skip retry
+  addi x20, x20, -1 # decrement retry count
+  bnez x20, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b23_success:
   # Check if x7 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x7, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b23, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b23_str)
   LA(x23, scratch) # reload base address
@@ -1961,10 +2631,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b23:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x25, x24) # load rs2: x24 = 0xda27285932b410bf
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b24_retry:
   lr.w x0, (x24) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b24:
   sc.w x10, x24, (x24) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b24_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b24_success:
   # Check if x10 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x10, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b24, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b24_str)
   LA(x24, scratch) # reload base address
@@ -1976,10 +2651,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b24:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x20, x25) # load rs2: x25 = 0x7b9a559e39318eee
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b25_retry:
   lr.w x0, (x25) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b25:
   sc.w x31, x25, (x25) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b25_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b25_success:
   # Check if x31 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x31, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b25, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b25_str)
   LA(x25, scratch) # reload base address
@@ -1990,10 +2670,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b25:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x20, x26) # load rs2: x26 = 0x1fc93326c7b0c770
   LA(x26, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b26_retry:
   lr.w x0, (x26) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b26:
   sc.w x23, x26, (x26) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b26_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b26_success:
   # Check if x23 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x23, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b26, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b26_str)
   LA(x26, scratch) # reload base address
@@ -2004,10 +2689,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b26:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x20, x27) # load rs2: x27 = 0x2a256c9a4e03ad4a
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b27_retry:
   lr.w x0, (x27) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b27:
   sc.w x24, x27, (x27) # perform operation
+  beqz x24, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b27_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b27_success:
   # Check if x24 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x24, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b27, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b27_str)
   LA(x27, scratch) # reload base address
@@ -2018,10 +2708,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b27:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x20, x28) # load rs2: x28 = 0xed0279575d8b28b7
   LA(x28, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b28_retry:
   lr.w x0, (x28) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b28:
   sc.w x25, x28, (x28) # perform operation
+  beqz x25, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b28_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b28_success:
   # Check if x25 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x25, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b28, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b28_str)
   LA(x28, scratch) # reload base address
@@ -2032,10 +2727,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b28:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x20, x29) # load rs2: x29 = 0x80d4f71d9e88a295
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b29_retry:
   lr.w x0, (x29) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b29:
   sc.w x28, x29, (x29) # perform operation
+  beqz x28, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b29_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b29_success:
   # Check if x28 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x28, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b29, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b29_str)
   LA(x29, scratch) # reload base address
@@ -2046,10 +2746,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b29:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x20, x30) # load rs2: x30 = 0x53f9394d5b2532d9
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b30_retry:
   lr.w x0, (x30) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b30:
   sc.w x8, x30, (x30) # perform operation
+  beqz x8, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b30_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b30_success:
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b30, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b30_str)
   LA(x30, scratch) # reload base address
@@ -2060,10 +2765,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b30:
 # Testcase cmp_rs1_rs2_nx0 (Test rs1 = rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x20, x31) # load rs2: x31 = 0x35f95789658bcf80
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b31_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b31:
   sc.w x19, x31, (x31) # perform operation
+  beqz x19, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b31_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b31_success:
   # Check if x19 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x19, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b31, Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b31_str)
   LA(x31, scratch) # reload base address
@@ -2078,10 +2788,15 @@ Zalrsc_sc_w_cg_cmp_rs1_rs2_nx0_b31:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x1)
   RVTEST_TESTDATA_LOAD_INT(x20, x8) # load rs2: x8 = 0xfab9dbdf39c47741
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b1_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b1:
   sc.w x1, x8, (x1) # perform operation
+  beqz x1, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b1_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b1_success:
   # Check if x1 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x1, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b1, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b1_str)
   LA(x1, scratch) # reload base address
@@ -2092,10 +2807,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b1:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x20, x15) # load rs2: x15 = 0xb81112479d78f494
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b2_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b2:
   sc.w x2, x15, (x2) # perform operation
+  beqz x2, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b2_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b2_success:
   # Check if x2 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x2, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b2, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b2_str)
   LA(x2, scratch) # reload base address
@@ -2106,10 +2826,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b2:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x3)
   RVTEST_TESTDATA_LOAD_INT(x20, x2) # load rs2: x2 = 0xde1dcec7b73c23e5
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b3_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b3:
   sc.w x3, x2, (x3) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b3_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b3_success:
   # Check if x3 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x3, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b3, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b3_str)
   LA(x3, scratch) # reload base address
@@ -2122,10 +2847,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b3:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x4)
   RVTEST_TESTDATA_LOAD_INT(x20, x25) # load rs2: x25 = 0xdf7030d4f88971c4
   LA(x4, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b4_retry:
   lr.w x0, (x4) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b4:
   sc.w x4, x25, (x4) # perform operation
+  beqz x4, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b4_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b4_success:
   # Check if x4 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x4, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b4, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b4_str)
   LA(x4, scratch) # reload base address
@@ -2136,10 +2866,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b4:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x20, x19) # load rs2: x19 = 0x94f0ccafb4e63af4
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x4, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b5_retry:
   lr.w x0, (x5) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b5:
   sc.w x5, x19, (x5) # perform operation
+  beqz x5, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b5_success # SC succeeded, skip retry
+  addi x4, x4, -1 # decrement retry count
+  bnez x4, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b5_success:
   # Check if x5 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x5, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b5, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b5_str)
   LA(x5, scratch) # reload base address
@@ -2150,10 +2885,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b5:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x20, x18) # load rs2: x18 = 0x40273c65372fe2dd
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x9, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b6_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b6:
   sc.w x6, x18, (x6) # perform operation
+  beqz x6, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b6_success # SC succeeded, skip retry
+  addi x9, x9, -1 # decrement retry count
+  bnez x9, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b6_success:
   # Check if x6 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x6, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b6, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b6_str)
   LA(x6, scratch) # reload base address
@@ -2166,10 +2906,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b6:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x7)
   RVTEST_TESTDATA_LOAD_INT(x20, x6) # load rs2: x6 = 0x0d6cae9e1f0182b3
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b7_retry:
   lr.w x0, (x7) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b7:
   sc.w x7, x6, (x7) # perform operation
+  beqz x7, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b7_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b7_success:
   # Check if x7 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x7, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b7, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b7_str)
   LA(x7, scratch) # reload base address
@@ -2180,10 +2925,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b7:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x20, x16) # load rs2: x16 = 0x0653adff23c1723b
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b8_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b8:
   sc.w x8, x16, (x8) # perform operation
+  beqz x8, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b8_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b8_success:
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b8, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b8_str)
   LA(x8, scratch) # reload base address
@@ -2194,10 +2944,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b8:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x20, x31) # load rs2: x31 = 0x945d9a963a1b2010
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b9_retry:
   lr.w x0, (x9) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b9:
   sc.w x9, x31, (x9) # perform operation
+  beqz x9, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b9_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b9_success:
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b9, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b9_str)
   LA(x9, scratch) # reload base address
@@ -2208,10 +2963,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b9:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x20, x27) # load rs2: x27 = 0xa6f29cb4d858810d
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b10_retry:
   lr.w x0, (x10) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b10:
   sc.w x10, x27, (x10) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b10_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b10_success:
   # Check if x10 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x10, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b10, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b10_str)
   LA(x10, scratch) # reload base address
@@ -2222,10 +2982,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b10:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x20, x13) # load rs2: x13 = 0x2f928f24f6b87bd1
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b11_retry:
   lr.w x0, (x11) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b11:
   sc.w x11, x13, (x11) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b11_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b11_success:
   # Check if x11 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x11, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b11, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b11_str)
   LA(x11, scratch) # reload base address
@@ -2236,10 +3001,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b11:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x20, x31) # load rs2: x31 = 0x3003a9acb6aae06b
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x24, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b12_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b12:
   sc.w x12, x31, (x12) # perform operation
+  beqz x12, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b12_success # SC succeeded, skip retry
+  addi x24, x24, -1 # decrement retry count
+  bnez x24, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b12_success:
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b12, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b12_str)
   LA(x12, scratch) # reload base address
@@ -2250,10 +3020,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b12:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x20, x31) # load rs2: x31 = 0xb77370bedae547ae
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b13_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b13:
   sc.w x13, x31, (x13) # perform operation
+  beqz x13, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b13_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b13_success:
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b13, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b13_str)
   LA(x13, scratch) # reload base address
@@ -2265,10 +3040,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b13:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x20, x23) # load rs2: x23 = 0xc6d32f4519657773
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b14_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b14:
   sc.w x14, x23, (x14) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b14_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b14_success:
   # Check if x14 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x14, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b14, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b14_str)
   LA(x14, scratch) # reload base address
@@ -2279,10 +3059,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b14:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x20, x30) # load rs2: x30 = 0x758f2fef3fbe46b1
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b15_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b15:
   sc.w x15, x30, (x15) # perform operation
+  beqz x15, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b15_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b15_success:
   # Check if x15 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x15, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b15, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b15_str)
   LA(x15, scratch) # reload base address
@@ -2293,10 +3078,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b15:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x16)
   RVTEST_TESTDATA_LOAD_INT(x20, x10) # load rs2: x10 = 0x43c23ed18dca7f19
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b16_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b16:
   sc.w x16, x10, (x16) # perform operation
+  beqz x16, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b16_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b16_success:
   # Check if x16 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x16, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b16, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b16_str)
   LA(x16, scratch) # reload base address
@@ -2307,10 +3097,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b16:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x17)
   RVTEST_TESTDATA_LOAD_INT(x20, x25) # load rs2: x25 = 0x7cb05cce8a762d2e
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x30, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b17_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b17:
   sc.w x17, x25, (x17) # perform operation
+  beqz x17, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b17_success # SC succeeded, skip retry
+  addi x30, x30, -1 # decrement retry count
+  bnez x30, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b17_success:
   # Check if x17 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x17, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b17, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b17_str)
   LA(x17, scratch) # reload base address
@@ -2321,10 +3116,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b17:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x18)
   RVTEST_TESTDATA_LOAD_INT(x20, x12) # load rs2: x12 = 0x47db9e5b067f0b75
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b18_retry:
   lr.w x0, (x18) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b18:
   sc.w x18, x12, (x18) # perform operation
+  beqz x18, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b18_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b18_success:
   # Check if x18 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x18, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b18, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b18_str)
   LA(x18, scratch) # reload base address
@@ -2335,10 +3135,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b18:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x19)
   RVTEST_TESTDATA_LOAD_INT(x20, x23) # load rs2: x23 = 0x4bd29b54f829c62b
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x24, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b19_retry:
   lr.w x0, (x19) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b19:
   sc.w x19, x23, (x19) # perform operation
+  beqz x19, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b19_success # SC succeeded, skip retry
+  addi x24, x24, -1 # decrement retry count
+  bnez x24, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b19_success:
   # Check if x19 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x19, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b19, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b19_str)
   LA(x19, scratch) # reload base address
@@ -2350,10 +3155,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b19:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x20)
   RVTEST_TESTDATA_LOAD_INT(x21, x12) # load rs2: x12 = 0x4cf2a5ce289255e8
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x24, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b20_retry:
   lr.w x0, (x20) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b20:
   sc.w x20, x12, (x20) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b20_success # SC succeeded, skip retry
+  addi x24, x24, -1 # decrement retry count
+  bnez x24, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b20_success:
   # Check if x20 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x20, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b20, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b20_str)
   LA(x20, scratch) # reload base address
@@ -2365,10 +3175,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b20:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x21)
   RVTEST_TESTDATA_LOAD_INT(x11, x3) # load rs2: x3 = 0x66c31e4149b659e1
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b21_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b21:
   sc.w x21, x3, (x21) # perform operation
+  beqz x21, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b21_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b21_success:
   # Check if x21 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x21, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b21, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b21_str)
   LA(x21, scratch) # reload base address
@@ -2379,10 +3194,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b21:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x22)
   RVTEST_TESTDATA_LOAD_INT(x11, x3) # load rs2: x3 = 0xf75d859ec372e04d
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b22_retry:
   lr.w x0, (x22) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b22:
   sc.w x22, x3, (x22) # perform operation
+  beqz x22, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b22_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b22_success:
   # Check if x22 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x22, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b22, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b22_str)
   LA(x22, scratch) # reload base address
@@ -2393,10 +3213,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b22:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x23)
   RVTEST_TESTDATA_LOAD_INT(x11, x19) # load rs2: x19 = 0x05bfc0abe9ea4792
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b23_retry:
   lr.w x0, (x23) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b23:
   sc.w x23, x19, (x23) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b23_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b23_success:
   # Check if x23 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x23, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b23, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b23_str)
   LA(x23, scratch) # reload base address
@@ -2407,10 +3232,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b23:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x24)
   RVTEST_TESTDATA_LOAD_INT(x11, x8) # load rs2: x8 = 0x1078029ef29df108
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b24_retry:
   lr.w x0, (x24) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b24:
   sc.w x24, x8, (x24) # perform operation
+  beqz x24, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b24_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b24_success:
   # Check if x24 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x24, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b24, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b24_str)
   LA(x24, scratch) # reload base address
@@ -2421,10 +3251,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b24:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x25)
   RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0x76204ad37fab4537
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b25_retry:
   lr.w x0, (x25) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b25:
   sc.w x25, x31, (x25) # perform operation
+  beqz x25, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b25_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b25_success:
   # Check if x25 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x25, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b25, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b25_str)
   LA(x25, scratch) # reload base address
@@ -2435,10 +3270,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b25:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x26)
   RVTEST_TESTDATA_LOAD_INT(x11, x10) # load rs2: x10 = 0x592986a19bb8cc2d
   LA(x26, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b26_retry:
   lr.w x0, (x26) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b26:
   sc.w x26, x10, (x26) # perform operation
+  beqz x26, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b26_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b26_success:
   # Check if x26 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x26, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b26, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b26_str)
   LA(x26, scratch) # reload base address
@@ -2449,10 +3289,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b26:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x27)
   RVTEST_TESTDATA_LOAD_INT(x11, x19) # load rs2: x19 = 0xdc6393ea2c923084
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b27_retry:
   lr.w x0, (x27) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b27:
   sc.w x27, x19, (x27) # perform operation
+  beqz x27, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b27_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b27_success:
   # Check if x27 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x27, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b27, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b27_str)
   LA(x27, scratch) # reload base address
@@ -2463,10 +3308,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b27:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x28)
   RVTEST_TESTDATA_LOAD_INT(x11, x20) # load rs2: x20 = 0xcd65cf5bab48820c
   LA(x28, scratch) # rs1 = base address
-  nop
+  LI(x30, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b28_retry:
   lr.w x0, (x28) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b28:
   sc.w x28, x20, (x28) # perform operation
+  beqz x28, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b28_success # SC succeeded, skip retry
+  addi x30, x30, -1 # decrement retry count
+  bnez x30, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b28_success:
   # Check if x28 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x28, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b28, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b28_str)
   LA(x28, scratch) # reload base address
@@ -2478,10 +3328,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b28:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x29)
   RVTEST_TESTDATA_LOAD_INT(x11, x22) # load rs2: x22 = 0xb7df5206cabe16cd
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b29_retry:
   lr.w x0, (x29) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b29:
   sc.w x29, x22, (x29) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b29_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b29_success:
   # Check if x29 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x29, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b29, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b29_str)
   LA(x29, scratch) # reload base address
@@ -2492,10 +3347,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b29:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x30)
   RVTEST_TESTDATA_LOAD_INT(x11, x29) # load rs2: x29 = 0x8971d38ff8aed566
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b30_retry:
   lr.w x0, (x30) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b30:
   sc.w x30, x29, (x30) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b30_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b30_success:
   # Check if x30 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x30, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b30, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b30_str)
   LA(x30, scratch) # reload base address
@@ -2506,10 +3366,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b30:
 # Testcase cmp_rd_rs1_nx0 (Test rd = rs1 = x31)
   RVTEST_TESTDATA_LOAD_INT(x11, x30) # load rs2: x30 = 0x32b0acf41394df42
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b31_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b31:
   sc.w x31, x30, (x31) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b31_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b31_success:
   # Check if x31 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x31, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b31, Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b31_str)
   LA(x31, scratch) # reload base address
@@ -2524,10 +3389,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_nx0_b31:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x0)
   RVTEST_TESTDATA_LOAD_INT(x11, x0) # load rs2: x0 = 0x73c98cf667cc2d1f
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b0_retry:
   lr.w x0, (x27) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b0:
   sc.w x0, x0, (x27) # perform operation
+  beqz x0, Zalrsc_sc_w_cg_cmp_rd_rs2_b0_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_w_cg_cmp_rd_rs2_b0_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b0_success:
   # Check if x0 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x0, Zalrsc_sc_w_cg_cmp_rd_rs2_b0, Zalrsc_sc_w_cg_cmp_rd_rs2_b0_str)
   LA(x27, scratch) # reload base address
@@ -2538,10 +3408,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b0:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x11, x1) # load rs2: x1 = 0x5cb83d2d446b3456
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b1_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b1:
   sc.w x1, x1, (x14) # perform operation
+  beqz x1, Zalrsc_sc_w_cg_cmp_rd_rs2_b1_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_w_cg_cmp_rd_rs2_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b1_success:
   # Check if x1 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x1, Zalrsc_sc_w_cg_cmp_rd_rs2_b1, Zalrsc_sc_w_cg_cmp_rd_rs2_b1_str)
   LA(x14, scratch) # reload base address
@@ -2552,10 +3427,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b1:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x11, x2) # load rs2: x2 = 0x75ab8d10eb00c0c7
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b2_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b2:
   sc.w x2, x2, (x13) # perform operation
+  beqz x2, Zalrsc_sc_w_cg_cmp_rd_rs2_b2_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_w_cg_cmp_rd_rs2_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b2_success:
   # Check if x2 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x2, Zalrsc_sc_w_cg_cmp_rd_rs2_b2, Zalrsc_sc_w_cg_cmp_rd_rs2_b2_str)
   LA(x13, scratch) # reload base address
@@ -2566,10 +3446,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b2:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x11, x3) # load rs2: x3 = 0x8b730f565e42bb1c
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x19, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b3_retry:
   lr.w x0, (x23) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b3:
   sc.w x3, x3, (x23) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cmp_rd_rs2_b3_success # SC succeeded, skip retry
+  addi x19, x19, -1 # decrement retry count
+  bnez x19, Zalrsc_sc_w_cg_cmp_rd_rs2_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b3_success:
   # Check if x3 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x3, Zalrsc_sc_w_cg_cmp_rd_rs2_b3, Zalrsc_sc_w_cg_cmp_rd_rs2_b3_str)
   LA(x23, scratch) # reload base address
@@ -2582,10 +3467,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b3:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x4)
   RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0x17e51bfa53c70b12
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x21, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b4_retry:
   lr.w x0, (x25) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b4:
   sc.w x4, x4, (x25) # perform operation
+  beqz x4, Zalrsc_sc_w_cg_cmp_rd_rs2_b4_success # SC succeeded, skip retry
+  addi x21, x21, -1 # decrement retry count
+  bnez x21, Zalrsc_sc_w_cg_cmp_rd_rs2_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b4_success:
   # Check if x4 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x4, Zalrsc_sc_w_cg_cmp_rd_rs2_b4, Zalrsc_sc_w_cg_cmp_rd_rs2_b4_str)
   LA(x25, scratch) # reload base address
@@ -2596,10 +3486,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b4:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0xe770db9fb04a609a
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b5_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b5:
   sc.w x5, x5, (x14) # perform operation
+  beqz x5, Zalrsc_sc_w_cg_cmp_rd_rs2_b5_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_w_cg_cmp_rd_rs2_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b5_success:
   # Check if x5 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x5, Zalrsc_sc_w_cg_cmp_rd_rs2_b5, Zalrsc_sc_w_cg_cmp_rd_rs2_b5_str)
   LA(x14, scratch) # reload base address
@@ -2610,10 +3505,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b5:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x11, x6) # load rs2: x6 = 0xeea094899fb7e511
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b6_retry:
   lr.w x0, (x18) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b6:
   sc.w x6, x6, (x18) # perform operation
+  beqz x6, Zalrsc_sc_w_cg_cmp_rd_rs2_b6_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cmp_rd_rs2_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b6_success:
   # Check if x6 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x6, Zalrsc_sc_w_cg_cmp_rd_rs2_b6, Zalrsc_sc_w_cg_cmp_rd_rs2_b6_str)
   LA(x18, scratch) # reload base address
@@ -2626,10 +3526,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b6:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x11, x7) # load rs2: x7 = 0x276d1dae3c22ca5b
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b7_retry:
   lr.w x0, (x5) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b7:
   sc.w x7, x7, (x5) # perform operation
+  beqz x7, Zalrsc_sc_w_cg_cmp_rd_rs2_b7_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_w_cg_cmp_rd_rs2_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b7_success:
   # Check if x7 contains the expected result. x20 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x20, x13, x12, x7, Zalrsc_sc_w_cg_cmp_rd_rs2_b7, Zalrsc_sc_w_cg_cmp_rd_rs2_b7_str)
   LA(x5, scratch) # reload base address
@@ -2640,10 +3545,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b7:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x11, x8) # load rs2: x8 = 0x8f135111a1930e69
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b8_retry:
   lr.w x0, (x23) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b8:
   sc.w x8, x8, (x23) # perform operation
+  beqz x8, Zalrsc_sc_w_cg_cmp_rd_rs2_b8_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_w_cg_cmp_rd_rs2_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b8_success:
   # Check if x8 contains the expected result. x20 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x20, x13, x12, x8, Zalrsc_sc_w_cg_cmp_rd_rs2_b8, Zalrsc_sc_w_cg_cmp_rd_rs2_b8_str)
   LA(x23, scratch) # reload base address
@@ -2654,10 +3564,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b8:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0xa9b61926ba460211
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b9_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b9:
   sc.w x9, x9, (x1) # perform operation
+  beqz x9, Zalrsc_sc_w_cg_cmp_rd_rs2_b9_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_w_cg_cmp_rd_rs2_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b9_success:
   # Check if x9 contains the expected result. x20 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x20, x13, x12, x9, Zalrsc_sc_w_cg_cmp_rd_rs2_b9, Zalrsc_sc_w_cg_cmp_rd_rs2_b9_str)
   LA(x1, scratch) # reload base address
@@ -2668,10 +3583,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b9:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x11, x10) # load rs2: x10 = 0x2b13dfea022a6b93
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b10_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b10:
   sc.w x10, x10, (x14) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cmp_rd_rs2_b10_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cmp_rd_rs2_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b10_success:
   # Check if x10 contains the expected result. x20 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x20, x13, x12, x10, Zalrsc_sc_w_cg_cmp_rd_rs2_b10, Zalrsc_sc_w_cg_cmp_rd_rs2_b10_str)
   LA(x14, scratch) # reload base address
@@ -2683,10 +3603,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b10:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xd6564b528b715f30
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x4, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b11_retry:
   lr.w x0, (x24) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b11:
   sc.w x11, x11, (x24) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cmp_rd_rs2_b11_success # SC succeeded, skip retry
+  addi x4, x4, -1 # decrement retry count
+  bnez x4, Zalrsc_sc_w_cg_cmp_rd_rs2_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b11_success:
   # Check if x11 contains the expected result. x20 is the signature ptr, x13 is the link ptr, x12 is a temp reg.
   RVTEST_SIGUPD(x20, x13, x12, x11, Zalrsc_sc_w_cg_cmp_rd_rs2_b11, Zalrsc_sc_w_cg_cmp_rd_rs2_b11_str)
   LA(x24, scratch) # reload base address
@@ -2699,10 +3624,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b11:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xc6f08a5256841575
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b12_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b12:
   sc.w x12, x12, (x16) # perform operation
+  beqz x12, Zalrsc_sc_w_cg_cmp_rd_rs2_b12_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_w_cg_cmp_rd_rs2_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b12_success:
   # Check if x12 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x12, Zalrsc_sc_w_cg_cmp_rd_rs2_b12, Zalrsc_sc_w_cg_cmp_rd_rs2_b12_str)
   LA(x16, scratch) # reload base address
@@ -2713,10 +3643,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b12:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xbf7eff29226c9dc6
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b13_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b13:
   sc.w x13, x13, (x16) # perform operation
+  beqz x13, Zalrsc_sc_w_cg_cmp_rd_rs2_b13_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cmp_rd_rs2_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b13_success:
   # Check if x13 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x13, Zalrsc_sc_w_cg_cmp_rd_rs2_b13, Zalrsc_sc_w_cg_cmp_rd_rs2_b13_str)
   LA(x16, scratch) # reload base address
@@ -2727,10 +3662,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b13:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x1c4b3c9770a64fcd
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b14_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b14:
   sc.w x14, x14, (x15) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cmp_rd_rs2_b14_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cmp_rd_rs2_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b14_success:
   # Check if x14 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x14, Zalrsc_sc_w_cg_cmp_rd_rs2_b14, Zalrsc_sc_w_cg_cmp_rd_rs2_b14_str)
   LA(x15, scratch) # reload base address
@@ -2741,10 +3681,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b14:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x482f7a6a151726a4
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b15_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b15:
   sc.w x15, x15, (x16) # perform operation
+  beqz x15, Zalrsc_sc_w_cg_cmp_rd_rs2_b15_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_w_cg_cmp_rd_rs2_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b15_success:
   # Check if x15 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x15, Zalrsc_sc_w_cg_cmp_rd_rs2_b15, Zalrsc_sc_w_cg_cmp_rd_rs2_b15_str)
   LA(x16, scratch) # reload base address
@@ -2755,10 +3700,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b15:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x3, x16) # load rs2: x16 = 0x2182ee6825878290
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b16_retry:
   lr.w x0, (x19) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b16:
   sc.w x16, x16, (x19) # perform operation
+  beqz x16, Zalrsc_sc_w_cg_cmp_rd_rs2_b16_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cmp_rd_rs2_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b16_success:
   # Check if x16 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x16, Zalrsc_sc_w_cg_cmp_rd_rs2_b16, Zalrsc_sc_w_cg_cmp_rd_rs2_b16_str)
   LA(x19, scratch) # reload base address
@@ -2769,10 +3719,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b16:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x3, x17) # load rs2: x17 = 0x39dd769532b39812
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b17_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b17:
   sc.w x17, x17, (x13) # perform operation
+  beqz x17, Zalrsc_sc_w_cg_cmp_rd_rs2_b17_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cmp_rd_rs2_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b17_success:
   # Check if x17 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x17, Zalrsc_sc_w_cg_cmp_rd_rs2_b17, Zalrsc_sc_w_cg_cmp_rd_rs2_b17_str)
   LA(x13, scratch) # reload base address
@@ -2783,10 +3738,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b17:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x3, x18) # load rs2: x18 = 0xc60fac7e38096527
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b18_retry:
   lr.w x0, (x19) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b18:
   sc.w x18, x18, (x19) # perform operation
+  beqz x18, Zalrsc_sc_w_cg_cmp_rd_rs2_b18_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_w_cg_cmp_rd_rs2_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b18_success:
   # Check if x18 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x18, Zalrsc_sc_w_cg_cmp_rd_rs2_b18, Zalrsc_sc_w_cg_cmp_rd_rs2_b18_str)
   LA(x19, scratch) # reload base address
@@ -2797,10 +3757,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b18:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x3, x19) # load rs2: x19 = 0x81839657d9c7d32a
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b19_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b19:
   sc.w x19, x19, (x17) # perform operation
+  beqz x19, Zalrsc_sc_w_cg_cmp_rd_rs2_b19_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_w_cg_cmp_rd_rs2_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b19_success:
   # Check if x19 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x19, Zalrsc_sc_w_cg_cmp_rd_rs2_b19, Zalrsc_sc_w_cg_cmp_rd_rs2_b19_str)
   LA(x17, scratch) # reload base address
@@ -2812,10 +3777,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b19:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x3, x20) # load rs2: x20 = 0x0e92dd9aa974d9c1
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b20_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b20:
   sc.w x20, x20, (x6) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cmp_rd_rs2_b20_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_w_cg_cmp_rd_rs2_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b20_success:
   # Check if x20 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x20, Zalrsc_sc_w_cg_cmp_rd_rs2_b20, Zalrsc_sc_w_cg_cmp_rd_rs2_b20_str)
   LA(x6, scratch) # reload base address
@@ -2826,10 +3796,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b20:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x3, x21) # load rs2: x21 = 0xe78480ba7f402b49
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x30, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b21_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b21:
   sc.w x21, x21, (x1) # perform operation
+  beqz x21, Zalrsc_sc_w_cg_cmp_rd_rs2_b21_success # SC succeeded, skip retry
+  addi x30, x30, -1 # decrement retry count
+  bnez x30, Zalrsc_sc_w_cg_cmp_rd_rs2_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b21_success:
   # Check if x21 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x21, Zalrsc_sc_w_cg_cmp_rd_rs2_b21, Zalrsc_sc_w_cg_cmp_rd_rs2_b21_str)
   LA(x1, scratch) # reload base address
@@ -2840,10 +3815,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b21:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x3, x22) # load rs2: x22 = 0xc92688ec0d58b876
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x7, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b22_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b22:
   sc.w x22, x22, (x1) # perform operation
+  beqz x22, Zalrsc_sc_w_cg_cmp_rd_rs2_b22_success # SC succeeded, skip retry
+  addi x7, x7, -1 # decrement retry count
+  bnez x7, Zalrsc_sc_w_cg_cmp_rd_rs2_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b22_success:
   # Check if x22 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x22, Zalrsc_sc_w_cg_cmp_rd_rs2_b22, Zalrsc_sc_w_cg_cmp_rd_rs2_b22_str)
   LA(x1, scratch) # reload base address
@@ -2854,10 +3834,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b22:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x3, x23) # load rs2: x23 = 0x72d01731e6d8a957
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x11, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b23_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b23:
   sc.w x23, x23, (x15) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cmp_rd_rs2_b23_success # SC succeeded, skip retry
+  addi x11, x11, -1 # decrement retry count
+  bnez x11, Zalrsc_sc_w_cg_cmp_rd_rs2_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b23_success:
   # Check if x23 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x23, Zalrsc_sc_w_cg_cmp_rd_rs2_b23, Zalrsc_sc_w_cg_cmp_rd_rs2_b23_str)
   LA(x15, scratch) # reload base address
@@ -2868,10 +3853,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b23:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x3, x24) # load rs2: x24 = 0x0f9b2d0cc3a2697e
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x25, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b24_retry:
   lr.w x0, (x7) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b24:
   sc.w x24, x24, (x7) # perform operation
+  beqz x24, Zalrsc_sc_w_cg_cmp_rd_rs2_b24_success # SC succeeded, skip retry
+  addi x25, x25, -1 # decrement retry count
+  bnez x25, Zalrsc_sc_w_cg_cmp_rd_rs2_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b24_success:
   # Check if x24 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x24, Zalrsc_sc_w_cg_cmp_rd_rs2_b24, Zalrsc_sc_w_cg_cmp_rd_rs2_b24_str)
   LA(x7, scratch) # reload base address
@@ -2882,10 +3872,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b24:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x3, x25) # load rs2: x25 = 0x040cd1ed082bfec3
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x30, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b25_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b25:
   sc.w x25, x25, (x12) # perform operation
+  beqz x25, Zalrsc_sc_w_cg_cmp_rd_rs2_b25_success # SC succeeded, skip retry
+  addi x30, x30, -1 # decrement retry count
+  bnez x30, Zalrsc_sc_w_cg_cmp_rd_rs2_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b25_success:
   # Check if x25 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x25, Zalrsc_sc_w_cg_cmp_rd_rs2_b25, Zalrsc_sc_w_cg_cmp_rd_rs2_b25_str)
   LA(x12, scratch) # reload base address
@@ -2896,10 +3891,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b25:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x3, x26) # load rs2: x26 = 0x5aa31d083ea185a2
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b26_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b26:
   sc.w x26, x26, (x15) # perform operation
+  beqz x26, Zalrsc_sc_w_cg_cmp_rd_rs2_b26_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_w_cg_cmp_rd_rs2_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b26_success:
   # Check if x26 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x26, Zalrsc_sc_w_cg_cmp_rd_rs2_b26, Zalrsc_sc_w_cg_cmp_rd_rs2_b26_str)
   LA(x15, scratch) # reload base address
@@ -2910,10 +3910,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b26:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x3, x27) # load rs2: x27 = 0xe59f6802940f002c
   LA(x26, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b27_retry:
   lr.w x0, (x26) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b27:
   sc.w x27, x27, (x26) # perform operation
+  beqz x27, Zalrsc_sc_w_cg_cmp_rd_rs2_b27_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rd_rs2_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b27_success:
   # Check if x27 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x27, Zalrsc_sc_w_cg_cmp_rd_rs2_b27, Zalrsc_sc_w_cg_cmp_rd_rs2_b27_str)
   LA(x26, scratch) # reload base address
@@ -2924,10 +3929,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b27:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x3, x28) # load rs2: x28 = 0x7d96db489f5b0a9d
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x16, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b28_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b28:
   sc.w x28, x28, (x8) # perform operation
+  beqz x28, Zalrsc_sc_w_cg_cmp_rd_rs2_b28_success # SC succeeded, skip retry
+  addi x16, x16, -1 # decrement retry count
+  bnez x16, Zalrsc_sc_w_cg_cmp_rd_rs2_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b28_success:
   # Check if x28 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x28, Zalrsc_sc_w_cg_cmp_rd_rs2_b28, Zalrsc_sc_w_cg_cmp_rd_rs2_b28_str)
   LA(x8, scratch) # reload base address
@@ -2938,10 +3948,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b28:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x3, x29) # load rs2: x29 = 0x20b55f886973e868
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b29_retry:
   lr.w x0, (x22) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b29:
   sc.w x29, x29, (x22) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cmp_rd_rs2_b29_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cmp_rd_rs2_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b29_success:
   # Check if x29 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x29, Zalrsc_sc_w_cg_cmp_rd_rs2_b29, Zalrsc_sc_w_cg_cmp_rd_rs2_b29_str)
   LA(x22, scratch) # reload base address
@@ -2952,10 +3967,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b29:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x3, x30) # load rs2: x30 = 0x1c3de5059fda9b9b
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b30_retry:
   lr.w x0, (x10) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b30:
   sc.w x30, x30, (x10) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cmp_rd_rs2_b30_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cmp_rd_rs2_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b30_success:
   # Check if x30 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x30, Zalrsc_sc_w_cg_cmp_rd_rs2_b30, Zalrsc_sc_w_cg_cmp_rd_rs2_b30_str)
   LA(x10, scratch) # reload base address
@@ -2966,10 +3986,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b30:
 # Testcase cmp_rd_rs2 (Test rd = rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x3, x31) # load rs2: x31 = 0xb6b21e1774aa515f
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x18, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs2_b31_retry:
   lr.w x0, (x25) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs2_b31:
   sc.w x31, x31, (x25) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cmp_rd_rs2_b31_success # SC succeeded, skip retry
+  addi x18, x18, -1 # decrement retry count
+  bnez x18, Zalrsc_sc_w_cg_cmp_rd_rs2_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs2_b31_success:
   # Check if x31 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x31, Zalrsc_sc_w_cg_cmp_rd_rs2_b31, Zalrsc_sc_w_cg_cmp_rd_rs2_b31_str)
   LA(x25, scratch) # reload base address
@@ -2984,10 +4009,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs2_b31:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0x93668219d19fdac8
   LA(x1, scratch) # rs1 = base address
-  nop
+  LI(x24, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b1_retry:
   lr.w x0, (x1) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b1:
   sc.w x1, x1, (x1) # perform operation
+  beqz x1, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b1_success # SC succeeded, skip retry
+  addi x24, x24, -1 # decrement retry count
+  bnez x24, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b1_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b1_success:
   # Check if x1 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x1, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b1, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b1_str)
   LA(x1, scratch) # reload base address
@@ -2998,10 +4028,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b1:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0xbbc4910ed6f829bb
   LA(x2, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b2_retry:
   lr.w x0, (x2) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b2:
   sc.w x2, x2, (x2) # perform operation
+  beqz x2, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b2_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b2_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b2_success:
   # Check if x2 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x2, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b2, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b2_str)
   LA(x2, scratch) # reload base address
@@ -3013,10 +4048,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b2:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x10, x3) # load rs2: x3 = 0x9009805baf75b6f1
   LA(x3, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b3_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b3:
   sc.w x3, x3, (x3) # perform operation
+  beqz x3, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b3_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b3_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b3_success:
   # Check if x3 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x3, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b3, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b3_str)
   LA(x3, scratch) # reload base address
@@ -3029,10 +4069,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b3:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x4)
   RVTEST_TESTDATA_LOAD_INT(x10, x4) # load rs2: x4 = 0x7024036dc9597814
   LA(x4, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b4_retry:
   lr.w x0, (x4) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b4:
   sc.w x4, x4, (x4) # perform operation
+  beqz x4, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b4_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b4_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b4_success:
   # Check if x4 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x4, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b4, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b4_str)
   LA(x4, scratch) # reload base address
@@ -3043,10 +4088,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b4:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x10, x5) # load rs2: x5 = 0xe3af6aaa3d23d64e
   LA(x5, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b5_retry:
   lr.w x0, (x5) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b5:
   sc.w x5, x5, (x5) # perform operation
+  beqz x5, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b5_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b5_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b5_success:
   # Check if x5 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x5, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b5, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b5_str)
   LA(x5, scratch) # reload base address
@@ -3057,10 +4107,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b5:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x10, x6) # load rs2: x6 = 0x1e4ce74890fbc5a2
   LA(x6, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b6_retry:
   lr.w x0, (x6) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b6:
   sc.w x6, x6, (x6) # perform operation
+  beqz x6, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b6_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b6_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b6_success:
   # Check if x6 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x6, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b6, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b6_str)
   LA(x6, scratch) # reload base address
@@ -3073,10 +4128,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b6:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x10, x7) # load rs2: x7 = 0x7e29276b374d630b
   LA(x7, scratch) # rs1 = base address
-  nop
+  LI(x30, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b7_retry:
   lr.w x0, (x7) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b7:
   sc.w x7, x7, (x7) # perform operation
+  beqz x7, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b7_success # SC succeeded, skip retry
+  addi x30, x30, -1 # decrement retry count
+  bnez x30, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b7_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b7_success:
   # Check if x7 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x7, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b7, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b7_str)
   LA(x7, scratch) # reload base address
@@ -3087,10 +4147,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b7:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x10, x8) # load rs2: x8 = 0xe0b6227b0467aa17
   LA(x8, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b8_retry:
   lr.w x0, (x8) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b8:
   sc.w x8, x8, (x8) # perform operation
+  beqz x8, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b8_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b8_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b8_success:
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b8, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b8_str)
   LA(x8, scratch) # reload base address
@@ -3101,10 +4166,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b8:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x10, x9) # load rs2: x9 = 0x3f103d982f6ee86e
   LA(x9, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b9_retry:
   lr.w x0, (x9) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b9:
   sc.w x9, x9, (x9) # perform operation
+  beqz x9, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b9_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b9_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b9_success:
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b9, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b9_str)
   LA(x9, scratch) # reload base address
@@ -3116,10 +4186,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b9:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x21, x10) # load rs2: x10 = 0x453e86bd0859d0d3
   LA(x10, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b10_retry:
   lr.w x0, (x10) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b10:
   sc.w x10, x10, (x10) # perform operation
+  beqz x10, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b10_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b10_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b10_success:
   # Check if x10 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x10, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b10, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b10_str)
   LA(x10, scratch) # reload base address
@@ -3130,10 +4205,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b10:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x21, x11) # load rs2: x11 = 0xcfca1b0d58a764e4
   LA(x11, scratch) # rs1 = base address
-  nop
+  LI(x31, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b11_retry:
   lr.w x0, (x11) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b11:
   sc.w x11, x11, (x11) # perform operation
+  beqz x11, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b11_success # SC succeeded, skip retry
+  addi x31, x31, -1 # decrement retry count
+  bnez x31, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b11_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b11_success:
   # Check if x11 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x11, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b11, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b11_str)
   LA(x11, scratch) # reload base address
@@ -3144,10 +4224,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b11:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x21, x12) # load rs2: x12 = 0x05d0e22df2df4461
   LA(x12, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b12_retry:
   lr.w x0, (x12) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b12:
   sc.w x12, x12, (x12) # perform operation
+  beqz x12, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b12_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b12_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b12_success:
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b12, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b12_str)
   LA(x12, scratch) # reload base address
@@ -3158,10 +4243,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b12:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x21, x13) # load rs2: x13 = 0x2b34dad3d4128300
   LA(x13, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b13_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b13:
   sc.w x13, x13, (x13) # perform operation
+  beqz x13, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b13_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b13_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b13_success:
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b13, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b13_str)
   LA(x13, scratch) # reload base address
@@ -3173,10 +4263,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b13:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x21, x14) # load rs2: x14 = 0x80d5c275b7084e76
   LA(x14, scratch) # rs1 = base address
-  nop
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b14_retry:
   lr.w x0, (x14) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b14:
   sc.w x14, x14, (x14) # perform operation
+  beqz x14, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b14_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b14_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b14_success:
   # Check if x14 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x14, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b14, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b14_str)
   LA(x14, scratch) # reload base address
@@ -3187,10 +4282,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b14:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x21, x15) # load rs2: x15 = 0xa23c6f50331dd4a6
   LA(x15, scratch) # rs1 = base address
-  nop
+  LI(x1, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b15_retry:
   lr.w x0, (x15) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b15:
   sc.w x15, x15, (x15) # perform operation
+  beqz x15, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b15_success # SC succeeded, skip retry
+  addi x1, x1, -1 # decrement retry count
+  bnez x1, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b15_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b15_success:
   # Check if x15 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x15, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b15, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b15_str)
   LA(x15, scratch) # reload base address
@@ -3201,10 +4301,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b15:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x21, x16) # load rs2: x16 = 0x2e8486708c0d7dbf
   LA(x16, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b16_retry:
   lr.w x0, (x16) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b16:
   sc.w x16, x16, (x16) # perform operation
+  beqz x16, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b16_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b16_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b16_success:
   # Check if x16 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x16, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b16, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b16_str)
   LA(x16, scratch) # reload base address
@@ -3215,10 +4320,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b16:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x21, x17) # load rs2: x17 = 0xfa1f4a48c5db678d
   LA(x17, scratch) # rs1 = base address
-  nop
+  LI(x6, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b17_retry:
   lr.w x0, (x17) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b17:
   sc.w x17, x17, (x17) # perform operation
+  beqz x17, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b17_success # SC succeeded, skip retry
+  addi x6, x6, -1 # decrement retry count
+  bnez x6, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b17_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b17_success:
   # Check if x17 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x17, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b17, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b17_str)
   LA(x17, scratch) # reload base address
@@ -3229,10 +4339,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b17:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x21, x18) # load rs2: x18 = 0x99f9ab56165a3de8
   LA(x18, scratch) # rs1 = base address
-  nop
+  LI(x22, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b18_retry:
   lr.w x0, (x18) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b18:
   sc.w x18, x18, (x18) # perform operation
+  beqz x18, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b18_success # SC succeeded, skip retry
+  addi x22, x22, -1 # decrement retry count
+  bnez x22, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b18_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b18_success:
   # Check if x18 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x18, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b18, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b18_str)
   LA(x18, scratch) # reload base address
@@ -3243,10 +4358,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b18:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x21, x19) # load rs2: x19 = 0x1473a6876c34f7e8
   LA(x19, scratch) # rs1 = base address
-  nop
+  LI(x13, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b19_retry:
   lr.w x0, (x19) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b19:
   sc.w x19, x19, (x19) # perform operation
+  beqz x19, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b19_success # SC succeeded, skip retry
+  addi x13, x13, -1 # decrement retry count
+  bnez x13, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b19_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b19_success:
   # Check if x19 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x19, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b19, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b19_str)
   LA(x19, scratch) # reload base address
@@ -3257,10 +4377,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b19:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x21, x20) # load rs2: x20 = 0x59e40b567a55a1b6
   LA(x20, scratch) # rs1 = base address
-  nop
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b20_retry:
   lr.w x0, (x20) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b20:
   sc.w x20, x20, (x20) # perform operation
+  beqz x20, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b20_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b20_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b20_success:
   # Check if x20 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x20, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b20, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b20_str)
   LA(x20, scratch) # reload base address
@@ -3272,10 +4397,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b20:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x16, x21) # load rs2: x21 = 0x4d42f562fd41f450
   LA(x21, scratch) # rs1 = base address
-  nop
+  LI(x26, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b21_retry:
   lr.w x0, (x21) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b21:
   sc.w x21, x21, (x21) # perform operation
+  beqz x21, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b21_success # SC succeeded, skip retry
+  addi x26, x26, -1 # decrement retry count
+  bnez x26, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b21_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b21_success:
   # Check if x21 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x21, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b21, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b21_str)
   LA(x21, scratch) # reload base address
@@ -3286,10 +4416,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b21:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x16, x22) # load rs2: x22 = 0x59be3892e87cae6a
   LA(x22, scratch) # rs1 = base address
-  nop
+  LI(x17, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b22_retry:
   lr.w x0, (x22) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b22:
   sc.w x22, x22, (x22) # perform operation
+  beqz x22, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b22_success # SC succeeded, skip retry
+  addi x17, x17, -1 # decrement retry count
+  bnez x17, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b22_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b22_success:
   # Check if x22 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x22, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b22, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b22_str)
   LA(x22, scratch) # reload base address
@@ -3300,10 +4435,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b22:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x16, x23) # load rs2: x23 = 0x90db87e4702db0bf
   LA(x23, scratch) # rs1 = base address
-  nop
+  LI(x10, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b23_retry:
   lr.w x0, (x23) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b23:
   sc.w x23, x23, (x23) # perform operation
+  beqz x23, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b23_success # SC succeeded, skip retry
+  addi x10, x10, -1 # decrement retry count
+  bnez x10, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b23_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b23_success:
   # Check if x23 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x23, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b23, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b23_str)
   LA(x23, scratch) # reload base address
@@ -3314,10 +4454,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b23:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x16, x24) # load rs2: x24 = 0xabe5c29625267f3d
   LA(x24, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b24_retry:
   lr.w x0, (x24) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b24:
   sc.w x24, x24, (x24) # perform operation
+  beqz x24, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b24_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b24_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b24_success:
   # Check if x24 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x24, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b24, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b24_str)
   LA(x24, scratch) # reload base address
@@ -3328,10 +4473,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b24:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x16, x25) # load rs2: x25 = 0x39ee1a4bdbb1ce52
   LA(x25, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b25_retry:
   lr.w x0, (x25) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b25:
   sc.w x25, x25, (x25) # perform operation
+  beqz x25, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b25_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b25_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b25_success:
   # Check if x25 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x25, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b25, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b25_str)
   LA(x25, scratch) # reload base address
@@ -3342,10 +4492,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b25:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x16, x26) # load rs2: x26 = 0xae1c33a769eb3af8
   LA(x26, scratch) # rs1 = base address
-  nop
+  LI(x23, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b26_retry:
   lr.w x0, (x26) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b26:
   sc.w x26, x26, (x26) # perform operation
+  beqz x26, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b26_success # SC succeeded, skip retry
+  addi x23, x23, -1 # decrement retry count
+  bnez x23, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b26_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b26_success:
   # Check if x26 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x26, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b26, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b26_str)
   LA(x26, scratch) # reload base address
@@ -3356,10 +4511,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b26:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x16, x27) # load rs2: x27 = 0x85608df82a512e0a
   LA(x27, scratch) # rs1 = base address
-  nop
+  LI(x12, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b27_retry:
   lr.w x0, (x27) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b27:
   sc.w x27, x27, (x27) # perform operation
+  beqz x27, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b27_success # SC succeeded, skip retry
+  addi x12, x12, -1 # decrement retry count
+  bnez x12, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b27_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b27_success:
   # Check if x27 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x27, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b27, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b27_str)
   LA(x27, scratch) # reload base address
@@ -3371,10 +4531,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b27:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x16, x28) # load rs2: x28 = 0xc5138e4d175d20d8
   LA(x28, scratch) # rs1 = base address
-  nop
+  LI(x29, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b28_retry:
   lr.w x0, (x28) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b28:
   sc.w x28, x28, (x28) # perform operation
+  beqz x28, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b28_success # SC succeeded, skip retry
+  addi x29, x29, -1 # decrement retry count
+  bnez x29, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b28_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b28_success:
   # Check if x28 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x28, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b28, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b28_str)
   LA(x28, scratch) # reload base address
@@ -3385,10 +4550,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b28:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x16, x29) # load rs2: x29 = 0xe253113ff57ab0d4
   LA(x29, scratch) # rs1 = base address
-  nop
+  LI(x28, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b29_retry:
   lr.w x0, (x29) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b29:
   sc.w x29, x29, (x29) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b29_success # SC succeeded, skip retry
+  addi x28, x28, -1 # decrement retry count
+  bnez x28, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b29_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b29_success:
   # Check if x29 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x29, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b29, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b29_str)
   LA(x29, scratch) # reload base address
@@ -3399,10 +4569,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b29:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x16, x30) # load rs2: x30 = 0xd8472e3113993a40
   LA(x30, scratch) # rs1 = base address
-  nop
+  LI(x3, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b30_retry:
   lr.w x0, (x30) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b30:
   sc.w x30, x30, (x30) # perform operation
+  beqz x30, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b30_success # SC succeeded, skip retry
+  addi x3, x3, -1 # decrement retry count
+  bnez x3, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b30_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b30_success:
   # Check if x30 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x30, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b30, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b30_str)
   LA(x30, scratch) # reload base address
@@ -3413,10 +4588,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b30:
 # Testcase cmp_rd_rs1_rs2_nx0 (Test rd = rs1 = rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x16, x31) # load rs2: x31 = 0xb3f3690050211835
   LA(x31, scratch) # rs1 = base address
-  nop
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b31_retry:
   lr.w x0, (x31) # establish reservation
 Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b31:
   sc.w x31, x31, (x31) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b31_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b31_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b31_success:
   # Check if x31 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x31, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b31, Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b31_str)
   LA(x31, scratch) # reload base address
@@ -3431,9 +4611,15 @@ Zalrsc_sc_w_cg_cmp_rd_rs1_rs2_nx0_b31:
 # Testcase: cp_custom_aqrl with suffix ''
   RVTEST_TESTDATA_LOAD_INT(x16, x2) # load rs2: x2 = 0xdd88eb95125f2fe5
   LA(x3, scratch) # rs1 = base address
+  LI(x27, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_custom_aqrl_retry:
   lr.w x0, (x3) # establish reservation
 Zalrsc_sc_w_cg_cp_custom_aqrl:
   sc.w x29, x2, (x3) # perform operation
+  beqz x29, Zalrsc_sc_w_cg_cp_custom_aqrl_success # SC succeeded, skip retry
+  addi x27, x27, -1 # decrement retry count
+  bnez x27, Zalrsc_sc_w_cg_cp_custom_aqrl_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_custom_aqrl_success:
   # Check if x29 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x29, Zalrsc_sc_w_cg_cp_custom_aqrl, Zalrsc_sc_w_cg_cp_custom_aqrl_str)
   LA(x3, scratch) # reload base address
@@ -3444,9 +4630,15 @@ Zalrsc_sc_w_cg_cp_custom_aqrl:
 # Testcase: cp_custom_aqrl with suffix '.rl'
   RVTEST_TESTDATA_LOAD_INT(x16, x23) # load rs2: x23 = 0x383ff64e2faa3c00
   LA(x20, scratch) # rs1 = base address
+  LI(x8, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_custom_aqrl_rl_retry:
   lr.w x0, (x20) # establish reservation
 Zalrsc_sc_w_cg_cp_custom_aqrl_rl:
   sc.w.rl x22, x23, (x20) # perform operation
+  beqz x22, Zalrsc_sc_w_cg_cp_custom_aqrl_rl_success # SC succeeded, skip retry
+  addi x8, x8, -1 # decrement retry count
+  bnez x8, Zalrsc_sc_w_cg_cp_custom_aqrl_rl_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_custom_aqrl_rl_success:
   # Check if x22 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x22, Zalrsc_sc_w_cg_cp_custom_aqrl_rl, Zalrsc_sc_w_cg_cp_custom_aqrl_rl_str)
   LA(x20, scratch) # reload base address
@@ -3457,9 +4649,15 @@ Zalrsc_sc_w_cg_cp_custom_aqrl_rl:
 # Testcase: cp_custom_aqrl with suffix '.aqrl'
   RVTEST_TESTDATA_LOAD_INT(x16, x17) # load rs2: x17 = 0xaba1570644e32802
   LA(x13, scratch) # rs1 = base address
+  LI(x15, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_custom_aqrl_aqrl_retry:
   lr.w x0, (x13) # establish reservation
 Zalrsc_sc_w_cg_cp_custom_aqrl_aqrl:
   sc.w.aqrl x31, x17, (x13) # perform operation
+  beqz x31, Zalrsc_sc_w_cg_cp_custom_aqrl_aqrl_success # SC succeeded, skip retry
+  addi x15, x15, -1 # decrement retry count
+  bnez x15, Zalrsc_sc_w_cg_cp_custom_aqrl_aqrl_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_custom_aqrl_aqrl_success:
   # Check if x31 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x31, Zalrsc_sc_w_cg_cp_custom_aqrl_aqrl, Zalrsc_sc_w_cg_cp_custom_aqrl_aqrl_str)
   LA(x13, scratch) # reload base address
@@ -3470,9 +4668,15 @@ Zalrsc_sc_w_cg_cp_custom_aqrl_aqrl:
 # Testcase: cp_custom_sc_lr with prev lr.w
   RVTEST_TESTDATA_LOAD_INT(x16, x30) # load rs2: x30 = 0x393804ce8c074f50
   LA(x26, scratch) # rs1 = base address
+  LI(x14, 100) # retry counter for constrained LR/SC loop
+Zalrsc_sc_w_cg_cp_custom_sc_lr_prev_lr_lr_w_retry:
   lr.w x0, (x26) # establish reservation
 Zalrsc_sc_w_cg_cp_custom_sc_lr_prev_lr_lr_w:
   sc.w x7, x30, (x26) # perform operation
+  beqz x7, Zalrsc_sc_w_cg_cp_custom_sc_lr_prev_lr_lr_w_success # SC succeeded, skip retry
+  addi x14, x14, -1 # decrement retry count
+  bnez x14, Zalrsc_sc_w_cg_cp_custom_sc_lr_prev_lr_lr_w_retry # retry LR/SC if not exhausted
+Zalrsc_sc_w_cg_cp_custom_sc_lr_prev_lr_lr_w_success:
   # Check if x7 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x7, Zalrsc_sc_w_cg_cp_custom_sc_lr_prev_lr_lr_w, Zalrsc_sc_w_cg_cp_custom_sc_lr_prev_lr_lr_w_str)
   LA(x26, scratch) # reload base address


### PR DESCRIPTION
Addresses issue https://github.com/riscv/riscv-arch-test/issues/1399

SC tests before lacks a retry loop, the RISC-V spec only guarantees a LR/SC sequence will eventually succeed if you actually retry. this means any failure, for exapmle interrupt, cache coherence event, etc, would silently record a wrong value with no recovery path. The sc_type.py nop workaround for a Spike bug is also resolved by the proper retry loop.

This address problems by same retry loop, fix is simple 