### PR TITLE
InterruptsS: Fixed wfi related coverpoints

### DIFF
--- a/coverpoints/priv/InterruptsS_coverage.svh
+++ b/coverpoints/priv/InterruptsS_coverage.svh
@@ -469,7 +469,7 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
     cp_priority_mideleg_m:       cross priv_mode_m, mret_insn, mstatus_mpp_s, mstatus_mie_zero, prev_mstatus_sie_one, mideleg_combinations_m, mip_ones_s, mie_ones;
     cp_priority_mideleg_s:       cross priv_mode_s_after, mstatus_mie_zero, prev_mstatus_sie_one, mideleg_combinations_s, mip_ones_s, mideleg_mie_eq_s;
     cp_wfi_s:                    cross priv_mode_s, wfi, mstatus_mie, mstatus_sie, mideleg_ones_zeros_real, mstatus_tw_zero, mie_mtie_one;
-    cp_wfi_timeout_s:            cross priv_mode_m, mstatus_mie, mstatus_sie, mideleg_ones_zeros_real, mstatus_tw_one, mie_mtie;
+    cp_wfi_timeout_s:            cross priv_mode_s, wfi, mstatus_mie, mstatus_sie, mideleg_ones_zeros_real, mstatus_tw_one, mie_mtie;
 
     // M-mode tests
     cp_interrupts_m:            cross priv_mode_m, mstatus_mie, mtvec_direct, mideleg_ones_zeros_real, mip_walking, mie_walking;
@@ -503,8 +503,8 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
     cp_user_sei_handled_m: cross priv_mode_m_after, mstatus_mpp_u, mstatus_mie, mideleg_sei_zero, stvec_mode, mie_seie_one, mip_seip;
     // 2. S-Mode Handled: SEI IS delegated AND we were in U or S mode
     cp_user_sei_handled_s: cross priv_mode_s_after, mstatus_sie, mideleg_sei_one, stvec_mode, mie_seie_one, mip_seip;
-    cp_wfi_u: cross priv_mode_m, mstatus_mie, mstatus_sie, mideleg_ones_zeros_real, mstatus_tw_zero, mie_mtie_one;
-    cp_wfi_timeout_u: cross priv_mode_m, mstatus_mie, mstatus_sie, mideleg_ones, mstatus_tw_one, mie_mtie_one;
+    cp_wfi_u: cross priv_mode_u, wfi, mstatus_mie, mstatus_sie, mideleg_ones_zeros_real, mstatus_tw_zero, mie_mtie_one;
+    cp_wfi_timeout_u: cross priv_mode_u, wfi, mstatus_mie, mstatus_sie, mideleg_ones, mstatus_tw_one, mie_mtie_one;
 
 endgroup
 

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsS.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsS.py
@@ -1867,8 +1867,13 @@ def _generate_wfi_timeout_s_tests(test_data: TestData) -> list[str]:
                         )
 
                         if mie_val:
-                            lines.append("# Set MIE")
-                            lines.append("csrsi mstatus, 8")
+                            lines.extend(
+                                [
+                                    "# Set MIE+MPIE so MIE=1 persists through MRET into U-mode",
+                                    f"LI(x{r_scratch}, 0x88)",
+                                    f"CSRS(mstatus, x{r_scratch})",
+                                ]
+                            )
 
                         if sie_val:
                             lines.append("# Set SIE")
@@ -4009,8 +4014,13 @@ def _generate_wfi_u_tests(test_data: TestData) -> list[str]:
                 )
 
                 if mie_val:
-                    lines.append("# Set MIE")
-                    lines.append("csrsi mstatus, 8")
+                    lines.extend(
+                        [
+                            "# Set MIE+MPIE so MIE=1 persists through MRET into U-mode",
+                            f"LI(x{r_scratch}, 0x88)",
+                            f"CSRS(mstatus, x{r_scratch})",
+                        ]
+                    )
 
                 if sie_val:
                     lines.append("# Set SIE")
@@ -4134,8 +4144,13 @@ def _generate_wfi_timeout_u_tests(test_data: TestData) -> list[str]:
             )
 
             if mie_val:
-                lines.append("# Set MIE")
-                lines.append("csrsi mstatus, 8")
+                lines.extend(
+                    [
+                        "# Set MIE+MPIE so MIE=1 persists through MRET into U-mode",
+                        f"LI(x{r_scratch}, 0x88)",
+                        f"CSRS(mstatus, x{r_scratch})",
+                    ]
+                )
 
             if sie_val:
                 lines.append("# Set SIE")


### PR DESCRIPTION
InterruptsS Coverpoints: 
The coverpoints related to wfi were not sampling whether a wfi instruction is actually executed, modified to account for that

Modified the test generator to also set MPIE when needing to set MIE so the MIE value does not go back to zero after changing to less privileged modes. 