### PR TITLE
cp_fp_reg_edges: honor _frm suffix on fs2 and fs3 generators

### DIFF
--- a/generators/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py
@@ -57,13 +57,21 @@ def make_fs2_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
     else:
         edges = FLOAT_EDGES.single
 
+    cross_frm = "_frm" in coverpoint
+
+    frm_modes = ("dyn", "rdn", "rmm", "rne", "rtz", "rup") if cross_frm else [None]
+
     test_chunks: list[TestChunk] = []
     for edge_val in edges:
-        params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs2val=edge_val)
-        desc = f"{coverpoint} (Test source fs2 value = {test_data.flen_format_str.format(edge_val)})"
-        tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, f"b{edge_val:#x}", coverpoint)
-        test_chunks.append(tc)
-        return_test_regs(test_data, params)
+        for frm_mode in frm_modes:
+            params = generate_random_params(
+                test_data, instr_type, exclude_regs=[0], fs2val=edge_val, frm=frm_mode
+            )
+            bin_name = f"b{edge_val:#x}{f'_{frm_mode}' if frm_mode is not None else ''}"
+            desc = f"{coverpoint} (Test source fs2 value = {test_data.flen_format_str.format(edge_val)}{f', frm = {frm_mode}' if frm_mode is not None else ''})"
+            tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, bin_name, coverpoint)
+            test_chunks.append(tc)
+            return_test_regs(test_data, params)
 
     return test_chunks
 
@@ -80,12 +88,20 @@ def make_fs3_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
     else:
         edges = FLOAT_EDGES.single
 
+    cross_frm = "_frm" in coverpoint
+
+    frm_modes = ("dyn", "rdn", "rmm", "rne", "rtz", "rup") if cross_frm else [None]
+
     test_chunks: list[TestChunk] = []
     for edge_val in edges:
-        params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs3val=edge_val)
-        desc = f"{coverpoint} (Test source fs3 value = {test_data.flen_format_str.format(edge_val)})"
-        tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, f"b{edge_val:#x}", coverpoint)
-        test_chunks.append(tc)
-        return_test_regs(test_data, params)
+        for frm_mode in frm_modes:
+            params = generate_random_params(
+                test_data, instr_type, exclude_regs=[0], fs3val=edge_val, frm=frm_mode
+            )
+            bin_name = f"b{edge_val:#x}{f'_{frm_mode}' if frm_mode is not None else ''}"
+            desc = f"{coverpoint} (Test source fs3 value = {test_data.flen_format_str.format(edge_val)}{f', frm = {frm_mode}' if frm_mode is not None else ''})"
+            tc = format_single_testcase(instr_name, instr_type, test_data, params, desc, bin_name, coverpoint)
+            test_chunks.append(tc)
+            return_test_regs(test_data, params)
 
     return test_chunks


### PR DESCRIPTION
## Summary

`make_fs1_edges` in `cp_fp_reg_edges.py` honors a `_frm` suffix on the coverpoint name and crosses each edge value with all six rounding modes. `make_fs2_edges` and `make_fs3_edges` ignore the suffix and emit one frm-unspecified test per edge value.

## Problem

Because the registry uses longest-prefix matching, a coverpoint named `cp_fs2_edges_frm` routes to `make_fs2_edges`, which silently drops the rounding-mode cross. The label says the suite covered the cross-product; the generated assembly did not. A DUT with a rounding-path bug that only triggers for specific `fs2` or `fs3` edge values (e.g., subnormal `fs2` with RTZ on `fmadd.s`) is never exercised, while the symmetric `fs1` case is.

## Fix

Mirror the `cross_frm` / `frm_modes` handling from `make_fs1_edges` into `make_fs2_edges` and `make_fs3_edges`, including the bin-name and description suffixes so the generated labels stay distinct per frm mode.

## Risk

Low. When the coverpoint does not end in `_frm`, `frm_modes = [None]` and the new loop runs exactly once per edge value with `frm=None`, producing the same output as before. Only coverpoint names containing `_frm` are affected.