### PR TITLE
fix(cv32e20): remove U-mode, add repo description to README

### DIFF
--- a/config/cores/cve2/cv32e20/README.md
+++ b/config/cores/cve2/cv32e20/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 ## DUT Configuration for the CV32E20
 
-The [CV32E20](https://github.com/openhwgroup/cve2) is a small 32 bit RISC-V CPU core (RV32IMC/EMC)
+The [CV32E20](https://github.com/openhwgroup/cve2) ([docs](https://docs.openhwgroup.org/projects/cve2-user-manual)) is a small 32 bit RISC-V CPU core (RV32IMC/EMC)
 with a two stage pipeline, based on the original zero-riscy work from ETH Zurich and Ibex work
 from lowRISC.
 

--- a/config/cores/cve2/cv32e20/README.md
+++ b/config/cores/cve2/cv32e20/README.md
@@ -5,6 +5,10 @@ SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 ## DUT Configuration for the CV32E20
 
+The [CV32E20](https://github.com/openhwgroup/cve2) is a small 32 bit RISC-V CPU core (RV32IMC/EMC)
+with a two stage pipeline, based on the original zero-riscy work from ETH Zurich and Ibex work
+from lowRISC.
+
 To build the UDB configuration, coverage files and ELFs run the following
 command from the top of your working copy of this repo:
 

--- a/config/cores/cve2/cv32e20/cv32e20.yaml
+++ b/config/cores/cve2/cv32e20/cv32e20.yaml
@@ -17,27 +17,22 @@ implemented_extensions:
   - { name: Zca, version: "= 1.0.0" }
   - { name: Zicsr, version: "= 2.0" }
   - { name: Zifencei, version: "= 2.0" }
-  - { name: U, version: "= 1.0.0" }
   - { name: Sm, version: "= 1.12.0" }
 
 params:
   # XLEN parameters (VERIFIED)
   MXLEN: 32
-  UXLEN: [32]
   PHYS_ADDR_WIDTH: 32
 
   # MISA (!VERIFIED)
   MUTABLE_MISA_M: false
   MUTABLE_MISA_C: false
-  MUTABLE_MISA_U: false
   MISA_CSR_IMPLEMENTED: true
 
   # endianness (VERIFIED)
   M_MODE_ENDIANNESS: little
-  U_MODE_ENDIANNESS: little
 
   # trap/exception behavior (VERIFIED)
-  TRAP_ON_ECALL_FROM_U: true
   TRAP_ON_ECALL_FROM_M: true
   TRAP_ON_EBREAK: true
   TRAP_ON_UNIMPLEMENTED_INSTRUCTION: true

--- a/config/cores/cve2/cv32e20/sail.json
+++ b/config/cores/cve2/cv32e20/sail.json
@@ -241,7 +241,7 @@
       "supported": false
     },
     "U": {
-      "supported": true
+      "supported": false
     },
     "Zibi": {
       "supported": false


### PR DESCRIPTION
It looks like I made mistake by introducing U-mode into configuration. Despite manual saying it is supporting it, and having partial support in RTL - U-mode is not supported. Issue was raised here - https://github.com/openhwgroup/cve2/issues/327

This PR removes U-mode, and adds description and link to core in readme