### PR TITLE
sail_to_rvvi: emit the final instruction instead of dropping it

### DIFF
--- a/framework/src/act/sail_to_rvvi.py
+++ b/framework/src/act/sail_to_rvvi.py
@@ -34,6 +34,7 @@ def sailLog2Trace(inputLogFile: Path, outputTraceFile: Path) -> None:
     with inputLogFile.open() as f, outputTraceFile.open("w") as outfile:
         lines = f.readlines()
         output_line = ""
+        prev_mode_num: str | None = None
         for i in range(len(lines)):
             line = lines[i]
 
@@ -71,3 +72,10 @@ def sailLog2Trace(inputLogFile: Path, outputTraceFile: Path) -> None:
                 output_line = output_line.format(mode_num=prev_mode_num)
                 outfile.write(output_line)
                 output_line = next_output
+
+        # Flush the final instruction. Sail logs mode at the start of an
+        # instruction, so the trailing instruction has no "next" mode to
+        # inherit from; fall back to its own start mode as the closest
+        # approximation rather than dropping it from the trace.
+        if output_line and prev_mode_num is not None:
+            outfile.write(output_line.format(mode_num=prev_mode_num))


### PR DESCRIPTION
## Summary

\`sailLog2Trace\` rotates \`output_line\` so each instruction is written only when the next instruction arrives — that's how RVVI's end-of-instruction mode field gets backfilled with the start mode of the following instruction (Sail logs mode at the start, RVVI expects it at the end). Once the outer loop exits, the trailing instruction is still sitting in \`output_line\` with its \`{mode_num}\` placeholder unfilled, and never reaches the trace file.

Every Sail-driven RVVI conversion silently truncates by exactly one instruction — typically the test's halt/sigupd at the tail. \`build_plan.py:320\` wires this into the live build path for every Sail config.

## Fix

After the loop, flush \`output_line\` using the last instruction's own start mode as the \`{mode_num}\` value. There is no architectural mode after the trailing instruction in the log; its own start mode is the closest defensible value rather than dropping the entry entirely.

Initialized \`prev_mode_num = None\` before the loop so the post-loop write is a clear no-op when the input contained zero parseable instruction lines.

## Risk

Low. Behavior is unchanged for every instruction *except* the last one in the log — that one was being silently dropped and now appears in the trace. No fields beyond \`{mode_num}\` change. No API change.