### PR TITLE
Corrected pmpaddr1 construction

### DIFF
--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_access_double_region.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_access_double_region.S
@@ -98,7 +98,7 @@ main:
 
     LA(x4, REGIONSTART)
     li t0, g
-    add x4, x4, g
+    add x4, x4, t0
     srl x4, x4, PMP_SHIFT
     csrw pmpaddr1, x4
 


### PR DESCRIPTION
Adding PMP grain to REGIONSTART by immediate loaded register (t0) rather than immediate