### PR TITLE
Fix Vector Issues from Recent Merges

### DIFF
--- a/generators/testgen/scripts/vector-testgen-unpriv.py
+++ b/generators/testgen/scripts/vector-testgen-unpriv.py
@@ -417,7 +417,7 @@ def make_vs2_fs1_edges(instruction, sew, vs2edges):
   for f1 in fedgesv:
     for v2 in vs2edges:
       f1_val = fedgesv[f1]
-      description = "cr_vs2_rs1_edges"
+      description = "cr_vs2_fs1_edges"
       cp = f"cp_vs2_fs1_edges_b{f1}_{v2}"
       instruction_data  = randomizeVectorInstructionData(instruction, sew, getBaseSuiteTestCount(), vs2_val_pointer = v2, fs1_val = f1_val)
 
@@ -1423,13 +1423,13 @@ def generate_extension(xlen_arg: int, extension_arg: str) -> str:
 
     if (test in vd_widen_ins) or (test in vs2_widen_ins):
       if (sew == 8):
-        f.write("#if ELEN > 8\n")
+        f.write("#if UDB_ELEN > 8\n")
       elif (sew == 16):
-        f.write("#if ELEN > 16\n")
+        f.write("#if UDB_ELEN > 16\n")
       elif (sew == 32):
-        f.write("#if ELEN > 32\n")
+        f.write("#if UDB_ELEN > 32\n")
       elif (sew == 64):
-        f.write("#if ELEN > 64\n")
+        f.write("#if UDB_ELEN > 64\n")
 
     clearCustomData()
     coverpoints = list(testplans[extension][test])

--- a/generators/testgen/scripts/vector_testgen_common.py
+++ b/generators/testgen/scripts/vector_testgen_common.py
@@ -1589,7 +1589,6 @@ def insertTemplate(test, signatureWords, name, sew=0, vdsew=0, test_data="", pri
         # rewrites it after the test body is fully generated and sigupd_count is final.
         .replace("@TESTCASE_STRINGS@", generate_testcase_string_section())
         .replace("@EXTRA_DEFINES@", (f"#define RVTEST_VECTOR\n"
-                                     f"#define RVTEST_FP\n"
                                      f"#define RVTEST_SEW {sew}\n"
                                      f"#define VDSEW {vdsew}\n"
                                      + (f"\n{getPrivExtraDefines()}" if priv else "")
@@ -2267,7 +2266,7 @@ def writeVecTest(instruction, cp, vd, sew, testline, *scalar_registers_used, tes
           writeLine(line, "# zero reload register for deterministic mask LS comparison")
       writeLine(load_testline, "# load value stored in memory to check against signature")
 
-    if (test in vfloattypes) and (test not in fvtype):
+    if (test in vfloattypes) and (test not in fvtype) and not vlmax_mask_prod:
       fcsrsaveReg = pickScalarScratch(scalar_registers_used)
       scalar_registers_used.append(fcsrsaveReg)
       writeLine(f"csrr x{fcsrsaveReg}, fcsr", f"# save fcsr into x{fcsrsaveReg} for signature")

--- a/generators/testgen/scripts/vector_testgen_common.py
+++ b/generators/testgen/scripts/vector_testgen_common.py
@@ -1800,9 +1800,12 @@ def writeSIGUPD_V(inst_ptr, vd, sew, avl=1, sig_lmul = None, vs1=0, load_testlin
       masked_flag = 1
 
     if vlmax_mask_prod:
+      writeLine("# The result is the same as the previous test, except that it is run at vlmax. On a DUT, the sigupd will nop here, but")
+      writeLine("# for the reference model, it will store a value. This is because for a mask-producing operation, there are 3 valid outputs")
+      writeLine("# in the tail region, as given by the spec: undisturbed, all ones, or computed as if vl = vlmax. So, to have self-checking tests")
+      writeLine("# this must be included as a no-op")
       writeLine(f"# RVTEST_SIGUPD_VLMAX_MASK_PROD(_SIG_PTR, _LINK_REG, _TEMP_REG, _VR, _VD_EEW, _LMUL)")
       writeLine(f"RVTEST_SIGUPD_VLMAX_MASK_PROD(x{sigReg}, x{linkReg}, x{tempReg}, v{vd}, {sew}, {emul})")
-      writeLine("# This nops in self-checking and stores a value in the signature if not")
     elif length_macro:
       scalar_dst_flag = 1 if scalar_dst else 0
       writeLine(f"# RVTEST_SIGUPD_V_LEN(_SIG_PTR, _LINK_REG, _TEMP_REG, _TEMP_REG2, _TEMP_REG3, _VTMP, _MTMP3, _MTMP2, _MTMP, _VR, _VS1, _MASKPROD_FLAG, _MASKED_FLAG, _VCOMPRESS_FLAG, _VD_EEW, _LMUL, _SCALAR_DST_FLAG, _INST_PTR, _STR_PTR)")
@@ -1814,6 +1817,8 @@ def writeSIGUPD_V(inst_ptr, vd, sew, avl=1, sig_lmul = None, vs1=0, load_testlin
         writeLine(
           f"RVTEST_SIGUPD_V_LEN(x{sigReg}, x{linkReg}, x{tempReg}, x{maskReg}, x{tempReg3}, v{vtmp}, v{vtmp3}, v{vtmp2}, v{mtmp}, v{vd}, v{vs1}, 1, {masked_flag}, 0, 8, {emul}, 0, {inst_ptr}, {str_ptr})")
         writeLine(f"# Check if v{vd} contains the expected result. x{sigReg} is the signature ptr, x{linkReg} is the link ptr, x{tempReg} is a temp reg.")
+        writeLine("# This is a mask producing operation, so in the tail region, there are 3 valid outputs: undisturbed, all onees, or computed as if vl = vlmax. This means")
+        writeLine("# that the next test will be a duplication of the work done in this test, so that a reference model can give an output in the two non-trivial cases.")
       else:
         writeLine(
           f"RVTEST_SIGUPD_V_LEN(x{sigReg}, x{linkReg}, x{tempReg}, x{maskReg}, x{tempReg3}, v{vtmp}, v{vtmp3}, v{vtmp2}, v{mtmp}, v{vd}, v{vs1}, 0, {masked_flag}, 0, {sew}, {emul}, {scalar_dst_flag}, {inst_ptr}, {str_ptr})")
@@ -2852,7 +2857,7 @@ def writeTest(description, instruction, cp, instruction_data=None,
       # Generate the test with the vlmax_mask_prod mode set, so that we get the behavior as if vl = vlmax,
       # which the spec says is valid.
       writeTest(
-        description, instruction, cp, instruction_data=instruction_data, sew=sew, lmul=lmul, vl="vlmax", vstart=vstart,
+        description, instruction, cp + "_reference_vlmax", instruction_data=instruction_data, sew=sew, lmul=lmul, vl="vlmax", vstart=vstart,
         maskval=maskval, vxrm=vxrm, frm=frm, vxsat=vxsat, vta=vta, vma=vma, suite=suite, clear_fflags=clear_fflags,
         force_vill=force_vill, pre_test_lines=pre_test_lines, pre_instruction_lines=pre_instruction_lines,
         pre_test_scratch_regs=pre_test_scratch_regs, vlmax_mask_prod=True)

--- a/generators/testgen/scripts/vector_testgen_common.py
+++ b/generators/testgen/scripts/vector_testgen_common.py
@@ -1435,11 +1435,10 @@ def genVtestdata(test, sew):
         test_data += genVsedges(test, sew, test[-2:])
       elif (test in xvmtype) or (test in maskopins):
         test_data += genVsedges(test, sew, "eew1")
-      elif (test in widening_mac_ins):
-        test_data += genVsedgesFP(test, sew, "1")
-        test_data += genVsedgesFP(test, sew, "2")
       elif (test in vfloattypes):
         test_data += genVsedgesFP(test, sew, "1")
+        if (test in widening_mac_ins):
+          test_data += genVsedgesFP(test, sew, "2")
       else:
         test_data += genVsedges(test, sew, "1")
 
@@ -1530,8 +1529,8 @@ def insertTemplate(test, signatureWords, name, sew=0, vdsew=0, test_data="", pri
 
       ext_parts = re.findall(r'Z[a-z]+|[A-Z]', extension)
 
-      ext_parts_no_I = ["zifencei"]
-      ext_str_no_I = "_zifenci"
+      ext_parts_no_I = []
+      ext_str_no_I = "_zifencei"
       for ext in ext_parts:
         if ext == "I":
           continue


### PR DESCRIPTION
The main change that caused problems was a UDB define change that meant every test was excluded by the preprocessor. Its fixed now. There is also a correction to the zifencei addition to march, and a change to make widening macs work again. 