### PR TITLE
Enhance TestChunk with split_name and implement file grouping

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -18,6 +18,7 @@ Each is described below.
   - [Creating New Spreadsheet Testplans](#creating-new-spreadsheet-testplans)
   - [Adding New Privileged Coverpoints](#adding-new-privileged-coverpoints)
   - [Adding New Privileged Tests](#adding-new-privileged-tests)
+  - [Splitting Privileged Tests](#splitting-privileged-tests)
 - [Debugging Coverage](#debugging-coverage)
 - [Adding a New Simulator or DUT Config](#adding-a-new-simulator-or-dut-config)
   - [Adding a Config for Running Locally](#adding-a-config-for-running-locally)
@@ -79,9 +80,9 @@ test suite
 
 - **Test chunk** (`TestChunk`): An unsplittable group of one or more testcases. A test chunk is the building block of test files. Test chunks are never split across multiple files. Standard coverpoint generators (e.g., `cp_rd`, `cp_imm_edges`) produce one chunk per testcase via `format_single_testcase()`. Special coverpoint generators and privileged tests bundle multiple testcases into a single chunk using `test_data.begin_test_chunk()` / `test_data.end_test_chunk()`, typically because the testcases share setup code.
 
-- **Test file**: A complete `.S` assembly file that is compiled into a self-checking ELF. Each test file contains one or more test chunks. When an instruction has many testcases (e.g., hundreds of register/immediate combinations), the framework splits the chunks across multiple test files using `TESTCASES_PER_FILE` as the limit. Test files are named like `I-add-00.S`, `I-add-01.S`, etc., where the suffix indicates the file index.
+- **Test file**: A complete `.S` assembly file that is compiled into a self-checking ELF. Each test file contains one or more test chunks. When an instruction has many testcases (e.g., hundreds of register/immediate combinations), the framework splits the chunks across multiple test files using `TESTCASES_PER_FILE` as the limit. Test files are named like `I-add-00.S`, `I-add-01.S`, etc., where the suffix indicates the file index. Privileged tests use the same length-based splitting (limit `TESTCASES_PER_PRIV_FILE`) and can additionally be split into named groups — see [Splitting Privileged Tests](#splitting-privileged-tests).
 
-- **Test suite**: All test files in a given directory. Each test suite corresponds to one extension or combination of extensions (e.g., `I`, `Zcb`, `ZcbZbb`, `ExceptionsSm`) and maps to a single coverage file. Unprivileged test suites contain one or more test files per instruction. For privileged tests, a test suite typically contains a single test file covering all coverpoints for that feature.
+- **Test suite**: All test files in a given directory. Each test suite corresponds to one extension or combination of extensions (e.g., `I`, `Zcb`, `ZcbZbb`, `ExceptionsSm`) and maps to a single coverage file. Unprivileged test suites contain one or more test files per instruction. For privileged tests, a test suite contains one or more test files covering all coverpoints for that feature — a single file unless splitting kicks in.
 
 ## Test YAML Header
 
@@ -654,34 +655,35 @@ The following applies to all privileged test generators:
 - All privileged generator functions must use the following signature:
 
   ```py
-  def make_name(test_data: TestData) -> list[str]:
+  def make_name(test_data: TestData) -> list[TestChunk]:
 
   ```
 
   - `test_data` is a dataclass that is passed to all parts of the test generation process and stores the signature count, debug strings, etc.
-  - The generator must return a list of strings. They will be combined with newlines separating each string in the final output test.
+  - The generator must return a list of `TestChunk` objects, built the same way as [Special Generators](#special-generators): wrap assembly in a chunk with `test_data.begin_test_chunk()` / `test_data.end_test_chunk()`. The framework uses these chunks to split the suite across test files — see [Splitting Privileged Tests](#splitting-privileged-tests).
 
 The body of most privileged test generator functions is a series of calls to other functions that generate the code for each coverpoint. For example, the main generator from [`Sm.py`](../generators/testgen/src/testgen/priv/extensions/Sm.py) is included below:
 
 ```py
 # All priv test generators use the @add_priv_test_generator decorator to specify the
 # name and required extensions.
-@add_priv_test_generator("Sm", required_extensions=["Sm", "Zicsr"])
+@add_priv_test_generator("Sm", required_extensions=["Sm"])
 # All priv test generators must use the standard function signature.
-def make_sm(test_data: TestData) -> list[str]:
+def make_sm(test_data: TestData) -> list[TestChunk]:
     """Generate tests for Sm machine-mode testsuite."""
-    lines: list[str] = []
-    # Priv test generators call other internal functions to build up the test
-    lines.extend(_generate_mcause_tests(test_data))
-    lines.extend(_generate_mstatus_sd_tests(test_data))
-    lines.extend(_generate_priv_inst_tests(test_data))
-    lines.extend(_generate_mret_tests(test_data))
-    lines.extend(_generate_sret_tests(test_data))
-    lines.extend(_generate_mcsr_tests(test_data))
-    lines.extend(_generate_mcsr_cntr_tests(test_data))
-    # A list of assembly strings is returned. These strings will be joined together
-    # with newlines in the final output file.
-    return lines
+    test_chunks: list[TestChunk] = []
+    tc = test_data.begin_test_chunk()
+    tc.code.extend(_generate_mcause_tests(test_data))
+    tc.code.extend(_generate_mstatus_sd_tests(test_data))
+    tc.code.extend(_generate_priv_inst_tests(test_data))
+    tc.code.extend(_generate_mret_tests(test_data))
+    tc.code.extend(_generate_sret_tests(test_data))
+    tc.code.extend(_generate_mcsr_tests(test_data))
+    tc.code.extend(_generate_mcsr_cntr_tests(test_data))
+    test_chunks.append(test_data.end_test_chunk())
+    # A list of TestChunk objects is returned; the framework combines/splits
+    # them into the final output file(s).
+    return test_chunks
 ```
 
 There are a few important gotchas to keep in mind when writing privileged tests:
@@ -700,6 +702,19 @@ For examples of how to write the individual coverpoint helper functions for priv
   - Pre-processor directives (`#ifdef`, etc.), comments, and labels are unindented.
   - Code (instructions and macros) is indented by 2 spaces.
   - If deviations from this help the readability of a test (most often indenting certain comments), use the `INDENT` global at the beginning of the line (e.g. `f"{INDENT}# comment`).
+
+### Splitting Privileged Tests
+
+- **Length-based splitting**: If the total `num_testcases` across a suite's chunks exceeds `TESTCASES_PER_PRIV_FILE` (in [`constants.py`](../generators/testgen/src/testgen/constants.py)), the framework breaks the chunk list into multiple files, never splitting a single chunk. Split files are named `<testsuite>-00.S`, `<testsuite>-01.S`, etc.
+- **Named splits**: A generator can additionally tag chunks so that a specific scope (e.g. "the CSR sweep" or "the illegal instruction sweep") always lands in its own set of files, regardless of where length-based splitting would otherwise fall. This makes failures easier to triage (the file name says what scope failed) and lets that scope be run independently.
+
+To opt in to named splits, pass a name to `test_data.begin_test_chunk(split_name)` on the chunk that starts a scope:
+
+- A chunk created with a non-`None` `split_name` starts a new named group — i.e. a new output file boundary — unless the current group already has that same name, in which case it merges in with no forced split.
+- A chunk created with `split_name=None` (the default) stays in whichever group is currently open.
+- Reusing a name after a different name has already closed that group (i.e. non-contiguous reuse) raises an error.
+
+Length-based splitting still applies _within_ each named group, so a large named scope can still become `<testsuite>_<split_name>-00.S`, `<testsuite>_<split_name>-01.S`, etc.
 
 ## Debugging Coverage
 

--- a/generators/testgen/src/testgen/data/state.py
+++ b/generators/testgen/src/testgen/data/state.py
@@ -144,7 +144,7 @@ class TestData:
         """Increment the test count by 1."""
         self._test_count += 1
 
-    def begin_test_chunk(self) -> TestChunk:
+    def begin_test_chunk(self, split_name: str | None = None) -> TestChunk:
         """Create and set a new active TestChunk.
 
         Snapshots the current signature/data pointer register assignments so
@@ -152,10 +152,14 @@ class TestData:
         file, the generator can emit code to re-establish those pointers (which
         would otherwise only live in the default registers set by
         RVTEST_BEGIN).
+
+        Args:
+            split_name: Optional named-split marker (see TestChunk.split_name).
         """
         self.test_chunk = TestChunk(
             start_sig_reg=self._int_regs.sig_reg,
             start_data_reg=self._int_regs.data_reg,
+            split_name=split_name,
         )
         return self.test_chunk
 

--- a/generators/testgen/src/testgen/data/test_chunk.py
+++ b/generators/testgen/src/testgen/data/test_chunk.py
@@ -27,6 +27,9 @@ class TestChunk:
         data_strings: Debug strings for .data section
         sigupd_count: Number of signature updates
         num_testcases: Number of individual testcases (for split counting)
+        split_name: Optional named-split marker. A non-None value starts a new
+                    named file group (unless the current group already has the
+                    same name); subsequent None chunks stay in that group.
         section_header: Optional banner comment before a coverpoint section
         start_sig_reg: Signature pointer register expected at the start of this chunk
         start_data_reg: Data pointer register expected at the start of this chunk
@@ -39,6 +42,7 @@ class TestChunk:
     data_strings: list[str] = field(default_factory=list)
     sigupd_count: int = 0
     num_testcases: int = 0
+    split_name: str | None = None
     section_header: str | None = None
     start_sig_reg: int = 2
     start_data_reg: int = 3
@@ -71,3 +75,40 @@ def split_test_chunks(test_chunks: list[TestChunk], max_per_file: int) -> list[l
     if current_file_chunks:
         test_files.append(current_file_chunks)
     return test_files
+
+
+def group_test_chunks(
+    test_chunks: list[TestChunk], max_per_file: int
+) -> list[tuple[str | None, list[list[TestChunk]]]]:
+    """
+    Group TestChunks by their split_name, then length-split each group.
+
+    A chunk with a non-None split_name starts a new named group unless the current
+    group already has that name; chunks with split_name=None stay in the current
+    group. An unnamed group can only occur before the first named chunk. Reusing a
+    name non-contiguously raises ValueError.
+
+    Returns an ordered list of (group_name, test_files) pairs, where test_files is
+    the length-based split of that group's chunks (max_per_file testcases per file).
+    """
+    if not test_chunks:
+        raise ValueError("No test chunks provided!")
+
+    groups: list[tuple[str | None, list[TestChunk]]] = []
+    seen_names: set[str] = set()
+    current_name: str | None = None
+    current_group: list[TestChunk] = []
+
+    for tc in test_chunks:
+        if tc.split_name is not None and tc.split_name != current_name:
+            if tc.split_name in seen_names:
+                raise ValueError(f'Split name "{tc.split_name}" reused non-contiguously!')
+            seen_names.add(tc.split_name)
+            if current_group:
+                groups.append((current_name, current_group))
+            current_name = tc.split_name
+            current_group = []
+        current_group.append(tc)
+    groups.append((current_name, current_group))
+
+    return [(name, split_test_chunks(chunks, max_per_file)) for name, chunks in groups]

--- a/generators/testgen/src/testgen/generate/priv.py
+++ b/generators/testgen/src/testgen/generate/priv.py
@@ -15,7 +15,7 @@ from testgen.asm.helpers import reproducible_hash
 from testgen.constants import TESTCASES_PER_PRIV_FILE
 from testgen.data.config import TestConfig
 from testgen.data.state import TestData
-from testgen.data.test_chunk import split_test_chunks
+from testgen.data.test_chunk import group_test_chunks
 from testgen.io.writer import write_test_file
 from testgen.priv.registry import (
     get_priv_test_defines,
@@ -64,10 +64,10 @@ def generate_priv_test(testsuite: str, output_test_dir: Path) -> None:
     priv_test_generator = get_priv_test_generator(testsuite)
     chunks = priv_test_generator(test_data)
 
-    # Split into test files and write
-    test_files = split_test_chunks(chunks, TESTCASES_PER_PRIV_FILE)
-    for file_idx, test_file_chunks in enumerate(test_files):
-        write_test_file(test_config, None, test_file_chunks, output_path, file_idx, extra_defines)
+    # Group by named split, split each group into test files, and write
+    for split_name, test_files in group_test_chunks(chunks, TESTCASES_PER_PRIV_FILE):
+        for file_idx, test_file_chunks in enumerate(test_files):
+            write_test_file(test_config, None, test_file_chunks, output_path, file_idx, extra_defines, split_name)
 
     # Clean up (make sure all registers were returned)
     test_data.int_regs.return_registers(priv_exclude_regs)

--- a/generators/testgen/src/testgen/io/writer.py
+++ b/generators/testgen/src/testgen/io/writer.py
@@ -54,6 +54,7 @@ def write_test_file(
     output_dir: Path,
     file_idx: int = 0,
     extra_defines: list[str] | None = None,
+    split_name: str | None = None,
 ) -> None:
     """
     Write a single test file.
@@ -65,7 +66,10 @@ def write_test_file(
         output_dir: Directory to write the test file to
         file_idx: File index for the filename suffix (default 00)
         extra_defines: Additional #define statements for the test (e.g., trap handlers)
+        split_name: Named-split label for priv tests (mutually exclusive with instr_name)
     """
+    if instr_name is not None and split_name is not None:
+        raise ValueError("instr_name and split_name are mutually exclusive! Unpriv tests should not use split name.")
     testsuite = test_config.testsuite
 
     # Combine data from all test chunks
@@ -76,6 +80,8 @@ def write_test_file(
     # Construct filename and paths
     if instr_name is not None:
         filename = f"{testsuite}-{instr_name}-{file_idx:02d}.S"
+    elif split_name is not None:
+        filename = f"{testsuite}_{split_name}-{file_idx:02d}.S"
     else:
         filename = f"{testsuite}-{file_idx:02d}.S"
     test_file = output_dir / filename

--- a/generators/testgen/src/testgen/io/writer.py
+++ b/generators/testgen/src/testgen/io/writer.py
@@ -69,7 +69,9 @@ def write_test_file(
         split_name: Named-split label for priv tests (mutually exclusive with instr_name)
     """
     if instr_name is not None and split_name is not None:
-        raise ValueError("instr_name and split_name are mutually exclusive! Unpriv tests should not use split name.")
+        raise ValueError("instr_name and split_name are mutually exclusive (unpriv tests should not use split_name).")
+    if split_name is not None and (".." in split_name or "/" in split_name or "\\" in split_name):
+        raise ValueError(f"Invalid split_name {split_name!r}; must not contain path separators or '..'.")
     testsuite = test_config.testsuite
 
     # Combine data from all test chunks

--- a/generators/testgen/src/testgen/priv/extensions/SsstrictCommon.py
+++ b/generators/testgen/src/testgen/priv/extensions/SsstrictCommon.py
@@ -176,6 +176,7 @@ def _emit_raw_words(
     setup: SetupFn | None = None,
     label: tuple[str, str, str] | None = None,
     section_header: str | None = None,
+    split_name: str | None = None,
 ) -> None:
     """Emit a template's encodings as one or more self-contained .word/.hword chunks.
 
@@ -201,7 +202,7 @@ def _emit_raw_words(
     total = len(encodings)
     for grp_start in range(0, total, MAX_WORDS_PER_CHUNK):
         group = encodings[grp_start : grp_start + MAX_WORDS_PER_CHUNK]
-        tc = test_data.begin_test_chunk()
+        tc = test_data.begin_test_chunk(split_name)
         if section_header is not None and grp_start == 0:
             tc.section_header = section_header
         lines: list[str] = []
@@ -230,9 +231,11 @@ def _emit_raw_sweeps(
     setup: SetupFn | None = None,
     label: tuple[str, str, str] | None = None,
     section_header: str | None = None,
+    split_name: str | None = None,
 ) -> None:
     next_label = label
     next_header = section_header
+    next_split_name = split_name
     for sweep in sweeps:
         _emit_raw_words(
             test_data,
@@ -244,9 +247,11 @@ def _emit_raw_sweeps(
             setup=setup,
             label=next_label,
             section_header=next_header,
+            split_name=next_split_name,
         )
         next_label = None
         next_header = None
+        next_split_name = None
 
 
 # ── CSR sweep body ────────────────────────────────────────────────────────
@@ -268,7 +273,7 @@ def _generate_csr_sweep_body(
     test_chunks: list[TestChunk] = []
     for batch_start in range(0, len(csr_addresses), CSRS_PER_CHUNK):
         batch = csr_addresses[batch_start : batch_start + CSRS_PER_CHUNK]
-        tc = test_data.begin_test_chunk()
+        tc = test_data.begin_test_chunk("CSR")
         if section_header is not None and batch_start == 0:
             tc.section_header = section_header
         lines: list[str] = []
@@ -321,6 +326,7 @@ def _generate_illegal_instr(
     # Only the first chunk carries the coverpoint testcase label and section banner.
     label: tuple[str, str, str] | None = ("illegal_instr_sweep", coverpoint, covergroup)
     section_header: str | None = comment_banner(coverpoint)
+    split_name = "IllegalInstr"
 
     scalar_sweeps = [
         [
@@ -437,6 +443,7 @@ def _generate_illegal_instr(
             setup=_scratch_setup,
             label=label,
             section_header=section_header,
+            split_name=split_name,
         )
         label = None
         section_header = None
@@ -524,6 +531,7 @@ def _generate_vector_illegal_instr(
         setup=_vector_setup(),
         label=label,
         section_header=vset_header,
+        split_name="VectorInstr",
     )
 
     # ── Reserved vector loads ── rs1 is the scratch base (B field) ──
@@ -664,6 +672,7 @@ def _generate_compressed_instr(
         compressed_sweeps,
         label=("compressed_sweep", coverpoint, covergroup),
         section_header=comment_banner(coverpoint, "Exhaustive 16-bit quadrant sweep."),
+        split_name="CompressedInstr",
     )
 
     return test_chunks


### PR DESCRIPTION
Add `split_name` as an optional parameter to `test_data.begin_test_chunk`. When a name is specified, the name is appended to the test file name. `test_chunks` with different names are always split, regardless of length. Subsequent chunks that do not have an explicit name use the same name as the previous chunk. Ssstrict is split into 4 named groups as an initial example.