### PR TITLE
build: delete a failed task's outputs so partial writes can't be reused

### DIFF
--- a/framework/src/act/build.py
+++ b/framework/src/act/build.py
@@ -133,6 +133,20 @@ def is_stale(task: BuildTask) -> bool:
     return any(inp.exists() and inp.stat().st_mtime > oldest_output_mtime for inp in all_inputs)
 
 
+def _discard_outputs(task: BuildTask) -> None:
+    """Delete a failed task's outputs so a partial write can't pose as up-to-date.
+
+    Staleness is judged by mtime, so a half-written output left behind by a
+    crashing action looks newer than its inputs on the next run and is silently
+    skipped. In the signature pipeline that means a truncated reference signature
+    could be baked into the self-check ELF and let a broken DUT pass. Mirror
+    GNU Make's .DELETE_ON_ERROR. The task's log file is not an output and is kept.
+    """
+    for out in task.outputs:
+        with contextlib.suppress(OSError):
+            out.unlink(missing_ok=True)
+
+
 def execute_task(
     task: BuildTask,
     *,
@@ -141,7 +155,28 @@ def execute_task(
     pgids_lock: threading.Lock,
     shutdown_event: threading.Event,
 ) -> BuildError | None:
-    """Execute a single build task. Returns None on success, BuildError on failure."""
+    """Run a build task, discarding its outputs if it fails. None on success."""
+    error = _run_action(
+        task,
+        verbose=verbose,
+        active_pgids=active_pgids,
+        pgids_lock=pgids_lock,
+        shutdown_event=shutdown_event,
+    )
+    if error is not None:
+        _discard_outputs(task)
+    return error
+
+
+def _run_action(
+    task: BuildTask,
+    *,
+    verbose: bool = False,
+    active_pgids: set[int],
+    pgids_lock: threading.Lock,
+    shutdown_event: threading.Event,
+) -> BuildError | None:
+    """Execute a single build task's action. Returns None on success, BuildError on failure."""
     if verbose:
         print(f"  {_task_str(task)}")
     action = task.action

--- a/framework/tests/test_build.py
+++ b/framework/tests/test_build.py
@@ -1,0 +1,103 @@
+##################################
+# test_build.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Regression tests for the DAG build executor, focused on delete-on-error:
+# a task that fails must not leave a half-written output behind, or a later
+# run would treat the stale file as up-to-date and silently skip it.
+##################################
+
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from act.build import BuildResult, BuildTask, PythonAction, build, is_stale
+
+
+def run_build(tasks: list[BuildTask]) -> BuildResult:
+    """Run a single-threaded build, swallowing the progress/console output."""
+    with redirect_stdout(io.StringIO()):
+        return build(tasks, jobs=1)
+
+
+def crashing_writer(out: Path) -> None:
+    """Write a partial output then fail, mimicking a ref model crashing mid-run."""
+    out.write_text("only half the answers\n")
+    raise RuntimeError("reference model crashed")
+
+
+class DeleteOnError(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.tmp = Path(tmp.name)
+
+    def test_partial_output_is_removed_on_failure(self) -> None:
+        out = self.tmp / "answer.key"
+        task = BuildTask(outputs=(out,), action=PythonAction(fn=crashing_writer, args=(out,)))
+
+        result = run_build([task])
+
+        self.assertEqual(result.failed, 1)
+        self.assertFalse(out.exists(), "a failed task must not leave its half-written output behind")
+
+    def test_failed_task_reruns_instead_of_caching(self) -> None:
+        # The crux: after a failure the task must stay stale so the next run
+        # regenerates it, rather than mistaking the leftover for a finished build.
+        src = self.tmp / "input.S"
+        src.write_text("source\n")
+        out = self.tmp / "answer.key"
+        task = BuildTask(
+            outputs=(out,),
+            extra_inputs=(src,),
+            action=PythonAction(fn=crashing_writer, args=(out,)),
+        )
+
+        run_build([task])
+        self.assertTrue(is_stale(task), "a failed task must remain stale")
+
+        second = run_build([task])
+        self.assertEqual(second.skipped, 0, "must not silently skip a previously failed task")
+        self.assertEqual(second.failed, 1)
+
+    def test_every_output_is_removed_even_if_only_one_was_written(self) -> None:
+        first, second = self.tmp / "a.bin", self.tmp / "b.bin"
+
+        def write_first_then_fail() -> None:
+            first.write_text("a\n")
+            raise RuntimeError("crashed before writing the second output")
+
+        task = BuildTask(outputs=(first, second), action=PythonAction(fn=write_first_then_fail))
+        run_build([task])
+
+        self.assertFalse(first.exists())
+        self.assertFalse(second.exists())
+
+
+class SuccessPathUnaffected(unittest.TestCase):
+    """Guard against over-zealous cleanup touching healthy builds."""
+
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.tmp = Path(tmp.name)
+
+    def test_successful_output_is_kept_and_cached(self) -> None:
+        out = self.tmp / "answer.key"
+        task = BuildTask(outputs=(out,), action=PythonAction(fn=lambda p: p.write_text("all answers\n"), args=(out,)))
+
+        first = run_build([task])
+        self.assertEqual(first.succeeded, 1)
+
+        second = run_build([task])
+        self.assertEqual(second.skipped, 1, "an up-to-date task should be skipped on re-run")
+        self.assertEqual(out.read_text(), "all answers\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,5 @@ exclude = [
 ]
 typeCheckingMode = "standard"
 pythonVersion = "3.10"
+# Resolve the `act` package for code outside framework/src (e.g. framework/tests).
+extraPaths = ["framework/src"]


### PR DESCRIPTION
## Problem

The DAG executor decides whether a task is up-to-date purely by mtime (`is_stale`): a task is skipped if its outputs exist and no input is newer.

If an action crashes *after* it has started writing its output, that half-written file is left on disk. On the next run it looks newer than its inputs, so `is_stale` returns `False` and the task is silently skipped the corrupt output is treated as a finished build. This is dangerous in the signature pipeline specifically:

`*.S` → `*.sig.elf` → **`*.sig` (reference model)** → `*.results` → self-check `*.elf`

If the reference model is interrupted or exits early mid-write, the truncated `*.sig` is turned into `*.results` and baked into the self-check ELF. The DUT then only checks the answers that survived the truncation; everything past that point is never verified, so a non-conformant DUT can pass.

## Fix

Apply GNU Make's `.DELETE_ON_ERROR` semantics: when a task's action fails, delete its declared outputs. The task then stays stale and is regenerated on the next run instead of reusing a partial file.

- The action runner is split out unchanged as `_run_action`; `execute_task` just layers the cleanup policy on top, so the existing subprocess / process-group logic is untouched.
- Only `task.outputs` are removed. The log file (`stdout_file`) is not an output and is deliberately kept for debugging the failure.

## Testing

Adds `framework/tests/test_build.py` (stdlib `unittest`, no new dependencies):

- a failed task's partial output is removed
- a failed task stays stale and re-runs (does not silently skip) on the next run
- every output of a multi-output task is removed even if only one was written
- a successful task keeps its output and is still skipped when up-to-date

Run with:

    python -m unittest discover -s framework/tests

The failure-path tests were confirmed to fail without the fix and pass with it. `ruff` and `pyright` are clean on both changed files.
Also adds `extraPaths = ["framework/src"]` to `[tool.pyright]` so files under `framework/tests` can statically resolve `import act...`. Without it pyright flags the editable-installed package as missing even though it imports fine at
runtime.

## Note

This builds on the executor introduced in #1427, so `execute_task` is a thin wrapper that forwards the `active_pgids` / `pgids_lock` / `shutdown_event` arguments to `_run_action`.
