### PR TITLE
Change termination jump to rvtest_code_end

### DIFF
--- a/tests/env/rvtest_setup.h
+++ b/tests/env/rvtest_setup.h
@@ -121,7 +121,7 @@
   // Terminate test with a failure message
   abort_test:
     LI(     T5, 0xBAD0DEAD)
-    j       cleanup_epilogs
+    j       rvtest_code_end // switch to M-mode and clean up, then terminate with message
 
   // Instantiate trap handlers for each priv mode
   // Guard matches the RVTEST_TRAP_EPILOG guard above: rvtest_Mend (and sibling


### PR DESCRIPTION
Resolves #1832.  Needs review that it doesn't break anything else.

Also, the error message printed is a bit weird:

```
✗ FAILED: ExceptionsU-00
  Output: work/whisper-rv32-max/build/priv/ExceptionsU/ExceptionsU-00.sig
  Error output:
    using /home/harris/cvw/addins/riscv-arch-test-dh/work/whisper-rv32-max/build/priv/ExceptionsU/ExceptionsU-00.sig.trace for trace output.
    begin_signature: 0x8000fcd0
    end_signature: 0x8001ea70
    
    RVCP-SUMMARY: TEST FAILED - Test File "ExceptionsU-00.S"
    RVCP: DEBUG INFORMATION FOLLOWS
    RVCP: Test Info: "The trap handler aborted the test before normal completion!"
    RVCP: ===== TRAP FAILURE DIAGNOSTICS =====
    RVCP: Failure: "The trap handler aborted the test before normal completion!"
    RVCP: Unrecognized trap failure context. Printing available CSR state:
    RVCP: Instruction that trapped: FAILURE: possible trap loop detected with MEPC=0x800057a8 and SEPC=0xacce
```