### PR TITLE
SmV: capture CSR read-back in walking-1s loop

### DIFF
--- a/generators/testgen/src/testgen/priv/extensions/SmV.py
+++ b/generators/testgen/src/testgen/priv/extensions/SmV.py
@@ -8,7 +8,7 @@
 
 """SmV privileged test generator: vector CSRs and vtype/vl/vstart behavior in M-mode."""
 
-from testgen.asm.helpers import comment_banner
+from testgen.asm.helpers import comment_banner, write_sigupd
 from testgen.data.state import TestData
 from testgen.priv.registry import add_priv_test_generator
 
@@ -92,6 +92,8 @@ def _gen_vcsrs_walking1s(test_data: TestData, temp_reg: int) -> list[str]:
     ]
     lines.extend(_set_vs(vs=3, temp_reg=temp_reg))
     lines.extend(_vector_setup(temp_reg))
+    # Read-back register: separate from walk_reg so the walking bit is not clobbered.
+    read_reg = test_data.int_regs.get_register()
     for csr in _VECTOR_CSRS_WR:
         lines.append(f"# walking-1s on {csr}")
         lines.append(f"LI(x{mask_reg}, -1)  # all 1s")
@@ -100,15 +102,21 @@ def _gen_vcsrs_walking1s(test_data: TestData, temp_reg: int) -> list[str]:
             lines.append(f"CSRC({csr}, x{mask_reg})  # clear all bits")
             lines.append(test_data.add_testcase(f"{csr}_bit_{i}", coverpoint, _CG))
             lines.append(f"CSRW({csr}, x{walk_reg})  # walking-1 bit {i}")
+            # Capture the CSR read-back so WARL masking is verified against the reference,
+            # not just "the write didn't trap".
+            lines.append(f"csrr x{read_reg}, {csr}")
+            lines.append(write_sigupd(read_reg, test_data, "int"))
             lines.append(f"slli x{walk_reg}, x{walk_reg}, 1")
         lines.append("#if __riscv_xlen == 64")
         for i in range(32, 64):
             lines.append(f"CSRC({csr}, x{mask_reg})  # clear all bits")
             lines.append(test_data.add_testcase(f"{csr}_bit_{i}", coverpoint, _CG))
             lines.append(f"CSRW({csr}, x{walk_reg})  # walking-1 bit {i}")
+            lines.append(f"csrr x{read_reg}, {csr}")
+            lines.append(write_sigupd(read_reg, test_data, "int"))
             lines.append(f"slli x{walk_reg}, x{walk_reg}, 1")
         lines.append("#endif")
-    test_data.int_regs.return_registers([walk_reg, mask_reg])
+    test_data.int_regs.return_registers([walk_reg, mask_reg, read_reg])
     return lines
 
 


### PR DESCRIPTION
## Summary

`cp_vcsrs_walking1s` in `SmV.py` writes each bit position of the four writable vector CSRs (`vstart`, `vxsat`, `vxrm`, `vcsr`) with `CSRW`, but never reads the CSR back. Nothing lands in the signature region. The only failure mode the test can catch today is an illegal-instruction trap.

## Problem

A DUT that silently drops writes, implements the wrong field width, or returns stale state passes the walking-1s test cleanly. The coverpoint name implies real verification of the write path; the generated assembly does not provide it.

## Fix

After each `CSRW`, emit `csrr` into a dedicated read-back register and pipe it through `write_sigupd` so the post-write CSR value is captured into the signature and compared against the reference's WARL behavior.

A separate `read_reg` is allocated so the walking bit in `walk_reg` is preserved across the `slli`. Mirror change inside the `#if __riscv_xlen == 64` block so RV64 high-bit coverage benefits too.

## Risk

Low. Only uses `csrr` (Zicsr, already added unconditionally by the header template) and the existing `write_sigupd` helper. `sigupd_count` auto-tracks the new entries, so the signature region sizes itself. VS is already `Dirty` before the loop, so the writes and reads are legal in M-mode.