### PR TITLE
testgen: dedicated cp_fpr_hazard generator

### DIFF
--- a/generators/testgen/src/testgen/coverpoints/hazards.py
+++ b/generators/testgen/src/testgen/coverpoints/hazards.py
@@ -120,24 +120,22 @@ def make_cp_fpr_hazard(instr_name: str, instr_type: str, coverpoint: str, test_d
 
     for haz_type in hazard_types:
         for i in range(2):
+            # Bail out before allocating the producer if the consumer can't form this
+            # hazard, otherwise params_a's regs would leak from the pool on continue.
+            if haz_type == "raw" and not consumer_fp_srcs:
+                continue
+            if haz_type in ("waw", "war") and not consumer_has_fd:
+                continue
+
             params_a = generate_random_params(test_data, producer_type)
             assert params_a.fs1 is not None and params_a.fs2 is not None and params_a.fd is not None
 
             if haz_type == "raw":
-                if consumer_fp_srcs:
-                    src_field = consumer_fp_srcs[i % len(consumer_fp_srcs)]
-                    params_b = generate_random_params(test_data, instr_type, **{src_field: params_a.fd})
-                else:
-                    # Consumer reads no FP source register — skip this iteration's hazard
-                    # rather than emit a no-op test that pretends to cover RAW.
-                    continue
+                src_field = consumer_fp_srcs[i % len(consumer_fp_srcs)]
+                params_b = generate_random_params(test_data, instr_type, **{src_field: params_a.fd})
             elif haz_type == "waw":
-                if not consumer_has_fd:
-                    continue
                 params_b = generate_random_params(test_data, instr_type, fd=params_a.fd)
             elif haz_type == "war":
-                if not consumer_has_fd:
-                    continue
                 src_of_a = params_a.fs1 if i % 2 == 0 else params_a.fs2
                 params_b = generate_random_params(test_data, instr_type, fd=src_of_a)
             elif haz_type == "nohaz":

--- a/generators/testgen/src/testgen/coverpoints/hazards.py
+++ b/generators/testgen/src/testgen/coverpoints/hazards.py
@@ -12,9 +12,10 @@ from testgen.data.state import TestData
 from testgen.data.test_chunk import TestChunk
 from testgen.formatters import format_instruction
 from testgen.formatters.params import generate_random_params
+from testgen.formatters.registry import get_instr_type_config
 
 
-@add_coverpoint_generator("cp_gpr_hazard", "cp_fpr_hazard")
+@add_coverpoint_generator("cp_gpr_hazard")
 def make_cp_gpr_hazard(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[TestChunk]:
     """Generate tests for register hazards (RAW, WAW, WAR)."""
     tc = test_data.begin_test_chunk()
@@ -80,6 +81,83 @@ def make_cp_gpr_hazard(instr_name: str, instr_type: str, coverpoint: str, test_d
                 test_lines.extend([check1, check2])
 
             # Return used registers
+            test_data.int_regs.return_registers(params_a.used_int_regs)
+            test_data.int_regs.return_registers(params_b.used_int_regs)
+
+    tc.code = "\n".join(test_lines)
+    return [test_data.end_test_chunk()]
+
+
+def _fp_producer_for(instr_name: str) -> tuple[str, str]:
+    """Pick an FP producer instruction whose precision matches the instruction under test."""
+    if instr_name.endswith(".d"):
+        return "fadd.d", "FR"
+    if instr_name.endswith(".h"):
+        return "fadd.h", "FR"
+    if instr_name.endswith(".q"):
+        return "fadd.q", "FR"
+    return "fadd.s", "FR"
+
+
+@add_coverpoint_generator("cp_fpr_hazard")
+def make_cp_fpr_hazard(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[TestChunk]:
+    """Generate tests for FP register hazards (RAW, WAW, WAR)."""
+    tc = test_data.begin_test_chunk()
+    parts = coverpoint.split("_")
+    haz_class = parts[-1] if len(parts) > 3 and parts[-1] in ["r", "w", "rw"] else "rw"
+
+    test_lines: list[str] = []
+    hazard_types: list[str] = ["nohaz"]
+    if "r" in haz_class:
+        hazard_types.append("raw")
+    if "w" in haz_class:
+        hazard_types.extend(["waw", "war"])
+
+    producer_instr, producer_type = _fp_producer_for(instr_name)
+    consumer_required = get_instr_type_config(instr_type).required_params or set()
+    consumer_fp_srcs = [f for f in ("fs1", "fs2", "fs3") if f in consumer_required]
+    consumer_has_fd = "fd" in consumer_required
+
+    for haz_type in hazard_types:
+        for i in range(2):
+            params_a = generate_random_params(test_data, producer_type)
+            assert params_a.fs1 is not None and params_a.fs2 is not None and params_a.fd is not None
+
+            if haz_type == "raw":
+                if consumer_fp_srcs:
+                    src_field = consumer_fp_srcs[i % len(consumer_fp_srcs)]
+                    params_b = generate_random_params(test_data, instr_type, **{src_field: params_a.fd})
+                else:
+                    # Consumer reads no FP source register — skip this iteration's hazard
+                    # rather than emit a no-op test that pretends to cover RAW.
+                    continue
+            elif haz_type == "waw":
+                if not consumer_has_fd:
+                    continue
+                params_b = generate_random_params(test_data, instr_type, fd=params_a.fd)
+            elif haz_type == "war":
+                if not consumer_has_fd:
+                    continue
+                src_of_a = params_a.fs1 if i % 2 == 0 else params_a.fs2
+                params_b = generate_random_params(test_data, instr_type, fd=src_of_a)
+            elif haz_type == "nohaz":
+                params_b = generate_random_params(test_data, instr_type)
+            else:
+                raise ValueError(f"Unknown hazard type: {haz_type}")
+
+            test_lines.append(f"\n# Testcase cp_fpr_hazard {haz_type} test")
+            setup1, test1, check1 = format_instruction(producer_instr, producer_type, test_data, params_a)
+            setup2, test2, check2 = format_instruction(instr_name, instr_type, test_data, params_b)
+
+            test_lines.extend([setup1, setup2])
+            test_lines.extend([test1, test2])
+            if haz_type == "waw":
+                test_lines.append(check2)
+            else:
+                test_lines.extend([check1, check2])
+
+            test_data.float_regs.return_registers(params_a.used_float_regs)
+            test_data.float_regs.return_registers(params_b.used_float_regs)
             test_data.int_regs.return_registers(params_a.used_int_regs)
             test_data.int_regs.return_registers(params_b.used_int_regs)
 


### PR DESCRIPTION
## Summary

`cp_fpr_hazard` was registered against the GPR hazard generator. The GPR
generator only pins integer registers (`rs1`/`rs2`/`rd`), which are not
required params for FP instruction types, so the pins were silently dropped
and the emitted test pair carried no real FP register dependency.

This PR introduces a dedicated `make_cp_fpr_hazard` generator and unbinds
`cp_fpr_hazard` from the GPR path.

## Problem

For an FP consumer (e.g. an `FR`-type `fmul.s`), the existing flow:

1. produced an integer `add` as instruction A,
2. tried to pin instruction B's `rs1`/`rs2`/`rd` to A's destination,
3. those fields were not in B's `required_params` set, so
   `generate_random_params` ignored them and randomly assigned B's
   `fs1`/`fs2`/`fs3`/`fd`.

Net effect: zero RAW/WAW/WAR coverage on the floating-point register file.
A DUT with broken FP forwarding would still pass `cp_fpr_hazard`.

## Fix

A new `make_cp_fpr_hazard` generator that:

- Selects an `fadd.{s,d,h,q}` producer matching the consumer instruction's
  precision suffix, so the producer writes a value-compatible `fd`.
- Introspects the consumer's `required_params` via
  `get_instr_type_config(instr_type)` and pins the appropriate FP fields:
  - **RAW** — pin one of the consumer's `fs1` / `fs2` / `fs3` to the
    producer's `fd`.
  - **WAW** — pin the consumer's `fd` to the producer's `fd`.
  - **WAR** — pin the consumer's `fd` to one of the producer's source regs.
- Skips a hazard variant when the consumer has no compatible FP field
  (e.g. RAW against an `FL` load, WAW against an `FS` store) rather than
  emitting a misleading no-op pair.

Both integer and float registers used by the two instructions are returned
to the pool after each iteration.

## Risk

Latent — no testplan in `coverpoints/` currently references
`cp_fpr_hazard`. The coverpoint is, however, advertised in
`docs/ctp/src/unpriv.adoc:76` as a 4-bin coverpoint (RAW / WAR / WAW /
nohaz). Without this fix, adding it to any Zfh/F/D testplan would have
silently generated dependency-free pairs.

## Test plan

- [ ] Build a small Zfh testplan referencing `cp_fpr_hazard_rw` and confirm
      the emitted assembly carries genuine FP register dependencies between
      the two instructions of each pair.
- [ ] Confirm `cp_gpr_hazard` output is unchanged (the GPR generator is now
      registered for a single coverpoint and otherwise untouched).