### PR TITLE
fix: replace addi with LI+add for PMP grain-dependent immediates

### DIFF
--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_tor_bot.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_tor_bot.S
@@ -160,7 +160,8 @@ main:
     csrw pmpcfg3, x4
 
     LA(x4, TEST_FOR_EXECUTION)
-    addi    x5, x4, g
+    LI(x5, g)
+    add x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
 

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_napot_all.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_napot_all.S
@@ -66,7 +66,8 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_2, test_2_str)                                   // Signature update
 
-    addi a5, a5, (g+4)
+    LI(t6, (g+4))
+    add a5, a5, t6
     \TEST_CASE\()_3:
     lw a4, 0(a5)
     nop

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-02.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-02.S
@@ -152,7 +152,8 @@ main:
 
     //addresses for a default TOR region
     LA(x4, TEST_FOR_EXECUTION)
-    addi    x5, x4, g
+    LI(x5, g)
+    add x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
 

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-03.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-03.S
@@ -152,7 +152,8 @@ main:
 
     //addresses for a default TOR region
     LA(x4, TEST_FOR_EXECUTION)
-    addi    x5, x4, g
+    LI(x5, g)
+    add x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
 

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_misaligned_tor.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_misaligned_tor.S
@@ -148,7 +148,8 @@ main:
     csrw pmpcfg3, x4
 
     LA(x4, TEST_FOR_EXECUTION)
-    addi    x5, x4, g
+    LI(x5, g)
+    add x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
 

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_napot_legal_lwxr.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_napot_legal_lwxr.S
@@ -84,7 +84,8 @@ RVTEST_BEGIN
     nop
     nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t6, (g-8))                  // REGIONSTART + g - 4
+    add a4, a4, t6
     LA(x1, 4f)                          // Store the return Address in x1
     jalr ra, 0(a4)
     nop
@@ -140,7 +141,8 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_5, test_5_str)
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t6, (g-8))                                      // REGIONSTART + g - 4
+    add a5, a5, t6
 
     \TEST_CASE\()_6:
     sw a4, 0(a5)
@@ -204,7 +206,8 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_14, test_14_str)                                   // Signature update
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t6, (g-8))                                      // REGIONSTART + g - 4
+    add a5, a5, t6
 
     \TEST_CASE\()_15:
     lw a4, 0(a5)

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_priority.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_priority.S
@@ -117,7 +117,6 @@ main:
 
     LA(x4, TEST_FOR_EXECUTION)
     srl x4, x4, PMP_SHIFT
-    LI(x5, g)
 
     // REGIONSTART in even PMPADDR
     .set pmpaddri, CSR_PMPADDR0

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_priority.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_priority.S
@@ -117,7 +117,7 @@ main:
 
     LA(x4, TEST_FOR_EXECUTION)
     srl x4, x4, PMP_SHIFT
-    addi x5, x0, g
+    LI(x5, g)
 
     // REGIONSTART in even PMPADDR
     .set pmpaddri, CSR_PMPADDR0
@@ -130,7 +130,8 @@ main:
     LA(x5, TEST_FOR_EXECUTION)
     .set pmpaddri, CSR_PMPADDR0+1
     .rept 7
-    addi x5, x5, g
+    LI(t6, g)
+    add x5, x5, t6
     srl x6, x5, PMP_SHIFT
     csrw pmpaddri, x6
     .set pmpaddri, pmpaddri+2

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_priority_off.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_priority_off.S
@@ -112,7 +112,8 @@ main:
     csrw pmpcfg3, x4
 
     LA(x4, TEST_FOR_EXECUTION)
-    addi x5, x4, g
+    LI(x5, g)
+    add x5, x4, x5
     srl x4, x4, PMP_SHIFT
     csrw pmpaddr0, x4
     csrw pmpaddr2, x4

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_tor_legal_lwxr.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_tor_legal_lwxr.S
@@ -75,7 +75,8 @@ RVTEST_BEGIN
     nop
     nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t6, (g-8))                  // REGIONSTART + g - 4
+    add a4, a4, t6
     LA(x1, 4f)                          // Store the return Address in x1
     jalr ra, 0(a4)
     nop
@@ -119,7 +120,8 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_3, test_3_str)
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t6, (g-8))                                      // REGIONSTART + g - 4
+    add a5, a5, t6
 
     \TEST_CASE\()_4:
     sw a4, 0(a5)
@@ -159,7 +161,8 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_8, test_8_str)                                   // Signature update
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t6, (g-8))                                      // REGIONSTART + g - 4
+    add a5, a5, t6
 
     \TEST_CASE\()_9:
     lw a4, 0(a5)
@@ -211,7 +214,8 @@ main:
     csrw pmpcfg3, x4
 
     LA(x4, TEST_FOR_EXECUTION)
-    addi x5, x4, g
+    LI(x5, g)
+    add x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
 
@@ -226,7 +230,8 @@ main:
 // Test Case: 1 : L -> 1 and No Permissions given to the PMP Region 11
 
     LA(x6, TEST_FOR_EXECUTION)
-    addi x6, x6, g
+    LI(t6, g)
+    add x6, x6, t6
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr11, x6
     LA(x5, TEST_FOR_EXECUTION)
@@ -241,7 +246,8 @@ main:
 // Test Case: 2 : L -> 1 and R Permissions given to the PMP Region 9
 
     LA(x6, TEST_FOR_EXECUTION)
-    addi x6, x6, g
+    LI(t6, g)
+    add x6, x6, t6
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr9, x6
     LA(x5, TEST_FOR_EXECUTION)
@@ -256,7 +262,8 @@ main:
 // Test Case: 3 : L -> 1 and WR Permissions given to the PMP Region 7
 
     LA(x6, TEST_FOR_EXECUTION)
-    addi x6, x6, g
+    LI(t6, g)
+    add x6, x6, t6
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr7, x6
     LA(x5, TEST_FOR_EXECUTION)
@@ -271,7 +278,8 @@ main:
 // Test Case: 4 : L -> 1 and X Permissions given to the PMP Region 5
 
     LA(x6, TEST_FOR_EXECUTION)
-    addi x6, x6, g
+    LI(t6, g)
+    add x6, x6, t6
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr5, x6
     LA(x5, TEST_FOR_EXECUTION)
@@ -286,7 +294,8 @@ main:
 // Test Case: 5 : L -> 1 and No Permissions given to the PMP Region 3
 
     LA(x6, TEST_FOR_EXECUTION)
-    addi x6, x6, g
+    LI(t6, g)
+    add x6, x6, t6
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr3, x6
     LA(x5, TEST_FOR_EXECUTION)
@@ -301,7 +310,8 @@ main:
 // Test Case: 6 : L -> 1 and XWR Permissions given to the PMP Region 1
 
     LA(x6, TEST_FOR_EXECUTION)
-    addi x6, x6, g
+    LI(t6, g)
+    add x6, x6, t6
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr1, x6
     LA(x5, TEST_FOR_EXECUTION)

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_tor_bot.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_tor_bot.S
@@ -161,7 +161,8 @@ main:
     csrw pmpcfg2, x4
 
     LA(x4, TEST_FOR_EXECUTION)
-    addi    x5, x4, g
+    LI(x5, g)
+    add x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_napot_all.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_napot_all.S
@@ -66,7 +66,8 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_2, test_2_str)                                   // Signature update
 
-    addi a5, a5, (g+4)
+    LI(t6, (g+4))
+    add a5, a5, t6
     \TEST_CASE\()_3:
     lw a4, 0(a5)
     nop

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_check-02.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_check-02.S
@@ -151,7 +151,8 @@ main:
 
     //addresses for a default TOR region
     LA(x4, TEST_FOR_EXECUTION)
-    addi    x5, x4, g
+    LI(x5, g)
+    add x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_check-03.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_check-03.S
@@ -151,7 +151,8 @@ main:
 
     //addresses for a default TOR region
     LA(x4, TEST_FOR_EXECUTION)
-    addi    x5, x4, g
+    LI(x5, g)
+    add x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_misaligned_tor.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_misaligned_tor.S
@@ -179,7 +179,8 @@ main:
     csrw pmpcfg2, x4
 
     LA(x4, TEST_FOR_EXECUTION)
-    addi    x5, x4, g
+    LI(x5, g)
+    add x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_napot_legal_lxwr-01.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_napot_legal_lxwr-01.S
@@ -76,7 +76,8 @@ RVTEST_BEGIN
 3:
     nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t6, (g-8))                  // REGIONSTART + g - 4
+    add a4, a4, t6
     LA(x1, 4f)                            // Store the return Address in x1
     jalr ra, 0(a4)
     nop
@@ -132,7 +133,8 @@ RVTEST_BEGIN
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_6, test_6_str)
 
 
-    addi a5, a5, (g-8)                                       // REGIONSTART + g - 4
+    LI(t6, (g-8))                                       // REGIONSTART + g - 4
+    add a5, a5, t6
 
     \TEST_CASE\()_7:
     sw a4, 0(a5)
@@ -201,7 +203,8 @@ RVTEST_BEGIN
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_17, test_17_str)
 
 
-    addi a5, a5, (g-8)
+    LI(t6, (g-8))
+    add a5, a5, t6
 
     \TEST_CASE\()_18:
     lw a4, 0(a5)

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_napot_legal_lxwr-02.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_napot_legal_lxwr-02.S
@@ -76,7 +76,8 @@ RVTEST_BEGIN
 3:
     nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t6, (g-8))                  // REGIONSTART + g - 4
+    add a4, a4, t6
     LA(x1, 4f)                            // Store the return Address in x1
     jalr ra, 0(a4)
     nop
@@ -132,7 +133,8 @@ RVTEST_BEGIN
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_6, test_6_str)
 
 
-    addi a5, a5, (g-8)                                       // REGIONSTART + g - 4
+    LI(t6, (g-8))                                       // REGIONSTART + g - 4
+    add a5, a5, t6
 
     \TEST_CASE\()_7:
     sw a4, 0(a5)
@@ -201,7 +203,8 @@ RVTEST_BEGIN
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_17, test_17_str)
 
 
-    addi a5, a5, (g-8)
+    LI(t6, (g-8))
+    add a5, a5, t6
 
     \TEST_CASE\()_18:
     lw a4, 0(a5)

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_priority.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_priority.S
@@ -116,7 +116,6 @@ main:
 
     LA(x4, TEST_FOR_EXECUTION)
     srl x4, x4, PMP_SHIFT
-    LI(x5, g)
 
     // REGIONSTART in even PMPADDR
     .set pmpaddri, CSR_PMPADDR0

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_priority.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_priority.S
@@ -116,7 +116,7 @@ main:
 
     LA(x4, TEST_FOR_EXECUTION)
     srl x4, x4, PMP_SHIFT
-    addi x5, x0, g
+    LI(x5, g)
 
     // REGIONSTART in even PMPADDR
     .set pmpaddri, CSR_PMPADDR0
@@ -129,7 +129,8 @@ main:
     LA(x5, TEST_FOR_EXECUTION)
     .set pmpaddri, CSR_PMPADDR0+1
     .rept 7
-    addi x5, x5, g
+    LI(t6, g)
+    add x5, x5, t6
     srl x6, x5, PMP_SHIFT
     csrw pmpaddri, x6
     .set pmpaddri, pmpaddri+2

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_priority_off.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_priority_off.S
@@ -111,7 +111,8 @@ main:
     csrw pmpcfg2, x4
 
     LA(x4, TEST_FOR_EXECUTION)
-    addi x5, x4, g
+    LI(x5, g)
+    add x5, x4, x5
     srl x4, x4, PMP_SHIFT
     csrw pmpaddr0, x4
     csrw pmpaddr2, x4

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_tor_legal_lxwr.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_tor_legal_lxwr.S
@@ -76,7 +76,8 @@ RVTEST_BEGIN
     nop
     nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t6, (g-8))                  // REGIONSTART + g - 4
+    add a4, a4, t6
     LA(x1, 4f)                            // Store the return Address in x1
     jalr ra, 0(a4)
     nop
@@ -123,7 +124,8 @@ RVTEST_BEGIN
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_3, test_3_str)
 
 
-    addi a5, a5, (g-8)                                    // REGIONSTART + g - 4
+    LI(t6, (g-8))                                    // REGIONSTART + g - 4
+    add a5, a5, t6
 
     \TEST_CASE\()_4:
     sw a4, 0(a5)
@@ -167,7 +169,8 @@ RVTEST_BEGIN
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_8, test_8_str)
 
 
-    addi a5, a5, (g-8)
+    LI(t6, (g-8))
+    add a5, a5, t6
 
     \TEST_CASE\()_9:
     lw a4, 0(a5)
@@ -220,7 +223,8 @@ main:
     csrw pmpcfg2, x4
 
     LA(x4, TEST_FOR_EXECUTION)
-    addi x5, x4, g
+    LI(x5, g)
+    add x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
 
@@ -235,7 +239,8 @@ main:
 // Test Case: 1 : L -> 1 and No Permissions given to the PMP Region 11
 
     LA(x6, TEST_FOR_EXECUTION)
-    addi x6, x6, g
+    LI(t6, g)
+    add x6, x6, t6
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr11, x6
     LA(x5, TEST_FOR_EXECUTION)
@@ -250,7 +255,8 @@ main:
 // Test Case: 2 : L -> 1 and R Permissions given to the PMP Region 9
 
     LA(x6, TEST_FOR_EXECUTION)
-    addi x6, x6, g
+    LI(t6, g)
+    add x6, x6, t6
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr9, x6
     LA(x5, TEST_FOR_EXECUTION)
@@ -265,7 +271,8 @@ main:
 // Test Case: 3 : L -> 1 and WR Permissions given to the PMP Region 7
 
     LA(x6, TEST_FOR_EXECUTION)
-    addi x6, x6, g
+    LI(t6, g)
+    add x6, x6, t6
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr7, x6
     LA(x5, TEST_FOR_EXECUTION)
@@ -280,7 +287,8 @@ main:
 // Test Case: 4 : L -> 1 and X Permissions given to the PMP Region 5
 
     LA(x6, TEST_FOR_EXECUTION)
-    addi x6, x6, g
+    LI(t6, g)
+    add x6, x6, t6
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr5, x6
     LA(x5, TEST_FOR_EXECUTION)
@@ -295,7 +303,8 @@ main:
 // Test Case: 5 : L -> 1 and No Permissions given to the PMP Region 3
 
     LA(x6, TEST_FOR_EXECUTION)
-    addi x6, x6, g
+    LI(t6, g)
+    add x6, x6, t6
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr3, x6
     LA(x5, TEST_FOR_EXECUTION)
@@ -310,7 +319,8 @@ main:
 // Test Case: 6 : L -> 1 and XWR Permissions given to the PMP Region 1
 
     LA(x6, TEST_FOR_EXECUTION)
-    addi x6, x6, g
+    LI(t6, g)
+    add x6, x6, t6
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr1, x6
     LA(x5, TEST_FOR_EXECUTION)


### PR DESCRIPTION
When RVMODEL_PMP_GRAIN > 9, g = (1 << (RVMODEL_PMP_GRAIN + 2)) exceeds
12 bits and cannot be encoded as an addi immediate, causing assembly
errors on high-granularity platforms.

Replace every `addi dst, dst, (g+N)` and `addi dst, dst, (g-N)` in 19
PMPSm test files with `LI(t6, (g+N))` / `add dst, dst, t6` so the
assembler uses the full-width LI expansion regardless of grain size.
Constant-4 addi instructions that do not involve g are left unchanged.

Fixes #1539.
