### PR TITLE
trap_report: don't strip trailing deadbeef from the trap region

### DIFF
--- a/framework/src/act/trap_report.py
+++ b/framework/src/act/trap_report.py
@@ -160,7 +160,6 @@ def _parse_trap_words(sig_path: Path, xlen: int) -> list[int] | None:
     """Parse the trap signature region from a .sig file. Returns None if no trap canary found."""
     trap_canary = TRAP_CANARY_32 if xlen == 32 else TRAP_CANARY_64
     end_canary = END_CANARY_32 if xlen == 32 else END_CANARY_64
-    deadbeef = DEADBEEF_32 if xlen == 32 else DEADBEEF_64
 
     sig_text = sig_path.read_text()
     lines = [line.strip() for line in sig_text.splitlines() if line.strip()]

--- a/framework/src/act/trap_report.py
+++ b/framework/src/act/trap_report.py
@@ -185,9 +185,10 @@ def _parse_trap_words(sig_path: Path, xlen: int) -> list[int] | None:
     except ValueError:
         raise ValueError("End canary not found in trap signature region")
 
-    # Trim trailing deadbeef padding
-    while raw_region and raw_region[-1] == deadbeef:
-        raw_region.pop()
+    # Do not strip trailing deadbeef here: it can be a legitimate padding word
+    # inside the last entry (e.g. word 3 of a 4-word interrupt entry with no
+    # IntID). The decode loop already rejects a standalone deadbeef as word0
+    # via its entry_size check.
 
     return raw_region
 


### PR DESCRIPTION
## Summary

\`_parse_trap_words\` in \`framework/src/act/trap_report.py\` stripped trailing \`0xDEADBEEF\` words from the trap region before handing it to the decode loop. That stripping contradicts the comment three lines above and silently drops the final trap entry whenever its last word happens to be a legitimate deadbeef padding value.

## Problem

The trap region uses deadbeef as in-entry padding. The most common case is a 4-word interrupt entry with no external IntID — word 3 is deadbeef but the entry's declared \`entry_size\` (in word0 bits [5:2]) is still 4. The decode side already understands this:

\`\`\`python
if is_interrupt:
    xip_val = raw_words[pos + 2]
    # IntID only for external interrupts; skip deadbeef padding
    if entry_size >= 4 and raw_words[pos + 3] != deadbeef:
        int_id = raw_words[pos + 3]
\`\`\`

But upstream of that, the parse function unconditionally pops trailing deadbeefs:

\`\`\`python
# Trim trailing deadbeef padding
while raw_region and raw_region[-1] == deadbeef:
    raw_region.pop()
\`\`\`

If the *last* trap in the region is exactly this shape (4-word interrupt entry, no IntID, so word 3 = deadbeef), the trim removes that legitimate padding. The decode loop then sees \`entry_size = 4\` in word0 but only 3 words remaining, hits \`pos + entry_size > len(raw_words)\`, breaks out of the loop, and the final trap entry is silently missing from the report.

This is a debuggability bug that hits exactly the cases you most want to debug — tests ending on a timer/software interrupt trap.

## Fix

Remove the stripping loop. The decode loop's existing \`entry_size not in (3, 4, 6)\` check already rejects a standalone deadbeef word0 (its bits [5:2] decode to \`0b1011\` → 11, not in {3,4,6}), so a tail of pure deadbeef padding (which shouldn't happen in well-formed output anyway) is still handled correctly without the pre-trim.

Replaced the trim with a comment explaining why.

## Risk

Low. The decode loop's invariants do all the bounds-checking the trim was sloppily approximating. Existing well-formed inputs (no padding) parse identically. Existing inputs whose last entry ends in a legitimate deadbeef now produce a *complete* report instead of a silently truncated one.