### PR TITLE
Add Spike reference model support

### DIFF
--- a/config/cores/cva6/cv32a65x/test_config.yaml
+++ b/config/cores/cva6/cv32a65x/test_config.yaml
@@ -1,7 +1,6 @@
 name: cv32a65x
 compiler_exe: riscv64-unknown-elf-gcc # executable name on $PATH or full path to executable
 objdump_exe: riscv64-unknown-elf-objdump # executable name on $PATH or full path to executable, optional
-ref_model_type: sail
 ref_model_exe: sail_riscv_sim
 udb_config: cv32a65x.yaml
 linker_script: link.ld

--- a/config/cores/cve2/cv32e20/test_config.yaml
+++ b/config/cores/cve2/cv32e20/test_config.yaml
@@ -2,7 +2,6 @@ name: cv32e20
 compiler_exe: riscv64-unknown-elf-gcc # executable name on $PATH or full path to executable
 objdump_exe: riscv64-unknown-elf-objdump # executable name on $PATH or full path to executable, optional
 ref_model_exe: sail_riscv_sim # executable name on $PATH or full path to executable
-ref_model_type: sail # sail or spike
 udb_config: cv32e20.yaml
 linker_script: link.ld
 dut_include_dir: . # Directory containing DUT specific model_test.h header

--- a/config/cores/cve4/cv32e40p-v1-rv32imc/test_config.yaml
+++ b/config/cores/cve4/cv32e40p-v1-rv32imc/test_config.yaml
@@ -2,7 +2,6 @@ name: cv32e40p-v1-rv32imc
 compiler_exe: riscv64-unknown-elf-gcc
 objdump_exe: riscv64-unknown-elf-objdump
 ref_model_exe: sail_riscv_sim
-ref_model_type: sail
 udb_config: cv32e40p-v1-rv32imc.yaml
 linker_script: link.ld
 dut_include_dir: .

--- a/config/cores/cve4/cv32e40p-v2-rv32imc/test_config.yaml
+++ b/config/cores/cve4/cv32e40p-v2-rv32imc/test_config.yaml
@@ -2,7 +2,6 @@ name: cv32e40p-v2-rv32imc
 compiler_exe: riscv64-unknown-elf-gcc
 objdump_exe: riscv64-unknown-elf-objdump
 ref_model_exe: sail_riscv_sim
-ref_model_type: sail
 udb_config: cv32e40p-v2-rv32imc.yaml
 linker_script: link.ld
 dut_include_dir: .

--- a/config/cores/cve4/cv32e40p-v2-rv32imcf/test_config.yaml
+++ b/config/cores/cve4/cv32e40p-v2-rv32imcf/test_config.yaml
@@ -2,7 +2,6 @@ name: cv32e40p-v2-rv32imcf
 compiler_exe: riscv64-unknown-elf-gcc
 objdump_exe: riscv64-unknown-elf-objdump
 ref_model_exe: sail_riscv_sim
-ref_model_type: sail
 udb_config: cv32e40p-v2-rv32imcf.yaml
 linker_script: link.ld
 dut_include_dir: .

--- a/framework/src/act/build.py
+++ b/framework/src/act/build.py
@@ -149,6 +149,7 @@ def execute_task(
         try:
             proc = subprocess.Popen(
                 action.cmd,
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,

--- a/framework/src/act/build_plan.py
+++ b/framework/src/act/build_plan.py
@@ -80,6 +80,8 @@ def _ref_model_sig_cmd(
         return cmd
     if config.ref_model_type == RefModelType.SPIKE:
         cmd = [str(config.ref_model_exe), f"--isa={spike_isa_string(xlen)}"]
+        if debug:
+            cmd.extend(["-l", "--log-commits", f"--log={sig_trace_file}"])
         cmd.extend(config.ref_model_type.signature_flags(sig_file, xlen // 8))
         cmd.append(str(sig_elf))
         return cmd

--- a/framework/src/act/build_plan.py
+++ b/framework/src/act/build_plan.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from pathlib import Path
 
 from act.build import BuildTask, PythonAction, SubprocessAction, SymlinkAction
-from act.config import CompilerType, Config, CoverageSimulator
+from act.config import CompilerType, Config, CoverageSimulator, RefModelType, spike_isa_string
 from act.coverreport import generate_report, merge_summaries
 from act.parse_test_constraints import TestMetadata
 from act.sail_to_rvvi import sailLog2Trace
@@ -59,6 +59,33 @@ def _compiler_cmd(config: Config, xlen: int, tests_dir: Path) -> list[str]:
     return cmd
 
 
+def _ref_model_sig_cmd(
+    config: Config,
+    sig_elf: Path,
+    sig_file: Path,
+    sig_trace_file: Path,
+    xlen: int,
+    debug: bool,
+) -> list[str]:
+    """Build the command for invoking the reference model to produce a signature file."""
+    if config.ref_model_type == RefModelType.SAIL:
+        sail_config_path = config.dut_include_dir / "sail.json"
+        cmd = [str(config.ref_model_exe)]
+        if debug:
+            cmd.append("--trace")
+            cmd.extend(["--trace-output", str(sig_trace_file)])
+        cmd.extend(["--config", str(sail_config_path)])
+        cmd.extend(config.ref_model_type.signature_flags(sig_file, xlen // 8))
+        cmd.append(str(sig_elf))
+        return cmd
+    if config.ref_model_type == RefModelType.SPIKE:
+        cmd = [str(config.ref_model_exe), f"--isa={spike_isa_string(xlen)}"]
+        cmd.extend(config.ref_model_type.signature_flags(sig_file, xlen // 8))
+        cmd.append(str(sig_elf))
+        return cmd
+    raise ValueError(f"Unsupported reference model type: {config.ref_model_type}")
+
+
 # ---------------------------------------------------------------------------
 # Per-test task generators
 # ---------------------------------------------------------------------------
@@ -72,14 +99,14 @@ def gen_compile_tasks(
     config: Config,
     compiler_cmd: list[str],
     compile_inputs: tuple[Path, ...] = (),
-    sail_inputs: tuple[Path, ...] = (),
+    ref_model_inputs: tuple[Path, ...] = (),
     debug: bool = False,
     fast: bool = False,
 ) -> list[BuildTask]:
     """Generate BuildTasks for the compilation pipeline of a single test.
 
     Build Pipeline:
-        add.S -> add.sig.elf -> add.sig (sail) -> add.results (sig_modify) -> add.elf
+        add.S -> add.sig.elf -> add.sig (ref model) -> add.results (sig_modify) -> add.elf
         Optional: add.sig.elf.objdump (if debug), add.elf.objdump (if not fast)
 
     Args:
@@ -90,7 +117,7 @@ def gen_compile_tasks(
         config: Configuration object.
         compiler_cmd: Pre-built compiler command prefix (from _compiler_cmd).
         compile_inputs: Shared inputs for compilation (env headers, DUT headers, linker script).
-        sail_inputs: Shared inputs for the Sail reference model (e.g. sail.json).
+        ref_model_inputs: Shared inputs for the reference model (e.g. sail.json for Sail).
         debug: Whether to generate debug output (signature objdump and trace files).
         fast: Whether to disable objdump generation for faster builds.
     """
@@ -105,7 +132,6 @@ def gen_compile_tasks(
     sig_trace_file = build_dir / test_name.with_suffix(".sig.trace")
     sig_log_file = build_dir / test_name.with_suffix(".sig.log")
     final_elf = elf_dir / test_name.with_suffix(".elf")
-    sail_config_path = config.dut_include_dir / "sail.json"
 
     # Metadata — substitute ${XLEN} placeholder used by priv tests
     march = test_metadata.march.replace("${XLEN}", str(xlen))
@@ -147,21 +173,14 @@ def gen_compile_tasks(
             )
         )
 
-    # 2. sig – run Sail reference model
-    sail_cmd = [str(config.ref_model_exe)]
-    if debug:
-        sail_cmd.append("--trace")
-        sail_cmd.extend(["--trace-output", str(sig_trace_file)])
-    sail_cmd.extend(["--config", str(sail_config_path)])
-    sail_cmd.extend(config.ref_model_type.signature_flags(sig_file, xlen // 8))
-    sail_cmd.append(str(sig_elf))
-
+    # 2. sig – run reference model
+    ref_model_cmd = _ref_model_sig_cmd(config, sig_elf, sig_file, sig_trace_file, xlen, debug)
     tasks.append(
         BuildTask(
             outputs=(sig_file,),
             deps=(sig_elf,),
-            extra_inputs=sail_inputs,
-            action=SubprocessAction(cmd=sail_cmd, stdout_file=sig_log_file),
+            extra_inputs=ref_model_inputs,
+            action=SubprocessAction(cmd=ref_model_cmd, stdout_file=sig_log_file),
         )
     )
 
@@ -236,10 +255,19 @@ def gen_rvvi_tasks(
     test_name: Path,
     base_dir: Path,
     config: Config,
-    sail_inputs: tuple[Path, ...] = (),
+    ref_model_inputs: tuple[Path, ...] = (),
     fast: bool = False,
 ) -> list[BuildTask]:
-    """Generate BuildTasks for RVVI trace generation (coverage pipeline)."""
+    """Generate BuildTasks for RVVI trace generation (coverage pipeline).
+
+    Only supported when the reference model is Sail; the converter parses Sail's
+    trace format.
+    """
+    if config.ref_model_type != RefModelType.SAIL:
+        raise ValueError(
+            f"Coverage trace generation requires the Sail reference model, "
+            f"but ref_model_type={config.ref_model_type.value} was selected."
+        )
     tasks: list[BuildTask] = []
 
     # Paths
@@ -276,7 +304,7 @@ def gen_rvvi_tasks(
         BuildTask(
             outputs=(sail_trace,),
             deps=(elf,),
-            extra_inputs=sail_inputs,
+            extra_inputs=ref_model_inputs,
             action=SubprocessAction(cmd=sail_cmd, stdout_file=sail_log),
         )
     )
@@ -430,6 +458,13 @@ def generate_build_plan(
     fast: bool = False,
 ) -> list[BuildTask]:
     """Build the full DAG of tasks for a single config."""
+    if coverage_enabled and config.ref_model_type != RefModelType.SAIL:
+        raise ValueError(
+            "Coverage generation is only supported with the Sail reference model, "
+            f"but ref_model_type={config.ref_model_type.value} was selected for "
+            f"config '{config.name}'. Switch back to Sail or drop --coverage."
+        )
+
     tasks: list[BuildTask] = []
 
     config_wkdir = workdir / config.name
@@ -445,9 +480,12 @@ def generate_build_plan(
     dut_headers = tuple(sorted(p.absolute() for p in config.dut_include_dir.iterdir() if p.suffix == ".h"))
     compile_inputs = (*env_headers, *dut_headers, config.linker_script.absolute())
 
-    # Sail config affects reference model output
-    sail_config = config.dut_include_dir / "sail.json"
-    sail_inputs = (sail_config.absolute(),) if sail_config.exists() else ()
+    # Sail config affects reference model output (Spike has no equivalent file).
+    ref_model_inputs: tuple[Path, ...] = ()
+    if config.ref_model_type == RefModelType.SAIL:
+        sail_config = config.dut_include_dir / "sail.json"
+        if sail_config.exists():
+            ref_model_inputs = (sail_config.absolute(),)
 
     for test_name_str, test_metadata in sorted(selected_tests.items()):
         test_name = Path(test_name_str)
@@ -462,7 +500,7 @@ def generate_build_plan(
                 config,
                 compiler_cmd,
                 compile_inputs,
-                sail_inputs,
+                ref_model_inputs,
                 debug,
                 fast,
             )
@@ -480,7 +518,7 @@ def generate_build_plan(
                     test_name,
                     config_wkdir,
                     config,
-                    sail_inputs,
+                    ref_model_inputs,
                     fast,
                 )
             )

--- a/framework/src/act/config.py
+++ b/framework/src/act/config.py
@@ -14,6 +14,7 @@ import subprocess
 from enum import Enum
 from pathlib import Path
 
+import rich
 from pydantic import BaseModel, DirectoryPath, FilePath, ValidationInfo, field_validator, model_validator
 from ruamel.yaml import YAML
 
@@ -21,17 +22,54 @@ from ruamel.yaml import YAML
 class RefModelType(str, Enum):
     """Reference model types with their associated flags."""
 
-    # TODO: Add support for additional reference models (Spike, Whisper, etc.)
     SAIL = "sail"
-    # SPIKE = "spike"
+    SPIKE = "spike"
 
     def signature_flags(self, sig_file: Path | str, granularity: int) -> list[str]:
         """Get the flags for this reference model."""
         flags_map: dict[RefModelType, list[str]] = {
             RefModelType.SAIL: [f"--test-signature={sig_file}", "--signature-granularity", str(granularity)],
-            # RefModelType.SPIKE: [f"+signature={sig_file}", f"+signature-granularity={granularity}"],
+            RefModelType.SPIKE: [f"+signature={sig_file}", f"+signature-granularity={granularity}"],
         }
         return flags_map[self]
+
+
+# Hardcoded spike ``--isa=`` strings — one per XLEN — covering every extension spike
+# supports for that XLEN. Derived from the curated lists in
+# ``config/spike/spike-rv{32,64}-max/run_cmd.txt``.
+_SPIKE_ISA: dict[int, str] = {
+    32: (
+        "rv32imafdcbv"
+        "_zicbom_zicboz_zicbop_zicfilp_zicfiss_zicond_zicsr_zicntr_zicclsm_ziccif"
+        "_zifencei_zihintntl_zihintpause_zihpm_zimop"
+        "_zabha_zacas_zaamo_zalrsc_zawrs"
+        "_zfa_zfbfmin_zfh"
+        "_zca_zcb_zcd_zcf_zcmop"
+        "_zbc_zkn_zkr_zks"
+        "_zvfbfmin_zvfbfwma_zvfh"
+        "_zvbb_zvbc_zvkg_zvkned_zvknha_zvknhb_zvksed_zvksh_zvkt"
+        "_sscofpmf_smcntrpmf_sstc"
+        "_svinval_svade_svadu"
+    ),
+    64: (
+        "rv64imafdcbvh"
+        "_zicbom_zicboz_zicbop_zicfilp_zicfiss_zicond_zicsr_zicntr_zicclsm_ziccif"
+        "_zifencei_zihintntl_zihintpause_zihpm_zimop"
+        "_zabha_zacas_zaamo_zalrsc_zawrs"
+        "_zfa_zfbfmin_zfh"
+        "_zca_zcb_zcd_zcmop"
+        "_zbc_zkn_zkr_zks"
+        "_zvfbfmin_zvfbfwma_zvfh"
+        "_zvbb_zvbc_zvkg_zvkned_zvknha_zvknhb_zvksed_zvksh_zvkt"
+        "_sscofpmf_smcntrpmf_sstc"
+        "_svinval_svade_svadu_svnapot_svpbmt"
+    ),
+}
+
+
+def spike_isa_string(xlen: int) -> str:
+    """Return spike's ``--isa=`` string for the given XLEN."""
+    return _SPIKE_ISA[xlen]
 
 
 class CompilerType(str, Enum):
@@ -58,8 +96,8 @@ class Config(BaseModel):
     compiler_exe: Path
     objdump_exe: Path | None = None
     compiler_type: CompilerType  # Inferred from compiler_exe by model validator
-    ref_model_type: RefModelType = RefModelType.SAIL
     ref_model_exe: Path
+    ref_model_type: RefModelType  # Inferred from ref_model_exe by model validator
     include_priv_tests: bool = True
 
     model_config = {"frozen": True}
@@ -89,6 +127,21 @@ class Config(BaseModel):
                 data["compiler_type"] = CompilerType.CLANG
             else:
                 data["compiler_type"] = CompilerType.GCC
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def infer_ref_model_type(cls, data: dict[str, object]) -> dict[str, object]:
+        """Infer reference model type from ref_model_exe if not explicitly set."""
+        if data.get("ref_model_type") is None:
+            ref_model_exe = data.get("ref_model_exe")
+            ref_model_str = str(ref_model_exe) if isinstance(ref_model_exe, (str, Path)) else None
+            if ref_model_str is None:
+                raise ValueError("Unable to infer reference model type from ref_model_exe.")
+            if "spike" in ref_model_str:
+                data["ref_model_type"] = RefModelType.SPIKE
+            else:
+                data["ref_model_type"] = RefModelType.SAIL
         return data
 
     @field_validator("udb_config", "linker_script", "dut_include_dir", mode="before")
@@ -141,6 +194,12 @@ def check_ref_model_version(config: Config) -> None:
             raise RuntimeError(f"Failed to check Sail version: {e}") from e
         except subprocess.TimeoutExpired as e:
             raise RuntimeError(f"Timeout while checking Sail version: {e}") from e
+    elif config.ref_model_type == RefModelType.SPIKE:
+        # Spike has no stable --version flag; just verify the executable runs.
+        rich.print(
+            "[yellow][bold]WARNING:[/bold] Using Spike as the reference model "
+            f"([cyan]{config.ref_model_exe}[/cyan]). Coverage generation is not supported with Spike.[/yellow]"
+        )
 
 
 def check_compiler_version(config: Config) -> None:

--- a/framework/src/act/config.py
+++ b/framework/src/act/config.py
@@ -197,13 +197,19 @@ def check_ref_model_version(config: Config) -> None:
     elif config.ref_model_type == RefModelType.SPIKE:
         # Spike has no stable --version flag; perform a lightweight startup check instead.
         try:
-            subprocess.run(
+            result = subprocess.run(
                 [str(config.ref_model_exe), "--help"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
                 check=False,
                 timeout=5,
             )
+            if result.returncode != 0:
+                error_output = result.stderr.strip() or result.stdout.strip()
+                details = f": {error_output}" if error_output else ""
+                raise RuntimeError(
+                    f"Spike reference model exited with status {result.returncode} during startup check{details}",
+                )
         except OSError as e:
             raise RuntimeError(f"Failed to start Spike reference model: {e}") from e
         except subprocess.TimeoutExpired as e:

--- a/framework/src/act/config.py
+++ b/framework/src/act/config.py
@@ -219,8 +219,9 @@ def check_ref_model_version(config: Config) -> None:
             raise RuntimeError(f"Timeout while starting Spike reference model: {e}") from e
 
         rich.print(
-            "[yellow][bold]WARNING:[/bold] Using Spike as the reference model "
-            f"([cyan]{config.ref_model_exe}[/cyan]). Coverage generation is not supported with Spike.[/yellow]"
+            f"[yellow][bold]WARNING:[/bold] Using Spike as the reference model ([cyan]{config.ref_model_exe}[/cyan]). "
+            "The reference model will not be configured to match your DUT and many privileged tests will likely mismatch. "
+            "Coverage generation is not supported with Spike.[/yellow]"
         )
 
 

--- a/framework/src/act/config.py
+++ b/framework/src/act/config.py
@@ -195,7 +195,20 @@ def check_ref_model_version(config: Config) -> None:
         except subprocess.TimeoutExpired as e:
             raise RuntimeError(f"Timeout while checking Sail version: {e}") from e
     elif config.ref_model_type == RefModelType.SPIKE:
-        # Spike has no stable --version flag; just verify the executable runs.
+        # Spike has no stable --version flag; perform a lightweight startup check instead.
+        try:
+            subprocess.run(
+                [str(config.ref_model_exe), "--help"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+                timeout=5,
+            )
+        except OSError as e:
+            raise RuntimeError(f"Failed to start Spike reference model: {e}") from e
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(f"Timeout while starting Spike reference model: {e}") from e
+
         rich.print(
             "[yellow][bold]WARNING:[/bold] Using Spike as the reference model "
             f"([cyan]{config.ref_model_exe}[/cyan]). Coverage generation is not supported with Spike.[/yellow]"

--- a/framework/src/act/config.py
+++ b/framework/src/act/config.py
@@ -138,10 +138,13 @@ class Config(BaseModel):
             ref_model_str = str(ref_model_exe) if isinstance(ref_model_exe, (str, Path)) else None
             if ref_model_str is None:
                 raise ValueError("Unable to infer reference model type from ref_model_exe.")
-            if "spike" in ref_model_str:
+            executable_name = Path(ref_model_str).name.lower()
+            if "spike" in executable_name:
                 data["ref_model_type"] = RefModelType.SPIKE
-            else:
+            elif "sail" in executable_name:
                 data["ref_model_type"] = RefModelType.SAIL
+            else:
+                raise ValueError(f"Unable to infer reference model type from ref_model_exe: {ref_model_exe}")
         return data
 
     @field_validator("udb_config", "linker_script", "dut_include_dir", mode="before")


### PR DESCRIPTION
Coverage collection is not supported when using Spike as the reference.

Spike can be selected as the reference model by setting `ref_model_exe` appropriately in the relevant `test_config.yaml` file.