### PR TITLE
Apply verbose setting to prepare_dut_outputs

### DIFF
--- a/framework/src/act/act.py
+++ b/framework/src/act/act.py
@@ -115,7 +115,7 @@ def run_act(
         config_dir = workdir / config.name
         loaded_configs.append((config, config_dir))
 
-    prepare_dut_outputs([cfg for cfg, _ in loaded_configs], workdir, jobs)
+    prepare_dut_outputs([cfg for cfg, _ in loaded_configs], workdir, jobs, verbose)
 
     for config, config_dir in loaded_configs:
         implemented_extensions = get_implemented_extensions(config_dir / "extensions.txt")

--- a/framework/src/act/parse_udb_config.py
+++ b/framework/src/act/parse_udb_config.py
@@ -115,7 +115,7 @@ def validate_udb_config(udb_config_file: Path, marker: Path) -> None:
     marker.touch()
 
 
-def prepare_dut_outputs(configs: list[Config], workdir: Path, jobs: int) -> None:
+def prepare_dut_outputs(configs: list[Config], workdir: Path, jobs: int, verbose: bool) -> None:
     """Generate every DUT-derived file (extensions.txt, rvtest_config.{h,svh},
     rvmodel_macros.svh) for every config, in parallel, using the same
     `build()` DAG executor as the main pipeline.
@@ -180,7 +180,7 @@ def prepare_dut_outputs(configs: list[Config], workdir: Path, jobs: int) -> None
         )
 
     start = time.monotonic()
-    result = build(tasks, jobs=jobs, phase_label="Preparing DUT configs")
+    result = build(tasks, jobs=jobs, verbose=verbose, phase_label="Preparing DUT configs")
     elapsed = time.monotonic() - start
 
     if result.errors:


### PR DESCRIPTION
Using the `VERBOSE` flag can help debug errors during UDB config validation, but it currently doesn't get passed to the `prepare_dut_outputs` function. This step wasn't included when the `VERBOSE` flag was added in #1220.