### PR TITLE
Add pre-commit hook to enforce LI/LA macros

### DIFF
--- a/.github/scripts/check-li-la-pseudoinstructions.sh
+++ b/.github/scripts/check-li-la-pseudoinstructions.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+pattern='(^\s*(li|la)\s)|(;\s*(li|la)\s)'
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  red='\033[31m'; bold='\033[1m'; reset='\033[0m'
+else
+  red=''; bold=''; reset=''
+fi
+found=0
+for f in "$@"; do
+  matches=$(grep -nE "$pattern" "$f" || true)
+  if [ -n "$matches" ]; then
+    found=1
+    while IFS= read -r line; do echo "$f:$line"; done <<< "$matches"
+  fi
+done
+if [ "$found" -ne 0 ]; then
+  echo
+  echo "${bold}${red}error:${reset} disallowed 'li'/'la' assembler pseudoinstruction found above."
+  echo "  Use 'LI(reg, imm)' or 'LA(reg, label)' macros instead (defined in tests/env/utils.h)."
+  exit 1
+fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,15 @@ repos:
     hooks:
       - id: renovate-config-validator
 
+  # Forbid li/la pseudoinstructions in favor of LI/LA macros
+  - repo: local
+    hooks:
+      - id: forbid-li-la-pseudoinstructions
+        name: forbid li/la pseudoinstructions (use LI/LA macros)
+        language: script
+        entry: .github/scripts/check-li-la-pseudoinstructions.sh
+        files: ^tests/.*\.(S|s)$
+
   # clang-format for assembly files
   # - repo: https://github.com/pre-commit/mirrors-clang-format
   #   rev: "v19.1.7"

--- a/generators/testgen/scripts/csrtests.py
+++ b/generators/testgen/scripts/csrtests.py
@@ -73,7 +73,7 @@ def csrtests(pathname, skipCsrs):
 
         print("\n// Testing CSR " + ih)
         print("\tcsrr x" + str(reg1) + ", " + ih + "\t// Read CSR")
-        print("\tli x" + reg2 + ", -1")
+        print("\tLI(x" + reg2 + ", -1)")
         print("\tcsrrw x" + reg3 + ", " + ih + ", x" + reg2 + "\t// Write all 1s to CSR")
         print("\tcsrrw x" + reg3 + ", " + ih + ", x0\t// Write all 0s to CSR")
         print("\tcsrrs x" + reg3 + ", " + ih + ", x" + reg2 + "\t// Set all CSR bits")
@@ -86,7 +86,7 @@ def readandswitchmode(regs, mode):
     # helper function to switch modes when reading csr
     if mode in ("U", "S"):
         mode_num = 0 if mode == "U" else 1  # convert 'U' to 0, 'S' to 1
-        print(f"\tli a0, {mode_num}     # switch to {mode}-mode")
+        print(f"\tLI(a0, {mode_num})     # switch to {mode}-mode")
         print(f"\tecall             # switch to {mode}-mode")
         for reg in regs:
             if reg == "satp":  # Skip satp to avoid enabling virtual memory

--- a/generators/testgen/scripts/custom/cp_custom_ffLS.py
+++ b/generators/testgen/scripts/custom/cp_custom_ffLS.py
@@ -75,7 +75,7 @@ def make(test: str, sew: int) -> None:
             f"vsetvli x{{s0}}, x0, e{sew}, m{lmulflag}, tu, mu",
         ]
         pre_inst_lines = [
-            f"li x{rs1}, {FAULT_ADDRESS}",
+            f"LI(x{rs1}, {FAULT_ADDRESS})",
         ]
         writeTest(
             description, test, data,

--- a/generators/testgen/scripts/custom/cp_custom_ls_indexed.py
+++ b/generators/testgen/scripts/custom/cp_custom_ls_indexed.py
@@ -60,7 +60,7 @@ def make(test: str, sew: int) -> None:
             # collision with rs1/sigReg, including post-switch sigReg.
             # Reload vs2 from custom data after sanitization.
             pre_lines = [
-                f"la x{{s0}}, {label}",
+                f"LA(x{{s0}}, {label})",
                 f"vle64.v v{vs2}, (x{{s0}})",
             ]
             writeTest(description, test, data, sew=sew, lmul=1, vl=1, pre_test_lines=pre_lines, pre_test_scratch_regs=1)

--- a/generators/testgen/scripts/vector-testgen-unpriv.py
+++ b/generators/testgen/scripts/vector-testgen-unpriv.py
@@ -1666,7 +1666,7 @@ def generate_extension(xlen_arg: int, extension_arg: str) -> str:
 
     f.write("\n")
     f.write("// Initial set vl = 1\n")
-    f.write("li x31, 1\n")
+    f.write("LI(x31, 1)\n")
     f.write(f"vsetvli x0, x31, e{sew}, m1, tu, mu\n\n\n")
 
     if (test in vd_widen_ins) or (test in vs2_widen_ins):

--- a/generators/testgen/scripts/vector_testgen_common.py
+++ b/generators/testgen/scripts/vector_testgen_common.py
@@ -2658,7 +2658,7 @@ def prepMaskV(maskval, sew, tempReg, lmul):
     writeLine(f"vmsltu.vx v0, v{mask_vreg}, x{tempReg}",     "# v0[i] = (i < VLMAX/2+1) ? 1 : 0")
   else: # random mask
     writeLine(f"vsetvli x{tempReg}, x0, e{sew}, m{lmulflag}, ta, ma",  f"# x{tempReg} = VLMAX")
-    writeLine(f"la x{tempReg}, {maskval}")
+    writeLine(f"LA(x{tempReg}, {maskval})")
     writeLine(f"vlm.v v0, (x{tempReg})",                      "# Load mask value into v0")
 
 def prepVstart(vstartval, lmul = 1, scratch = 8, scratch2 = 28, sew=8):
@@ -2669,7 +2669,7 @@ def prepVstart(vstartval, lmul = 1, scratch = 8, scratch2 = 28, sew=8):
   # pointer mid-test and triggering a chain of store-fault traps.
   vstart_reg = scratch
   if   (vstartval == "one"):
-    writeLine(f"li x{vstart_reg}, 1",                                    f"# Load x{vstart_reg} = 1 for vstart")
+    writeLine(f"LI(x{vstart_reg}, 1)",                                   f"# Load x{vstart_reg} = 1 for vstart")
   elif (vstartval == "vlmaxm1"):
     writeLine(f"vsetvli x{vstart_reg}, x0, e{sew}, m{lmul}, ta, ma",    f"# x{vstart_reg} = VLMAX")
     writeLine(f"addi x{vstart_reg}, x{vstart_reg}, -1",                  f"# x{vstart_reg} = VLMAX - 1")
@@ -2679,7 +2679,7 @@ def prepVstart(vstartval, lmul = 1, scratch = 8, scratch2 = 28, sew=8):
   else: # random vstart
     randvstart = randint(3, maxVLEN)  # TODO: check logic for this
     writeLine(f"vsetvli x{vstart_reg}, x0, e{sew}, m{lmul}, ta, ma",    f"# x{vstart_reg} = VLMAX")
-    writeLine(f"li x{scratch2}, {randvstart}")
+    writeLine(f"LI(x{scratch2}, {randvstart})")
     writeLine(f"remu x{scratch2}, x{scratch2}, x{vstart_reg}",           f"# x{scratch2} = randvstart % VLMAX (< VLMAX)")
     vstart_reg = scratch2  # randomized vstart value lives in scratch2 from here on
   writeLine(f"csrw vstart, x{vstart_reg}",                               f"# Write desired vstart value to the CSR")

--- a/generators/testgen/src/testgen/coverpoints/cp_imm_edges_jal.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_imm_edges_jal.py
@@ -40,13 +40,13 @@ def make_cp_imm_edges_jal(instr_name: str, instr_type: str, coverpoint: str, tes
         max_fwd_align = 13  # 2^13 = 8192
         max_bwd_align = 13  # 2^13 = 8192
         min_align = 2
-        li_instr = "li"
+        li_call = lambda reg, val: f"LI(x{reg}, {val})"
     elif coverpoint == "cp_imm_edges_c_jal":
         instr_size = 2
         max_fwd_align = 10  # 2^10 = 1024
         max_bwd_align = 11  # 2^11 = 2048
         min_align = 1
-        li_instr = "c.li"
+        li_call = lambda reg, val: f"c.li x{reg}, {val}"
     else:
         raise ValueError(f"Unsupported coverpoint variant for cp_imm_edges_jal/cp_imm_edges_c_jal: {coverpoint}")
 
@@ -59,13 +59,13 @@ def make_cp_imm_edges_jal(instr_name: str, instr_type: str, coverpoint: str, tes
         tc.code.extend(
             [
                 f"# {coverpoint}: forward jump by {1 << align}",
-                f"{li_instr} x{params.temp_reg}, 1 # success code"
+                f"{li_call(params.temp_reg, 1)} # success code"
                 if not skip_check
                 else f"{INDENT}# offset too small, skipping self-check",
                 f".p2align {align}",
                 test_data.add_testcase(f"b_{align}", coverpoint),
                 f"{instr_name} {f'x{params.rd},' if instr_name == 'jal' else ''} {coverpoint}_fwd_{bin_name}",
-                f"{li_instr} x{params.temp_reg}, 7 # failure code"
+                f"{li_call(params.temp_reg, 7)} # failure code"
                 if not skip_check
                 else f"{INDENT}# offset too small, skipping self-check",
                 f".p2align {align}",
@@ -89,7 +89,7 @@ def make_cp_imm_edges_jal(instr_name: str, instr_type: str, coverpoint: str, tes
         tc.code.extend(
             [
                 f"# {coverpoint}: backward jump by {1 << align}",
-                f"{li_instr} x{params.temp_reg}, 1 # success code"
+                f"{li_call(params.temp_reg, 1)} # success code"
                 if not skip_check
                 else f"{INDENT}# offset too small, skipping self-check",
                 f".p2align {align + 1}",
@@ -132,7 +132,7 @@ def make_cp_imm_edges_jal(instr_name: str, instr_type: str, coverpoint: str, tes
         # Fall-through failure case and done label
         tc.code.extend(
             [
-                f"{li_instr} x{params.temp_reg}, 7 # failure code"
+                f"{li_call(params.temp_reg, 7)} # failure code"
                 if not skip_check
                 else f"{INDENT}# offset too small, skipping self-check",
                 f"{coverpoint}_done_{bin_name}:",

--- a/generators/testgen/src/testgen/formatters/types/csr_type.py
+++ b/generators/testgen/src/testgen/formatters/types/csr_type.py
@@ -21,7 +21,7 @@ def zicsr_acccess(instr_name: str, rd: int, rs1: int) -> str:
 
     # instret requires special treatment because it is not writable, and the value is not initialized
     if instr_name in ["csrrw", "csrrwi"] or rs1 == 0 or rd == 0:
-        instret_access = f"li x{rd}, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0"
+        instret_access = f"LI(x{rd}, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0"
     else:
         instret_access = (
             f"{instr_name} x{rs1}, instret, x0\n"

--- a/generators/testgen/src/testgen/formatters/types/csri_type.py
+++ b/generators/testgen/src/testgen/formatters/types/csri_type.py
@@ -22,7 +22,7 @@ def zicsr_acccessi(instr_name: str, rd: int, rs2: int, immval: int) -> str:
 
     # instret requires special treatment because it is not writable, and the value is not initialized
     if instr_name in ["csrrw", "csrrwi"] or rs2 == 0 or rd == 0:
-        instret_access = f"li x{rd}, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0"
+        instret_access = f"LI(x{rd}, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0"
     else:
         instret_access = (
             f"{instr_name} x{rs2}, instret, 0\n"

--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsF.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsF.py
@@ -631,7 +631,7 @@ def make_exceptionsf(test_data: TestData) -> list[TestChunk]:
     for i in range(32):
         tc.code.extend(
             [
-                f"li t0, {i + 1}",
+                f"LI(t0, {i + 1})",
                 f"fcvt.s.w f{i}, t0",
             ]
         )

--- a/generators/testgen/src/testgen/priv/extensions/Ssccptr.py
+++ b/generators/testgen/src/testgen/priv/extensions/Ssccptr.py
@@ -67,7 +67,7 @@ def _setup_identity_map(test_data: TestData) -> list[str]:
         f"and x{r0}, x{r0}, x{r1}",  # r0 = superpage-aligned base PA
         f"srli x{r0}, x{r0}, 12",  # r0 = PPN
         f"slli x{r0}, x{r0}, 10",  # r0 = PPN in PTE field position
-        f"li x{r1}, (PTE_D | PTE_A | PTE_R | PTE_W | PTE_X | PTE_V)",
+        f"LI(x{r1}, (PTE_D | PTE_A | PTE_R | PTE_W | PTE_X | PTE_V))",
         f"or x{r0}, x{r0}, x{r1}",  # r0 = leaf PTE value
         f"LA(x{r2}, rvtest_Sroot_pg_tbl)",  # r2 = root page table base
         f"LA(x{r1}, rvtest_code_begin)",  # r1 = code base address

--- a/generators/testgen/src/testgen/priv/extensions/Sstvala.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sstvala.py
@@ -91,11 +91,11 @@ def _pf_identity_map_sv39() -> list[str]:
     return [
         "# Sv39: 1 GiB identity superpage for code+data (PC-relative, link-address agnostic)",
         "auipc t0, 0",
-        "li t1, ~((1 << 30) - 1)",  # 1 GiB alignment mask
+        "LI(t1, ~((1 << 30) - 1))",  # 1 GiB alignment mask
         "and t0, t0, t1",  # t0 = superpage base PA
         "srli t0, t0, 12",
         "slli t0, t0, 10",  # PPN in PTE position
-        "li t1, (PTE_D | PTE_A | PTE_R | PTE_W | PTE_X | PTE_V)",
+        "LI(t1, (PTE_D | PTE_A | PTE_R | PTE_W | PTE_X | PTE_V))",
         "or t0, t0, t1",  # leaf PTE value
         "LA(t2, rvtest_Sroot_pg_tbl)",
         "LA(t1, rvtest_code_begin)",
@@ -116,11 +116,11 @@ def _pf_identity_map_sv32() -> list[str]:
     return [
         "# Sv32: 4 MiB identity superpage for code+data (PC-relative, link-address agnostic)",
         "auipc t0, 0",
-        "li t1, ~((1 << 22) - 1)",  # 4 MiB alignment mask
+        "LI(t1, ~((1 << 22) - 1))",  # 4 MiB alignment mask
         "and t0, t0, t1",  # t0 = superpage base PA
         "srli t0, t0, 12",
         "slli t0, t0, 10",  # PPN in PTE position
-        "li t1, (PTE_D | PTE_A | PTE_R | PTE_W | PTE_X | PTE_V)",
+        "LI(t1, (PTE_D | PTE_A | PTE_R | PTE_W | PTE_X | PTE_V))",
         "or t0, t0, t1",  # leaf PTE value
         "LA(t2, rvtest_Sroot_pg_tbl)",
         "LA(t1, rvtest_code_begin)",

--- a/tests/priv/ExceptionsSv/sv32_exceptions_Smode.S
+++ b/tests/priv/ExceptionsSv/sv32_exceptions_Smode.S
@@ -195,7 +195,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in S-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 3 faults
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Smode, va_data, LEVEL1, test9
   sfence.vma

--- a/tests/priv/ExceptionsSv/sv32_exceptions_Umode.S
+++ b/tests/priv/ExceptionsSv/sv32_exceptions_Umode.S
@@ -109,7 +109,7 @@ RVTEST_BEGIN
     add x1, x1, a0      // VA of an Spage that points to 1f
 
     mv  t0, x3          // Temporarily store x3
-    li  x3, 0
+    LI(x3, 0)
     GOTO_S_OP           // Go to Smode
     nop                 // GOTO_S_OP returns here. This will raise a fetch-page-fault (S-mode accessing Upage).
   1:
@@ -229,7 +229,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in U-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 3 faults
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Umode, va_data, LEVEL1, test9
   sfence.vma

--- a/tests/priv/ExceptionsSv/sv32_exceptions_mprv_S_Mmode.S
+++ b/tests/priv/ExceptionsSv/sv32_exceptions_mprv_S_Mmode.S
@@ -211,7 +211,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in M-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 2 faults
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Mmode, va_data, LEVEL1, test9
   sfence.vma

--- a/tests/priv/ExceptionsSv/sv32_exceptions_mprv_U_Mmode.S
+++ b/tests/priv/ExceptionsSv/sv32_exceptions_mprv_U_Mmode.S
@@ -209,7 +209,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in M-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 2 faults
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Mmode, va_data, LEVEL1, test9
   sfence.vma

--- a/tests/priv/ExceptionsSv/sv39_exceptions_Smode.S
+++ b/tests/priv/ExceptionsSv/sv39_exceptions_Smode.S
@@ -198,7 +198,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in S-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 3 faults
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Smode, va_data, LEVEL2, test9
   sfence.vma

--- a/tests/priv/ExceptionsSv/sv39_exceptions_Umode.S
+++ b/tests/priv/ExceptionsSv/sv39_exceptions_Umode.S
@@ -112,7 +112,7 @@ RVTEST_BEGIN
     add x1, x1, a0      // VA of an Spage that points to 1f
 
     mv  t0, x3          // Temporarily store x3
-    li  x3, 0
+    LI(x3, 0)
     GOTO_S_OP           // Go to Smode
     nop                 // GOTO_S_OP returns here. This will raise a fetch-page-fault (S-mode accessing Upage).
   1:
@@ -232,7 +232,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in U-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 3 faults
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Umode, va_data, LEVEL2, test9
   sfence.vma

--- a/tests/priv/ExceptionsSv/sv39_exceptions_mprv_S_Mmode.S
+++ b/tests/priv/ExceptionsSv/sv39_exceptions_mprv_S_Mmode.S
@@ -214,7 +214,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in M-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 2 faults
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Mmode, va_data, LEVEL2, test9
   sfence.vma

--- a/tests/priv/ExceptionsSv/sv39_exceptions_mprv_U_Mmode.S
+++ b/tests/priv/ExceptionsSv/sv39_exceptions_mprv_U_Mmode.S
@@ -212,7 +212,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in M-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 2 faults
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Mmode, va_data, LEVEL2, test9
   sfence.vma

--- a/tests/priv/ExceptionsSvZaamo/sv32_exceptions_Zaamo_Mmode.S
+++ b/tests/priv/ExceptionsSvZaamo/sv32_exceptions_Zaamo_Mmode.S
@@ -179,7 +179,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in M-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 1 Store/AMO page fault
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Mmode, va_data, LEVEL1, test9
   sfence.vma

--- a/tests/priv/ExceptionsSvZaamo/sv32_exceptions_Zaamo_Smode.S
+++ b/tests/priv/ExceptionsSvZaamo/sv32_exceptions_Zaamo_Smode.S
@@ -173,7 +173,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in S-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 1 Store/AMO page fault
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Smode, va_data, LEVEL1, test9
   sfence.vma

--- a/tests/priv/ExceptionsSvZaamo/sv32_exceptions_Zaamo_Umode.S
+++ b/tests/priv/ExceptionsSvZaamo/sv32_exceptions_Zaamo_Umode.S
@@ -89,7 +89,7 @@ RVTEST_BEGIN
     add x1, x1, a0      // VA of an Spage that points to 1f
 
     mv  t0, x3          // Temporarily store x3
-    li  x3, 0
+    LI(x3, 0)
     GOTO_S_OP           // Go to Smode
     nop                 // GOTO_S_OP returns here. This will raise a fetch-page-fault (S-mode accessing Upage).
   1:
@@ -207,7 +207,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in U-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 1 Store/AMO page fault
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Umode, va_data, LEVEL1, test9
   sfence.vma

--- a/tests/priv/ExceptionsSvZaamo/sv39_exceptions_Zaamo_Mmode.S
+++ b/tests/priv/ExceptionsSvZaamo/sv39_exceptions_Zaamo_Mmode.S
@@ -179,7 +179,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in M-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 1 Store/AMO page fault
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Mmode, va_data, LEVEL2, test9
   sfence.vma

--- a/tests/priv/ExceptionsSvZaamo/sv39_exceptions_Zaamo_Smode.S
+++ b/tests/priv/ExceptionsSvZaamo/sv39_exceptions_Zaamo_Smode.S
@@ -173,7 +173,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in S-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 1 Store/AMO page fault
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Smode, va_data, LEVEL2, test9
   sfence.vma

--- a/tests/priv/ExceptionsSvZaamo/sv39_exceptions_Zaamo_Umode.S
+++ b/tests/priv/ExceptionsSvZaamo/sv39_exceptions_Zaamo_Umode.S
@@ -89,7 +89,7 @@ RVTEST_BEGIN
     add x1, x1, a0      // VA of an Spage that points to 1f
 
     mv  t0, x3          // Temporarily store x3
-    li  x3, 0
+    LI(x3, 0)
     GOTO_S_OP           // Go to Smode
     nop                 // GOTO_S_OP returns here. This will raise a fetch-page-fault (S-mode accessing Upage).
   1:
@@ -207,7 +207,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in U-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 1 Store/AMO page fault
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Umode, va_data, LEVEL2, test9
   sfence.vma

--- a/tests/priv/ExceptionsSvZalrsc/sv32_exceptions_Zalrsc_Mmode.S
+++ b/tests/priv/ExceptionsSvZalrsc/sv32_exceptions_Zalrsc_Mmode.S
@@ -196,7 +196,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in M-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 2 faults
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Mmode, va_data, LEVEL1, test9
   sfence.vma

--- a/tests/priv/ExceptionsSvZalrsc/sv32_exceptions_Zalrsc_Smode.S
+++ b/tests/priv/ExceptionsSvZalrsc/sv32_exceptions_Zalrsc_Smode.S
@@ -187,7 +187,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in S-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 2 faults
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Smode, va_data, LEVEL1, test9
   sfence.vma

--- a/tests/priv/ExceptionsSvZalrsc/sv32_exceptions_Zalrsc_Umode.S
+++ b/tests/priv/ExceptionsSvZalrsc/sv32_exceptions_Zalrsc_Umode.S
@@ -102,7 +102,7 @@ RVTEST_BEGIN
     add x1, x1, a0      // VA of an Spage that points to 1f
 
     mv  t0, x3          // Temporarily store x3
-    li  x3, 0
+    LI(x3, 0)
     GOTO_S_OP           // Go to Smode
     nop                 // GOTO_S_OP returns here. This will raise a fetch-page-fault (S-mode accessing Upage).
   1:
@@ -221,7 +221,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in U-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 2 faults
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Umode, va_data, LEVEL1, test9
   sfence.vma

--- a/tests/priv/ExceptionsSvZalrsc/sv39_exceptions_Zalrsc_Mmode.S
+++ b/tests/priv/ExceptionsSvZalrsc/sv39_exceptions_Zalrsc_Mmode.S
@@ -196,7 +196,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in M-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 2 faults
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Mmode, va_data, LEVEL2, test9
   sfence.vma

--- a/tests/priv/ExceptionsSvZalrsc/sv39_exceptions_Zalrsc_Smode.S
+++ b/tests/priv/ExceptionsSvZalrsc/sv39_exceptions_Zalrsc_Smode.S
@@ -187,7 +187,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in S-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 2 faults
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Smode, va_data, LEVEL2, test9
   sfence.vma

--- a/tests/priv/ExceptionsSvZalrsc/sv39_exceptions_Zalrsc_Umode.S
+++ b/tests/priv/ExceptionsSvZalrsc/sv39_exceptions_Zalrsc_Umode.S
@@ -102,7 +102,7 @@ RVTEST_BEGIN
     add x1, x1, a0      // VA of an Spage that points to 1f
 
     mv  t0, x3          // Temporarily store x3
-    li  x3, 0
+    LI(x3, 0)
     GOTO_S_OP           // Go to Smode
     nop                 // GOTO_S_OP returns here. This will raise a fetch-page-fault (S-mode accessing Upage).
   1:
@@ -221,7 +221,7 @@ main:
   sfence.vma
 
   // Test case 9-10: Test in U-Mode | Valid & Invalid PTEs | RWX set | medeleg[0] set | expected = 2 faults
-  li a1, 1
+  LI(a1, 1)
   CSRW(medeleg, a1)
   TEST_CASES_RUNNER Umode, va_data, LEVEL2, test9
   sfence.vma

--- a/tests/priv/Sv/sv32_mstatus_sbe_and_sum_set_Smode.S
+++ b/tests/priv/Sv/sv32_mstatus_sbe_and_sum_set_Smode.S
@@ -69,9 +69,9 @@ RVTEST_BEGIN
 
 .macro CHANGE_PTE_TO_BE
   // After PTE_SETUP_SV32 completes, a0 has the PTE (PPN and Permission bits) while t1 has the PTE address
-  li a3, 0
-  li a4, 0
-  li a5, 24
+  LI(a3, 0)
+  LI(a4, 0)
+  LI(a5, 24)
   .rept(4)
     andi a3, a0, 0xFF
     srli a0, a0, 8

--- a/tests/priv/Sv/sv32_mstatus_sbe_set_Smode.S
+++ b/tests/priv/Sv/sv32_mstatus_sbe_set_Smode.S
@@ -75,9 +75,9 @@ RVTEST_BEGIN
 
 .macro CHANGE_PTE_TO_BE
   // After PTE_SETUP_SV32 completes, a0 has the PTE (PPN and Permission bits) while t1 has the PTE address
-  li a3, 0
-  li a4, 0
-  li a5, 24
+  LI(a3, 0)
+  LI(a4, 0)
+  LI(a5, 24)
   .rept(4)
     andi a3, a0, 0xFF
     srli a0, a0, 8

--- a/tests/priv/Sv/sv32_satp_access_test.S
+++ b/tests/priv/Sv/sv32_satp_access_test.S
@@ -45,17 +45,17 @@ main:
 // Test case 1: Access satp in M-mode using csrrw, csrrs, csrrc | Expected: Successful access
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li a0, 1
+  LI(a0, 1)
   CSRW(satp, a0)
   test1_csrw:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test1_csrw, test1_csrw_str)
 
-  li a0, 2
+  LI(a0, 2)
   CSRS(satp, a0)
   test1_csrs:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test1_csrs, test1_csrs_str)
 
-  li a0, 1
+  LI(a0, 1)
   CSRC(satp, t0)
   test1_csrc:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test1_csrc, test1_csrc_str)
@@ -67,17 +67,17 @@ main:
 
   RVTEST_GOTO_LOWER_MODE Smode
 
-  li a0, 4
+  LI(a0, 4)
   CSRW(satp, a0)
   test2_csrw:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test2_csrw, test2_csrw_str)
 
-  li a0, 8
+  LI(a0, 8)
   CSRS(satp, a0)
   test2_csrs:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test2_csrs, test2_csrs_str)
 
-  li a0, 4
+  LI(a0, 4)
   CSRC(satp, t0)
   test2_csrc:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test2_csrc, test2_csrc_str)
@@ -91,13 +91,13 @@ main:
 
   RVTEST_GOTO_LOWER_MODE Umode
 
-  li a0, 3
+  LI(a0, 3)
   CSRW(satp, a0)
 
-  li a0, 12
+  LI(a0, 12)
   CSRS(satp, a0)
 
-  li a0, 6
+  LI(a0, 6)
   CSRC(satp, t0)
 
   RVTEST_GOTO_MMODE
@@ -136,7 +136,7 @@ main:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test5_ones, test5_ones_str)
 
   // satp.PPN = Walking Ones
-  li a2, 1
+  LI(a2, 1)
   .rept(22)
     or   a0, a1, a2
     CSRW(satp, a0)
@@ -167,7 +167,7 @@ main:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test6_ones, test6_ones_str)
 
   // satp.ASID = Walking Ones
-  li   a2, 1
+  LI(a2, 1)
   slli a2, a2, 22
   .rept(9)
     or   a0, a1, a2

--- a/tests/priv/Sv/sv39_VA_all_ones_Smode.S
+++ b/tests/priv/Sv/sv39_VA_all_ones_Smode.S
@@ -68,7 +68,7 @@ RVTEST_BEGIN
 
 
 main:
-  li a2, 0x12               // Test signature initialization
+  LI(a2, 0x12               // Test signature initialization)
 
 //---------------------------------------------------------------------------------------------------------------------------------
 //                                   Virtual addresses definition for code and test regions

--- a/tests/priv/Sv/sv39_VA_all_zeros_Smode.S
+++ b/tests/priv/Sv/sv39_VA_all_zeros_Smode.S
@@ -68,7 +68,7 @@ RVTEST_BEGIN
 
 
 main:
-  li a2, 0x12               // Test signature initialization
+  LI(a2, 0x12               // Test signature initialization)
 
 //---------------------------------------------------------------------------------------------------------------------------------
 //                                   Virtual addresses definition for code and test regions

--- a/tests/priv/Sv/sv39_mstatus_sbe_and_sum_set_Smode.S
+++ b/tests/priv/Sv/sv39_mstatus_sbe_and_sum_set_Smode.S
@@ -70,9 +70,9 @@ RVTEST_BEGIN
 
 .macro CHANGE_PTE_TO_BE
   // After PTE_SETUP_SV39 completes, a0 has the PTE (PPN and Permission bits) while t1 has the PTE address
-  li a3, 0
-  li a4, 0
-  li a5, 56
+  LI(a3, 0)
+  LI(a4, 0)
+  LI(a5, 56)
   .rept(8)
     andi a3, a0, 0xFF
     srli a0, a0, 8

--- a/tests/priv/Sv/sv39_mstatus_sbe_set_Smode.S
+++ b/tests/priv/Sv/sv39_mstatus_sbe_set_Smode.S
@@ -76,9 +76,9 @@ RVTEST_BEGIN
 
 .macro CHANGE_PTE_TO_BE
   // After PTE_SETUP_SV39 completes, a0 has the PTE (PPN and Permission bits) while t1 has the PTE address
-  li a3, 0
-  li a4, 0
-  li a5, 56
+  LI(a3, 0)
+  LI(a4, 0)
+  LI(a5, 56)
   .rept(8)
     andi a3, a0, 0xFF
     srli a0, a0, 8

--- a/tests/priv/Sv/sv39_satp_access_test.S
+++ b/tests/priv/Sv/sv39_satp_access_test.S
@@ -33,17 +33,17 @@ main:
 // Test case 1: Access satp in M-mode using csrrw, csrrs, csrrc | Expected: Successful access
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li a0, 1
+  LI(a0, 1)
   CSRW(satp, a0)
   test1_csrw:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test1_csrw, test1_csrw_str)
 
-  li a0, 2
+  LI(a0, 2)
   CSRS(satp, a0)
   test1_csrs:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test1_csrs, test1_csrs_str)
 
-  li a0, 1
+  LI(a0, 1)
   CSRC(satp, t0)
   test1_csrc:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test1_csrc, test1_csrc_str)
@@ -55,17 +55,17 @@ main:
 
   RVTEST_GOTO_LOWER_MODE Smode
 
-  li a0, 4
+  LI(a0, 4)
   CSRW(satp, a0)
   test2_csrw:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test2_csrw, test2_csrw_str)
 
-  li a0, 8
+  LI(a0, 8)
   CSRS(satp, a0)
   test2_csrs:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test2_csrs, test2_csrs_str)
 
-  li a0, 4
+  LI(a0, 4)
   CSRC(satp, t0)
   test2_csrc:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test2_csrc, test2_csrc_str)
@@ -79,13 +79,13 @@ main:
 
   RVTEST_GOTO_LOWER_MODE Umode
 
-  li a0, 3
+  LI(a0, 3)
   CSRW(satp, a0)
 
-  li a0, 12
+  LI(a0, 12)
   CSRS(satp, a0)
 
-  li a0, 6
+  LI(a0, 6)
   CSRC(satp, t0)
 
   RVTEST_GOTO_MMODE
@@ -124,7 +124,7 @@ main:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test5_ones, test5_ones_str)
 
   // satp.PPN = Walking Ones
-  li a2, 1
+  LI(a2, 1)
   .rept(44)
     or   a0, a1, a2
     CSRW(satp, a0)
@@ -155,7 +155,7 @@ main:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test6_ones, test6_ones_str)
 
   // satp.ASID = Walking Ones
-  li   a2, 1
+  LI(a2, 1)
   slli a2, a2, 44
   .rept(16)
     or   a0, a1, a2

--- a/tests/priv/Sv/sv48_VA_all_ones_Smode.S
+++ b/tests/priv/Sv/sv48_VA_all_ones_Smode.S
@@ -68,7 +68,7 @@ RVTEST_BEGIN
 
 
 main:
-  li a2, 0x12               // Test signature initialization
+  LI(a2, 0x12               // Test signature initialization)
 
 //---------------------------------------------------------------------------------------------------------------------------------
 //                                   Virtual addresses definition for code and test regions

--- a/tests/priv/Sv/sv48_VA_all_zeros_Smode.S
+++ b/tests/priv/Sv/sv48_VA_all_zeros_Smode.S
@@ -68,7 +68,7 @@ RVTEST_BEGIN
 
 
 main:
-  li a2, 0x12               // Test signature initialization
+  LI(a2, 0x12               // Test signature initialization)
 
 //---------------------------------------------------------------------------------------------------------------------------------
 //                                   Virtual addresses definition for code and test regions

--- a/tests/priv/Sv/sv48_mstatus_sbe_and_sum_set_Smode.S
+++ b/tests/priv/Sv/sv48_mstatus_sbe_and_sum_set_Smode.S
@@ -72,9 +72,9 @@ RVTEST_BEGIN
 
 .macro CHANGE_PTE_TO_BE
   // After PTE_SETUP_SV48 completes, a0 has the PTE (PPN and Permission bits) while t1 has the PTE address
-  li a3, 0
-  li a4, 0
-  li a5, 56
+  LI(a3, 0)
+  LI(a4, 0)
+  LI(a5, 56)
   .rept(8)
     andi a3, a0, 0xFF
     srli a0, a0, 8

--- a/tests/priv/Sv/sv48_mstatus_sbe_set_Smode.S
+++ b/tests/priv/Sv/sv48_mstatus_sbe_set_Smode.S
@@ -78,9 +78,9 @@ RVTEST_BEGIN
 
 .macro CHANGE_PTE_TO_BE
   // After PTE_SETUP_SV48 completes, a0 has the PTE (PPN and Permission bits) while t1 has the PTE address
-  li a3, 0
-  li a4, 0
-  li a5, 56
+  LI(a3, 0)
+  LI(a4, 0)
+  LI(a5, 56)
   .rept(8)
     andi a3, a0, 0xFF
     srli a0, a0, 8

--- a/tests/priv/Sv/sv48_satp_access_test.S
+++ b/tests/priv/Sv/sv48_satp_access_test.S
@@ -56,7 +56,7 @@ main:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test2_ones, test2_ones_str)
 
   // satp.PPN = Walking Ones
-  li a2, 1
+  LI(a2, 1)
   .rept(44)
     or   a0, a1, a2
     CSRW(satp, a0)
@@ -87,7 +87,7 @@ main:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test3_ones, test3_ones_str)
 
   // satp.ASID = Walking Ones
-  li   a2, 1
+  LI(a2, 1)
   slli a2, a2, 44
   .rept(16)
     or   a0, a1, a2

--- a/tests/priv/Sv/sv57_VA_all_ones_Smode.S
+++ b/tests/priv/Sv/sv57_VA_all_ones_Smode.S
@@ -68,7 +68,7 @@ RVTEST_BEGIN
 
 
 main:
-  li a2, 0x12               // Test signature initialization
+  LI(a2, 0x12               // Test signature initialization)
 
 //---------------------------------------------------------------------------------------------------------------------------------
 //                                   Virtual addresses definition for code and test regions

--- a/tests/priv/Sv/sv57_VA_all_zeros_Smode.S
+++ b/tests/priv/Sv/sv57_VA_all_zeros_Smode.S
@@ -68,7 +68,7 @@ RVTEST_BEGIN
 
 
 main:
-  li a2, 0x12               // Test signature initialization
+  LI(a2, 0x12               // Test signature initialization)
 
 //---------------------------------------------------------------------------------------------------------------------------------
 //                                   Virtual addresses definition for code and test regions

--- a/tests/priv/Sv/sv57_mstatus_sbe_and_sum_set_Smode.S
+++ b/tests/priv/Sv/sv57_mstatus_sbe_and_sum_set_Smode.S
@@ -74,9 +74,9 @@ RVTEST_BEGIN
 
 .macro CHANGE_PTE_TO_BE
   // After PTE_SETUP_SV57 completes, a0 has the PTE (PPN and Permission bits) while t1 has the PTE address
-  li a3, 0
-  li a4, 0
-  li a5, 56
+  LI(a3, 0)
+  LI(a4, 0)
+  LI(a5, 56)
   .rept(8)
     andi a3, a0, 0xFF
     srli a0, a0, 8

--- a/tests/priv/Sv/sv57_mstatus_sbe_set_Smode.S
+++ b/tests/priv/Sv/sv57_mstatus_sbe_set_Smode.S
@@ -80,9 +80,9 @@ RVTEST_BEGIN
 
 .macro CHANGE_PTE_TO_BE
   // After PTE_SETUP_SV57 completes, a0 has the PTE (PPN and Permission bits) while t1 has the PTE address
-  li a3, 0
-  li a4, 0
-  li a5, 56
+  LI(a3, 0)
+  LI(a4, 0)
+  LI(a5, 56)
   .rept(8)
     andi a3, a0, 0xFF
     srli a0, a0, 8

--- a/tests/priv/Sv/sv57_satp_access_test.S
+++ b/tests/priv/Sv/sv57_satp_access_test.S
@@ -56,7 +56,7 @@ main:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test2_ones, test2_ones_str)
 
   // satp.PPN = Walking Ones
-  li a2, 1
+  LI(a2, 1)
   .rept(44)
     or   a0, a1, a2
     CSRW(satp, a0)
@@ -87,7 +87,7 @@ main:
   RVTEST_SIGUPD_CSR_READ(satp, a4, test3_ones, test3_ones_str)
 
   // satp.ASID = Walking Ones
-  li   a2, 1
+  LI(a2, 1)
   slli a2, a2, 44
   .rept(16)
     or   a0, a1, a2

--- a/tests/priv/SvPMP/sv32_pmp_on_pa_Smode.S
+++ b/tests/priv/SvPMP/sv32_pmp_on_pa_Smode.S
@@ -96,9 +96,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp3cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp3cfg0 (TOR))
   csrw pmpaddr2, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr3, t2
 
   LA (t2, rvtest_data_1)    // Configure test region as NAPOT

--- a/tests/priv/SvPMP/sv32_pmp_on_pa_Umode.S
+++ b/tests/priv/SvPMP/sv32_pmp_on_pa_Umode.S
@@ -96,9 +96,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp3cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp3cfg0 (TOR))
   csrw pmpaddr2, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr3, t2
 
   LA (t2, rvtest_data_1)    // Configure test region as NAPOT

--- a/tests/priv/SvPMP/sv32_pmp_on_pte_Smode.S
+++ b/tests/priv/SvPMP/sv32_pmp_on_pte_Smode.S
@@ -96,9 +96,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMP/sv32_pmp_on_pte_Umode.S
+++ b/tests/priv/SvPMP/sv32_pmp_on_pte_Umode.S
@@ -96,9 +96,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMP/sv39_pmp_on_pa_Smode.S
+++ b/tests/priv/SvPMP/sv39_pmp_on_pa_Smode.S
@@ -93,9 +93,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp3cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp3cfg0 (TOR))
   csrw pmpaddr2, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr3, t2
 
   LA (t2, rvtest_data_1)    // Configure test region as NAPOT

--- a/tests/priv/SvPMP/sv39_pmp_on_pa_Umode.S
+++ b/tests/priv/SvPMP/sv39_pmp_on_pa_Umode.S
@@ -93,9 +93,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp3cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp3cfg0 (TOR))
   csrw pmpaddr2, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr3, t2
 
   LA (t2, rvtest_data_1)    // Configure test region as NAPOT

--- a/tests/priv/SvPMP/sv39_pmp_on_pte_Smode.S
+++ b/tests/priv/SvPMP/sv39_pmp_on_pte_Smode.S
@@ -97,9 +97,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMP/sv39_pmp_on_pte_Umode.S
+++ b/tests/priv/SvPMP/sv39_pmp_on_pte_Umode.S
@@ -97,9 +97,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMP/sv48_pmp_on_pa_Smode.S
+++ b/tests/priv/SvPMP/sv48_pmp_on_pa_Smode.S
@@ -93,9 +93,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp3cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp3cfg0 (TOR))
   csrw pmpaddr2, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr3, t2
 
   LA (t2, rvtest_data_1)    // Configure test region as NAPOT

--- a/tests/priv/SvPMP/sv48_pmp_on_pa_Umode.S
+++ b/tests/priv/SvPMP/sv48_pmp_on_pa_Umode.S
@@ -93,9 +93,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp3cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp3cfg0 (TOR))
   csrw pmpaddr2, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr3, t2
 
   LA (t2, rvtest_data_1)    // Configure test region as NAPOT

--- a/tests/priv/SvPMP/sv48_pmp_on_pte_Smode.S
+++ b/tests/priv/SvPMP/sv48_pmp_on_pte_Smode.S
@@ -101,9 +101,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMP/sv48_pmp_on_pte_Umode.S
+++ b/tests/priv/SvPMP/sv48_pmp_on_pte_Umode.S
@@ -101,9 +101,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMP/sv57_pmp_on_pa_Smode.S
+++ b/tests/priv/SvPMP/sv57_pmp_on_pa_Smode.S
@@ -93,9 +93,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp3cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp3cfg0 (TOR))
   csrw pmpaddr2, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr3, t2
 
   LA (t2, rvtest_data_1)    // Configure test region as NAPOT

--- a/tests/priv/SvPMP/sv57_pmp_on_pa_Umode.S
+++ b/tests/priv/SvPMP/sv57_pmp_on_pa_Umode.S
@@ -93,9 +93,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp3cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp3cfg0 (TOR))
   csrw pmpaddr2, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr3, t2
 
   LA (t2, rvtest_data_1)    // Configure test region as NAPOT

--- a/tests/priv/SvPMP/sv57_pmp_on_pte_Smode.S
+++ b/tests/priv/SvPMP/sv57_pmp_on_pte_Smode.S
@@ -104,9 +104,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMP/sv57_pmp_on_pte_Umode.S
+++ b/tests/priv/SvPMP/sv57_pmp_on_pte_Umode.S
@@ -104,9 +104,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMPZicbo/sv32_pmp_on_pa_zicbom_Smode.S
+++ b/tests/priv/SvPMPZicbo/sv32_pmp_on_pa_zicbom_Smode.S
@@ -76,9 +76,9 @@ main:
 //                                                    Setup pmp registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
   LA (t2, rvtest_data_1)                          // Configure test region as NAPOT

--- a/tests/priv/SvPMPZicbo/sv32_pmp_on_pa_zicbom_Umode.S
+++ b/tests/priv/SvPMPZicbo/sv32_pmp_on_pa_zicbom_Umode.S
@@ -76,9 +76,9 @@ main:
 //                                                    Setup pmp registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
   LA (t2, rvtest_data_1)                          // Configure test region as NAPOT

--- a/tests/priv/SvPMPZicbo/sv32_pmp_on_pa_zicboz_Smode.S
+++ b/tests/priv/SvPMPZicbo/sv32_pmp_on_pa_zicboz_Smode.S
@@ -70,9 +70,9 @@ main:
 //                                                    Setup pmp registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
   LA (t2, rvtest_data_1)                          // Configure test region as NAPOT

--- a/tests/priv/SvPMPZicbo/sv32_pmp_on_pa_zicboz_Umode.S
+++ b/tests/priv/SvPMPZicbo/sv32_pmp_on_pa_zicboz_Umode.S
@@ -70,9 +70,9 @@ main:
 //                                                    Setup pmp registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
   LA (t2, rvtest_data_1)                          // Configure test region as NAPOT

--- a/tests/priv/SvPMPZicbo/sv32_pmp_on_pte_zicbom_Smode.S
+++ b/tests/priv/SvPMPZicbo/sv32_pmp_on_pte_zicbom_Smode.S
@@ -85,9 +85,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMPZicbo/sv32_pmp_on_pte_zicbom_Umode.S
+++ b/tests/priv/SvPMPZicbo/sv32_pmp_on_pte_zicbom_Umode.S
@@ -85,9 +85,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMPZicbo/sv32_pmp_on_pte_zicboz_Smode.S
+++ b/tests/priv/SvPMPZicbo/sv32_pmp_on_pte_zicboz_Smode.S
@@ -79,9 +79,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMPZicbo/sv32_pmp_on_pte_zicboz_Umode.S
+++ b/tests/priv/SvPMPZicbo/sv32_pmp_on_pte_zicboz_Umode.S
@@ -79,9 +79,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMPZicbo/sv39_pmp_on_pa_zicbom_Smode.S
+++ b/tests/priv/SvPMPZicbo/sv39_pmp_on_pa_zicbom_Smode.S
@@ -75,9 +75,9 @@ main:
 //                                                    Setup pmp registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
   LA (t2, rvtest_data_1)                          // Configure test region as NAPOT

--- a/tests/priv/SvPMPZicbo/sv39_pmp_on_pa_zicbom_Umode.S
+++ b/tests/priv/SvPMPZicbo/sv39_pmp_on_pa_zicbom_Umode.S
@@ -75,9 +75,9 @@ main:
 //                                                    Setup pmp registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
   LA (t2, rvtest_data_1)                          // Configure test region as NAPOT

--- a/tests/priv/SvPMPZicbo/sv39_pmp_on_pa_zicboz_Smode.S
+++ b/tests/priv/SvPMPZicbo/sv39_pmp_on_pa_zicboz_Smode.S
@@ -69,9 +69,9 @@ main:
 //                                                    Setup pmp registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
   LA (t2, rvtest_data_1)                          // Configure test region as NAPOT

--- a/tests/priv/SvPMPZicbo/sv39_pmp_on_pa_zicboz_Umode.S
+++ b/tests/priv/SvPMPZicbo/sv39_pmp_on_pa_zicboz_Umode.S
@@ -69,9 +69,9 @@ main:
 //                                                    Setup pmp registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
   LA (t2, rvtest_data_1)                          // Configure test region as NAPOT

--- a/tests/priv/SvPMPZicbo/sv39_pmp_on_pte_zicbom_Smode.S
+++ b/tests/priv/SvPMPZicbo/sv39_pmp_on_pte_zicbom_Smode.S
@@ -86,9 +86,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMPZicbo/sv39_pmp_on_pte_zicbom_Umode.S
+++ b/tests/priv/SvPMPZicbo/sv39_pmp_on_pte_zicbom_Umode.S
@@ -86,9 +86,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMPZicbo/sv39_pmp_on_pte_zicboz_Smode.S
+++ b/tests/priv/SvPMPZicbo/sv39_pmp_on_pte_zicboz_Smode.S
@@ -80,9 +80,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMPZicbo/sv39_pmp_on_pte_zicboz_Umode.S
+++ b/tests/priv/SvPMPZicbo/sv39_pmp_on_pte_zicboz_Umode.S
@@ -80,9 +80,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMPZicbo/sv48_pmp_on_pa_zicbom_Smode.S
+++ b/tests/priv/SvPMPZicbo/sv48_pmp_on_pa_zicbom_Smode.S
@@ -77,9 +77,9 @@ main:
 //                                                    Setup pmp registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
   LA (t2, rvtest_data_1)                          // Configure test region as NAPOT

--- a/tests/priv/SvPMPZicbo/sv48_pmp_on_pa_zicbom_Umode.S
+++ b/tests/priv/SvPMPZicbo/sv48_pmp_on_pa_zicbom_Umode.S
@@ -77,9 +77,9 @@ main:
 //                                                    Setup pmp registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
   LA (t2, rvtest_data_1)                          // Configure test region as NAPOT

--- a/tests/priv/SvPMPZicbo/sv48_pmp_on_pa_zicboz_Smode.S
+++ b/tests/priv/SvPMPZicbo/sv48_pmp_on_pa_zicboz_Smode.S
@@ -71,9 +71,9 @@ main:
 //                                                    Setup pmp registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
   LA (t2, rvtest_data_1)                          // Configure test region as NAPOT

--- a/tests/priv/SvPMPZicbo/sv48_pmp_on_pa_zicboz_Umode.S
+++ b/tests/priv/SvPMPZicbo/sv48_pmp_on_pa_zicboz_Umode.S
@@ -71,9 +71,9 @@ main:
 //                                                    Setup pmp registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
   LA (t2, rvtest_data_1)                          // Configure test region as NAPOT

--- a/tests/priv/SvPMPZicbo/sv48_pmp_on_pte_zicbom_Smode.S
+++ b/tests/priv/SvPMPZicbo/sv48_pmp_on_pte_zicbom_Smode.S
@@ -89,9 +89,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMPZicbo/sv48_pmp_on_pte_zicbom_Umode.S
+++ b/tests/priv/SvPMPZicbo/sv48_pmp_on_pte_zicbom_Umode.S
@@ -89,9 +89,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMPZicbo/sv48_pmp_on_pte_zicboz_Smode.S
+++ b/tests/priv/SvPMPZicbo/sv48_pmp_on_pte_zicboz_Smode.S
@@ -83,9 +83,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMPZicbo/sv48_pmp_on_pte_zicboz_Umode.S
+++ b/tests/priv/SvPMPZicbo/sv48_pmp_on_pte_zicboz_Umode.S
@@ -83,9 +83,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMPZicbo/sv57_pmp_on_pa_zicbom_Smode.S
+++ b/tests/priv/SvPMPZicbo/sv57_pmp_on_pa_zicbom_Smode.S
@@ -79,9 +79,9 @@ main:
 //                                                    Setup pmp registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
   LA (t2, rvtest_data_1)                          // Configure test region as NAPOT

--- a/tests/priv/SvPMPZicbo/sv57_pmp_on_pa_zicbom_Umode.S
+++ b/tests/priv/SvPMPZicbo/sv57_pmp_on_pa_zicbom_Umode.S
@@ -79,9 +79,9 @@ main:
 //                                                    Setup pmp registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
   LA (t2, rvtest_data_1)                          // Configure test region as NAPOT

--- a/tests/priv/SvPMPZicbo/sv57_pmp_on_pa_zicboz_Smode.S
+++ b/tests/priv/SvPMPZicbo/sv57_pmp_on_pa_zicboz_Smode.S
@@ -73,9 +73,9 @@ main:
 //                                                    Setup pmp registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
   LA (t2, rvtest_data_1)                          // Configure test region as NAPOT

--- a/tests/priv/SvPMPZicbo/sv57_pmp_on_pa_zicboz_Umode.S
+++ b/tests/priv/SvPMPZicbo/sv57_pmp_on_pa_zicboz_Umode.S
@@ -73,9 +73,9 @@ main:
 //                                                    Setup pmp registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                                        // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
   LA (t2, rvtest_data_1)                          // Configure test region as NAPOT

--- a/tests/priv/SvPMPZicbo/sv57_pmp_on_pte_zicbom_Smode.S
+++ b/tests/priv/SvPMPZicbo/sv57_pmp_on_pte_zicbom_Smode.S
@@ -92,9 +92,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMPZicbo/sv57_pmp_on_pte_zicbom_Umode.S
+++ b/tests/priv/SvPMPZicbo/sv57_pmp_on_pte_zicbom_Umode.S
@@ -92,9 +92,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMPZicbo/sv57_pmp_on_pte_zicboz_Smode.S
+++ b/tests/priv/SvPMPZicbo/sv57_pmp_on_pte_zicboz_Smode.S
@@ -86,9 +86,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvPMPZicbo/sv57_pmp_on_pte_zicboz_Umode.S
+++ b/tests/priv/SvPMPZicbo/sv57_pmp_on_pte_zicboz_Umode.S
@@ -86,9 +86,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvaduPMP/sv32_Svadu_no_pmp_perm_Smode.S
+++ b/tests/priv/SvaduPMP/sv32_Svadu_no_pmp_perm_Smode.S
@@ -105,9 +105,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvaduPMP/sv32_Svadu_no_pmp_perm_Umode.S
+++ b/tests/priv/SvaduPMP/sv32_Svadu_no_pmp_perm_Umode.S
@@ -105,9 +105,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvaduPMP/sv39_Svadu_no_pmp_perm_Smode.S
+++ b/tests/priv/SvaduPMP/sv39_Svadu_no_pmp_perm_Smode.S
@@ -115,9 +115,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvaduPMP/sv39_Svadu_no_pmp_perm_Umode.S
+++ b/tests/priv/SvaduPMP/sv39_Svadu_no_pmp_perm_Umode.S
@@ -115,9 +115,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvaduPMP/sv48_Svadu_no_pmp_perm_Smode.S
+++ b/tests/priv/SvaduPMP/sv48_Svadu_no_pmp_perm_Smode.S
@@ -125,9 +125,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvaduPMP/sv48_Svadu_no_pmp_perm_Umode.S
+++ b/tests/priv/SvaduPMP/sv48_Svadu_no_pmp_perm_Umode.S
@@ -125,9 +125,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvaduPMP/sv57_Svadu_no_pmp_perm_Smode.S
+++ b/tests/priv/SvaduPMP/sv57_Svadu_no_pmp_perm_Smode.S
@@ -135,9 +135,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/SvaduPMP/sv57_Svadu_no_pmp_perm_Umode.S
+++ b/tests/priv/SvaduPMP/sv57_Svadu_no_pmp_perm_Umode.S
@@ -135,9 +135,9 @@ main:
 //                                                    Setup pmpaddr registers
 //---------------------------------------------------------------------------------------------------------------------------------
 
-  li t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR)
+  LI(t2, 0                  // Set PMP permission for all memory in pmp2cfg0 (TOR))
   csrw pmpaddr1, t2
-  li t2, -1
+  LI(t2, -1)
   csrw pmpaddr2, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/priv/pmp/pmp32/PMPF/pmpf_cfg_wr.S
+++ b/tests/priv/pmp/pmp32/PMPF/pmpf_cfg_wr.S
@@ -92,7 +92,7 @@ main:
 
     // Enable the FPU: set mstatus.FS = 01 (Initial)
     // mstatus bits 14:13 = FS. Value 0x00006000 sets FS=11 (Dirty), safe for all F ops.
-    li   x4, 0x00006000
+    LI(x4, 0x00006000)
     csrs mstatus, x4        // set FS bits without disturbing anything else
 
     // zero out fcsr so fflags start clean

--- a/tests/priv/pmp/pmp32/PMPS/pmps_mprv_check-01.S
+++ b/tests/priv/pmp/pmp32/PMPS/pmps_mprv_check-01.S
@@ -136,40 +136,40 @@ main:
 //                                            Verification Section
 // Test Case: 1 : mstatus.MPRV = 0, L = 0, mstatus.MPP = 01 and No Permissions given to the PMP Region 0
 
-    li t0, (MPRV|M_MODE)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPRV|M_MODE)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_X    TEST_FOR_EXECUTION, test_1
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_W    TEST_FOR_EXECUTION, test_2
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_R    TEST_FOR_EXECUTION, test_3
 
 // Test Case: 2 : mstatus.MPRV = 1, L = 0, mstatus.MPP = 01 and No Permissions given to the PMP Region 0
 
-    li t0, (M_MODE|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (M_MODE|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_X    TEST_FOR_EXECUTION, test_4
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_W    TEST_FOR_EXECUTION, test_5
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_R    TEST_FOR_EXECUTION, test_6
@@ -189,40 +189,40 @@ main:
 
 // Test Case: 3 : mstatus.MPRV = 0, L = 1, mstatus.MPP = 01 and No Permissions given to the PMP Region 0
 
-    li t0, (MPRV|M_MODE)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPRV|M_MODE)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_X    TEST_FOR_EXECUTION, test_7
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_W    TEST_FOR_EXECUTION, test_8
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_R    TEST_FOR_EXECUTION, test_9
 
 // Test Case: 4 : mstatus.MPRV = 1, L = 1, mstatus.MPP = 01 and No Permissions given to the PMP Region 0
 
-    li t0, (M_MODE|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (M_MODE|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_X    TEST_FOR_EXECUTION, test_10
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_W    TEST_FOR_EXECUTION, test_11
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_R    TEST_FOR_EXECUTION, test_12

--- a/tests/priv/pmp/pmp32/PMPS/pmps_mprv_check-02.S
+++ b/tests/priv/pmp/pmp32/PMPS/pmps_mprv_check-02.S
@@ -133,40 +133,40 @@ main:
 //                                            Verification Section
 // Test Case: 1 : mstatus.MPRV = 0, L = 0, mstatus.MPP = 01 and XWR Permissions given to the PMP Region 0
 
-    li t0, (MPRV|M_MODE)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPRV|M_MODE)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_X    TEST_FOR_EXECUTION, test_1
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_W    TEST_FOR_EXECUTION, test_2
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_R    TEST_FOR_EXECUTION, test_3
 
 // Test Case: 2 : mstatus.MPRV = 1, L = 0, mstatus.MPP = 01 and XWR Permissions given to the PMP Region 0
 
-    li t0, (M_MODE|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (M_MODE|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_X    TEST_FOR_EXECUTION, test_4
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_W    TEST_FOR_EXECUTION, test_5
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_R    TEST_FOR_EXECUTION, test_6
@@ -186,40 +186,40 @@ main:
 
 // Test Case: 3 : mstatus.MPRV = 0, L = 1, mstatus.MPP = 01 and XWR Permissions given to the PMP Region 0
 
-    li t0, (MPRV|M_MODE)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPRV|M_MODE)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_X    TEST_FOR_EXECUTION, test_7
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_W    TEST_FOR_EXECUTION, test_8
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_R    TEST_FOR_EXECUTION, test_9
 
 // Test Case: 4 : mstatus.MPRV = 1, L = 1, mstatus.MPP = 01 and XWR Permissions given to the PMP Region 0
 
-    li t0, (M_MODE|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (M_MODE|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_X    TEST_FOR_EXECUTION, test_10
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_W    TEST_FOR_EXECUTION, test_11
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_R    TEST_FOR_EXECUTION, test_12

--- a/tests/priv/pmp/pmp32/PMPS/pmps_tor_legal_lxwr.S
+++ b/tests/priv/pmp/pmp32/PMPS/pmps_tor_legal_lxwr.S
@@ -83,7 +83,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_13, test_13_str)
 
-    li   t0, (g - 8)
+    LI(t0, (g - 8))
     add a4, a4, t0                  // REGIONSTART + g - 4
     LA(x1, 4f)                          // Store the return Address in x1
     \TEST_CASE\()_14:
@@ -132,7 +132,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_3, test_3_str)
 
-    li   t0, (g - 8)
+    LI(t0, (g - 8))
     add a5, a5, t0                                      // REGIONSTART + g - 4
 
     \TEST_CASE\()_4:
@@ -173,7 +173,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_8, test_8_str)                                   // Signature update
 
-    li   t0, (g - 8)
+    LI(t0, (g - 8))
     add a5, a5, t0                                      // REGIONSTART + g - 4
 
     \TEST_CASE\()_9:
@@ -231,7 +231,7 @@ main:
 // Test Case: 1 : L -> 0 and No Permissions given to the PMP Region 11
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr11, x6
@@ -248,7 +248,7 @@ main:
 // Test Case: 2 : L -> 0 and R Permissions given to the PMP Region 9
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr9, x6
@@ -265,7 +265,7 @@ main:
 // Test Case: 3 : L -> 0 and WR Permissions given to the PMP Region 7
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr7, x6
@@ -282,7 +282,7 @@ main:
 // Test Case: 4 : L -> 0 and X Permissions given to the PMP Region 5
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr5, x6
@@ -299,7 +299,7 @@ main:
 // Test Case: 5 : L -> 0 and RX Permissions given to the PMP Region 3
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr3, x6
@@ -316,7 +316,7 @@ main:
 // Test Case: 6 : L -> 0 and XWR Permissions given to the PMP Region 1
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr1, x6

--- a/tests/priv/pmp/pmp32/PMPU/pmpu_mprv_check-01.S
+++ b/tests/priv/pmp/pmp32/PMPU/pmpu_mprv_check-01.S
@@ -97,17 +97,17 @@ main:
 //                                            Verification Section
 // Test Case: 1 : mstatus.MPRV = 0, L = 0, mstatus.MPP = 00 and No Permissions given to the PMP Region 0
 
-    li t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
     PMP_VERIFICATION_RWX    TEST_FOR_EXECUTION, test_1
 
 // Test Case: 2 : mstatus.MPRV = 1, L = 0, mstatus.MPP = 00 and No Permissions given to the PMP Region 0
 
-    li t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (MPRV)
+    LI(t0, (MPRV))
     csrs mstatus, t0
 
     PMP_VERIFICATION_RWX    TEST_FOR_EXECUTION, test_2
@@ -127,17 +127,17 @@ main:
 
 // Test Case: 1 : mstatus.MPRV = 0, L = 1, mstatus.MPP = 00 and No Permissions given to the PMP Region 0
 
-    li t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
     PMP_VERIFICATION_RWX    TEST_FOR_EXECUTION, test_3
 
 // Test Case: 2 : mstatus.MPRV = 1, L = 1, mstatus.MPP = 00 and No Permissions given to the PMP Region 0
 
-    li t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (MPRV)
+    LI(t0, (MPRV))
     csrs mstatus, t0
 
     PMP_VERIFICATION_RWX    TEST_FOR_EXECUTION, test_4

--- a/tests/priv/pmp/pmp32/PMPU/pmpu_mprv_check-02.S
+++ b/tests/priv/pmp/pmp32/PMPU/pmpu_mprv_check-02.S
@@ -97,17 +97,17 @@ main:
 //                                            Verification Section
 // Test Case: 1 : mstatus.MPRV = 0, L = 0, mstatus.MPP = 00 and XWR Permissions given to the PMP Region 0
 
-    li t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
     PMP_VERIFICATION_RWX    TEST_FOR_EXECUTION, test_1
 
 // Test Case: 2 : mstatus.MPRV = 1, L = 0, mstatus.MPP = 00 and XWR Permissions given to the PMP Region 0
 
-    li t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (MPRV)
+    LI(t0, (MPRV))
     csrs mstatus, t0
 
     PMP_VERIFICATION_RWX    TEST_FOR_EXECUTION, test_2
@@ -127,17 +127,17 @@ main:
 
 // Test Case: 3 : mstatus.MPRV = 0, L = 1, mstatus.MPP = 00 and XWR Permissions given to the PMP Region 0
 
-    li t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
     PMP_VERIFICATION_RWX    TEST_FOR_EXECUTION, test_3
 
 // Test Case: 4 : mstatus.MPRV = 1, L = 1, mstatus.MPP = 00 and XWR Permissions given to the PMP Region 0
 
-    li t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (MPRV)
+    LI(t0, (MPRV))
     csrs mstatus, t0
 
     PMP_VERIFICATION_RWX    TEST_FOR_EXECUTION, test_4

--- a/tests/priv/pmp/pmp32/PMPU/pmpu_napot_legal_lxwr-01.S
+++ b/tests/priv/pmp/pmp32/PMPU/pmpu_napot_legal_lxwr-01.S
@@ -87,7 +87,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_19, test_19_str)
 
-    li t0, (g-8)
+    LI(t0, (g-8))
     add a4, a4, t0                  // REGIONSTART + g - 4
     LA(x1, 4f)                          // Store the return Address in x1
     \TEST_CASE\()_20:
@@ -148,7 +148,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_5, test_5_str)
 
-    li t0, (g-8)
+    LI(t0, (g-8))
     add a5, a5, t0                                      // REGIONSTART + g - 4
 
     \TEST_CASE\()_6:
@@ -213,7 +213,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_14, test_14_str)                                   // Signature update
 
-    li t0, (g-8)
+    LI(t0, (g-8))
     add a5, a5, t0                                      // REGIONSTART + g - 4
 
     \TEST_CASE\()_15:

--- a/tests/priv/pmp/pmp32/PMPU/pmpu_napot_legal_lxwr-02.S
+++ b/tests/priv/pmp/pmp32/PMPU/pmpu_napot_legal_lxwr-02.S
@@ -85,7 +85,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_19, test_19_str)
 
-    li t0, (g-8)
+    LI(t0, (g-8))
     add a4, a4, t0                  // REGIONSTART + g - 4
     LA(x1, 4f)                          // Store the return Address in x1
     \TEST_CASE\()_20:
@@ -146,7 +146,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_5, test_5_str)
 
-    li t0, (g-8)
+    LI(t0, (g-8))
     add a5, a5, t0                                      // REGIONSTART + g - 4
 
     \TEST_CASE\()_6:
@@ -211,7 +211,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_14, test_14_str)                                   // Signature update
 
-    li t0, (g-8)
+    LI(t0, (g-8))
     add a5, a5, t0                                      // REGIONSTART + g - 4
 
     \TEST_CASE\()_15:

--- a/tests/priv/pmp/pmp32/PMPU/pmpu_tor_legal_lxwr.S
+++ b/tests/priv/pmp/pmp32/PMPU/pmpu_tor_legal_lxwr.S
@@ -81,7 +81,7 @@ main:
 // Test Case: 1 : L -> 0 and No Permissions given to the PMP Region 11
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr11, x6
@@ -98,7 +98,7 @@ main:
 // Test Case: 2 : L -> 0 and R Permissions given to the PMP Region 9
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr9, x6
@@ -115,7 +115,7 @@ main:
 // Test Case: 3 : L -> 0 and WR Permissions given to the PMP Region 7
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr7, x6
@@ -132,7 +132,7 @@ main:
 // Test Case: 4 : L -> 0 and X Permissions given to the PMP Region 5
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr5, x6
@@ -149,7 +149,7 @@ main:
 // Test Case: 5 : L -> 0 and RX Permissions given to the PMP Region 3
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr3, x6
@@ -166,7 +166,7 @@ main:
 // Test Case: 6 : L -> 0 and XWR Permissions given to the PMP Region 1
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr1, x6

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzcd_legal_lxwr.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzcd_legal_lxwr.S
@@ -59,7 +59,7 @@ main:
 
     // Enable the FPU: set mstatus.FS = 01 (Initial)
     // mstatus bits 14:13 = FS. Value 0x00006000 sets FS=11 (Dirty), safe for all F ops.
-    li   x4, 0x00006000
+    LI(x4, 0x00006000)
     csrs mstatus, x4        // set FS bits without disturbing anything else
 
     // zero out fcsr so fflags start clean

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzcf_legal_lxwr.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzcf_legal_lxwr.S
@@ -44,7 +44,7 @@ RVTEST_BEGIN
 
 .macro VERIFICATION_RWX ADDRESS TEST_CASE
 
-    li    x15, 0x3f800000    // bit pattern for 1.0f (IEEE-754 single)
+    LI(x15, 0x3f800000    // bit pattern for 1.0f (IEEE-754 single))
     fmv.w.x f8, x15          // move 32-bit integer bits into float reg f8
     // Store Access Check
     LA(x8, \ADDRESS)                                         // Address to be verified
@@ -93,7 +93,7 @@ main:
 
     // Enable the FPU: set mstatus.FS = 01 (Initial)
     // mstatus bits 14:13 = FS. Value 0x00006000 sets FS=11 (Dirty), safe for all F ops.
-    li   x4, 0x00006000
+    LI(x4, 0x00006000)
     csrs mstatus, x4        // set FS bits without disturbing anything else
 
     // zero out fcsr so fflags start clean

--- a/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_01.S
+++ b/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_01.S
@@ -71,7 +71,7 @@ main:
     LI(x4, PMP_REGION_GLOBAL)
     csrw pmpcfg3, x4
 
-    li a4, MENVCFG
+    LI(a4, MENVCFG)
     csrrs zero, menvcfg, a4
 
 //                                                Verification Section

--- a/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_02.S
+++ b/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_02.S
@@ -70,7 +70,7 @@ main:
     LI(x4, PMP_REGION_GLOBAL)
     csrw pmpcfg3, x4
 
-    li t0, MENVCFG
+    LI(t0, MENVCFG)
     csrrs zero, menvcfg, t0
 
 //                                                Verification Section

--- a/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_03.S
+++ b/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_03.S
@@ -71,7 +71,7 @@ main:
     LI(x4, PMP_REGION_GLOBAL)
     csrw pmpcfg3, x4
 
-    li a4, MENVCFG
+    LI(a4, MENVCFG)
     csrrs zero, menvcfg, a4
 
 //                                                Verification Section

--- a/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_prefetch.S
+++ b/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_prefetch.S
@@ -99,7 +99,7 @@ main:
     LI(x4, PMP_REGION_GLOBAL)
     csrw pmpcfg3, x4
 
-    li t0, MENVCFG
+    LI(t0, MENVCFG)
     csrrs zero, menvcfg, t0
 
 //                                                Verification Section

--- a/tests/priv/pmp/pmp64/PMPF/pmpf_cfg_wr.S
+++ b/tests/priv/pmp/pmp64/PMPF/pmpf_cfg_wr.S
@@ -92,7 +92,7 @@ main:
 
     // Enable the FPU: set mstatus.FS = 01 (Initial)
     // mstatus bits 14:13 = FS. Value 0x00006000 sets FS=11 (Dirty), safe for all F ops.
-    li   x4, 0x00006000
+    LI(x4, 0x00006000)
     csrs mstatus, x4        // set FS bits without disturbing anything else
 
     // zero out fcsr so fflags start clean

--- a/tests/priv/pmp/pmp64/PMPS/pmps_mprv_check-01.S
+++ b/tests/priv/pmp/pmp64/PMPS/pmps_mprv_check-01.S
@@ -133,40 +133,40 @@ main:
 //                                            Verification Section
 // Test Case: 1 : mstatus.MPRV = 0, L = 0, mstatus.MPP = 01 and No Permissions given to the PMP Region 0
 
-    li t0, (MPRV|M_MODE)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPRV|M_MODE)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_X    TEST_FOR_EXECUTION, test_1
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_W    TEST_FOR_EXECUTION, test_2
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_R    TEST_FOR_EXECUTION, test_3
 
 // Test Case: 2 : mstatus.MPRV = 1, L = 0, mstatus.MPP = 01 and No Permissions given to the PMP Region 0
 
-    li t0, (M_MODE|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (M_MODE|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_X    TEST_FOR_EXECUTION, test_4
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_W    TEST_FOR_EXECUTION, test_5
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_R    TEST_FOR_EXECUTION, test_6
@@ -186,40 +186,40 @@ main:
 
 // Test Case: 3 : mstatus.MPRV = 0, L = 1, mstatus.MPP = 01 and No Permissions given to the PMP Region 0
 
-    li t0, (MPRV|M_MODE)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPRV|M_MODE)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_X    TEST_FOR_EXECUTION, test_7
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_W    TEST_FOR_EXECUTION, test_8
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_R    TEST_FOR_EXECUTION, test_9
 
 // Test Case: 4 : mstatus.MPRV = 1, L = 1, mstatus.MPP = 01 and No Permissions given to the PMP Region 0
 
-    li t0, (M_MODE|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (M_MODE|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_X    TEST_FOR_EXECUTION, test_10
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_W    TEST_FOR_EXECUTION, test_11
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_R    TEST_FOR_EXECUTION, test_12

--- a/tests/priv/pmp/pmp64/PMPS/pmps_mprv_check-02.S
+++ b/tests/priv/pmp/pmp64/PMPS/pmps_mprv_check-02.S
@@ -133,40 +133,40 @@ main:
 //                                            Verification Section
 // Test Case: 1 : mstatus.MPRV = 0, L = 0, mstatus.MPP = 01 and XWR Permissions given to the PMP Region 0
 
-    li t0, (MPRV|M_MODE)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPRV|M_MODE)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_X    TEST_FOR_EXECUTION, test_1
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_W    TEST_FOR_EXECUTION, test_2
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_R    TEST_FOR_EXECUTION, test_3
 
 // Test Case: 2 : mstatus.MPRV = 1, L = 0, mstatus.MPP = 01 and XWR Permissions given to the PMP Region 0
 
-    li t0, (M_MODE|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (M_MODE|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_X    TEST_FOR_EXECUTION, test_4
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_W    TEST_FOR_EXECUTION, test_5
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_R    TEST_FOR_EXECUTION, test_6
@@ -186,40 +186,40 @@ main:
 
 // Test Case: 3 : mstatus.MPRV = 0, L = 1, mstatus.MPP = 01 and XWR Permissions given to the PMP Region 0
 
-    li t0, (MPRV|M_MODE)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPRV|M_MODE)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_X    TEST_FOR_EXECUTION, test_7
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_W    TEST_FOR_EXECUTION, test_8
 
-    li t0, (S_MODE)
+    LI(t0, (S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_R    TEST_FOR_EXECUTION, test_9
 
 // Test Case: 4 : mstatus.MPRV = 1, L = 1, mstatus.MPP = 01 and XWR Permissions given to the PMP Region 0
 
-    li t0, (M_MODE|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (M_MODE|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_X    TEST_FOR_EXECUTION, test_10
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_W    TEST_FOR_EXECUTION, test_11
 
-    li t0, (MPRV|S_MODE)
+    LI(t0, (MPRV|S_MODE))
     csrs mstatus, t0
 
     VERIFICATION_R    TEST_FOR_EXECUTION, test_12

--- a/tests/priv/pmp/pmp64/PMPS/pmps_napot_legal_lxwr-01.S
+++ b/tests/priv/pmp/pmp64/PMPS/pmps_napot_legal_lxwr-01.S
@@ -87,7 +87,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_19, test_19_str)
 
-    li   t0, (g - 8)
+    LI(t0, (g - 8))
     add  a4, a4, t0                  // REGIONSTART + g - 4
     LA(x1, 4f)                          // Store the return Address in x1
     \TEST_CASE\()_20:
@@ -148,7 +148,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_5, test_5_str)
 
-    li t0, (g-8)
+    LI(t0, (g-8))
     add a5, a5, t0                                      // REGIONSTART + g - 4
 
     \TEST_CASE\()_6:
@@ -213,7 +213,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_14, test_14_str)                                   // Signature update
 
-    li t0, (g-8)
+    LI(t0, (g-8))
     add a5, a5, t0                                      // REGIONSTART + g - 4
 
     \TEST_CASE\()_15:

--- a/tests/priv/pmp/pmp64/PMPS/pmps_tor_legal_lxwr-01.S
+++ b/tests/priv/pmp/pmp64/PMPS/pmps_tor_legal_lxwr-01.S
@@ -81,7 +81,7 @@ main:
 // Test Case: 1 : L -> 0 and No Permissions given to the PMP Region 11
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr11, x6
@@ -98,7 +98,7 @@ main:
 // Test Case: 2 : L -> 0 and R Permissions given to the PMP Region 9
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr9, x6
@@ -115,7 +115,7 @@ main:
 // Test Case: 3 : L -> 0 and WR Permissions given to the PMP Region 7
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr7, x6

--- a/tests/priv/pmp/pmp64/PMPS/pmps_tor_legal_lxwr-02.S
+++ b/tests/priv/pmp/pmp64/PMPS/pmps_tor_legal_lxwr-02.S
@@ -85,7 +85,7 @@ RVTEST_BEGIN
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_13, test_13_str)
 
     LA (a4, \ADDRESS)
-    li t0, (g-8)
+    LI(t0, (g-8))
     add a4, a4, t0                  // REGIONSTART + g - 4
     LA(x1, 4f)                          // Store the return Address in x1
     \TEST_CASE\()_14:
@@ -138,7 +138,7 @@ RVTEST_BEGIN
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_3, test_3_str)
 
     LA(a5, \ADDRESS)                                        // Address to be verified
-    li t0, (g-8)
+    LI(t0, (g-8))
     add a5, a5, t0                                      // REGIONSTART + g - 4
 
     \TEST_CASE\()_4:
@@ -180,7 +180,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_8, test_8_str)                                   // Signature update
 
-    li t0, (g-8)
+    LI(t0, (g-8))
     add a5, a5, t0                                     // REGIONSTART + g - 4
 
     \TEST_CASE\()_9:
@@ -239,7 +239,7 @@ main:
 // Test Case: 4 : L -> 0 and X Permissions given to the PMP Region 5
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr5, x6
@@ -256,7 +256,7 @@ main:
 // Test Case: 5 : L -> 0 and RX Permissions given to the PMP Region 3
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr3, x6
@@ -273,7 +273,7 @@ main:
 // Test Case: 6 : L -> 0 and XWR Permissions given to the PMP Region 1
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr1, x6

--- a/tests/priv/pmp/pmp64/PMPU/pmpu_mprv_check-01.S
+++ b/tests/priv/pmp/pmp64/PMPU/pmpu_mprv_check-01.S
@@ -97,17 +97,17 @@ main:
 //                                            Verification Section
 // Test Case: 1 : mstatus.MPRV = 0, L = 0, mstatus.MPP = 00 and No Permissions given to the PMP Region 0
 
-    li t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
     PMP_VERIFICATION_RWX    TEST_FOR_EXECUTION, test_1
 
 // Test Case: 2 : mstatus.MPRV = 1, L = 0, mstatus.MPP = 00 and No Permissions given to the PMP Region 0
 
-    li t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (MPRV)
+    LI(t0, (MPRV))
     csrs mstatus, t0
 
     PMP_VERIFICATION_RWX    TEST_FOR_EXECUTION, test_2
@@ -127,17 +127,17 @@ main:
 
 // Test Case: 3 : mstatus.MPRV = 0, L = 1, mstatus.MPP = 00 and No Permissions given to the PMP Region 0
 
-    li t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
     PMP_VERIFICATION_RWX    TEST_FOR_EXECUTION, test_3
 
 // Test Case: 4 : mstatus.MPRV = 1, L = 1, mstatus.MPP = 00 and No Permissions given to the PMP Region 0
 
-    li t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (MPRV)
+    LI(t0, (MPRV))
     csrs mstatus, t0
 
     PMP_VERIFICATION_RWX    TEST_FOR_EXECUTION, test_4

--- a/tests/priv/pmp/pmp64/PMPU/pmpu_mprv_check-02.S
+++ b/tests/priv/pmp/pmp64/PMPU/pmpu_mprv_check-02.S
@@ -97,17 +97,17 @@ main:
 //                                            Verification Section
 // Test Case: 1 : mstatus.MPRV = 0, L = 0, mstatus.MPP = 00 and XWR Permissions given to the PMP Region 0
 
-    li t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
     PMP_VERIFICATION_RWX    TEST_FOR_EXECUTION, test_1
 
 // Test Case: 2 : mstatus.MPRV = 1, L = 0, mstatus.MPP = 00 and XWR Permissions given to the PMP Region 0
 
-    li t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (MPRV)
+    LI(t0, (MPRV))
     csrs mstatus, t0
 
     PMP_VERIFICATION_RWX    TEST_FOR_EXECUTION, test_2
@@ -127,17 +127,17 @@ main:
 
 // Test Case: 3 : mstatus.MPRV = 0, L = 1, mstatus.MPP = 00 and XWR Permissions given to the PMP Region 0
 
-    li t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
     PMP_VERIFICATION_RWX    TEST_FOR_EXECUTION, test_3
 
 // Test Case: 4 : mstatus.MPRV = 1, L = 1, mstatus.MPP = 00 and XWR Permissions given to the PMP Region 0
 
-    li t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP
+    LI(t0, (MPP|MPRV)        // Initialize mstatus.MPRV & mstatus.MPP)
     csrc mstatus, t0
 
-    li t0, (MPRV)
+    LI(t0, (MPRV))
     csrs mstatus, t0
 
     PMP_VERIFICATION_RWX    TEST_FOR_EXECUTION, test_4

--- a/tests/priv/pmp/pmp64/PMPU/pmpu_napot_legal_lxwr-02.S
+++ b/tests/priv/pmp/pmp64/PMPU/pmpu_napot_legal_lxwr-02.S
@@ -85,7 +85,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_19, test_19_str)
 
-    li t0, (g-8)
+    LI(t0, (g-8))
     add a4, a4, t0                  // REGIONSTART + g - 4
     LA(x1, 4f)                          // Store the return Address in x1
     \TEST_CASE\()_20:
@@ -146,7 +146,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_5, test_5_str)
 
-    li t0, (g-8)
+    LI(t0, (g-8))
     add a5, a5, t0                                      // REGIONSTART + g - 4
 
     \TEST_CASE\()_6:
@@ -211,7 +211,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4, \TEST_CASE\()_14, test_14_str)                                   // Signature update
 
-    li t0, (g-8)
+    LI(t0, (g-8))
     add a5, a5, t0                                      // REGIONSTART + g - 4
 
     \TEST_CASE\()_15:

--- a/tests/priv/pmp/pmp64/PMPU/pmpu_tor_legal_lxwr-01.S
+++ b/tests/priv/pmp/pmp64/PMPU/pmpu_tor_legal_lxwr-01.S
@@ -81,7 +81,7 @@ main:
 // Test Case: 1 : L -> 0 and No Permissions given to the PMP Region 11
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr11, x6
@@ -98,7 +98,7 @@ main:
 // Test Case: 2 : L -> 0 and R Permissions given to the PMP Region 9
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr9, x6
@@ -115,7 +115,7 @@ main:
 // Test Case: 3 : L -> 0 and WR Permissions given to the PMP Region 7
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr7, x6

--- a/tests/priv/pmp/pmp64/PMPU/pmpu_tor_legal_lxwr-02.S
+++ b/tests/priv/pmp/pmp64/PMPU/pmpu_tor_legal_lxwr-02.S
@@ -81,7 +81,7 @@ main:
 // Test Case: 4 : L -> 0 and X Permissions given to the PMP Region 5
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr5, x6
@@ -98,7 +98,7 @@ main:
 // Test Case: 5 : L -> 0 and RX Permissions given to the PMP Region 3
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr3, x6
@@ -115,7 +115,7 @@ main:
 // Test Case: 6 : L -> 0 and XWR Permissions given to the PMP Region 1
 
     LA(x6, REGIONSTART)
-    li t0, g
+    LI(t0, g)
     add x6, x6, t0
     srl x6, x6, PMP_SHIFT
     csrw pmpaddr1, x6

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzcd_legal_lwxr.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzcd_legal_lwxr.S
@@ -55,7 +55,7 @@ main:
 
     // Enable the FPU: set mstatus.FS = 01 (Initial)
     // mstatus bits 14:13 = FS. Value 0x00006000 sets FS=11 (Dirty), safe for all F ops.
-    li   x4, 0x00006000
+    LI(x4, 0x00006000)
     csrs mstatus, x4        // set FS bits without disturbing anything else
 
     // zero out fcsr so fflags start clean

--- a/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_01.S
+++ b/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_01.S
@@ -71,7 +71,7 @@ main:
     LI(x4, PMP_REGION_GLOBAL)
     csrw pmpcfg2, x4
 
-    li t0, MENVCFG
+    LI(t0, MENVCFG)
     csrrs zero, menvcfg, t0
 
 //                                                Verification Section

--- a/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_02.S
+++ b/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_02.S
@@ -70,7 +70,7 @@ main:
     LI(x4, PMP_REGION_GLOBAL)
     csrw pmpcfg2, x4
 
-    li t0, MENVCFG
+    LI(t0, MENVCFG)
     csrrs zero, menvcfg, t0
 
 //                                                Verification Section

--- a/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_03.S
+++ b/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_03.S
@@ -72,7 +72,7 @@ main:
     LI(x4, PMP_REGION_GLOBAL)
     csrw pmpcfg2, x4
 
-    li t0, MENVCFG
+    LI(t0, MENVCFG)
     csrrs zero, menvcfg, t0
 
 //                                                Verification Section

--- a/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_prefetch.S
+++ b/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_prefetch.S
@@ -99,7 +99,7 @@ main:
     LI(x4, PMP_REGION_GLOBAL)
     csrw pmpcfg2, x4
 
-    li t0, MENVCFG
+    LI(t0, MENVCFG)
     csrrs zero, menvcfg, t0
 
 //                                                Verification Section

--- a/tests/rv32e/E/E-jal-00.S
+++ b/tests/rv32e/E/E-jal-00.S
@@ -244,11 +244,11 @@ cp_imm_edges_jal_fwd_b_4:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_2, E_jal_cg_cp_imm_edges_jal_b_2_str)
 
 # cp_imm_edges_jal: forward jump by 8
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 3
 E_jal_cg_cp_imm_edges_jal_b_3:
   jal x7, cp_imm_edges_jal_fwd_b_8
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 3
 cp_imm_edges_jal_fwd_b_8:
   # Check jump taken/not-taken
@@ -259,11 +259,11 @@ cp_imm_edges_jal_fwd_b_8:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_3, E_jal_cg_cp_imm_edges_jal_b_3_str)
 
 # cp_imm_edges_jal: forward jump by 16
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 4
 E_jal_cg_cp_imm_edges_jal_b_4:
   jal x7, cp_imm_edges_jal_fwd_b_16
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 4
 cp_imm_edges_jal_fwd_b_16:
   # Check jump taken/not-taken
@@ -274,11 +274,11 @@ cp_imm_edges_jal_fwd_b_16:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_4, E_jal_cg_cp_imm_edges_jal_b_4_str)
 
 # cp_imm_edges_jal: forward jump by 32
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 5
 E_jal_cg_cp_imm_edges_jal_b_5:
   jal x7, cp_imm_edges_jal_fwd_b_32
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 5
 cp_imm_edges_jal_fwd_b_32:
   # Check jump taken/not-taken
@@ -289,11 +289,11 @@ cp_imm_edges_jal_fwd_b_32:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_5, E_jal_cg_cp_imm_edges_jal_b_5_str)
 
 # cp_imm_edges_jal: forward jump by 64
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 6
 E_jal_cg_cp_imm_edges_jal_b_6:
   jal x7, cp_imm_edges_jal_fwd_b_64
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 6
 cp_imm_edges_jal_fwd_b_64:
   # Check jump taken/not-taken
@@ -304,11 +304,11 @@ cp_imm_edges_jal_fwd_b_64:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_6, E_jal_cg_cp_imm_edges_jal_b_6_str)
 
 # cp_imm_edges_jal: forward jump by 128
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 7
 E_jal_cg_cp_imm_edges_jal_b_7:
   jal x7, cp_imm_edges_jal_fwd_b_128
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 7
 cp_imm_edges_jal_fwd_b_128:
   # Check jump taken/not-taken
@@ -319,11 +319,11 @@ cp_imm_edges_jal_fwd_b_128:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_7, E_jal_cg_cp_imm_edges_jal_b_7_str)
 
 # cp_imm_edges_jal: forward jump by 256
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 8
 E_jal_cg_cp_imm_edges_jal_b_8:
   jal x7, cp_imm_edges_jal_fwd_b_256
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 8
 cp_imm_edges_jal_fwd_b_256:
   # Check jump taken/not-taken
@@ -334,11 +334,11 @@ cp_imm_edges_jal_fwd_b_256:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_8, E_jal_cg_cp_imm_edges_jal_b_8_str)
 
 # cp_imm_edges_jal: forward jump by 512
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 9
 E_jal_cg_cp_imm_edges_jal_b_9:
   jal x7, cp_imm_edges_jal_fwd_b_512
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 9
 cp_imm_edges_jal_fwd_b_512:
   # Check jump taken/not-taken
@@ -349,11 +349,11 @@ cp_imm_edges_jal_fwd_b_512:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_9, E_jal_cg_cp_imm_edges_jal_b_9_str)
 
 # cp_imm_edges_jal: forward jump by 1024
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 10
 E_jal_cg_cp_imm_edges_jal_b_10:
   jal x7, cp_imm_edges_jal_fwd_b_1024
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 10
 cp_imm_edges_jal_fwd_b_1024:
   # Check jump taken/not-taken
@@ -364,11 +364,11 @@ cp_imm_edges_jal_fwd_b_1024:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_10, E_jal_cg_cp_imm_edges_jal_b_10_str)
 
 # cp_imm_edges_jal: forward jump by 2048
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 11
 E_jal_cg_cp_imm_edges_jal_b_11:
   jal x7, cp_imm_edges_jal_fwd_b_2048
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 11
 cp_imm_edges_jal_fwd_b_2048:
   # Check jump taken/not-taken
@@ -379,11 +379,11 @@ cp_imm_edges_jal_fwd_b_2048:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_11, E_jal_cg_cp_imm_edges_jal_b_11_str)
 
 # cp_imm_edges_jal: forward jump by 4096
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 12
 E_jal_cg_cp_imm_edges_jal_b_12:
   jal x7, cp_imm_edges_jal_fwd_b_4096
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 12
 cp_imm_edges_jal_fwd_b_4096:
   # Check jump taken/not-taken
@@ -394,11 +394,11 @@ cp_imm_edges_jal_fwd_b_4096:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_12, E_jal_cg_cp_imm_edges_jal_b_12_str)
 
 # cp_imm_edges_jal: forward jump by 8192
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 13
 E_jal_cg_cp_imm_edges_jal_b_13:
   jal x7, cp_imm_edges_jal_fwd_b_8192
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 13
 cp_imm_edges_jal_fwd_b_8192:
   # Check jump taken/not-taken
@@ -428,7 +428,7 @@ cp_imm_edges_jal_done_b_m4:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m2, E_jal_cg_cp_imm_edges_jal_b_m2_str)
 
 # cp_imm_edges_jal: backward jump by 8
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 4
 E_jal_cg_cp_imm_edges_jal_b_m3:
   jal x7, cp_imm_edges_jal_skip_b_m8
@@ -438,7 +438,7 @@ cp_imm_edges_jal_bwd_b_m8:
 cp_imm_edges_jal_skip_b_m8:
   .p2align 4
   jal x7, cp_imm_edges_jal_bwd_b_m8
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m8:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -448,7 +448,7 @@ cp_imm_edges_jal_done_b_m8:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m3, E_jal_cg_cp_imm_edges_jal_b_m3_str)
 
 # cp_imm_edges_jal: backward jump by 16
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 5
 E_jal_cg_cp_imm_edges_jal_b_m4:
   jal x7, cp_imm_edges_jal_skip_b_m16
@@ -458,7 +458,7 @@ cp_imm_edges_jal_bwd_b_m16:
 cp_imm_edges_jal_skip_b_m16:
   .p2align 5
   jal x7, cp_imm_edges_jal_bwd_b_m16
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m16:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -468,7 +468,7 @@ cp_imm_edges_jal_done_b_m16:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m4, E_jal_cg_cp_imm_edges_jal_b_m4_str)
 
 # cp_imm_edges_jal: backward jump by 32
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 6
 E_jal_cg_cp_imm_edges_jal_b_m5:
   jal x7, cp_imm_edges_jal_skip_b_m32
@@ -478,7 +478,7 @@ cp_imm_edges_jal_bwd_b_m32:
 cp_imm_edges_jal_skip_b_m32:
   .p2align 6
   jal x7, cp_imm_edges_jal_bwd_b_m32
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m32:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -488,7 +488,7 @@ cp_imm_edges_jal_done_b_m32:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m5, E_jal_cg_cp_imm_edges_jal_b_m5_str)
 
 # cp_imm_edges_jal: backward jump by 64
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 7
 E_jal_cg_cp_imm_edges_jal_b_m6:
   jal x7, cp_imm_edges_jal_skip_b_m64
@@ -498,7 +498,7 @@ cp_imm_edges_jal_bwd_b_m64:
 cp_imm_edges_jal_skip_b_m64:
   .p2align 7
   jal x7, cp_imm_edges_jal_bwd_b_m64
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m64:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -508,7 +508,7 @@ cp_imm_edges_jal_done_b_m64:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m6, E_jal_cg_cp_imm_edges_jal_b_m6_str)
 
 # cp_imm_edges_jal: backward jump by 128
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 8
 E_jal_cg_cp_imm_edges_jal_b_m7:
   jal x7, cp_imm_edges_jal_skip_b_m128
@@ -518,7 +518,7 @@ cp_imm_edges_jal_bwd_b_m128:
 cp_imm_edges_jal_skip_b_m128:
   .p2align 8
   jal x7, cp_imm_edges_jal_bwd_b_m128
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m128:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -528,7 +528,7 @@ cp_imm_edges_jal_done_b_m128:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m7, E_jal_cg_cp_imm_edges_jal_b_m7_str)
 
 # cp_imm_edges_jal: backward jump by 256
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 9
 E_jal_cg_cp_imm_edges_jal_b_m8:
   jal x7, cp_imm_edges_jal_skip_b_m256
@@ -538,7 +538,7 @@ cp_imm_edges_jal_bwd_b_m256:
 cp_imm_edges_jal_skip_b_m256:
   .p2align 9
   jal x7, cp_imm_edges_jal_bwd_b_m256
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m256:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -548,7 +548,7 @@ cp_imm_edges_jal_done_b_m256:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m8, E_jal_cg_cp_imm_edges_jal_b_m8_str)
 
 # cp_imm_edges_jal: backward jump by 512
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 10
 E_jal_cg_cp_imm_edges_jal_b_m9:
   jal x7, cp_imm_edges_jal_skip_b_m512
@@ -558,7 +558,7 @@ cp_imm_edges_jal_bwd_b_m512:
 cp_imm_edges_jal_skip_b_m512:
   .p2align 10
   jal x7, cp_imm_edges_jal_bwd_b_m512
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m512:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -568,7 +568,7 @@ cp_imm_edges_jal_done_b_m512:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m9, E_jal_cg_cp_imm_edges_jal_b_m9_str)
 
 # cp_imm_edges_jal: backward jump by 1024
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 11
 E_jal_cg_cp_imm_edges_jal_b_m10:
   jal x7, cp_imm_edges_jal_skip_b_m1024
@@ -578,7 +578,7 @@ cp_imm_edges_jal_bwd_b_m1024:
 cp_imm_edges_jal_skip_b_m1024:
   .p2align 11
   jal x7, cp_imm_edges_jal_bwd_b_m1024
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m1024:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -588,7 +588,7 @@ cp_imm_edges_jal_done_b_m1024:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m10, E_jal_cg_cp_imm_edges_jal_b_m10_str)
 
 # cp_imm_edges_jal: backward jump by 2048
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 12
 E_jal_cg_cp_imm_edges_jal_b_m11:
   jal x7, cp_imm_edges_jal_skip_b_m2048
@@ -598,7 +598,7 @@ cp_imm_edges_jal_bwd_b_m2048:
 cp_imm_edges_jal_skip_b_m2048:
   .p2align 12
   jal x7, cp_imm_edges_jal_bwd_b_m2048
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m2048:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -608,7 +608,7 @@ cp_imm_edges_jal_done_b_m2048:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m11, E_jal_cg_cp_imm_edges_jal_b_m11_str)
 
 # cp_imm_edges_jal: backward jump by 4096
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 13
 E_jal_cg_cp_imm_edges_jal_b_m12:
   jal x7, cp_imm_edges_jal_skip_b_m4096
@@ -618,7 +618,7 @@ cp_imm_edges_jal_bwd_b_m4096:
 cp_imm_edges_jal_skip_b_m4096:
   .p2align 13
   jal x7, cp_imm_edges_jal_bwd_b_m4096
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m4096:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -628,7 +628,7 @@ cp_imm_edges_jal_done_b_m4096:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m12, E_jal_cg_cp_imm_edges_jal_b_m12_str)
 
 # cp_imm_edges_jal: backward jump by 8192
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 14
 E_jal_cg_cp_imm_edges_jal_b_m13:
   jal x7, cp_imm_edges_jal_skip_b_m8192
@@ -638,7 +638,7 @@ cp_imm_edges_jal_bwd_b_m8192:
 cp_imm_edges_jal_skip_b_m8192:
   .p2align 14
   jal x7, cp_imm_edges_jal_bwd_b_m8192
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m8192:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.

--- a/tests/rv32i/I/I-jal-00.S
+++ b/tests/rv32i/I/I-jal-00.S
@@ -421,11 +421,11 @@ cp_imm_edges_jal_fwd_b_4:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_2, I_jal_cg_cp_imm_edges_jal_b_2_str)
 
 # cp_imm_edges_jal: forward jump by 8
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 3
 I_jal_cg_cp_imm_edges_jal_b_3:
   jal x10, cp_imm_edges_jal_fwd_b_8
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 3
 cp_imm_edges_jal_fwd_b_8:
   # Check jump taken/not-taken
@@ -436,11 +436,11 @@ cp_imm_edges_jal_fwd_b_8:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_3, I_jal_cg_cp_imm_edges_jal_b_3_str)
 
 # cp_imm_edges_jal: forward jump by 16
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 4
 I_jal_cg_cp_imm_edges_jal_b_4:
   jal x10, cp_imm_edges_jal_fwd_b_16
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 4
 cp_imm_edges_jal_fwd_b_16:
   # Check jump taken/not-taken
@@ -451,11 +451,11 @@ cp_imm_edges_jal_fwd_b_16:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_4, I_jal_cg_cp_imm_edges_jal_b_4_str)
 
 # cp_imm_edges_jal: forward jump by 32
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 5
 I_jal_cg_cp_imm_edges_jal_b_5:
   jal x10, cp_imm_edges_jal_fwd_b_32
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 5
 cp_imm_edges_jal_fwd_b_32:
   # Check jump taken/not-taken
@@ -466,11 +466,11 @@ cp_imm_edges_jal_fwd_b_32:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_5, I_jal_cg_cp_imm_edges_jal_b_5_str)
 
 # cp_imm_edges_jal: forward jump by 64
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 6
 I_jal_cg_cp_imm_edges_jal_b_6:
   jal x10, cp_imm_edges_jal_fwd_b_64
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 6
 cp_imm_edges_jal_fwd_b_64:
   # Check jump taken/not-taken
@@ -481,11 +481,11 @@ cp_imm_edges_jal_fwd_b_64:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_6, I_jal_cg_cp_imm_edges_jal_b_6_str)
 
 # cp_imm_edges_jal: forward jump by 128
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 7
 I_jal_cg_cp_imm_edges_jal_b_7:
   jal x10, cp_imm_edges_jal_fwd_b_128
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 7
 cp_imm_edges_jal_fwd_b_128:
   # Check jump taken/not-taken
@@ -496,11 +496,11 @@ cp_imm_edges_jal_fwd_b_128:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_7, I_jal_cg_cp_imm_edges_jal_b_7_str)
 
 # cp_imm_edges_jal: forward jump by 256
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 8
 I_jal_cg_cp_imm_edges_jal_b_8:
   jal x10, cp_imm_edges_jal_fwd_b_256
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 8
 cp_imm_edges_jal_fwd_b_256:
   # Check jump taken/not-taken
@@ -511,11 +511,11 @@ cp_imm_edges_jal_fwd_b_256:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_8, I_jal_cg_cp_imm_edges_jal_b_8_str)
 
 # cp_imm_edges_jal: forward jump by 512
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 9
 I_jal_cg_cp_imm_edges_jal_b_9:
   jal x10, cp_imm_edges_jal_fwd_b_512
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 9
 cp_imm_edges_jal_fwd_b_512:
   # Check jump taken/not-taken
@@ -526,11 +526,11 @@ cp_imm_edges_jal_fwd_b_512:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_9, I_jal_cg_cp_imm_edges_jal_b_9_str)
 
 # cp_imm_edges_jal: forward jump by 1024
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 10
 I_jal_cg_cp_imm_edges_jal_b_10:
   jal x10, cp_imm_edges_jal_fwd_b_1024
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 10
 cp_imm_edges_jal_fwd_b_1024:
   # Check jump taken/not-taken
@@ -541,11 +541,11 @@ cp_imm_edges_jal_fwd_b_1024:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_10, I_jal_cg_cp_imm_edges_jal_b_10_str)
 
 # cp_imm_edges_jal: forward jump by 2048
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 11
 I_jal_cg_cp_imm_edges_jal_b_11:
   jal x10, cp_imm_edges_jal_fwd_b_2048
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 11
 cp_imm_edges_jal_fwd_b_2048:
   # Check jump taken/not-taken
@@ -556,11 +556,11 @@ cp_imm_edges_jal_fwd_b_2048:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_11, I_jal_cg_cp_imm_edges_jal_b_11_str)
 
 # cp_imm_edges_jal: forward jump by 4096
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 12
 I_jal_cg_cp_imm_edges_jal_b_12:
   jal x10, cp_imm_edges_jal_fwd_b_4096
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 12
 cp_imm_edges_jal_fwd_b_4096:
   # Check jump taken/not-taken
@@ -571,11 +571,11 @@ cp_imm_edges_jal_fwd_b_4096:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_12, I_jal_cg_cp_imm_edges_jal_b_12_str)
 
 # cp_imm_edges_jal: forward jump by 8192
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 13
 I_jal_cg_cp_imm_edges_jal_b_13:
   jal x10, cp_imm_edges_jal_fwd_b_8192
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 13
 cp_imm_edges_jal_fwd_b_8192:
   # Check jump taken/not-taken
@@ -605,7 +605,7 @@ cp_imm_edges_jal_done_b_m4:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m2, I_jal_cg_cp_imm_edges_jal_b_m2_str)
 
 # cp_imm_edges_jal: backward jump by 8
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 4
 I_jal_cg_cp_imm_edges_jal_b_m3:
   jal x10, cp_imm_edges_jal_skip_b_m8
@@ -615,7 +615,7 @@ cp_imm_edges_jal_bwd_b_m8:
 cp_imm_edges_jal_skip_b_m8:
   .p2align 4
   jal x10, cp_imm_edges_jal_bwd_b_m8
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m8:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -625,7 +625,7 @@ cp_imm_edges_jal_done_b_m8:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m3, I_jal_cg_cp_imm_edges_jal_b_m3_str)
 
 # cp_imm_edges_jal: backward jump by 16
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 5
 I_jal_cg_cp_imm_edges_jal_b_m4:
   jal x10, cp_imm_edges_jal_skip_b_m16
@@ -635,7 +635,7 @@ cp_imm_edges_jal_bwd_b_m16:
 cp_imm_edges_jal_skip_b_m16:
   .p2align 5
   jal x10, cp_imm_edges_jal_bwd_b_m16
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m16:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -645,7 +645,7 @@ cp_imm_edges_jal_done_b_m16:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m4, I_jal_cg_cp_imm_edges_jal_b_m4_str)
 
 # cp_imm_edges_jal: backward jump by 32
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 6
 I_jal_cg_cp_imm_edges_jal_b_m5:
   jal x10, cp_imm_edges_jal_skip_b_m32
@@ -655,7 +655,7 @@ cp_imm_edges_jal_bwd_b_m32:
 cp_imm_edges_jal_skip_b_m32:
   .p2align 6
   jal x10, cp_imm_edges_jal_bwd_b_m32
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m32:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -665,7 +665,7 @@ cp_imm_edges_jal_done_b_m32:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m5, I_jal_cg_cp_imm_edges_jal_b_m5_str)
 
 # cp_imm_edges_jal: backward jump by 64
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 7
 I_jal_cg_cp_imm_edges_jal_b_m6:
   jal x10, cp_imm_edges_jal_skip_b_m64
@@ -675,7 +675,7 @@ cp_imm_edges_jal_bwd_b_m64:
 cp_imm_edges_jal_skip_b_m64:
   .p2align 7
   jal x10, cp_imm_edges_jal_bwd_b_m64
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m64:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -685,7 +685,7 @@ cp_imm_edges_jal_done_b_m64:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m6, I_jal_cg_cp_imm_edges_jal_b_m6_str)
 
 # cp_imm_edges_jal: backward jump by 128
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 8
 I_jal_cg_cp_imm_edges_jal_b_m7:
   jal x10, cp_imm_edges_jal_skip_b_m128
@@ -695,7 +695,7 @@ cp_imm_edges_jal_bwd_b_m128:
 cp_imm_edges_jal_skip_b_m128:
   .p2align 8
   jal x10, cp_imm_edges_jal_bwd_b_m128
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m128:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -705,7 +705,7 @@ cp_imm_edges_jal_done_b_m128:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m7, I_jal_cg_cp_imm_edges_jal_b_m7_str)
 
 # cp_imm_edges_jal: backward jump by 256
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 9
 I_jal_cg_cp_imm_edges_jal_b_m8:
   jal x10, cp_imm_edges_jal_skip_b_m256
@@ -715,7 +715,7 @@ cp_imm_edges_jal_bwd_b_m256:
 cp_imm_edges_jal_skip_b_m256:
   .p2align 9
   jal x10, cp_imm_edges_jal_bwd_b_m256
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m256:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -725,7 +725,7 @@ cp_imm_edges_jal_done_b_m256:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m8, I_jal_cg_cp_imm_edges_jal_b_m8_str)
 
 # cp_imm_edges_jal: backward jump by 512
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 10
 I_jal_cg_cp_imm_edges_jal_b_m9:
   jal x10, cp_imm_edges_jal_skip_b_m512
@@ -735,7 +735,7 @@ cp_imm_edges_jal_bwd_b_m512:
 cp_imm_edges_jal_skip_b_m512:
   .p2align 10
   jal x10, cp_imm_edges_jal_bwd_b_m512
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m512:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -745,7 +745,7 @@ cp_imm_edges_jal_done_b_m512:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m9, I_jal_cg_cp_imm_edges_jal_b_m9_str)
 
 # cp_imm_edges_jal: backward jump by 1024
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 11
 I_jal_cg_cp_imm_edges_jal_b_m10:
   jal x10, cp_imm_edges_jal_skip_b_m1024
@@ -755,7 +755,7 @@ cp_imm_edges_jal_bwd_b_m1024:
 cp_imm_edges_jal_skip_b_m1024:
   .p2align 11
   jal x10, cp_imm_edges_jal_bwd_b_m1024
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m1024:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -765,7 +765,7 @@ cp_imm_edges_jal_done_b_m1024:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m10, I_jal_cg_cp_imm_edges_jal_b_m10_str)
 
 # cp_imm_edges_jal: backward jump by 2048
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 12
 I_jal_cg_cp_imm_edges_jal_b_m11:
   jal x10, cp_imm_edges_jal_skip_b_m2048
@@ -775,7 +775,7 @@ cp_imm_edges_jal_bwd_b_m2048:
 cp_imm_edges_jal_skip_b_m2048:
   .p2align 12
   jal x10, cp_imm_edges_jal_bwd_b_m2048
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m2048:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -785,7 +785,7 @@ cp_imm_edges_jal_done_b_m2048:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m11, I_jal_cg_cp_imm_edges_jal_b_m11_str)
 
 # cp_imm_edges_jal: backward jump by 4096
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 13
 I_jal_cg_cp_imm_edges_jal_b_m12:
   jal x10, cp_imm_edges_jal_skip_b_m4096
@@ -795,7 +795,7 @@ cp_imm_edges_jal_bwd_b_m4096:
 cp_imm_edges_jal_skip_b_m4096:
   .p2align 13
   jal x10, cp_imm_edges_jal_bwd_b_m4096
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m4096:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -805,7 +805,7 @@ cp_imm_edges_jal_done_b_m4096:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m12, I_jal_cg_cp_imm_edges_jal_b_m12_str)
 
 # cp_imm_edges_jal: backward jump by 8192
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 14
 I_jal_cg_cp_imm_edges_jal_b_m13:
   jal x10, cp_imm_edges_jal_skip_b_m8192
@@ -815,7 +815,7 @@ cp_imm_edges_jal_bwd_b_m8192:
 cp_imm_edges_jal_skip_b_m8192:
   .p2align 14
   jal x10, cp_imm_edges_jal_bwd_b_m8192
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m8192:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.

--- a/tests/rv32i/Zicsr/Zicsr-csrrc-00.S
+++ b/tests/rv32i/Zicsr/Zicsr-csrrc-00.S
@@ -46,7 +46,7 @@ RVTEST_BEGIN
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -60,7 +60,7 @@ Zicsr_csrrc_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrc x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -75,7 +75,7 @@ Zicsr_csrrc_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -95,7 +95,7 @@ Zicsr_csrrc_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -127,7 +127,7 @@ Zicsr_csrrc_cg_cp_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -148,7 +148,7 @@ Zicsr_csrrc_cg_cp_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -180,7 +180,7 @@ Zicsr_csrrc_cg_cp_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -201,7 +201,7 @@ Zicsr_csrrc_cg_cp_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -233,7 +233,7 @@ Zicsr_csrrc_cg_cp_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -255,7 +255,7 @@ Zicsr_csrrc_cg_cp_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -287,7 +287,7 @@ Zicsr_csrrc_cg_cp_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -307,7 +307,7 @@ Zicsr_csrrc_cg_cp_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -339,7 +339,7 @@ Zicsr_csrrc_cg_cp_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -359,7 +359,7 @@ Zicsr_csrrc_cg_cp_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -391,7 +391,7 @@ Zicsr_csrrc_cg_cp_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -413,7 +413,7 @@ Zicsr_csrrc_cg_cp_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -445,7 +445,7 @@ Zicsr_csrrc_cg_cp_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -465,7 +465,7 @@ Zicsr_csrrc_cg_cp_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -497,7 +497,7 @@ Zicsr_csrrc_cg_cp_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -517,7 +517,7 @@ Zicsr_csrrc_cg_cp_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -549,7 +549,7 @@ Zicsr_csrrc_cg_cp_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -569,7 +569,7 @@ Zicsr_csrrc_cg_cp_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -601,7 +601,7 @@ Zicsr_csrrc_cg_cp_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -621,7 +621,7 @@ Zicsr_csrrc_cg_cp_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -653,7 +653,7 @@ Zicsr_csrrc_cg_cp_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -675,7 +675,7 @@ Zicsr_csrrc_cg_cp_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -707,7 +707,7 @@ Zicsr_csrrc_cg_cp_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -727,7 +727,7 @@ Zicsr_csrrc_cg_cp_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -759,7 +759,7 @@ Zicsr_csrrc_cg_cp_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -779,7 +779,7 @@ Zicsr_csrrc_cg_cp_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -811,7 +811,7 @@ Zicsr_csrrc_cg_cp_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -831,7 +831,7 @@ Zicsr_csrrc_cg_cp_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -863,7 +863,7 @@ Zicsr_csrrc_cg_cp_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -883,7 +883,7 @@ Zicsr_csrrc_cg_cp_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -915,7 +915,7 @@ Zicsr_csrrc_cg_cp_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -935,7 +935,7 @@ Zicsr_csrrc_cg_cp_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -967,7 +967,7 @@ Zicsr_csrrc_cg_cp_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -987,7 +987,7 @@ Zicsr_csrrc_cg_cp_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1019,7 +1019,7 @@ Zicsr_csrrc_cg_cp_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1039,7 +1039,7 @@ Zicsr_csrrc_cg_cp_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1071,7 +1071,7 @@ Zicsr_csrrc_cg_cp_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1091,7 +1091,7 @@ Zicsr_csrrc_cg_cp_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1123,7 +1123,7 @@ Zicsr_csrrc_cg_cp_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1143,7 +1143,7 @@ Zicsr_csrrc_cg_cp_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1175,7 +1175,7 @@ Zicsr_csrrc_cg_cp_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1196,7 +1196,7 @@ Zicsr_csrrc_cg_cp_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1228,7 +1228,7 @@ Zicsr_csrrc_cg_cp_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1248,7 +1248,7 @@ Zicsr_csrrc_cg_cp_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1280,7 +1280,7 @@ Zicsr_csrrc_cg_cp_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1300,7 +1300,7 @@ Zicsr_csrrc_cg_cp_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1332,7 +1332,7 @@ Zicsr_csrrc_cg_cp_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1352,7 +1352,7 @@ Zicsr_csrrc_cg_cp_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1384,7 +1384,7 @@ Zicsr_csrrc_cg_cp_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1404,7 +1404,7 @@ Zicsr_csrrc_cg_cp_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1436,7 +1436,7 @@ Zicsr_csrrc_cg_cp_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1457,7 +1457,7 @@ Zicsr_csrrc_cg_cp_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1489,7 +1489,7 @@ Zicsr_csrrc_cg_cp_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1509,7 +1509,7 @@ Zicsr_csrrc_cg_cp_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1541,7 +1541,7 @@ Zicsr_csrrc_cg_cp_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1561,7 +1561,7 @@ Zicsr_csrrc_cg_cp_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1593,7 +1593,7 @@ Zicsr_csrrc_cg_cp_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1614,7 +1614,7 @@ Zicsr_csrrc_cg_cp_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1646,7 +1646,7 @@ Zicsr_csrrc_cg_cp_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1666,7 +1666,7 @@ Zicsr_csrrc_cg_cp_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1698,7 +1698,7 @@ Zicsr_csrrc_cg_cp_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1722,7 +1722,7 @@ Zicsr_csrrc_cg_cp_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1736,7 +1736,7 @@ Zicsr_csrrc_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrc x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1751,7 +1751,7 @@ Zicsr_csrrc_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1771,7 +1771,7 @@ Zicsr_csrrc_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1803,7 +1803,7 @@ Zicsr_csrrc_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1823,7 +1823,7 @@ Zicsr_csrrc_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1855,7 +1855,7 @@ Zicsr_csrrc_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1875,7 +1875,7 @@ Zicsr_csrrc_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1907,7 +1907,7 @@ Zicsr_csrrc_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1927,7 +1927,7 @@ Zicsr_csrrc_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1959,7 +1959,7 @@ Zicsr_csrrc_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1979,7 +1979,7 @@ Zicsr_csrrc_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2011,7 +2011,7 @@ Zicsr_csrrc_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2031,7 +2031,7 @@ Zicsr_csrrc_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2063,7 +2063,7 @@ Zicsr_csrrc_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2085,7 +2085,7 @@ Zicsr_csrrc_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2117,7 +2117,7 @@ Zicsr_csrrc_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2137,7 +2137,7 @@ Zicsr_csrrc_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2169,7 +2169,7 @@ Zicsr_csrrc_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2189,7 +2189,7 @@ Zicsr_csrrc_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2221,7 +2221,7 @@ Zicsr_csrrc_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2241,7 +2241,7 @@ Zicsr_csrrc_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2273,7 +2273,7 @@ Zicsr_csrrc_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2293,7 +2293,7 @@ Zicsr_csrrc_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2325,7 +2325,7 @@ Zicsr_csrrc_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2347,7 +2347,7 @@ Zicsr_csrrc_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2379,7 +2379,7 @@ Zicsr_csrrc_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2399,7 +2399,7 @@ Zicsr_csrrc_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2431,7 +2431,7 @@ Zicsr_csrrc_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2452,7 +2452,7 @@ Zicsr_csrrc_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2484,7 +2484,7 @@ Zicsr_csrrc_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2504,7 +2504,7 @@ Zicsr_csrrc_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2536,7 +2536,7 @@ Zicsr_csrrc_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2556,7 +2556,7 @@ Zicsr_csrrc_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2588,7 +2588,7 @@ Zicsr_csrrc_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2608,7 +2608,7 @@ Zicsr_csrrc_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2640,7 +2640,7 @@ Zicsr_csrrc_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2660,7 +2660,7 @@ Zicsr_csrrc_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2692,7 +2692,7 @@ Zicsr_csrrc_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2712,7 +2712,7 @@ Zicsr_csrrc_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2744,7 +2744,7 @@ Zicsr_csrrc_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2764,7 +2764,7 @@ Zicsr_csrrc_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2796,7 +2796,7 @@ Zicsr_csrrc_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2816,7 +2816,7 @@ Zicsr_csrrc_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2848,7 +2848,7 @@ Zicsr_csrrc_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2868,7 +2868,7 @@ Zicsr_csrrc_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2900,7 +2900,7 @@ Zicsr_csrrc_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2920,7 +2920,7 @@ Zicsr_csrrc_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2952,7 +2952,7 @@ Zicsr_csrrc_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2973,7 +2973,7 @@ Zicsr_csrrc_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3005,7 +3005,7 @@ Zicsr_csrrc_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3025,7 +3025,7 @@ Zicsr_csrrc_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3057,7 +3057,7 @@ Zicsr_csrrc_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3077,7 +3077,7 @@ Zicsr_csrrc_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3109,7 +3109,7 @@ Zicsr_csrrc_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3129,7 +3129,7 @@ Zicsr_csrrc_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3161,7 +3161,7 @@ Zicsr_csrrc_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3181,7 +3181,7 @@ Zicsr_csrrc_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3213,7 +3213,7 @@ Zicsr_csrrc_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3234,7 +3234,7 @@ Zicsr_csrrc_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3266,7 +3266,7 @@ Zicsr_csrrc_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3286,7 +3286,7 @@ Zicsr_csrrc_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3318,7 +3318,7 @@ Zicsr_csrrc_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3338,7 +3338,7 @@ Zicsr_csrrc_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3370,7 +3370,7 @@ Zicsr_csrrc_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3394,7 +3394,7 @@ Zicsr_csrrc_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3426,7 +3426,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x0:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3446,7 +3446,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3478,7 +3478,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x1:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3498,7 +3498,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3530,7 +3530,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x2:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3550,7 +3550,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3582,7 +3582,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x80000000:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3602,7 +3602,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x80000000:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3634,7 +3634,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x80000001:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3654,7 +3654,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x80000001:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3686,7 +3686,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x7fffffff:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3706,7 +3706,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x7fffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3738,7 +3738,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x7ffffffe:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3758,7 +3758,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x7ffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3790,7 +3790,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0xffffffff:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3810,7 +3810,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0xffffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3842,7 +3842,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0xfffffffe:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3862,7 +3862,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0xfffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3894,7 +3894,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x5bbc8872:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3914,7 +3914,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x5bbc8872:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3946,7 +3946,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0xaaaaaaaa:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3966,7 +3966,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0xaaaaaaaa:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3998,7 +3998,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x55555555:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4022,7 +4022,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x55555555:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4036,7 +4036,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrc x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4051,7 +4051,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4071,7 +4071,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4103,7 +4103,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4123,7 +4123,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4155,7 +4155,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4176,7 +4176,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4208,7 +4208,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4228,7 +4228,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4260,7 +4260,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4280,7 +4280,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4312,7 +4312,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4332,7 +4332,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4364,7 +4364,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4386,7 +4386,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4418,7 +4418,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4438,7 +4438,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4470,7 +4470,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4491,7 +4491,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4523,7 +4523,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4543,7 +4543,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4575,7 +4575,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4595,7 +4595,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4627,7 +4627,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4649,7 +4649,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4681,7 +4681,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4701,7 +4701,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4733,7 +4733,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4753,7 +4753,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4785,7 +4785,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4805,7 +4805,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4837,7 +4837,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4857,7 +4857,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4889,7 +4889,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4910,7 +4910,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4942,7 +4942,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4962,7 +4962,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4994,7 +4994,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5014,7 +5014,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5046,7 +5046,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5066,7 +5066,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5098,7 +5098,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5118,7 +5118,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5150,7 +5150,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5170,7 +5170,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5202,7 +5202,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5223,7 +5223,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5255,7 +5255,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5275,7 +5275,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5307,7 +5307,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5328,7 +5328,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5360,7 +5360,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5380,7 +5380,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5412,7 +5412,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5432,7 +5432,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5464,7 +5464,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5484,7 +5484,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5516,7 +5516,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5536,7 +5536,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5568,7 +5568,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5589,7 +5589,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5621,7 +5621,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5641,7 +5641,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5673,7 +5673,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif

--- a/tests/rv32i/Zicsr/Zicsr-csrrci-00.S
+++ b/tests/rv32i/Zicsr/Zicsr-csrrci-00.S
@@ -45,7 +45,7 @@ RVTEST_BEGIN
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -59,7 +59,7 @@ Zicsr_csrrci_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrci x0, mepc, 16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -74,7 +74,7 @@ Zicsr_csrrci_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -93,7 +93,7 @@ Zicsr_csrrci_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -125,7 +125,7 @@ Zicsr_csrrci_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -145,7 +145,7 @@ Zicsr_csrrci_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -177,7 +177,7 @@ Zicsr_csrrci_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -197,7 +197,7 @@ Zicsr_csrrci_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -229,7 +229,7 @@ Zicsr_csrrci_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -250,7 +250,7 @@ Zicsr_csrrci_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -282,7 +282,7 @@ Zicsr_csrrci_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -301,7 +301,7 @@ Zicsr_csrrci_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -333,7 +333,7 @@ Zicsr_csrrci_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -352,7 +352,7 @@ Zicsr_csrrci_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -384,7 +384,7 @@ Zicsr_csrrci_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -403,7 +403,7 @@ Zicsr_csrrci_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -435,7 +435,7 @@ Zicsr_csrrci_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -454,7 +454,7 @@ Zicsr_csrrci_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -486,7 +486,7 @@ Zicsr_csrrci_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -505,7 +505,7 @@ Zicsr_csrrci_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -537,7 +537,7 @@ Zicsr_csrrci_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -556,7 +556,7 @@ Zicsr_csrrci_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -588,7 +588,7 @@ Zicsr_csrrci_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -607,7 +607,7 @@ Zicsr_csrrci_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -639,7 +639,7 @@ Zicsr_csrrci_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -660,7 +660,7 @@ Zicsr_csrrci_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -674,7 +674,7 @@ Zicsr_csrrci_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrci x12, mepc, 13
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -689,7 +689,7 @@ Zicsr_csrrci_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -708,7 +708,7 @@ Zicsr_csrrci_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -740,7 +740,7 @@ Zicsr_csrrci_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -759,7 +759,7 @@ Zicsr_csrrci_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -791,7 +791,7 @@ Zicsr_csrrci_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -810,7 +810,7 @@ Zicsr_csrrci_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -842,7 +842,7 @@ Zicsr_csrrci_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -861,7 +861,7 @@ Zicsr_csrrci_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -893,7 +893,7 @@ Zicsr_csrrci_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -912,7 +912,7 @@ Zicsr_csrrci_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -944,7 +944,7 @@ Zicsr_csrrci_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -963,7 +963,7 @@ Zicsr_csrrci_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -995,7 +995,7 @@ Zicsr_csrrci_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1014,7 +1014,7 @@ Zicsr_csrrci_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1046,7 +1046,7 @@ Zicsr_csrrci_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1065,7 +1065,7 @@ Zicsr_csrrci_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1097,7 +1097,7 @@ Zicsr_csrrci_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1116,7 +1116,7 @@ Zicsr_csrrci_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1148,7 +1148,7 @@ Zicsr_csrrci_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1168,7 +1168,7 @@ Zicsr_csrrci_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1200,7 +1200,7 @@ Zicsr_csrrci_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1219,7 +1219,7 @@ Zicsr_csrrci_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1251,7 +1251,7 @@ Zicsr_csrrci_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1271,7 +1271,7 @@ Zicsr_csrrci_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1303,7 +1303,7 @@ Zicsr_csrrci_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1322,7 +1322,7 @@ Zicsr_csrrci_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1354,7 +1354,7 @@ Zicsr_csrrci_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1373,7 +1373,7 @@ Zicsr_csrrci_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1405,7 +1405,7 @@ Zicsr_csrrci_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1424,7 +1424,7 @@ Zicsr_csrrci_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1456,7 +1456,7 @@ Zicsr_csrrci_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1475,7 +1475,7 @@ Zicsr_csrrci_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1507,7 +1507,7 @@ Zicsr_csrrci_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1526,7 +1526,7 @@ Zicsr_csrrci_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1558,7 +1558,7 @@ Zicsr_csrrci_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1577,7 +1577,7 @@ Zicsr_csrrci_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1609,7 +1609,7 @@ Zicsr_csrrci_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1628,7 +1628,7 @@ Zicsr_csrrci_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1660,7 +1660,7 @@ Zicsr_csrrci_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1683,7 +1683,7 @@ Zicsr_csrrci_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1715,7 +1715,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm0:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1734,7 +1734,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1766,7 +1766,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm1:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1785,7 +1785,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1817,7 +1817,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm2:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1836,7 +1836,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1868,7 +1868,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm3:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1887,7 +1887,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1919,7 +1919,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm4:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1938,7 +1938,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1952,7 +1952,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm5:
 #elif !defined(U_SUPPORTED)
   csrrci x30, mepc, 5
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1967,7 +1967,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm5:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1986,7 +1986,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2018,7 +2018,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm6:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2037,7 +2037,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2069,7 +2069,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm7:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2088,7 +2088,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2120,7 +2120,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm8:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2139,7 +2139,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2171,7 +2171,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm9:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2190,7 +2190,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2222,7 +2222,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm10:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2241,7 +2241,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2273,7 +2273,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm11:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2292,7 +2292,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2324,7 +2324,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm12:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2343,7 +2343,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2375,7 +2375,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm13:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2394,7 +2394,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2426,7 +2426,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm14:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2445,7 +2445,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2477,7 +2477,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm15:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2496,7 +2496,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2510,7 +2510,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm16:
 #elif !defined(U_SUPPORTED)
   csrrci x27, mepc, 16
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2525,7 +2525,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm16:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2544,7 +2544,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2576,7 +2576,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm17:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2595,7 +2595,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2627,7 +2627,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm18:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2646,7 +2646,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2678,7 +2678,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm19:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2697,7 +2697,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2729,7 +2729,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm20:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2748,7 +2748,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2780,7 +2780,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm21:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2799,7 +2799,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2831,7 +2831,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm22:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2850,7 +2850,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2864,7 +2864,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm23:
 #elif !defined(U_SUPPORTED)
   csrrci x0, mepc, 23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2879,7 +2879,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm23:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2898,7 +2898,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2930,7 +2930,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm24:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2949,7 +2949,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2981,7 +2981,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm25:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3000,7 +3000,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3032,7 +3032,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm26:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3051,7 +3051,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3083,7 +3083,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm27:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3102,7 +3102,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3134,7 +3134,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm28:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3153,7 +3153,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3185,7 +3185,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm29:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3204,7 +3204,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3236,7 +3236,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm30:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3255,7 +3255,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3287,7 +3287,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm31:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif

--- a/tests/rv32i/Zicsr/Zicsr-csrrs-00.S
+++ b/tests/rv32i/Zicsr/Zicsr-csrrs-00.S
@@ -46,7 +46,7 @@ RVTEST_BEGIN
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -60,7 +60,7 @@ Zicsr_csrrs_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -75,7 +75,7 @@ Zicsr_csrrs_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -95,7 +95,7 @@ Zicsr_csrrs_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -127,7 +127,7 @@ Zicsr_csrrs_cg_cp_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -148,7 +148,7 @@ Zicsr_csrrs_cg_cp_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -180,7 +180,7 @@ Zicsr_csrrs_cg_cp_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -201,7 +201,7 @@ Zicsr_csrrs_cg_cp_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -233,7 +233,7 @@ Zicsr_csrrs_cg_cp_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -255,7 +255,7 @@ Zicsr_csrrs_cg_cp_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -287,7 +287,7 @@ Zicsr_csrrs_cg_cp_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -307,7 +307,7 @@ Zicsr_csrrs_cg_cp_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -339,7 +339,7 @@ Zicsr_csrrs_cg_cp_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -359,7 +359,7 @@ Zicsr_csrrs_cg_cp_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -391,7 +391,7 @@ Zicsr_csrrs_cg_cp_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -413,7 +413,7 @@ Zicsr_csrrs_cg_cp_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -445,7 +445,7 @@ Zicsr_csrrs_cg_cp_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -465,7 +465,7 @@ Zicsr_csrrs_cg_cp_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -497,7 +497,7 @@ Zicsr_csrrs_cg_cp_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -517,7 +517,7 @@ Zicsr_csrrs_cg_cp_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -549,7 +549,7 @@ Zicsr_csrrs_cg_cp_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -569,7 +569,7 @@ Zicsr_csrrs_cg_cp_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -601,7 +601,7 @@ Zicsr_csrrs_cg_cp_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -621,7 +621,7 @@ Zicsr_csrrs_cg_cp_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -653,7 +653,7 @@ Zicsr_csrrs_cg_cp_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -673,7 +673,7 @@ Zicsr_csrrs_cg_cp_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -705,7 +705,7 @@ Zicsr_csrrs_cg_cp_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -725,7 +725,7 @@ Zicsr_csrrs_cg_cp_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -757,7 +757,7 @@ Zicsr_csrrs_cg_cp_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -777,7 +777,7 @@ Zicsr_csrrs_cg_cp_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -809,7 +809,7 @@ Zicsr_csrrs_cg_cp_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -829,7 +829,7 @@ Zicsr_csrrs_cg_cp_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -861,7 +861,7 @@ Zicsr_csrrs_cg_cp_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -881,7 +881,7 @@ Zicsr_csrrs_cg_cp_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -913,7 +913,7 @@ Zicsr_csrrs_cg_cp_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -933,7 +933,7 @@ Zicsr_csrrs_cg_cp_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -965,7 +965,7 @@ Zicsr_csrrs_cg_cp_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -986,7 +986,7 @@ Zicsr_csrrs_cg_cp_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1018,7 +1018,7 @@ Zicsr_csrrs_cg_cp_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1039,7 +1039,7 @@ Zicsr_csrrs_cg_cp_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1053,7 +1053,7 @@ Zicsr_csrrs_cg_cp_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1068,7 +1068,7 @@ Zicsr_csrrs_cg_cp_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1088,7 +1088,7 @@ Zicsr_csrrs_cg_cp_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1120,7 +1120,7 @@ Zicsr_csrrs_cg_cp_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1140,7 +1140,7 @@ Zicsr_csrrs_cg_cp_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1172,7 +1172,7 @@ Zicsr_csrrs_cg_cp_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1192,7 +1192,7 @@ Zicsr_csrrs_cg_cp_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1224,7 +1224,7 @@ Zicsr_csrrs_cg_cp_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1244,7 +1244,7 @@ Zicsr_csrrs_cg_cp_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1276,7 +1276,7 @@ Zicsr_csrrs_cg_cp_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1296,7 +1296,7 @@ Zicsr_csrrs_cg_cp_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1328,7 +1328,7 @@ Zicsr_csrrs_cg_cp_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1348,7 +1348,7 @@ Zicsr_csrrs_cg_cp_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1380,7 +1380,7 @@ Zicsr_csrrs_cg_cp_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1400,7 +1400,7 @@ Zicsr_csrrs_cg_cp_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1432,7 +1432,7 @@ Zicsr_csrrs_cg_cp_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1453,7 +1453,7 @@ Zicsr_csrrs_cg_cp_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1485,7 +1485,7 @@ Zicsr_csrrs_cg_cp_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1505,7 +1505,7 @@ Zicsr_csrrs_cg_cp_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1537,7 +1537,7 @@ Zicsr_csrrs_cg_cp_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1557,7 +1557,7 @@ Zicsr_csrrs_cg_cp_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1589,7 +1589,7 @@ Zicsr_csrrs_cg_cp_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1609,7 +1609,7 @@ Zicsr_csrrs_cg_cp_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1641,7 +1641,7 @@ Zicsr_csrrs_cg_cp_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1661,7 +1661,7 @@ Zicsr_csrrs_cg_cp_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1693,7 +1693,7 @@ Zicsr_csrrs_cg_cp_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1717,7 +1717,7 @@ Zicsr_csrrs_cg_cp_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1731,7 +1731,7 @@ Zicsr_csrrs_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1746,7 +1746,7 @@ Zicsr_csrrs_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1766,7 +1766,7 @@ Zicsr_csrrs_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1798,7 +1798,7 @@ Zicsr_csrrs_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1818,7 +1818,7 @@ Zicsr_csrrs_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1850,7 +1850,7 @@ Zicsr_csrrs_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1870,7 +1870,7 @@ Zicsr_csrrs_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1902,7 +1902,7 @@ Zicsr_csrrs_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1924,7 +1924,7 @@ Zicsr_csrrs_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1956,7 +1956,7 @@ Zicsr_csrrs_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1976,7 +1976,7 @@ Zicsr_csrrs_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2008,7 +2008,7 @@ Zicsr_csrrs_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2028,7 +2028,7 @@ Zicsr_csrrs_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2060,7 +2060,7 @@ Zicsr_csrrs_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2080,7 +2080,7 @@ Zicsr_csrrs_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2112,7 +2112,7 @@ Zicsr_csrrs_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2132,7 +2132,7 @@ Zicsr_csrrs_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2164,7 +2164,7 @@ Zicsr_csrrs_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2185,7 +2185,7 @@ Zicsr_csrrs_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2217,7 +2217,7 @@ Zicsr_csrrs_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2237,7 +2237,7 @@ Zicsr_csrrs_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2251,7 +2251,7 @@ Zicsr_csrrs_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2266,7 +2266,7 @@ Zicsr_csrrs_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2286,7 +2286,7 @@ Zicsr_csrrs_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2300,7 +2300,7 @@ Zicsr_csrrs_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2315,7 +2315,7 @@ Zicsr_csrrs_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2337,7 +2337,7 @@ Zicsr_csrrs_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2351,7 +2351,7 @@ Zicsr_csrrs_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2366,7 +2366,7 @@ Zicsr_csrrs_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2386,7 +2386,7 @@ Zicsr_csrrs_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2418,7 +2418,7 @@ Zicsr_csrrs_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2438,7 +2438,7 @@ Zicsr_csrrs_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2470,7 +2470,7 @@ Zicsr_csrrs_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2490,7 +2490,7 @@ Zicsr_csrrs_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2522,7 +2522,7 @@ Zicsr_csrrs_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2542,7 +2542,7 @@ Zicsr_csrrs_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2574,7 +2574,7 @@ Zicsr_csrrs_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2594,7 +2594,7 @@ Zicsr_csrrs_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2626,7 +2626,7 @@ Zicsr_csrrs_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2646,7 +2646,7 @@ Zicsr_csrrs_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2678,7 +2678,7 @@ Zicsr_csrrs_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2699,7 +2699,7 @@ Zicsr_csrrs_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2731,7 +2731,7 @@ Zicsr_csrrs_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2752,7 +2752,7 @@ Zicsr_csrrs_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2784,7 +2784,7 @@ Zicsr_csrrs_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2804,7 +2804,7 @@ Zicsr_csrrs_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2836,7 +2836,7 @@ Zicsr_csrrs_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2856,7 +2856,7 @@ Zicsr_csrrs_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2888,7 +2888,7 @@ Zicsr_csrrs_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2908,7 +2908,7 @@ Zicsr_csrrs_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2940,7 +2940,7 @@ Zicsr_csrrs_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2960,7 +2960,7 @@ Zicsr_csrrs_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2992,7 +2992,7 @@ Zicsr_csrrs_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3012,7 +3012,7 @@ Zicsr_csrrs_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3044,7 +3044,7 @@ Zicsr_csrrs_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3065,7 +3065,7 @@ Zicsr_csrrs_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3079,7 +3079,7 @@ Zicsr_csrrs_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3094,7 +3094,7 @@ Zicsr_csrrs_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3114,7 +3114,7 @@ Zicsr_csrrs_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3146,7 +3146,7 @@ Zicsr_csrrs_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3166,7 +3166,7 @@ Zicsr_csrrs_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3180,7 +3180,7 @@ Zicsr_csrrs_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3195,7 +3195,7 @@ Zicsr_csrrs_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3215,7 +3215,7 @@ Zicsr_csrrs_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3229,7 +3229,7 @@ Zicsr_csrrs_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3244,7 +3244,7 @@ Zicsr_csrrs_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3264,7 +3264,7 @@ Zicsr_csrrs_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3296,7 +3296,7 @@ Zicsr_csrrs_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3316,7 +3316,7 @@ Zicsr_csrrs_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3348,7 +3348,7 @@ Zicsr_csrrs_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3372,7 +3372,7 @@ Zicsr_csrrs_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3404,7 +3404,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x0:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3424,7 +3424,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3456,7 +3456,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x1:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3476,7 +3476,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3508,7 +3508,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x2:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3528,7 +3528,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3560,7 +3560,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x80000000:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3580,7 +3580,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x80000000:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3612,7 +3612,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x80000001:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3632,7 +3632,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x80000001:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3664,7 +3664,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x7fffffff:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3684,7 +3684,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x7fffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3716,7 +3716,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x7ffffffe:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3736,7 +3736,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x7ffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3768,7 +3768,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0xffffffff:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3788,7 +3788,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0xffffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3820,7 +3820,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0xfffffffe:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3840,7 +3840,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0xfffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3872,7 +3872,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x5bbc8872:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3892,7 +3892,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x5bbc8872:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3924,7 +3924,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0xaaaaaaaa:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3944,7 +3944,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0xaaaaaaaa:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3976,7 +3976,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x55555555:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4000,7 +4000,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x55555555:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4014,7 +4014,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4029,7 +4029,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4049,7 +4049,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4081,7 +4081,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4101,7 +4101,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4133,7 +4133,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4153,7 +4153,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4185,7 +4185,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4207,7 +4207,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4239,7 +4239,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4259,7 +4259,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4291,7 +4291,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4311,7 +4311,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4343,7 +4343,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4363,7 +4363,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4395,7 +4395,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4415,7 +4415,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4447,7 +4447,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4467,7 +4467,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4499,7 +4499,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4519,7 +4519,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4551,7 +4551,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4571,7 +4571,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4603,7 +4603,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4625,7 +4625,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4657,7 +4657,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4677,7 +4677,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4709,7 +4709,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4729,7 +4729,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4761,7 +4761,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4782,7 +4782,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4814,7 +4814,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4834,7 +4834,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4866,7 +4866,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4886,7 +4886,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4918,7 +4918,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4938,7 +4938,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4970,7 +4970,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4991,7 +4991,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5023,7 +5023,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5043,7 +5043,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5075,7 +5075,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5095,7 +5095,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5127,7 +5127,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5147,7 +5147,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5179,7 +5179,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5199,7 +5199,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5231,7 +5231,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5251,7 +5251,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5283,7 +5283,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5303,7 +5303,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5335,7 +5335,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5355,7 +5355,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5387,7 +5387,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5407,7 +5407,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5439,7 +5439,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5459,7 +5459,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5491,7 +5491,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5511,7 +5511,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5543,7 +5543,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5563,7 +5563,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5595,7 +5595,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5615,7 +5615,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5647,7 +5647,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif

--- a/tests/rv32i/Zicsr/Zicsr-csrrsi-00.S
+++ b/tests/rv32i/Zicsr/Zicsr-csrrsi-00.S
@@ -45,7 +45,7 @@ RVTEST_BEGIN
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -59,7 +59,7 @@ Zicsr_csrrsi_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrsi x0, mepc, 30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -74,7 +74,7 @@ Zicsr_csrrsi_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -93,7 +93,7 @@ Zicsr_csrrsi_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -125,7 +125,7 @@ Zicsr_csrrsi_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -145,7 +145,7 @@ Zicsr_csrrsi_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -177,7 +177,7 @@ Zicsr_csrrsi_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -197,7 +197,7 @@ Zicsr_csrrsi_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -229,7 +229,7 @@ Zicsr_csrrsi_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -250,7 +250,7 @@ Zicsr_csrrsi_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -264,7 +264,7 @@ Zicsr_csrrsi_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrsi x4, mepc, 27
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -279,7 +279,7 @@ Zicsr_csrrsi_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -298,7 +298,7 @@ Zicsr_csrrsi_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -330,7 +330,7 @@ Zicsr_csrrsi_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -349,7 +349,7 @@ Zicsr_csrrsi_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -363,7 +363,7 @@ Zicsr_csrrsi_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrsi x6, mepc, 13
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -378,7 +378,7 @@ Zicsr_csrrsi_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -397,7 +397,7 @@ Zicsr_csrrsi_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -429,7 +429,7 @@ Zicsr_csrrsi_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -448,7 +448,7 @@ Zicsr_csrrsi_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -480,7 +480,7 @@ Zicsr_csrrsi_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -499,7 +499,7 @@ Zicsr_csrrsi_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -531,7 +531,7 @@ Zicsr_csrrsi_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -550,7 +550,7 @@ Zicsr_csrrsi_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -582,7 +582,7 @@ Zicsr_csrrsi_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -601,7 +601,7 @@ Zicsr_csrrsi_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -633,7 +633,7 @@ Zicsr_csrrsi_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -654,7 +654,7 @@ Zicsr_csrrsi_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -686,7 +686,7 @@ Zicsr_csrrsi_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -705,7 +705,7 @@ Zicsr_csrrsi_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -737,7 +737,7 @@ Zicsr_csrrsi_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -756,7 +756,7 @@ Zicsr_csrrsi_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -788,7 +788,7 @@ Zicsr_csrrsi_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -807,7 +807,7 @@ Zicsr_csrrsi_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -839,7 +839,7 @@ Zicsr_csrrsi_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -858,7 +858,7 @@ Zicsr_csrrsi_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -890,7 +890,7 @@ Zicsr_csrrsi_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -909,7 +909,7 @@ Zicsr_csrrsi_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -941,7 +941,7 @@ Zicsr_csrrsi_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -960,7 +960,7 @@ Zicsr_csrrsi_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -992,7 +992,7 @@ Zicsr_csrrsi_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1011,7 +1011,7 @@ Zicsr_csrrsi_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1043,7 +1043,7 @@ Zicsr_csrrsi_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1062,7 +1062,7 @@ Zicsr_csrrsi_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1094,7 +1094,7 @@ Zicsr_csrrsi_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1113,7 +1113,7 @@ Zicsr_csrrsi_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1145,7 +1145,7 @@ Zicsr_csrrsi_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1164,7 +1164,7 @@ Zicsr_csrrsi_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1196,7 +1196,7 @@ Zicsr_csrrsi_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1215,7 +1215,7 @@ Zicsr_csrrsi_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1247,7 +1247,7 @@ Zicsr_csrrsi_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1266,7 +1266,7 @@ Zicsr_csrrsi_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1298,7 +1298,7 @@ Zicsr_csrrsi_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1317,7 +1317,7 @@ Zicsr_csrrsi_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1349,7 +1349,7 @@ Zicsr_csrrsi_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1368,7 +1368,7 @@ Zicsr_csrrsi_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1400,7 +1400,7 @@ Zicsr_csrrsi_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1420,7 +1420,7 @@ Zicsr_csrrsi_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1452,7 +1452,7 @@ Zicsr_csrrsi_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1471,7 +1471,7 @@ Zicsr_csrrsi_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1503,7 +1503,7 @@ Zicsr_csrrsi_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1522,7 +1522,7 @@ Zicsr_csrrsi_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1554,7 +1554,7 @@ Zicsr_csrrsi_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1573,7 +1573,7 @@ Zicsr_csrrsi_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1587,7 +1587,7 @@ Zicsr_csrrsi_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrsi x30, mepc, 15
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1602,7 +1602,7 @@ Zicsr_csrrsi_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1621,7 +1621,7 @@ Zicsr_csrrsi_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1653,7 +1653,7 @@ Zicsr_csrrsi_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1676,7 +1676,7 @@ Zicsr_csrrsi_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1708,7 +1708,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm0:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1727,7 +1727,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1759,7 +1759,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm1:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1778,7 +1778,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1810,7 +1810,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm2:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1829,7 +1829,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1861,7 +1861,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm3:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1880,7 +1880,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1912,7 +1912,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm4:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1931,7 +1931,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1963,7 +1963,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm5:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1982,7 +1982,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1996,7 +1996,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm6:
 #elif !defined(U_SUPPORTED)
   csrrsi x30, mepc, 6
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2011,7 +2011,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm6:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2030,7 +2030,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2062,7 +2062,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm7:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2081,7 +2081,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2113,7 +2113,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm8:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2132,7 +2132,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2164,7 +2164,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm9:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2183,7 +2183,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2197,7 +2197,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm10:
 #elif !defined(U_SUPPORTED)
   csrrsi x0, mepc, 10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2212,7 +2212,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm10:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2231,7 +2231,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2263,7 +2263,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm11:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2282,7 +2282,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2314,7 +2314,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm12:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2333,7 +2333,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2365,7 +2365,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm13:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2384,7 +2384,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2416,7 +2416,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm14:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2435,7 +2435,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2467,7 +2467,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm15:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2486,7 +2486,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2518,7 +2518,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm16:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2537,7 +2537,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2569,7 +2569,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm17:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2588,7 +2588,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2620,7 +2620,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm18:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2639,7 +2639,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2671,7 +2671,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm19:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2690,7 +2690,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2722,7 +2722,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm20:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2741,7 +2741,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2773,7 +2773,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm21:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2792,7 +2792,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2824,7 +2824,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm22:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2843,7 +2843,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2875,7 +2875,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm23:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2894,7 +2894,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2926,7 +2926,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm24:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2945,7 +2945,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2977,7 +2977,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm25:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2996,7 +2996,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3028,7 +3028,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm26:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3047,7 +3047,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3079,7 +3079,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm27:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3098,7 +3098,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3130,7 +3130,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm28:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3149,7 +3149,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3181,7 +3181,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm29:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3200,7 +3200,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3232,7 +3232,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm30:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3251,7 +3251,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3283,7 +3283,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm31:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif

--- a/tests/rv32i/Zicsr/Zicsr-csrrw-00.S
+++ b/tests/rv32i/Zicsr/Zicsr-csrrw-00.S
@@ -46,7 +46,7 @@ RVTEST_BEGIN
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -60,7 +60,7 @@ Zicsr_csrrw_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -75,7 +75,7 @@ Zicsr_csrrw_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -95,7 +95,7 @@ Zicsr_csrrw_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -109,7 +109,7 @@ Zicsr_csrrw_cg_cp_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x14, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -124,7 +124,7 @@ Zicsr_csrrw_cg_cp_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -145,7 +145,7 @@ Zicsr_csrrw_cg_cp_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -159,7 +159,7 @@ Zicsr_csrrw_cg_cp_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x18, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -174,7 +174,7 @@ Zicsr_csrrw_cg_cp_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -195,7 +195,7 @@ Zicsr_csrrw_cg_cp_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -209,7 +209,7 @@ Zicsr_csrrw_cg_cp_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x30, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -224,7 +224,7 @@ Zicsr_csrrw_cg_cp_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -246,7 +246,7 @@ Zicsr_csrrw_cg_cp_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -260,7 +260,7 @@ Zicsr_csrrw_cg_cp_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x27, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -275,7 +275,7 @@ Zicsr_csrrw_cg_cp_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -295,7 +295,7 @@ Zicsr_csrrw_cg_cp_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -309,7 +309,7 @@ Zicsr_csrrw_cg_cp_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x8, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -324,7 +324,7 @@ Zicsr_csrrw_cg_cp_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -345,7 +345,7 @@ Zicsr_csrrw_cg_cp_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -359,7 +359,7 @@ Zicsr_csrrw_cg_cp_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x15, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -374,7 +374,7 @@ Zicsr_csrrw_cg_cp_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -394,7 +394,7 @@ Zicsr_csrrw_cg_cp_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -408,7 +408,7 @@ Zicsr_csrrw_cg_cp_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x11, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -423,7 +423,7 @@ Zicsr_csrrw_cg_cp_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -443,7 +443,7 @@ Zicsr_csrrw_cg_cp_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -457,7 +457,7 @@ Zicsr_csrrw_cg_cp_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x29, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -472,7 +472,7 @@ Zicsr_csrrw_cg_cp_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -492,7 +492,7 @@ Zicsr_csrrw_cg_cp_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -506,7 +506,7 @@ Zicsr_csrrw_cg_cp_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x30, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -521,7 +521,7 @@ Zicsr_csrrw_cg_cp_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -541,7 +541,7 @@ Zicsr_csrrw_cg_cp_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -555,7 +555,7 @@ Zicsr_csrrw_cg_cp_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x18, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -570,7 +570,7 @@ Zicsr_csrrw_cg_cp_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -590,7 +590,7 @@ Zicsr_csrrw_cg_cp_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -604,7 +604,7 @@ Zicsr_csrrw_cg_cp_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x14, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -619,7 +619,7 @@ Zicsr_csrrw_cg_cp_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -641,7 +641,7 @@ Zicsr_csrrw_cg_cp_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -655,7 +655,7 @@ Zicsr_csrrw_cg_cp_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x13, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -670,7 +670,7 @@ Zicsr_csrrw_cg_cp_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -690,7 +690,7 @@ Zicsr_csrrw_cg_cp_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -704,7 +704,7 @@ Zicsr_csrrw_cg_cp_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x19, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -719,7 +719,7 @@ Zicsr_csrrw_cg_cp_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -739,7 +739,7 @@ Zicsr_csrrw_cg_cp_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -753,7 +753,7 @@ Zicsr_csrrw_cg_cp_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x19, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -768,7 +768,7 @@ Zicsr_csrrw_cg_cp_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -788,7 +788,7 @@ Zicsr_csrrw_cg_cp_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -802,7 +802,7 @@ Zicsr_csrrw_cg_cp_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x27, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -817,7 +817,7 @@ Zicsr_csrrw_cg_cp_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -837,7 +837,7 @@ Zicsr_csrrw_cg_cp_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -851,7 +851,7 @@ Zicsr_csrrw_cg_cp_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x9, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -866,7 +866,7 @@ Zicsr_csrrw_cg_cp_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -886,7 +886,7 @@ Zicsr_csrrw_cg_cp_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -900,7 +900,7 @@ Zicsr_csrrw_cg_cp_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x11, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -915,7 +915,7 @@ Zicsr_csrrw_cg_cp_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -935,7 +935,7 @@ Zicsr_csrrw_cg_cp_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -949,7 +949,7 @@ Zicsr_csrrw_cg_cp_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x22, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -964,7 +964,7 @@ Zicsr_csrrw_cg_cp_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -984,7 +984,7 @@ Zicsr_csrrw_cg_cp_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -998,7 +998,7 @@ Zicsr_csrrw_cg_cp_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x17, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1013,7 +1013,7 @@ Zicsr_csrrw_cg_cp_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1033,7 +1033,7 @@ Zicsr_csrrw_cg_cp_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1047,7 +1047,7 @@ Zicsr_csrrw_cg_cp_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x10, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1062,7 +1062,7 @@ Zicsr_csrrw_cg_cp_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1083,7 +1083,7 @@ Zicsr_csrrw_cg_cp_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1097,7 +1097,7 @@ Zicsr_csrrw_cg_cp_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x14, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1112,7 +1112,7 @@ Zicsr_csrrw_cg_cp_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1132,7 +1132,7 @@ Zicsr_csrrw_cg_cp_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1146,7 +1146,7 @@ Zicsr_csrrw_cg_cp_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x13, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1161,7 +1161,7 @@ Zicsr_csrrw_cg_cp_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1181,7 +1181,7 @@ Zicsr_csrrw_cg_cp_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1195,7 +1195,7 @@ Zicsr_csrrw_cg_cp_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x11, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1210,7 +1210,7 @@ Zicsr_csrrw_cg_cp_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1230,7 +1230,7 @@ Zicsr_csrrw_cg_cp_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1244,7 +1244,7 @@ Zicsr_csrrw_cg_cp_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x25, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1259,7 +1259,7 @@ Zicsr_csrrw_cg_cp_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1279,7 +1279,7 @@ Zicsr_csrrw_cg_cp_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1293,7 +1293,7 @@ Zicsr_csrrw_cg_cp_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x1, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1308,7 +1308,7 @@ Zicsr_csrrw_cg_cp_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1329,7 +1329,7 @@ Zicsr_csrrw_cg_cp_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1343,7 +1343,7 @@ Zicsr_csrrw_cg_cp_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x30, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1358,7 +1358,7 @@ Zicsr_csrrw_cg_cp_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1378,7 +1378,7 @@ Zicsr_csrrw_cg_cp_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1392,7 +1392,7 @@ Zicsr_csrrw_cg_cp_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x1, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1407,7 +1407,7 @@ Zicsr_csrrw_cg_cp_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1427,7 +1427,7 @@ Zicsr_csrrw_cg_cp_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1441,7 +1441,7 @@ Zicsr_csrrw_cg_cp_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x19, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1456,7 +1456,7 @@ Zicsr_csrrw_cg_cp_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1477,7 +1477,7 @@ Zicsr_csrrw_cg_cp_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1491,7 +1491,7 @@ Zicsr_csrrw_cg_cp_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x16, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1506,7 +1506,7 @@ Zicsr_csrrw_cg_cp_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1526,7 +1526,7 @@ Zicsr_csrrw_cg_cp_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1540,7 +1540,7 @@ Zicsr_csrrw_cg_cp_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x9, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1555,7 +1555,7 @@ Zicsr_csrrw_cg_cp_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1575,7 +1575,7 @@ Zicsr_csrrw_cg_cp_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1589,7 +1589,7 @@ Zicsr_csrrw_cg_cp_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x20, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1604,7 +1604,7 @@ Zicsr_csrrw_cg_cp_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1628,7 +1628,7 @@ Zicsr_csrrw_cg_cp_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1642,7 +1642,7 @@ Zicsr_csrrw_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1657,7 +1657,7 @@ Zicsr_csrrw_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1677,7 +1677,7 @@ Zicsr_csrrw_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1691,7 +1691,7 @@ Zicsr_csrrw_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x1, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1706,7 +1706,7 @@ Zicsr_csrrw_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1726,7 +1726,7 @@ Zicsr_csrrw_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1740,7 +1740,7 @@ Zicsr_csrrw_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x2, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1755,7 +1755,7 @@ Zicsr_csrrw_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1776,7 +1776,7 @@ Zicsr_csrrw_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1790,7 +1790,7 @@ Zicsr_csrrw_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x3, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1805,7 +1805,7 @@ Zicsr_csrrw_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1827,7 +1827,7 @@ Zicsr_csrrw_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1841,7 +1841,7 @@ Zicsr_csrrw_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x4, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1856,7 +1856,7 @@ Zicsr_csrrw_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1876,7 +1876,7 @@ Zicsr_csrrw_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1890,7 +1890,7 @@ Zicsr_csrrw_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x5, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1905,7 +1905,7 @@ Zicsr_csrrw_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1925,7 +1925,7 @@ Zicsr_csrrw_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1939,7 +1939,7 @@ Zicsr_csrrw_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x6, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1954,7 +1954,7 @@ Zicsr_csrrw_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1976,7 +1976,7 @@ Zicsr_csrrw_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1990,7 +1990,7 @@ Zicsr_csrrw_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x7, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2005,7 +2005,7 @@ Zicsr_csrrw_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2025,7 +2025,7 @@ Zicsr_csrrw_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2039,7 +2039,7 @@ Zicsr_csrrw_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x8, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2054,7 +2054,7 @@ Zicsr_csrrw_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2074,7 +2074,7 @@ Zicsr_csrrw_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2088,7 +2088,7 @@ Zicsr_csrrw_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x9, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2103,7 +2103,7 @@ Zicsr_csrrw_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2123,7 +2123,7 @@ Zicsr_csrrw_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2137,7 +2137,7 @@ Zicsr_csrrw_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x10, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2152,7 +2152,7 @@ Zicsr_csrrw_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2172,7 +2172,7 @@ Zicsr_csrrw_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2186,7 +2186,7 @@ Zicsr_csrrw_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x11, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2201,7 +2201,7 @@ Zicsr_csrrw_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2223,7 +2223,7 @@ Zicsr_csrrw_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2237,7 +2237,7 @@ Zicsr_csrrw_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x12, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2252,7 +2252,7 @@ Zicsr_csrrw_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2272,7 +2272,7 @@ Zicsr_csrrw_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2286,7 +2286,7 @@ Zicsr_csrrw_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x13, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2301,7 +2301,7 @@ Zicsr_csrrw_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2321,7 +2321,7 @@ Zicsr_csrrw_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2335,7 +2335,7 @@ Zicsr_csrrw_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2350,7 +2350,7 @@ Zicsr_csrrw_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2370,7 +2370,7 @@ Zicsr_csrrw_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2384,7 +2384,7 @@ Zicsr_csrrw_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x15, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2399,7 +2399,7 @@ Zicsr_csrrw_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2419,7 +2419,7 @@ Zicsr_csrrw_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2433,7 +2433,7 @@ Zicsr_csrrw_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x16, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2448,7 +2448,7 @@ Zicsr_csrrw_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2468,7 +2468,7 @@ Zicsr_csrrw_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2482,7 +2482,7 @@ Zicsr_csrrw_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x17, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2497,7 +2497,7 @@ Zicsr_csrrw_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2517,7 +2517,7 @@ Zicsr_csrrw_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2531,7 +2531,7 @@ Zicsr_csrrw_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x18, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2546,7 +2546,7 @@ Zicsr_csrrw_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2566,7 +2566,7 @@ Zicsr_csrrw_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2580,7 +2580,7 @@ Zicsr_csrrw_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x19, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2595,7 +2595,7 @@ Zicsr_csrrw_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2615,7 +2615,7 @@ Zicsr_csrrw_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2629,7 +2629,7 @@ Zicsr_csrrw_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x20, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2644,7 +2644,7 @@ Zicsr_csrrw_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2664,7 +2664,7 @@ Zicsr_csrrw_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2678,7 +2678,7 @@ Zicsr_csrrw_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x21, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2693,7 +2693,7 @@ Zicsr_csrrw_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2713,7 +2713,7 @@ Zicsr_csrrw_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2727,7 +2727,7 @@ Zicsr_csrrw_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x22, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2742,7 +2742,7 @@ Zicsr_csrrw_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2762,7 +2762,7 @@ Zicsr_csrrw_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2776,7 +2776,7 @@ Zicsr_csrrw_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x23, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2791,7 +2791,7 @@ Zicsr_csrrw_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2811,7 +2811,7 @@ Zicsr_csrrw_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2825,7 +2825,7 @@ Zicsr_csrrw_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x24, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2840,7 +2840,7 @@ Zicsr_csrrw_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2861,7 +2861,7 @@ Zicsr_csrrw_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2875,7 +2875,7 @@ Zicsr_csrrw_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x25, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2890,7 +2890,7 @@ Zicsr_csrrw_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2910,7 +2910,7 @@ Zicsr_csrrw_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2924,7 +2924,7 @@ Zicsr_csrrw_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x26, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2939,7 +2939,7 @@ Zicsr_csrrw_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2959,7 +2959,7 @@ Zicsr_csrrw_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2973,7 +2973,7 @@ Zicsr_csrrw_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x27, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2988,7 +2988,7 @@ Zicsr_csrrw_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3008,7 +3008,7 @@ Zicsr_csrrw_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3022,7 +3022,7 @@ Zicsr_csrrw_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x28, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3037,7 +3037,7 @@ Zicsr_csrrw_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3057,7 +3057,7 @@ Zicsr_csrrw_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3071,7 +3071,7 @@ Zicsr_csrrw_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x29, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3086,7 +3086,7 @@ Zicsr_csrrw_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3106,7 +3106,7 @@ Zicsr_csrrw_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3120,7 +3120,7 @@ Zicsr_csrrw_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x30, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3135,7 +3135,7 @@ Zicsr_csrrw_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3155,7 +3155,7 @@ Zicsr_csrrw_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3169,7 +3169,7 @@ Zicsr_csrrw_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x31, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3184,7 +3184,7 @@ Zicsr_csrrw_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3208,7 +3208,7 @@ Zicsr_csrrw_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3222,7 +3222,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x0:
 #elif !defined(U_SUPPORTED)
   csrrw x15, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3237,7 +3237,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x0:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3257,7 +3257,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3271,7 +3271,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x1:
 #elif !defined(U_SUPPORTED)
   csrrw x13, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3286,7 +3286,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x1:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3306,7 +3306,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3320,7 +3320,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x2:
 #elif !defined(U_SUPPORTED)
   csrrw x19, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3335,7 +3335,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x2:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3355,7 +3355,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3369,7 +3369,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x80000000:
 #elif !defined(U_SUPPORTED)
   csrrw x14, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3384,7 +3384,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x80000000:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3404,7 +3404,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x80000000:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3418,7 +3418,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x80000001:
 #elif !defined(U_SUPPORTED)
   csrrw x28, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3433,7 +3433,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x80000001:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3453,7 +3453,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x80000001:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3467,7 +3467,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x7fffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x25, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3482,7 +3482,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x7fffffff:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3502,7 +3502,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x7fffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3516,7 +3516,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x7ffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x30, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3531,7 +3531,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x7ffffffe:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3551,7 +3551,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x7ffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3565,7 +3565,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xffffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x14, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3580,7 +3580,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xffffffff:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3600,7 +3600,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xffffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3614,7 +3614,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xfffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x11, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3629,7 +3629,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xfffffffe:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3649,7 +3649,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xfffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3663,7 +3663,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x5bbc8872:
 #elif !defined(U_SUPPORTED)
   csrrw x9, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3678,7 +3678,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x5bbc8872:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3698,7 +3698,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x5bbc8872:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3712,7 +3712,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xaaaaaaaa:
 #elif !defined(U_SUPPORTED)
   csrrw x26, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3727,7 +3727,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xaaaaaaaa:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3747,7 +3747,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xaaaaaaaa:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3761,7 +3761,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x55555555:
 #elif !defined(U_SUPPORTED)
   csrrw x29, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3776,7 +3776,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x55555555:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3800,7 +3800,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x55555555:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3814,7 +3814,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3829,7 +3829,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3849,7 +3849,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3863,7 +3863,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x1, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3878,7 +3878,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3899,7 +3899,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3913,7 +3913,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x2, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3928,7 +3928,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3948,7 +3948,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3962,7 +3962,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x3, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3977,7 +3977,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3997,7 +3997,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4011,7 +4011,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x4, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4026,7 +4026,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4046,7 +4046,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4060,7 +4060,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x5, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4075,7 +4075,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4096,7 +4096,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4110,7 +4110,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x6, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4125,7 +4125,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4147,7 +4147,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4161,7 +4161,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x7, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4176,7 +4176,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4196,7 +4196,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4210,7 +4210,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x8, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4225,7 +4225,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4245,7 +4245,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4259,7 +4259,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x9, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4274,7 +4274,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4294,7 +4294,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4308,7 +4308,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x10, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4323,7 +4323,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4344,7 +4344,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4358,7 +4358,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x11, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4373,7 +4373,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4393,7 +4393,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4407,7 +4407,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x12, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4422,7 +4422,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4442,7 +4442,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4456,7 +4456,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x13, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4471,7 +4471,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4491,7 +4491,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4505,7 +4505,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x14, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4520,7 +4520,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4540,7 +4540,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4554,7 +4554,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x15, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4569,7 +4569,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4589,7 +4589,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4603,7 +4603,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x16, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4618,7 +4618,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4638,7 +4638,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4652,7 +4652,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x17, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4667,7 +4667,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4687,7 +4687,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4701,7 +4701,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x18, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4716,7 +4716,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4736,7 +4736,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4750,7 +4750,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x19, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4765,7 +4765,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4785,7 +4785,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4799,7 +4799,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x20, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4814,7 +4814,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4834,7 +4834,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4848,7 +4848,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x21, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4863,7 +4863,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4883,7 +4883,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4897,7 +4897,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x22, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4912,7 +4912,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4932,7 +4932,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4946,7 +4946,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x23, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4961,7 +4961,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4981,7 +4981,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4995,7 +4995,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x24, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5010,7 +5010,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5031,7 +5031,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5045,7 +5045,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x25, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5060,7 +5060,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5080,7 +5080,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5094,7 +5094,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x26, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5109,7 +5109,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5129,7 +5129,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5143,7 +5143,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x27, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5158,7 +5158,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5178,7 +5178,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5192,7 +5192,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x28, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5207,7 +5207,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5227,7 +5227,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5241,7 +5241,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x29, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5256,7 +5256,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5276,7 +5276,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5290,7 +5290,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x30, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5305,7 +5305,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5325,7 +5325,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5339,7 +5339,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x31, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5354,7 +5354,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif

--- a/tests/rv32i/Zicsr/Zicsr-csrrwi-00.S
+++ b/tests/rv32i/Zicsr/Zicsr-csrrwi-00.S
@@ -45,7 +45,7 @@ RVTEST_BEGIN
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -59,7 +59,7 @@ Zicsr_csrrwi_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrwi x0, mepc, 12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -74,7 +74,7 @@ Zicsr_csrrwi_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -93,7 +93,7 @@ Zicsr_csrrwi_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -107,7 +107,7 @@ Zicsr_csrrwi_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrwi x1, mepc, 12
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -122,7 +122,7 @@ Zicsr_csrrwi_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -142,7 +142,7 @@ Zicsr_csrrwi_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -156,7 +156,7 @@ Zicsr_csrrwi_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrwi x2, mepc, 13
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -171,7 +171,7 @@ Zicsr_csrrwi_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -191,7 +191,7 @@ Zicsr_csrrwi_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -205,7 +205,7 @@ Zicsr_csrrwi_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrwi x3, mepc, 17
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -220,7 +220,7 @@ Zicsr_csrrwi_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -241,7 +241,7 @@ Zicsr_csrrwi_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -255,7 +255,7 @@ Zicsr_csrrwi_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrwi x4, mepc, 0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -270,7 +270,7 @@ Zicsr_csrrwi_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -289,7 +289,7 @@ Zicsr_csrrwi_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -303,7 +303,7 @@ Zicsr_csrrwi_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrwi x5, mepc, 12
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -318,7 +318,7 @@ Zicsr_csrrwi_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -338,7 +338,7 @@ Zicsr_csrrwi_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -352,7 +352,7 @@ Zicsr_csrrwi_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrwi x6, mepc, 0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -367,7 +367,7 @@ Zicsr_csrrwi_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -386,7 +386,7 @@ Zicsr_csrrwi_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -400,7 +400,7 @@ Zicsr_csrrwi_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrwi x7, mepc, 17
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -415,7 +415,7 @@ Zicsr_csrrwi_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -434,7 +434,7 @@ Zicsr_csrrwi_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -448,7 +448,7 @@ Zicsr_csrrwi_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrwi x8, mepc, 28
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -463,7 +463,7 @@ Zicsr_csrrwi_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -482,7 +482,7 @@ Zicsr_csrrwi_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -496,7 +496,7 @@ Zicsr_csrrwi_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrwi x9, mepc, 11
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -511,7 +511,7 @@ Zicsr_csrrwi_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -530,7 +530,7 @@ Zicsr_csrrwi_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -544,7 +544,7 @@ Zicsr_csrrwi_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrwi x10, mepc, 25
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -559,7 +559,7 @@ Zicsr_csrrwi_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -578,7 +578,7 @@ Zicsr_csrrwi_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -592,7 +592,7 @@ Zicsr_csrrwi_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrwi x11, mepc, 24
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -607,7 +607,7 @@ Zicsr_csrrwi_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -628,7 +628,7 @@ Zicsr_csrrwi_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -642,7 +642,7 @@ Zicsr_csrrwi_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrwi x12, mepc, 28
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -657,7 +657,7 @@ Zicsr_csrrwi_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -676,7 +676,7 @@ Zicsr_csrrwi_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -690,7 +690,7 @@ Zicsr_csrrwi_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrwi x13, mepc, 27
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -705,7 +705,7 @@ Zicsr_csrrwi_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -724,7 +724,7 @@ Zicsr_csrrwi_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -738,7 +738,7 @@ Zicsr_csrrwi_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrwi x14, mepc, 18
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -753,7 +753,7 @@ Zicsr_csrrwi_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -772,7 +772,7 @@ Zicsr_csrrwi_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -786,7 +786,7 @@ Zicsr_csrrwi_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrwi x15, mepc, 9
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -801,7 +801,7 @@ Zicsr_csrrwi_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -820,7 +820,7 @@ Zicsr_csrrwi_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -834,7 +834,7 @@ Zicsr_csrrwi_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrwi x16, mepc, 11
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -849,7 +849,7 @@ Zicsr_csrrwi_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -868,7 +868,7 @@ Zicsr_csrrwi_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -882,7 +882,7 @@ Zicsr_csrrwi_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrwi x17, mepc, 31
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -897,7 +897,7 @@ Zicsr_csrrwi_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -916,7 +916,7 @@ Zicsr_csrrwi_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -930,7 +930,7 @@ Zicsr_csrrwi_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrwi x18, mepc, 19
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -945,7 +945,7 @@ Zicsr_csrrwi_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -964,7 +964,7 @@ Zicsr_csrrwi_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -978,7 +978,7 @@ Zicsr_csrrwi_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrwi x19, mepc, 24
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -993,7 +993,7 @@ Zicsr_csrrwi_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1012,7 +1012,7 @@ Zicsr_csrrwi_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1026,7 +1026,7 @@ Zicsr_csrrwi_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrwi x20, mepc, 18
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1041,7 +1041,7 @@ Zicsr_csrrwi_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1061,7 +1061,7 @@ Zicsr_csrrwi_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1075,7 +1075,7 @@ Zicsr_csrrwi_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrwi x21, mepc, 15
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1090,7 +1090,7 @@ Zicsr_csrrwi_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1109,7 +1109,7 @@ Zicsr_csrrwi_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1123,7 +1123,7 @@ Zicsr_csrrwi_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrwi x22, mepc, 31
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1138,7 +1138,7 @@ Zicsr_csrrwi_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1157,7 +1157,7 @@ Zicsr_csrrwi_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1171,7 +1171,7 @@ Zicsr_csrrwi_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrwi x23, mepc, 10
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1186,7 +1186,7 @@ Zicsr_csrrwi_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1205,7 +1205,7 @@ Zicsr_csrrwi_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1219,7 +1219,7 @@ Zicsr_csrrwi_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrwi x24, mepc, 6
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1234,7 +1234,7 @@ Zicsr_csrrwi_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1253,7 +1253,7 @@ Zicsr_csrrwi_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1267,7 +1267,7 @@ Zicsr_csrrwi_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrwi x25, mepc, 19
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1282,7 +1282,7 @@ Zicsr_csrrwi_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1301,7 +1301,7 @@ Zicsr_csrrwi_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1315,7 +1315,7 @@ Zicsr_csrrwi_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrwi x26, mepc, 4
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1330,7 +1330,7 @@ Zicsr_csrrwi_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1349,7 +1349,7 @@ Zicsr_csrrwi_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1363,7 +1363,7 @@ Zicsr_csrrwi_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrwi x27, mepc, 20
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1378,7 +1378,7 @@ Zicsr_csrrwi_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1397,7 +1397,7 @@ Zicsr_csrrwi_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1411,7 +1411,7 @@ Zicsr_csrrwi_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrwi x28, mepc, 31
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1426,7 +1426,7 @@ Zicsr_csrrwi_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1445,7 +1445,7 @@ Zicsr_csrrwi_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1459,7 +1459,7 @@ Zicsr_csrrwi_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrwi x29, mepc, 19
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1474,7 +1474,7 @@ Zicsr_csrrwi_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1493,7 +1493,7 @@ Zicsr_csrrwi_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1507,7 +1507,7 @@ Zicsr_csrrwi_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrwi x30, mepc, 31
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1522,7 +1522,7 @@ Zicsr_csrrwi_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1541,7 +1541,7 @@ Zicsr_csrrwi_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1555,7 +1555,7 @@ Zicsr_csrrwi_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrwi x31, mepc, 27
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1570,7 +1570,7 @@ Zicsr_csrrwi_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1593,7 +1593,7 @@ Zicsr_csrrwi_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1607,7 +1607,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm0:
 #elif !defined(U_SUPPORTED)
   csrrwi x18, mepc, 0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1622,7 +1622,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm0:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1641,7 +1641,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1655,7 +1655,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm1:
 #elif !defined(U_SUPPORTED)
   csrrwi x26, mepc, 1
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1670,7 +1670,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm1:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1689,7 +1689,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1703,7 +1703,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm2:
 #elif !defined(U_SUPPORTED)
   csrrwi x29, mepc, 2
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1718,7 +1718,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm2:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1737,7 +1737,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1751,7 +1751,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm3:
 #elif !defined(U_SUPPORTED)
   csrrwi x0, mepc, 3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1766,7 +1766,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm3:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1785,7 +1785,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1799,7 +1799,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm4:
 #elif !defined(U_SUPPORTED)
   csrrwi x23, mepc, 4
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1814,7 +1814,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm4:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1833,7 +1833,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1847,7 +1847,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm5:
 #elif !defined(U_SUPPORTED)
   csrrwi x28, mepc, 5
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1862,7 +1862,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm5:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1881,7 +1881,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1895,7 +1895,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm6:
 #elif !defined(U_SUPPORTED)
   csrrwi x18, mepc, 6
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1910,7 +1910,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm6:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1929,7 +1929,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1943,7 +1943,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm7:
 #elif !defined(U_SUPPORTED)
   csrrwi x31, mepc, 7
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1958,7 +1958,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm7:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1977,7 +1977,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1991,7 +1991,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm8:
 #elif !defined(U_SUPPORTED)
   csrrwi x22, mepc, 8
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2006,7 +2006,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm8:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2025,7 +2025,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2039,7 +2039,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm9:
 #elif !defined(U_SUPPORTED)
   csrrwi x8, mepc, 9
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2054,7 +2054,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm9:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2073,7 +2073,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2087,7 +2087,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm10:
 #elif !defined(U_SUPPORTED)
   csrrwi x16, mepc, 10
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2102,7 +2102,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm10:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2121,7 +2121,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2135,7 +2135,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm11:
 #elif !defined(U_SUPPORTED)
   csrrwi x23, mepc, 11
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2150,7 +2150,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm11:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2169,7 +2169,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2183,7 +2183,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm12:
 #elif !defined(U_SUPPORTED)
   csrrwi x28, mepc, 12
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2198,7 +2198,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm12:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2217,7 +2217,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2231,7 +2231,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm13:
 #elif !defined(U_SUPPORTED)
   csrrwi x10, mepc, 13
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2246,7 +2246,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm13:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2265,7 +2265,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2279,7 +2279,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm14:
 #elif !defined(U_SUPPORTED)
   csrrwi x8, mepc, 14
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2294,7 +2294,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm14:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2313,7 +2313,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2327,7 +2327,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm15:
 #elif !defined(U_SUPPORTED)
   csrrwi x15, mepc, 15
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2342,7 +2342,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm15:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2361,7 +2361,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2375,7 +2375,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm16:
 #elif !defined(U_SUPPORTED)
   csrrwi x28, mepc, 16
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2390,7 +2390,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm16:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2409,7 +2409,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2423,7 +2423,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm17:
 #elif !defined(U_SUPPORTED)
   csrrwi x26, mepc, 17
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2438,7 +2438,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm17:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2457,7 +2457,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2471,7 +2471,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm18:
 #elif !defined(U_SUPPORTED)
   csrrwi x17, mepc, 18
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2486,7 +2486,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm18:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2505,7 +2505,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2519,7 +2519,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm19:
 #elif !defined(U_SUPPORTED)
   csrrwi x31, mepc, 19
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2534,7 +2534,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm19:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2553,7 +2553,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2567,7 +2567,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm20:
 #elif !defined(U_SUPPORTED)
   csrrwi x27, mepc, 20
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2582,7 +2582,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm20:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2601,7 +2601,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2615,7 +2615,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm21:
 #elif !defined(U_SUPPORTED)
   csrrwi x16, mepc, 21
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2630,7 +2630,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm21:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2649,7 +2649,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2663,7 +2663,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm22:
 #elif !defined(U_SUPPORTED)
   csrrwi x29, mepc, 22
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2678,7 +2678,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm22:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2697,7 +2697,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2711,7 +2711,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm23:
 #elif !defined(U_SUPPORTED)
   csrrwi x10, mepc, 23
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2726,7 +2726,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm23:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2745,7 +2745,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2759,7 +2759,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm24:
 #elif !defined(U_SUPPORTED)
   csrrwi x12, mepc, 24
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2774,7 +2774,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm24:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2793,7 +2793,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2807,7 +2807,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm25:
 #elif !defined(U_SUPPORTED)
   csrrwi x8, mepc, 25
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2822,7 +2822,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm25:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2841,7 +2841,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2855,7 +2855,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm26:
 #elif !defined(U_SUPPORTED)
   csrrwi x18, mepc, 26
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2870,7 +2870,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm26:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2889,7 +2889,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2903,7 +2903,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm27:
 #elif !defined(U_SUPPORTED)
   csrrwi x7, mepc, 27
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2918,7 +2918,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm27:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2937,7 +2937,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2951,7 +2951,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm28:
 #elif !defined(U_SUPPORTED)
   csrrwi x9, mepc, 28
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2966,7 +2966,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm28:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2985,7 +2985,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2999,7 +2999,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm29:
 #elif !defined(U_SUPPORTED)
   csrrwi x10, mepc, 29
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3014,7 +3014,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm29:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3033,7 +3033,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3047,7 +3047,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm30:
 #elif !defined(U_SUPPORTED)
   csrrwi x16, mepc, 30
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3062,7 +3062,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm30:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3081,7 +3081,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3095,7 +3095,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm31:
 #elif !defined(U_SUPPORTED)
   csrrwi x12, mepc, 31
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3110,7 +3110,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm31:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif

--- a/tests/rv64e/E/E-jal-00.S
+++ b/tests/rv64e/E/E-jal-00.S
@@ -244,11 +244,11 @@ cp_imm_edges_jal_fwd_b_4:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_2, E_jal_cg_cp_imm_edges_jal_b_2_str)
 
 # cp_imm_edges_jal: forward jump by 8
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 3
 E_jal_cg_cp_imm_edges_jal_b_3:
   jal x7, cp_imm_edges_jal_fwd_b_8
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 3
 cp_imm_edges_jal_fwd_b_8:
   # Check jump taken/not-taken
@@ -259,11 +259,11 @@ cp_imm_edges_jal_fwd_b_8:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_3, E_jal_cg_cp_imm_edges_jal_b_3_str)
 
 # cp_imm_edges_jal: forward jump by 16
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 4
 E_jal_cg_cp_imm_edges_jal_b_4:
   jal x7, cp_imm_edges_jal_fwd_b_16
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 4
 cp_imm_edges_jal_fwd_b_16:
   # Check jump taken/not-taken
@@ -274,11 +274,11 @@ cp_imm_edges_jal_fwd_b_16:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_4, E_jal_cg_cp_imm_edges_jal_b_4_str)
 
 # cp_imm_edges_jal: forward jump by 32
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 5
 E_jal_cg_cp_imm_edges_jal_b_5:
   jal x7, cp_imm_edges_jal_fwd_b_32
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 5
 cp_imm_edges_jal_fwd_b_32:
   # Check jump taken/not-taken
@@ -289,11 +289,11 @@ cp_imm_edges_jal_fwd_b_32:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_5, E_jal_cg_cp_imm_edges_jal_b_5_str)
 
 # cp_imm_edges_jal: forward jump by 64
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 6
 E_jal_cg_cp_imm_edges_jal_b_6:
   jal x7, cp_imm_edges_jal_fwd_b_64
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 6
 cp_imm_edges_jal_fwd_b_64:
   # Check jump taken/not-taken
@@ -304,11 +304,11 @@ cp_imm_edges_jal_fwd_b_64:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_6, E_jal_cg_cp_imm_edges_jal_b_6_str)
 
 # cp_imm_edges_jal: forward jump by 128
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 7
 E_jal_cg_cp_imm_edges_jal_b_7:
   jal x7, cp_imm_edges_jal_fwd_b_128
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 7
 cp_imm_edges_jal_fwd_b_128:
   # Check jump taken/not-taken
@@ -319,11 +319,11 @@ cp_imm_edges_jal_fwd_b_128:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_7, E_jal_cg_cp_imm_edges_jal_b_7_str)
 
 # cp_imm_edges_jal: forward jump by 256
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 8
 E_jal_cg_cp_imm_edges_jal_b_8:
   jal x7, cp_imm_edges_jal_fwd_b_256
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 8
 cp_imm_edges_jal_fwd_b_256:
   # Check jump taken/not-taken
@@ -334,11 +334,11 @@ cp_imm_edges_jal_fwd_b_256:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_8, E_jal_cg_cp_imm_edges_jal_b_8_str)
 
 # cp_imm_edges_jal: forward jump by 512
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 9
 E_jal_cg_cp_imm_edges_jal_b_9:
   jal x7, cp_imm_edges_jal_fwd_b_512
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 9
 cp_imm_edges_jal_fwd_b_512:
   # Check jump taken/not-taken
@@ -349,11 +349,11 @@ cp_imm_edges_jal_fwd_b_512:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_9, E_jal_cg_cp_imm_edges_jal_b_9_str)
 
 # cp_imm_edges_jal: forward jump by 1024
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 10
 E_jal_cg_cp_imm_edges_jal_b_10:
   jal x7, cp_imm_edges_jal_fwd_b_1024
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 10
 cp_imm_edges_jal_fwd_b_1024:
   # Check jump taken/not-taken
@@ -364,11 +364,11 @@ cp_imm_edges_jal_fwd_b_1024:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_10, E_jal_cg_cp_imm_edges_jal_b_10_str)
 
 # cp_imm_edges_jal: forward jump by 2048
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 11
 E_jal_cg_cp_imm_edges_jal_b_11:
   jal x7, cp_imm_edges_jal_fwd_b_2048
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 11
 cp_imm_edges_jal_fwd_b_2048:
   # Check jump taken/not-taken
@@ -379,11 +379,11 @@ cp_imm_edges_jal_fwd_b_2048:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_11, E_jal_cg_cp_imm_edges_jal_b_11_str)
 
 # cp_imm_edges_jal: forward jump by 4096
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 12
 E_jal_cg_cp_imm_edges_jal_b_12:
   jal x7, cp_imm_edges_jal_fwd_b_4096
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 12
 cp_imm_edges_jal_fwd_b_4096:
   # Check jump taken/not-taken
@@ -394,11 +394,11 @@ cp_imm_edges_jal_fwd_b_4096:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_12, E_jal_cg_cp_imm_edges_jal_b_12_str)
 
 # cp_imm_edges_jal: forward jump by 8192
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 13
 E_jal_cg_cp_imm_edges_jal_b_13:
   jal x7, cp_imm_edges_jal_fwd_b_8192
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
   .p2align 13
 cp_imm_edges_jal_fwd_b_8192:
   # Check jump taken/not-taken
@@ -428,7 +428,7 @@ cp_imm_edges_jal_done_b_m4:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m2, E_jal_cg_cp_imm_edges_jal_b_m2_str)
 
 # cp_imm_edges_jal: backward jump by 8
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 4
 E_jal_cg_cp_imm_edges_jal_b_m3:
   jal x7, cp_imm_edges_jal_skip_b_m8
@@ -438,7 +438,7 @@ cp_imm_edges_jal_bwd_b_m8:
 cp_imm_edges_jal_skip_b_m8:
   .p2align 4
   jal x7, cp_imm_edges_jal_bwd_b_m8
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m8:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -448,7 +448,7 @@ cp_imm_edges_jal_done_b_m8:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m3, E_jal_cg_cp_imm_edges_jal_b_m3_str)
 
 # cp_imm_edges_jal: backward jump by 16
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 5
 E_jal_cg_cp_imm_edges_jal_b_m4:
   jal x7, cp_imm_edges_jal_skip_b_m16
@@ -458,7 +458,7 @@ cp_imm_edges_jal_bwd_b_m16:
 cp_imm_edges_jal_skip_b_m16:
   .p2align 5
   jal x7, cp_imm_edges_jal_bwd_b_m16
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m16:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -468,7 +468,7 @@ cp_imm_edges_jal_done_b_m16:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m4, E_jal_cg_cp_imm_edges_jal_b_m4_str)
 
 # cp_imm_edges_jal: backward jump by 32
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 6
 E_jal_cg_cp_imm_edges_jal_b_m5:
   jal x7, cp_imm_edges_jal_skip_b_m32
@@ -478,7 +478,7 @@ cp_imm_edges_jal_bwd_b_m32:
 cp_imm_edges_jal_skip_b_m32:
   .p2align 6
   jal x7, cp_imm_edges_jal_bwd_b_m32
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m32:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -488,7 +488,7 @@ cp_imm_edges_jal_done_b_m32:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m5, E_jal_cg_cp_imm_edges_jal_b_m5_str)
 
 # cp_imm_edges_jal: backward jump by 64
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 7
 E_jal_cg_cp_imm_edges_jal_b_m6:
   jal x7, cp_imm_edges_jal_skip_b_m64
@@ -498,7 +498,7 @@ cp_imm_edges_jal_bwd_b_m64:
 cp_imm_edges_jal_skip_b_m64:
   .p2align 7
   jal x7, cp_imm_edges_jal_bwd_b_m64
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m64:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -508,7 +508,7 @@ cp_imm_edges_jal_done_b_m64:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m6, E_jal_cg_cp_imm_edges_jal_b_m6_str)
 
 # cp_imm_edges_jal: backward jump by 128
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 8
 E_jal_cg_cp_imm_edges_jal_b_m7:
   jal x7, cp_imm_edges_jal_skip_b_m128
@@ -518,7 +518,7 @@ cp_imm_edges_jal_bwd_b_m128:
 cp_imm_edges_jal_skip_b_m128:
   .p2align 8
   jal x7, cp_imm_edges_jal_bwd_b_m128
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m128:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -528,7 +528,7 @@ cp_imm_edges_jal_done_b_m128:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m7, E_jal_cg_cp_imm_edges_jal_b_m7_str)
 
 # cp_imm_edges_jal: backward jump by 256
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 9
 E_jal_cg_cp_imm_edges_jal_b_m8:
   jal x7, cp_imm_edges_jal_skip_b_m256
@@ -538,7 +538,7 @@ cp_imm_edges_jal_bwd_b_m256:
 cp_imm_edges_jal_skip_b_m256:
   .p2align 9
   jal x7, cp_imm_edges_jal_bwd_b_m256
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m256:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -548,7 +548,7 @@ cp_imm_edges_jal_done_b_m256:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m8, E_jal_cg_cp_imm_edges_jal_b_m8_str)
 
 # cp_imm_edges_jal: backward jump by 512
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 10
 E_jal_cg_cp_imm_edges_jal_b_m9:
   jal x7, cp_imm_edges_jal_skip_b_m512
@@ -558,7 +558,7 @@ cp_imm_edges_jal_bwd_b_m512:
 cp_imm_edges_jal_skip_b_m512:
   .p2align 10
   jal x7, cp_imm_edges_jal_bwd_b_m512
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m512:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -568,7 +568,7 @@ cp_imm_edges_jal_done_b_m512:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m9, E_jal_cg_cp_imm_edges_jal_b_m9_str)
 
 # cp_imm_edges_jal: backward jump by 1024
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 11
 E_jal_cg_cp_imm_edges_jal_b_m10:
   jal x7, cp_imm_edges_jal_skip_b_m1024
@@ -578,7 +578,7 @@ cp_imm_edges_jal_bwd_b_m1024:
 cp_imm_edges_jal_skip_b_m1024:
   .p2align 11
   jal x7, cp_imm_edges_jal_bwd_b_m1024
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m1024:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -588,7 +588,7 @@ cp_imm_edges_jal_done_b_m1024:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m10, E_jal_cg_cp_imm_edges_jal_b_m10_str)
 
 # cp_imm_edges_jal: backward jump by 2048
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 12
 E_jal_cg_cp_imm_edges_jal_b_m11:
   jal x7, cp_imm_edges_jal_skip_b_m2048
@@ -598,7 +598,7 @@ cp_imm_edges_jal_bwd_b_m2048:
 cp_imm_edges_jal_skip_b_m2048:
   .p2align 12
   jal x7, cp_imm_edges_jal_bwd_b_m2048
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m2048:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -608,7 +608,7 @@ cp_imm_edges_jal_done_b_m2048:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m11, E_jal_cg_cp_imm_edges_jal_b_m11_str)
 
 # cp_imm_edges_jal: backward jump by 4096
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 13
 E_jal_cg_cp_imm_edges_jal_b_m12:
   jal x7, cp_imm_edges_jal_skip_b_m4096
@@ -618,7 +618,7 @@ cp_imm_edges_jal_bwd_b_m4096:
 cp_imm_edges_jal_skip_b_m4096:
   .p2align 13
   jal x7, cp_imm_edges_jal_bwd_b_m4096
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m4096:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -628,7 +628,7 @@ cp_imm_edges_jal_done_b_m4096:
   RVTEST_SIGUPD(x9, x5, x4, x7, E_jal_cg_cp_imm_edges_jal_b_m12, E_jal_cg_cp_imm_edges_jal_b_m12_str)
 
 # cp_imm_edges_jal: backward jump by 8192
-  li x1, 1 # success code
+  LI(x1, 1) # success code
   .p2align 14
 E_jal_cg_cp_imm_edges_jal_b_m13:
   jal x7, cp_imm_edges_jal_skip_b_m8192
@@ -638,7 +638,7 @@ cp_imm_edges_jal_bwd_b_m8192:
 cp_imm_edges_jal_skip_b_m8192:
   .p2align 14
   jal x7, cp_imm_edges_jal_bwd_b_m8192
-  li x1, 7 # failure code
+  LI(x1, 7) # failure code
 cp_imm_edges_jal_done_b_m8192:
   # Check jump taken/not-taken
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.

--- a/tests/rv64i/I/I-jal-00.S
+++ b/tests/rv64i/I/I-jal-00.S
@@ -421,11 +421,11 @@ cp_imm_edges_jal_fwd_b_4:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_2, I_jal_cg_cp_imm_edges_jal_b_2_str)
 
 # cp_imm_edges_jal: forward jump by 8
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 3
 I_jal_cg_cp_imm_edges_jal_b_3:
   jal x10, cp_imm_edges_jal_fwd_b_8
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 3
 cp_imm_edges_jal_fwd_b_8:
   # Check jump taken/not-taken
@@ -436,11 +436,11 @@ cp_imm_edges_jal_fwd_b_8:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_3, I_jal_cg_cp_imm_edges_jal_b_3_str)
 
 # cp_imm_edges_jal: forward jump by 16
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 4
 I_jal_cg_cp_imm_edges_jal_b_4:
   jal x10, cp_imm_edges_jal_fwd_b_16
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 4
 cp_imm_edges_jal_fwd_b_16:
   # Check jump taken/not-taken
@@ -451,11 +451,11 @@ cp_imm_edges_jal_fwd_b_16:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_4, I_jal_cg_cp_imm_edges_jal_b_4_str)
 
 # cp_imm_edges_jal: forward jump by 32
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 5
 I_jal_cg_cp_imm_edges_jal_b_5:
   jal x10, cp_imm_edges_jal_fwd_b_32
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 5
 cp_imm_edges_jal_fwd_b_32:
   # Check jump taken/not-taken
@@ -466,11 +466,11 @@ cp_imm_edges_jal_fwd_b_32:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_5, I_jal_cg_cp_imm_edges_jal_b_5_str)
 
 # cp_imm_edges_jal: forward jump by 64
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 6
 I_jal_cg_cp_imm_edges_jal_b_6:
   jal x10, cp_imm_edges_jal_fwd_b_64
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 6
 cp_imm_edges_jal_fwd_b_64:
   # Check jump taken/not-taken
@@ -481,11 +481,11 @@ cp_imm_edges_jal_fwd_b_64:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_6, I_jal_cg_cp_imm_edges_jal_b_6_str)
 
 # cp_imm_edges_jal: forward jump by 128
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 7
 I_jal_cg_cp_imm_edges_jal_b_7:
   jal x10, cp_imm_edges_jal_fwd_b_128
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 7
 cp_imm_edges_jal_fwd_b_128:
   # Check jump taken/not-taken
@@ -496,11 +496,11 @@ cp_imm_edges_jal_fwd_b_128:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_7, I_jal_cg_cp_imm_edges_jal_b_7_str)
 
 # cp_imm_edges_jal: forward jump by 256
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 8
 I_jal_cg_cp_imm_edges_jal_b_8:
   jal x10, cp_imm_edges_jal_fwd_b_256
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 8
 cp_imm_edges_jal_fwd_b_256:
   # Check jump taken/not-taken
@@ -511,11 +511,11 @@ cp_imm_edges_jal_fwd_b_256:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_8, I_jal_cg_cp_imm_edges_jal_b_8_str)
 
 # cp_imm_edges_jal: forward jump by 512
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 9
 I_jal_cg_cp_imm_edges_jal_b_9:
   jal x10, cp_imm_edges_jal_fwd_b_512
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 9
 cp_imm_edges_jal_fwd_b_512:
   # Check jump taken/not-taken
@@ -526,11 +526,11 @@ cp_imm_edges_jal_fwd_b_512:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_9, I_jal_cg_cp_imm_edges_jal_b_9_str)
 
 # cp_imm_edges_jal: forward jump by 1024
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 10
 I_jal_cg_cp_imm_edges_jal_b_10:
   jal x10, cp_imm_edges_jal_fwd_b_1024
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 10
 cp_imm_edges_jal_fwd_b_1024:
   # Check jump taken/not-taken
@@ -541,11 +541,11 @@ cp_imm_edges_jal_fwd_b_1024:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_10, I_jal_cg_cp_imm_edges_jal_b_10_str)
 
 # cp_imm_edges_jal: forward jump by 2048
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 11
 I_jal_cg_cp_imm_edges_jal_b_11:
   jal x10, cp_imm_edges_jal_fwd_b_2048
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 11
 cp_imm_edges_jal_fwd_b_2048:
   # Check jump taken/not-taken
@@ -556,11 +556,11 @@ cp_imm_edges_jal_fwd_b_2048:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_11, I_jal_cg_cp_imm_edges_jal_b_11_str)
 
 # cp_imm_edges_jal: forward jump by 4096
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 12
 I_jal_cg_cp_imm_edges_jal_b_12:
   jal x10, cp_imm_edges_jal_fwd_b_4096
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 12
 cp_imm_edges_jal_fwd_b_4096:
   # Check jump taken/not-taken
@@ -571,11 +571,11 @@ cp_imm_edges_jal_fwd_b_4096:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_12, I_jal_cg_cp_imm_edges_jal_b_12_str)
 
 # cp_imm_edges_jal: forward jump by 8192
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 13
 I_jal_cg_cp_imm_edges_jal_b_13:
   jal x10, cp_imm_edges_jal_fwd_b_8192
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
   .p2align 13
 cp_imm_edges_jal_fwd_b_8192:
   # Check jump taken/not-taken
@@ -605,7 +605,7 @@ cp_imm_edges_jal_done_b_m4:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m2, I_jal_cg_cp_imm_edges_jal_b_m2_str)
 
 # cp_imm_edges_jal: backward jump by 8
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 4
 I_jal_cg_cp_imm_edges_jal_b_m3:
   jal x10, cp_imm_edges_jal_skip_b_m8
@@ -615,7 +615,7 @@ cp_imm_edges_jal_bwd_b_m8:
 cp_imm_edges_jal_skip_b_m8:
   .p2align 4
   jal x10, cp_imm_edges_jal_bwd_b_m8
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m8:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -625,7 +625,7 @@ cp_imm_edges_jal_done_b_m8:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m3, I_jal_cg_cp_imm_edges_jal_b_m3_str)
 
 # cp_imm_edges_jal: backward jump by 16
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 5
 I_jal_cg_cp_imm_edges_jal_b_m4:
   jal x10, cp_imm_edges_jal_skip_b_m16
@@ -635,7 +635,7 @@ cp_imm_edges_jal_bwd_b_m16:
 cp_imm_edges_jal_skip_b_m16:
   .p2align 5
   jal x10, cp_imm_edges_jal_bwd_b_m16
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m16:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -645,7 +645,7 @@ cp_imm_edges_jal_done_b_m16:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m4, I_jal_cg_cp_imm_edges_jal_b_m4_str)
 
 # cp_imm_edges_jal: backward jump by 32
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 6
 I_jal_cg_cp_imm_edges_jal_b_m5:
   jal x10, cp_imm_edges_jal_skip_b_m32
@@ -655,7 +655,7 @@ cp_imm_edges_jal_bwd_b_m32:
 cp_imm_edges_jal_skip_b_m32:
   .p2align 6
   jal x10, cp_imm_edges_jal_bwd_b_m32
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m32:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -665,7 +665,7 @@ cp_imm_edges_jal_done_b_m32:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m5, I_jal_cg_cp_imm_edges_jal_b_m5_str)
 
 # cp_imm_edges_jal: backward jump by 64
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 7
 I_jal_cg_cp_imm_edges_jal_b_m6:
   jal x10, cp_imm_edges_jal_skip_b_m64
@@ -675,7 +675,7 @@ cp_imm_edges_jal_bwd_b_m64:
 cp_imm_edges_jal_skip_b_m64:
   .p2align 7
   jal x10, cp_imm_edges_jal_bwd_b_m64
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m64:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -685,7 +685,7 @@ cp_imm_edges_jal_done_b_m64:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m6, I_jal_cg_cp_imm_edges_jal_b_m6_str)
 
 # cp_imm_edges_jal: backward jump by 128
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 8
 I_jal_cg_cp_imm_edges_jal_b_m7:
   jal x10, cp_imm_edges_jal_skip_b_m128
@@ -695,7 +695,7 @@ cp_imm_edges_jal_bwd_b_m128:
 cp_imm_edges_jal_skip_b_m128:
   .p2align 8
   jal x10, cp_imm_edges_jal_bwd_b_m128
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m128:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -705,7 +705,7 @@ cp_imm_edges_jal_done_b_m128:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m7, I_jal_cg_cp_imm_edges_jal_b_m7_str)
 
 # cp_imm_edges_jal: backward jump by 256
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 9
 I_jal_cg_cp_imm_edges_jal_b_m8:
   jal x10, cp_imm_edges_jal_skip_b_m256
@@ -715,7 +715,7 @@ cp_imm_edges_jal_bwd_b_m256:
 cp_imm_edges_jal_skip_b_m256:
   .p2align 9
   jal x10, cp_imm_edges_jal_bwd_b_m256
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m256:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -725,7 +725,7 @@ cp_imm_edges_jal_done_b_m256:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m8, I_jal_cg_cp_imm_edges_jal_b_m8_str)
 
 # cp_imm_edges_jal: backward jump by 512
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 10
 I_jal_cg_cp_imm_edges_jal_b_m9:
   jal x10, cp_imm_edges_jal_skip_b_m512
@@ -735,7 +735,7 @@ cp_imm_edges_jal_bwd_b_m512:
 cp_imm_edges_jal_skip_b_m512:
   .p2align 10
   jal x10, cp_imm_edges_jal_bwd_b_m512
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m512:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -745,7 +745,7 @@ cp_imm_edges_jal_done_b_m512:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m9, I_jal_cg_cp_imm_edges_jal_b_m9_str)
 
 # cp_imm_edges_jal: backward jump by 1024
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 11
 I_jal_cg_cp_imm_edges_jal_b_m10:
   jal x10, cp_imm_edges_jal_skip_b_m1024
@@ -755,7 +755,7 @@ cp_imm_edges_jal_bwd_b_m1024:
 cp_imm_edges_jal_skip_b_m1024:
   .p2align 11
   jal x10, cp_imm_edges_jal_bwd_b_m1024
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m1024:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -765,7 +765,7 @@ cp_imm_edges_jal_done_b_m1024:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m10, I_jal_cg_cp_imm_edges_jal_b_m10_str)
 
 # cp_imm_edges_jal: backward jump by 2048
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 12
 I_jal_cg_cp_imm_edges_jal_b_m11:
   jal x10, cp_imm_edges_jal_skip_b_m2048
@@ -775,7 +775,7 @@ cp_imm_edges_jal_bwd_b_m2048:
 cp_imm_edges_jal_skip_b_m2048:
   .p2align 12
   jal x10, cp_imm_edges_jal_bwd_b_m2048
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m2048:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -785,7 +785,7 @@ cp_imm_edges_jal_done_b_m2048:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m11, I_jal_cg_cp_imm_edges_jal_b_m11_str)
 
 # cp_imm_edges_jal: backward jump by 4096
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 13
 I_jal_cg_cp_imm_edges_jal_b_m12:
   jal x10, cp_imm_edges_jal_skip_b_m4096
@@ -795,7 +795,7 @@ cp_imm_edges_jal_bwd_b_m4096:
 cp_imm_edges_jal_skip_b_m4096:
   .p2align 13
   jal x10, cp_imm_edges_jal_bwd_b_m4096
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m4096:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -805,7 +805,7 @@ cp_imm_edges_jal_done_b_m4096:
   RVTEST_SIGUPD(x27, x8, x7, x10, I_jal_cg_cp_imm_edges_jal_b_m12, I_jal_cg_cp_imm_edges_jal_b_m12_str)
 
 # cp_imm_edges_jal: backward jump by 8192
-  li x3, 1 # success code
+  LI(x3, 1) # success code
   .p2align 14
 I_jal_cg_cp_imm_edges_jal_b_m13:
   jal x10, cp_imm_edges_jal_skip_b_m8192
@@ -815,7 +815,7 @@ cp_imm_edges_jal_bwd_b_m8192:
 cp_imm_edges_jal_skip_b_m8192:
   .p2align 14
   jal x10, cp_imm_edges_jal_bwd_b_m8192
-  li x3, 7 # failure code
+  LI(x3, 7) # failure code
 cp_imm_edges_jal_done_b_m8192:
   # Check jump taken/not-taken
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.

--- a/tests/rv64i/Zicsr/Zicsr-csrrc-00.S
+++ b/tests/rv64i/Zicsr/Zicsr-csrrc-00.S
@@ -46,7 +46,7 @@ RVTEST_BEGIN
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -60,7 +60,7 @@ Zicsr_csrrc_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrc x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -75,7 +75,7 @@ Zicsr_csrrc_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -95,7 +95,7 @@ Zicsr_csrrc_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -127,7 +127,7 @@ Zicsr_csrrc_cg_cp_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -148,7 +148,7 @@ Zicsr_csrrc_cg_cp_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -180,7 +180,7 @@ Zicsr_csrrc_cg_cp_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -201,7 +201,7 @@ Zicsr_csrrc_cg_cp_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -233,7 +233,7 @@ Zicsr_csrrc_cg_cp_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -255,7 +255,7 @@ Zicsr_csrrc_cg_cp_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -287,7 +287,7 @@ Zicsr_csrrc_cg_cp_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -307,7 +307,7 @@ Zicsr_csrrc_cg_cp_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -339,7 +339,7 @@ Zicsr_csrrc_cg_cp_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -359,7 +359,7 @@ Zicsr_csrrc_cg_cp_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -391,7 +391,7 @@ Zicsr_csrrc_cg_cp_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -413,7 +413,7 @@ Zicsr_csrrc_cg_cp_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -445,7 +445,7 @@ Zicsr_csrrc_cg_cp_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -465,7 +465,7 @@ Zicsr_csrrc_cg_cp_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -497,7 +497,7 @@ Zicsr_csrrc_cg_cp_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -517,7 +517,7 @@ Zicsr_csrrc_cg_cp_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -549,7 +549,7 @@ Zicsr_csrrc_cg_cp_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -569,7 +569,7 @@ Zicsr_csrrc_cg_cp_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -601,7 +601,7 @@ Zicsr_csrrc_cg_cp_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -621,7 +621,7 @@ Zicsr_csrrc_cg_cp_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -653,7 +653,7 @@ Zicsr_csrrc_cg_cp_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -675,7 +675,7 @@ Zicsr_csrrc_cg_cp_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -707,7 +707,7 @@ Zicsr_csrrc_cg_cp_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -727,7 +727,7 @@ Zicsr_csrrc_cg_cp_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -759,7 +759,7 @@ Zicsr_csrrc_cg_cp_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -779,7 +779,7 @@ Zicsr_csrrc_cg_cp_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -811,7 +811,7 @@ Zicsr_csrrc_cg_cp_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -831,7 +831,7 @@ Zicsr_csrrc_cg_cp_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -863,7 +863,7 @@ Zicsr_csrrc_cg_cp_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -884,7 +884,7 @@ Zicsr_csrrc_cg_cp_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -916,7 +916,7 @@ Zicsr_csrrc_cg_cp_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -936,7 +936,7 @@ Zicsr_csrrc_cg_cp_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -968,7 +968,7 @@ Zicsr_csrrc_cg_cp_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -988,7 +988,7 @@ Zicsr_csrrc_cg_cp_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1020,7 +1020,7 @@ Zicsr_csrrc_cg_cp_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1040,7 +1040,7 @@ Zicsr_csrrc_cg_cp_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1072,7 +1072,7 @@ Zicsr_csrrc_cg_cp_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1092,7 +1092,7 @@ Zicsr_csrrc_cg_cp_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1124,7 +1124,7 @@ Zicsr_csrrc_cg_cp_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1145,7 +1145,7 @@ Zicsr_csrrc_cg_cp_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1177,7 +1177,7 @@ Zicsr_csrrc_cg_cp_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1197,7 +1197,7 @@ Zicsr_csrrc_cg_cp_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1229,7 +1229,7 @@ Zicsr_csrrc_cg_cp_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1249,7 +1249,7 @@ Zicsr_csrrc_cg_cp_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1281,7 +1281,7 @@ Zicsr_csrrc_cg_cp_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1301,7 +1301,7 @@ Zicsr_csrrc_cg_cp_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1333,7 +1333,7 @@ Zicsr_csrrc_cg_cp_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1353,7 +1353,7 @@ Zicsr_csrrc_cg_cp_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1385,7 +1385,7 @@ Zicsr_csrrc_cg_cp_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1405,7 +1405,7 @@ Zicsr_csrrc_cg_cp_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1437,7 +1437,7 @@ Zicsr_csrrc_cg_cp_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1457,7 +1457,7 @@ Zicsr_csrrc_cg_cp_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1489,7 +1489,7 @@ Zicsr_csrrc_cg_cp_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1509,7 +1509,7 @@ Zicsr_csrrc_cg_cp_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1541,7 +1541,7 @@ Zicsr_csrrc_cg_cp_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1561,7 +1561,7 @@ Zicsr_csrrc_cg_cp_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1593,7 +1593,7 @@ Zicsr_csrrc_cg_cp_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1613,7 +1613,7 @@ Zicsr_csrrc_cg_cp_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1645,7 +1645,7 @@ Zicsr_csrrc_cg_cp_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1665,7 +1665,7 @@ Zicsr_csrrc_cg_cp_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1697,7 +1697,7 @@ Zicsr_csrrc_cg_cp_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1721,7 +1721,7 @@ Zicsr_csrrc_cg_cp_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1735,7 +1735,7 @@ Zicsr_csrrc_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrc x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1750,7 +1750,7 @@ Zicsr_csrrc_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1770,7 +1770,7 @@ Zicsr_csrrc_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1802,7 +1802,7 @@ Zicsr_csrrc_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1822,7 +1822,7 @@ Zicsr_csrrc_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1854,7 +1854,7 @@ Zicsr_csrrc_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1874,7 +1874,7 @@ Zicsr_csrrc_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1906,7 +1906,7 @@ Zicsr_csrrc_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1926,7 +1926,7 @@ Zicsr_csrrc_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1958,7 +1958,7 @@ Zicsr_csrrc_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1978,7 +1978,7 @@ Zicsr_csrrc_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2010,7 +2010,7 @@ Zicsr_csrrc_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2031,7 +2031,7 @@ Zicsr_csrrc_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2063,7 +2063,7 @@ Zicsr_csrrc_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2085,7 +2085,7 @@ Zicsr_csrrc_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2117,7 +2117,7 @@ Zicsr_csrrc_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2137,7 +2137,7 @@ Zicsr_csrrc_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2169,7 +2169,7 @@ Zicsr_csrrc_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2189,7 +2189,7 @@ Zicsr_csrrc_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2221,7 +2221,7 @@ Zicsr_csrrc_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2241,7 +2241,7 @@ Zicsr_csrrc_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2273,7 +2273,7 @@ Zicsr_csrrc_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2294,7 +2294,7 @@ Zicsr_csrrc_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2326,7 +2326,7 @@ Zicsr_csrrc_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2348,7 +2348,7 @@ Zicsr_csrrc_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2380,7 +2380,7 @@ Zicsr_csrrc_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2400,7 +2400,7 @@ Zicsr_csrrc_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2432,7 +2432,7 @@ Zicsr_csrrc_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2452,7 +2452,7 @@ Zicsr_csrrc_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2484,7 +2484,7 @@ Zicsr_csrrc_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2504,7 +2504,7 @@ Zicsr_csrrc_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2536,7 +2536,7 @@ Zicsr_csrrc_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2556,7 +2556,7 @@ Zicsr_csrrc_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2588,7 +2588,7 @@ Zicsr_csrrc_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2608,7 +2608,7 @@ Zicsr_csrrc_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2640,7 +2640,7 @@ Zicsr_csrrc_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2660,7 +2660,7 @@ Zicsr_csrrc_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2692,7 +2692,7 @@ Zicsr_csrrc_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2712,7 +2712,7 @@ Zicsr_csrrc_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2744,7 +2744,7 @@ Zicsr_csrrc_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2764,7 +2764,7 @@ Zicsr_csrrc_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2796,7 +2796,7 @@ Zicsr_csrrc_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2816,7 +2816,7 @@ Zicsr_csrrc_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2848,7 +2848,7 @@ Zicsr_csrrc_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2868,7 +2868,7 @@ Zicsr_csrrc_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2900,7 +2900,7 @@ Zicsr_csrrc_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2920,7 +2920,7 @@ Zicsr_csrrc_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2952,7 +2952,7 @@ Zicsr_csrrc_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2972,7 +2972,7 @@ Zicsr_csrrc_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3004,7 +3004,7 @@ Zicsr_csrrc_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3024,7 +3024,7 @@ Zicsr_csrrc_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3056,7 +3056,7 @@ Zicsr_csrrc_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3076,7 +3076,7 @@ Zicsr_csrrc_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3108,7 +3108,7 @@ Zicsr_csrrc_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3128,7 +3128,7 @@ Zicsr_csrrc_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3160,7 +3160,7 @@ Zicsr_csrrc_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3181,7 +3181,7 @@ Zicsr_csrrc_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3213,7 +3213,7 @@ Zicsr_csrrc_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3233,7 +3233,7 @@ Zicsr_csrrc_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3265,7 +3265,7 @@ Zicsr_csrrc_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3286,7 +3286,7 @@ Zicsr_csrrc_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3318,7 +3318,7 @@ Zicsr_csrrc_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3338,7 +3338,7 @@ Zicsr_csrrc_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3370,7 +3370,7 @@ Zicsr_csrrc_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3394,7 +3394,7 @@ Zicsr_csrrc_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3426,7 +3426,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x0:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3446,7 +3446,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3478,7 +3478,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x1:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3498,7 +3498,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3530,7 +3530,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x2:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3550,7 +3550,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3582,7 +3582,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x8000000000000000:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3602,7 +3602,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x8000000000000000:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3634,7 +3634,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x8000000000000001:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3654,7 +3654,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x8000000000000001:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3686,7 +3686,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x7fffffffffffffff:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3706,7 +3706,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x7fffffffffffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3738,7 +3738,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x7ffffffffffffffe:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3758,7 +3758,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x7ffffffffffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3790,7 +3790,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0xffffffffffffffff:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3810,7 +3810,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0xffffffffffffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3842,7 +3842,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0xfffffffffffffffe:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3862,7 +3862,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0xfffffffffffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3894,7 +3894,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x5bbc887763ae86f2:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3914,7 +3914,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x5bbc887763ae86f2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3946,7 +3946,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0xaaaaaaaaaaaaaaaa:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3966,7 +3966,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0xaaaaaaaaaaaaaaaa:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3998,7 +3998,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x5555555555555555:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4018,7 +4018,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x5555555555555555:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4050,7 +4050,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0xffffffff:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4070,7 +4070,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0xffffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4102,7 +4102,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0xfffffffe:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4122,7 +4122,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0xfffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4154,7 +4154,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x100000000:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4174,7 +4174,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x100000000:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4206,7 +4206,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x100000001:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4230,7 +4230,7 @@ Zicsr_csrrc_cg_cp_rs1_edges_0x100000001:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4244,7 +4244,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrc x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4259,7 +4259,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4279,7 +4279,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4311,7 +4311,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4331,7 +4331,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4363,7 +4363,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4383,7 +4383,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4415,7 +4415,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4437,7 +4437,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4469,7 +4469,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4489,7 +4489,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4521,7 +4521,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4541,7 +4541,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4573,7 +4573,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4593,7 +4593,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4625,7 +4625,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4645,7 +4645,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4677,7 +4677,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4697,7 +4697,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4729,7 +4729,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4750,7 +4750,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4782,7 +4782,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4802,7 +4802,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4834,7 +4834,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4856,7 +4856,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4888,7 +4888,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4908,7 +4908,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4940,7 +4940,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4960,7 +4960,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4992,7 +4992,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5012,7 +5012,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5044,7 +5044,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5064,7 +5064,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5096,7 +5096,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5116,7 +5116,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5148,7 +5148,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5168,7 +5168,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5200,7 +5200,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5220,7 +5220,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5252,7 +5252,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5272,7 +5272,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5304,7 +5304,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5324,7 +5324,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5356,7 +5356,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5377,7 +5377,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5409,7 +5409,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5430,7 +5430,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5462,7 +5462,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5482,7 +5482,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5514,7 +5514,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5534,7 +5534,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5566,7 +5566,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5586,7 +5586,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5618,7 +5618,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5638,7 +5638,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5670,7 +5670,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5690,7 +5690,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5722,7 +5722,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5742,7 +5742,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5774,7 +5774,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5794,7 +5794,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5826,7 +5826,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5846,7 +5846,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5878,7 +5878,7 @@ Zicsr_csrrc_cg_cmp_rd_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif

--- a/tests/rv64i/Zicsr/Zicsr-csrrci-00.S
+++ b/tests/rv64i/Zicsr/Zicsr-csrrci-00.S
@@ -45,7 +45,7 @@ RVTEST_BEGIN
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -59,7 +59,7 @@ Zicsr_csrrci_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrci x0, mepc, 14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -74,7 +74,7 @@ Zicsr_csrrci_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -93,7 +93,7 @@ Zicsr_csrrci_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -125,7 +125,7 @@ Zicsr_csrrci_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -145,7 +145,7 @@ Zicsr_csrrci_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -177,7 +177,7 @@ Zicsr_csrrci_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -197,7 +197,7 @@ Zicsr_csrrci_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -229,7 +229,7 @@ Zicsr_csrrci_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -250,7 +250,7 @@ Zicsr_csrrci_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -282,7 +282,7 @@ Zicsr_csrrci_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -301,7 +301,7 @@ Zicsr_csrrci_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -333,7 +333,7 @@ Zicsr_csrrci_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -352,7 +352,7 @@ Zicsr_csrrci_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -384,7 +384,7 @@ Zicsr_csrrci_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -403,7 +403,7 @@ Zicsr_csrrci_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -435,7 +435,7 @@ Zicsr_csrrci_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -454,7 +454,7 @@ Zicsr_csrrci_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -486,7 +486,7 @@ Zicsr_csrrci_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -505,7 +505,7 @@ Zicsr_csrrci_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -537,7 +537,7 @@ Zicsr_csrrci_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -556,7 +556,7 @@ Zicsr_csrrci_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -588,7 +588,7 @@ Zicsr_csrrci_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -607,7 +607,7 @@ Zicsr_csrrci_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -639,7 +639,7 @@ Zicsr_csrrci_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -660,7 +660,7 @@ Zicsr_csrrci_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -692,7 +692,7 @@ Zicsr_csrrci_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -711,7 +711,7 @@ Zicsr_csrrci_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -743,7 +743,7 @@ Zicsr_csrrci_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -762,7 +762,7 @@ Zicsr_csrrci_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -794,7 +794,7 @@ Zicsr_csrrci_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -813,7 +813,7 @@ Zicsr_csrrci_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -845,7 +845,7 @@ Zicsr_csrrci_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -864,7 +864,7 @@ Zicsr_csrrci_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -896,7 +896,7 @@ Zicsr_csrrci_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -915,7 +915,7 @@ Zicsr_csrrci_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -947,7 +947,7 @@ Zicsr_csrrci_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -966,7 +966,7 @@ Zicsr_csrrci_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -998,7 +998,7 @@ Zicsr_csrrci_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1017,7 +1017,7 @@ Zicsr_csrrci_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1049,7 +1049,7 @@ Zicsr_csrrci_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1068,7 +1068,7 @@ Zicsr_csrrci_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1100,7 +1100,7 @@ Zicsr_csrrci_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1119,7 +1119,7 @@ Zicsr_csrrci_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1151,7 +1151,7 @@ Zicsr_csrrci_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1170,7 +1170,7 @@ Zicsr_csrrci_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1202,7 +1202,7 @@ Zicsr_csrrci_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1222,7 +1222,7 @@ Zicsr_csrrci_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1254,7 +1254,7 @@ Zicsr_csrrci_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1273,7 +1273,7 @@ Zicsr_csrrci_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1305,7 +1305,7 @@ Zicsr_csrrci_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1324,7 +1324,7 @@ Zicsr_csrrci_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1356,7 +1356,7 @@ Zicsr_csrrci_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1375,7 +1375,7 @@ Zicsr_csrrci_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1407,7 +1407,7 @@ Zicsr_csrrci_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1426,7 +1426,7 @@ Zicsr_csrrci_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1458,7 +1458,7 @@ Zicsr_csrrci_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1478,7 +1478,7 @@ Zicsr_csrrci_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1510,7 +1510,7 @@ Zicsr_csrrci_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1529,7 +1529,7 @@ Zicsr_csrrci_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1561,7 +1561,7 @@ Zicsr_csrrci_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1580,7 +1580,7 @@ Zicsr_csrrci_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1594,7 +1594,7 @@ Zicsr_csrrci_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrci x30, mepc, 8
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1609,7 +1609,7 @@ Zicsr_csrrci_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1628,7 +1628,7 @@ Zicsr_csrrci_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1660,7 +1660,7 @@ Zicsr_csrrci_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1683,7 +1683,7 @@ Zicsr_csrrci_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1715,7 +1715,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm0:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1734,7 +1734,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1766,7 +1766,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm1:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1785,7 +1785,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1817,7 +1817,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm2:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1836,7 +1836,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1868,7 +1868,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm3:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1887,7 +1887,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1919,7 +1919,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm4:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1938,7 +1938,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1970,7 +1970,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm5:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1989,7 +1989,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2021,7 +2021,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm6:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2040,7 +2040,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2072,7 +2072,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm7:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2091,7 +2091,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2123,7 +2123,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm8:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2142,7 +2142,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2174,7 +2174,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm9:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2193,7 +2193,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2225,7 +2225,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm10:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2244,7 +2244,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2276,7 +2276,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm11:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2295,7 +2295,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2327,7 +2327,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm12:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2346,7 +2346,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2378,7 +2378,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm13:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2397,7 +2397,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2429,7 +2429,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm14:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2448,7 +2448,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2480,7 +2480,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm15:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2499,7 +2499,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2531,7 +2531,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm16:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2550,7 +2550,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2582,7 +2582,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm17:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2601,7 +2601,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2615,7 +2615,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm18:
 #elif !defined(U_SUPPORTED)
   csrrci x0, mepc, 18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2630,7 +2630,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm18:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2649,7 +2649,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2681,7 +2681,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm19:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2700,7 +2700,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2732,7 +2732,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm20:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2751,7 +2751,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2783,7 +2783,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm21:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2802,7 +2802,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2834,7 +2834,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm22:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2853,7 +2853,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2885,7 +2885,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm23:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2904,7 +2904,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2936,7 +2936,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm24:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2955,7 +2955,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2987,7 +2987,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm25:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3006,7 +3006,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3038,7 +3038,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm26:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3057,7 +3057,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3089,7 +3089,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm27:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3108,7 +3108,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3122,7 +3122,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm28:
 #elif !defined(U_SUPPORTED)
   csrrci x0, mepc, 28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3137,7 +3137,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm28:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3156,7 +3156,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3188,7 +3188,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm29:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3207,7 +3207,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3239,7 +3239,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm30:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3258,7 +3258,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3290,7 +3290,7 @@ Zicsr_csrrci_cg_cp_uimm_5_uimm31:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif

--- a/tests/rv64i/Zicsr/Zicsr-csrrs-00.S
+++ b/tests/rv64i/Zicsr/Zicsr-csrrs-00.S
@@ -46,7 +46,7 @@ RVTEST_BEGIN
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -60,7 +60,7 @@ Zicsr_csrrs_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -75,7 +75,7 @@ Zicsr_csrrs_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -95,7 +95,7 @@ Zicsr_csrrs_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -127,7 +127,7 @@ Zicsr_csrrs_cg_cp_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -148,7 +148,7 @@ Zicsr_csrrs_cg_cp_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -180,7 +180,7 @@ Zicsr_csrrs_cg_cp_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -201,7 +201,7 @@ Zicsr_csrrs_cg_cp_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -233,7 +233,7 @@ Zicsr_csrrs_cg_cp_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -255,7 +255,7 @@ Zicsr_csrrs_cg_cp_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -287,7 +287,7 @@ Zicsr_csrrs_cg_cp_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -307,7 +307,7 @@ Zicsr_csrrs_cg_cp_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -339,7 +339,7 @@ Zicsr_csrrs_cg_cp_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -360,7 +360,7 @@ Zicsr_csrrs_cg_cp_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -392,7 +392,7 @@ Zicsr_csrrs_cg_cp_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -414,7 +414,7 @@ Zicsr_csrrs_cg_cp_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -446,7 +446,7 @@ Zicsr_csrrs_cg_cp_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -466,7 +466,7 @@ Zicsr_csrrs_cg_cp_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -498,7 +498,7 @@ Zicsr_csrrs_cg_cp_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -518,7 +518,7 @@ Zicsr_csrrs_cg_cp_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -550,7 +550,7 @@ Zicsr_csrrs_cg_cp_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -571,7 +571,7 @@ Zicsr_csrrs_cg_cp_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -603,7 +603,7 @@ Zicsr_csrrs_cg_cp_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -623,7 +623,7 @@ Zicsr_csrrs_cg_cp_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -655,7 +655,7 @@ Zicsr_csrrs_cg_cp_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -675,7 +675,7 @@ Zicsr_csrrs_cg_cp_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -707,7 +707,7 @@ Zicsr_csrrs_cg_cp_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -727,7 +727,7 @@ Zicsr_csrrs_cg_cp_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -759,7 +759,7 @@ Zicsr_csrrs_cg_cp_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -779,7 +779,7 @@ Zicsr_csrrs_cg_cp_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -811,7 +811,7 @@ Zicsr_csrrs_cg_cp_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -831,7 +831,7 @@ Zicsr_csrrs_cg_cp_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -863,7 +863,7 @@ Zicsr_csrrs_cg_cp_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -883,7 +883,7 @@ Zicsr_csrrs_cg_cp_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -915,7 +915,7 @@ Zicsr_csrrs_cg_cp_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -935,7 +935,7 @@ Zicsr_csrrs_cg_cp_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -967,7 +967,7 @@ Zicsr_csrrs_cg_cp_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -987,7 +987,7 @@ Zicsr_csrrs_cg_cp_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1019,7 +1019,7 @@ Zicsr_csrrs_cg_cp_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1039,7 +1039,7 @@ Zicsr_csrrs_cg_cp_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1071,7 +1071,7 @@ Zicsr_csrrs_cg_cp_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1091,7 +1091,7 @@ Zicsr_csrrs_cg_cp_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1123,7 +1123,7 @@ Zicsr_csrrs_cg_cp_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1143,7 +1143,7 @@ Zicsr_csrrs_cg_cp_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1175,7 +1175,7 @@ Zicsr_csrrs_cg_cp_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1195,7 +1195,7 @@ Zicsr_csrrs_cg_cp_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1227,7 +1227,7 @@ Zicsr_csrrs_cg_cp_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1247,7 +1247,7 @@ Zicsr_csrrs_cg_cp_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1279,7 +1279,7 @@ Zicsr_csrrs_cg_cp_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1299,7 +1299,7 @@ Zicsr_csrrs_cg_cp_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1331,7 +1331,7 @@ Zicsr_csrrs_cg_cp_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1351,7 +1351,7 @@ Zicsr_csrrs_cg_cp_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1383,7 +1383,7 @@ Zicsr_csrrs_cg_cp_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1403,7 +1403,7 @@ Zicsr_csrrs_cg_cp_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1435,7 +1435,7 @@ Zicsr_csrrs_cg_cp_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1455,7 +1455,7 @@ Zicsr_csrrs_cg_cp_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1487,7 +1487,7 @@ Zicsr_csrrs_cg_cp_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1508,7 +1508,7 @@ Zicsr_csrrs_cg_cp_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1540,7 +1540,7 @@ Zicsr_csrrs_cg_cp_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1561,7 +1561,7 @@ Zicsr_csrrs_cg_cp_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1593,7 +1593,7 @@ Zicsr_csrrs_cg_cp_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1613,7 +1613,7 @@ Zicsr_csrrs_cg_cp_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1645,7 +1645,7 @@ Zicsr_csrrs_cg_cp_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1665,7 +1665,7 @@ Zicsr_csrrs_cg_cp_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1697,7 +1697,7 @@ Zicsr_csrrs_cg_cp_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1721,7 +1721,7 @@ Zicsr_csrrs_cg_cp_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1735,7 +1735,7 @@ Zicsr_csrrs_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1750,7 +1750,7 @@ Zicsr_csrrs_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1770,7 +1770,7 @@ Zicsr_csrrs_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1802,7 +1802,7 @@ Zicsr_csrrs_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1822,7 +1822,7 @@ Zicsr_csrrs_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1854,7 +1854,7 @@ Zicsr_csrrs_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1874,7 +1874,7 @@ Zicsr_csrrs_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1906,7 +1906,7 @@ Zicsr_csrrs_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1928,7 +1928,7 @@ Zicsr_csrrs_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1960,7 +1960,7 @@ Zicsr_csrrs_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1980,7 +1980,7 @@ Zicsr_csrrs_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2012,7 +2012,7 @@ Zicsr_csrrs_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2032,7 +2032,7 @@ Zicsr_csrrs_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2064,7 +2064,7 @@ Zicsr_csrrs_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2084,7 +2084,7 @@ Zicsr_csrrs_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2116,7 +2116,7 @@ Zicsr_csrrs_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2136,7 +2136,7 @@ Zicsr_csrrs_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2150,7 +2150,7 @@ Zicsr_csrrs_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2165,7 +2165,7 @@ Zicsr_csrrs_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2185,7 +2185,7 @@ Zicsr_csrrs_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2217,7 +2217,7 @@ Zicsr_csrrs_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2237,7 +2237,7 @@ Zicsr_csrrs_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2269,7 +2269,7 @@ Zicsr_csrrs_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2289,7 +2289,7 @@ Zicsr_csrrs_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2321,7 +2321,7 @@ Zicsr_csrrs_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2343,7 +2343,7 @@ Zicsr_csrrs_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2375,7 +2375,7 @@ Zicsr_csrrs_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2395,7 +2395,7 @@ Zicsr_csrrs_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2427,7 +2427,7 @@ Zicsr_csrrs_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2447,7 +2447,7 @@ Zicsr_csrrs_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2479,7 +2479,7 @@ Zicsr_csrrs_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2499,7 +2499,7 @@ Zicsr_csrrs_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2531,7 +2531,7 @@ Zicsr_csrrs_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2551,7 +2551,7 @@ Zicsr_csrrs_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2583,7 +2583,7 @@ Zicsr_csrrs_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2603,7 +2603,7 @@ Zicsr_csrrs_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2635,7 +2635,7 @@ Zicsr_csrrs_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2655,7 +2655,7 @@ Zicsr_csrrs_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2687,7 +2687,7 @@ Zicsr_csrrs_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2708,7 +2708,7 @@ Zicsr_csrrs_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2740,7 +2740,7 @@ Zicsr_csrrs_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2760,7 +2760,7 @@ Zicsr_csrrs_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2792,7 +2792,7 @@ Zicsr_csrrs_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2812,7 +2812,7 @@ Zicsr_csrrs_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2844,7 +2844,7 @@ Zicsr_csrrs_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2864,7 +2864,7 @@ Zicsr_csrrs_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2896,7 +2896,7 @@ Zicsr_csrrs_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2917,7 +2917,7 @@ Zicsr_csrrs_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2949,7 +2949,7 @@ Zicsr_csrrs_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2969,7 +2969,7 @@ Zicsr_csrrs_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3001,7 +3001,7 @@ Zicsr_csrrs_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3021,7 +3021,7 @@ Zicsr_csrrs_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3053,7 +3053,7 @@ Zicsr_csrrs_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3073,7 +3073,7 @@ Zicsr_csrrs_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3105,7 +3105,7 @@ Zicsr_csrrs_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3125,7 +3125,7 @@ Zicsr_csrrs_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3139,7 +3139,7 @@ Zicsr_csrrs_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3154,7 +3154,7 @@ Zicsr_csrrs_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3174,7 +3174,7 @@ Zicsr_csrrs_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3206,7 +3206,7 @@ Zicsr_csrrs_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3226,7 +3226,7 @@ Zicsr_csrrs_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3258,7 +3258,7 @@ Zicsr_csrrs_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3278,7 +3278,7 @@ Zicsr_csrrs_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3310,7 +3310,7 @@ Zicsr_csrrs_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3330,7 +3330,7 @@ Zicsr_csrrs_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3362,7 +3362,7 @@ Zicsr_csrrs_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3386,7 +3386,7 @@ Zicsr_csrrs_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3418,7 +3418,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x0:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3438,7 +3438,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3470,7 +3470,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x1:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3490,7 +3490,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3522,7 +3522,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x2:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3542,7 +3542,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3574,7 +3574,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x8000000000000000:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3594,7 +3594,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x8000000000000000:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3626,7 +3626,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x8000000000000001:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3646,7 +3646,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x8000000000000001:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3678,7 +3678,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x7fffffffffffffff:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3698,7 +3698,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x7fffffffffffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3730,7 +3730,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x7ffffffffffffffe:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3750,7 +3750,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x7ffffffffffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3782,7 +3782,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0xffffffffffffffff:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3802,7 +3802,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0xffffffffffffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3834,7 +3834,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0xfffffffffffffffe:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3854,7 +3854,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0xfffffffffffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3886,7 +3886,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x5bbc887763ae86f2:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3906,7 +3906,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x5bbc887763ae86f2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3938,7 +3938,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0xaaaaaaaaaaaaaaaa:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3958,7 +3958,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0xaaaaaaaaaaaaaaaa:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3990,7 +3990,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x5555555555555555:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4010,7 +4010,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x5555555555555555:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4042,7 +4042,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0xffffffff:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4062,7 +4062,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0xffffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4094,7 +4094,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0xfffffffe:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4114,7 +4114,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0xfffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4146,7 +4146,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x100000000:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4166,7 +4166,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x100000000:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4198,7 +4198,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x100000001:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4222,7 +4222,7 @@ Zicsr_csrrs_cg_cp_rs1_edges_0x100000001:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4236,7 +4236,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4251,7 +4251,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4272,7 +4272,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4304,7 +4304,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4324,7 +4324,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4356,7 +4356,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4376,7 +4376,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4408,7 +4408,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4430,7 +4430,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4462,7 +4462,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4482,7 +4482,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4514,7 +4514,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4534,7 +4534,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4566,7 +4566,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4588,7 +4588,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4620,7 +4620,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4640,7 +4640,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4672,7 +4672,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4693,7 +4693,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4725,7 +4725,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4745,7 +4745,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4777,7 +4777,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4798,7 +4798,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4830,7 +4830,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4852,7 +4852,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4884,7 +4884,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4904,7 +4904,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4936,7 +4936,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4956,7 +4956,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4988,7 +4988,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5008,7 +5008,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5040,7 +5040,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5060,7 +5060,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5092,7 +5092,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5112,7 +5112,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5144,7 +5144,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5164,7 +5164,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5196,7 +5196,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5216,7 +5216,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5248,7 +5248,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5268,7 +5268,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5300,7 +5300,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5321,7 +5321,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5353,7 +5353,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5373,7 +5373,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5405,7 +5405,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5425,7 +5425,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5457,7 +5457,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5477,7 +5477,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5509,7 +5509,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5529,7 +5529,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5561,7 +5561,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5582,7 +5582,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5614,7 +5614,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5634,7 +5634,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5666,7 +5666,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5686,7 +5686,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5718,7 +5718,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5739,7 +5739,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5771,7 +5771,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5791,7 +5791,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5823,7 +5823,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5843,7 +5843,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5875,7 +5875,7 @@ Zicsr_csrrs_cg_cmp_rd_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif

--- a/tests/rv64i/Zicsr/Zicsr-csrrsi-00.S
+++ b/tests/rv64i/Zicsr/Zicsr-csrrsi-00.S
@@ -45,7 +45,7 @@ RVTEST_BEGIN
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -59,7 +59,7 @@ Zicsr_csrrsi_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrsi x0, mepc, 20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -74,7 +74,7 @@ Zicsr_csrrsi_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -93,7 +93,7 @@ Zicsr_csrrsi_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -125,7 +125,7 @@ Zicsr_csrrsi_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -145,7 +145,7 @@ Zicsr_csrrsi_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -177,7 +177,7 @@ Zicsr_csrrsi_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -197,7 +197,7 @@ Zicsr_csrrsi_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -229,7 +229,7 @@ Zicsr_csrrsi_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -250,7 +250,7 @@ Zicsr_csrrsi_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -282,7 +282,7 @@ Zicsr_csrrsi_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -301,7 +301,7 @@ Zicsr_csrrsi_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -333,7 +333,7 @@ Zicsr_csrrsi_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -352,7 +352,7 @@ Zicsr_csrrsi_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -384,7 +384,7 @@ Zicsr_csrrsi_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -405,7 +405,7 @@ Zicsr_csrrsi_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -437,7 +437,7 @@ Zicsr_csrrsi_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -456,7 +456,7 @@ Zicsr_csrrsi_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -488,7 +488,7 @@ Zicsr_csrrsi_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -507,7 +507,7 @@ Zicsr_csrrsi_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -539,7 +539,7 @@ Zicsr_csrrsi_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -558,7 +558,7 @@ Zicsr_csrrsi_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -590,7 +590,7 @@ Zicsr_csrrsi_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -609,7 +609,7 @@ Zicsr_csrrsi_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -641,7 +641,7 @@ Zicsr_csrrsi_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -660,7 +660,7 @@ Zicsr_csrrsi_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -692,7 +692,7 @@ Zicsr_csrrsi_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -711,7 +711,7 @@ Zicsr_csrrsi_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -743,7 +743,7 @@ Zicsr_csrrsi_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -762,7 +762,7 @@ Zicsr_csrrsi_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -794,7 +794,7 @@ Zicsr_csrrsi_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -813,7 +813,7 @@ Zicsr_csrrsi_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -845,7 +845,7 @@ Zicsr_csrrsi_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -864,7 +864,7 @@ Zicsr_csrrsi_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -896,7 +896,7 @@ Zicsr_csrrsi_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -915,7 +915,7 @@ Zicsr_csrrsi_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -947,7 +947,7 @@ Zicsr_csrrsi_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -966,7 +966,7 @@ Zicsr_csrrsi_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -998,7 +998,7 @@ Zicsr_csrrsi_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1017,7 +1017,7 @@ Zicsr_csrrsi_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1049,7 +1049,7 @@ Zicsr_csrrsi_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1068,7 +1068,7 @@ Zicsr_csrrsi_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1100,7 +1100,7 @@ Zicsr_csrrsi_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1120,7 +1120,7 @@ Zicsr_csrrsi_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1134,7 +1134,7 @@ Zicsr_csrrsi_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrsi x21, mepc, 28
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1149,7 +1149,7 @@ Zicsr_csrrsi_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1168,7 +1168,7 @@ Zicsr_csrrsi_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1200,7 +1200,7 @@ Zicsr_csrrsi_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1220,7 +1220,7 @@ Zicsr_csrrsi_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1252,7 +1252,7 @@ Zicsr_csrrsi_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1271,7 +1271,7 @@ Zicsr_csrrsi_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1303,7 +1303,7 @@ Zicsr_csrrsi_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1322,7 +1322,7 @@ Zicsr_csrrsi_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1354,7 +1354,7 @@ Zicsr_csrrsi_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1373,7 +1373,7 @@ Zicsr_csrrsi_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1405,7 +1405,7 @@ Zicsr_csrrsi_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1424,7 +1424,7 @@ Zicsr_csrrsi_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1456,7 +1456,7 @@ Zicsr_csrrsi_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1476,7 +1476,7 @@ Zicsr_csrrsi_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1490,7 +1490,7 @@ Zicsr_csrrsi_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrsi x28, mepc, 20
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1505,7 +1505,7 @@ Zicsr_csrrsi_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1524,7 +1524,7 @@ Zicsr_csrrsi_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1556,7 +1556,7 @@ Zicsr_csrrsi_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1575,7 +1575,7 @@ Zicsr_csrrsi_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1607,7 +1607,7 @@ Zicsr_csrrsi_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1626,7 +1626,7 @@ Zicsr_csrrsi_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1658,7 +1658,7 @@ Zicsr_csrrsi_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1681,7 +1681,7 @@ Zicsr_csrrsi_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1713,7 +1713,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm0:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1732,7 +1732,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1746,7 +1746,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm1:
 #elif !defined(U_SUPPORTED)
   csrrsi x0, mepc, 1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1761,7 +1761,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm1:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1780,7 +1780,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1812,7 +1812,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm2:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1831,7 +1831,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1863,7 +1863,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm3:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1882,7 +1882,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1914,7 +1914,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm4:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1933,7 +1933,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1965,7 +1965,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm5:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1984,7 +1984,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2016,7 +2016,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm6:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2035,7 +2035,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2049,7 +2049,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm7:
 #elif !defined(U_SUPPORTED)
   csrrsi x0, mepc, 7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2064,7 +2064,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm7:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2083,7 +2083,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2115,7 +2115,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm8:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2134,7 +2134,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2166,7 +2166,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm9:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2185,7 +2185,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2217,7 +2217,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm10:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2236,7 +2236,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2268,7 +2268,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm11:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2287,7 +2287,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2319,7 +2319,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm12:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2338,7 +2338,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2370,7 +2370,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm13:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2389,7 +2389,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2421,7 +2421,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm14:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2440,7 +2440,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2472,7 +2472,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm15:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2491,7 +2491,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2523,7 +2523,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm16:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2542,7 +2542,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2574,7 +2574,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm17:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2593,7 +2593,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2625,7 +2625,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm18:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2644,7 +2644,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2676,7 +2676,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm19:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2695,7 +2695,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2727,7 +2727,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm20:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2746,7 +2746,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2760,7 +2760,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm21:
 #elif !defined(U_SUPPORTED)
   csrrsi x28, mepc, 21
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2775,7 +2775,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm21:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2794,7 +2794,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2826,7 +2826,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm22:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2845,7 +2845,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2877,7 +2877,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm23:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2896,7 +2896,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2928,7 +2928,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm24:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2947,7 +2947,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2979,7 +2979,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm25:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2998,7 +2998,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3030,7 +3030,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm26:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3049,7 +3049,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3081,7 +3081,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm27:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3100,7 +3100,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3114,7 +3114,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm28:
 #elif !defined(U_SUPPORTED)
   csrrsi x0, mepc, 28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3129,7 +3129,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm28:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3148,7 +3148,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3180,7 +3180,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm29:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3199,7 +3199,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3231,7 +3231,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm30:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3250,7 +3250,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3282,7 +3282,7 @@ Zicsr_csrrsi_cg_cp_uimm_5_uimm31:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif

--- a/tests/rv64i/Zicsr/Zicsr-csrrw-00.S
+++ b/tests/rv64i/Zicsr/Zicsr-csrrw-00.S
@@ -46,7 +46,7 @@ RVTEST_BEGIN
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -60,7 +60,7 @@ Zicsr_csrrw_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -75,7 +75,7 @@ Zicsr_csrrw_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -95,7 +95,7 @@ Zicsr_csrrw_cg_cp_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -109,7 +109,7 @@ Zicsr_csrrw_cg_cp_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x15, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -124,7 +124,7 @@ Zicsr_csrrw_cg_cp_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -145,7 +145,7 @@ Zicsr_csrrw_cg_cp_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -159,7 +159,7 @@ Zicsr_csrrw_cg_cp_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x20, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -174,7 +174,7 @@ Zicsr_csrrw_cg_cp_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -195,7 +195,7 @@ Zicsr_csrrw_cg_cp_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -209,7 +209,7 @@ Zicsr_csrrw_cg_cp_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x11, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -224,7 +224,7 @@ Zicsr_csrrw_cg_cp_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -246,7 +246,7 @@ Zicsr_csrrw_cg_cp_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -260,7 +260,7 @@ Zicsr_csrrw_cg_cp_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x18, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -275,7 +275,7 @@ Zicsr_csrrw_cg_cp_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -295,7 +295,7 @@ Zicsr_csrrw_cg_cp_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -309,7 +309,7 @@ Zicsr_csrrw_cg_cp_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x11, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -324,7 +324,7 @@ Zicsr_csrrw_cg_cp_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -344,7 +344,7 @@ Zicsr_csrrw_cg_cp_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -358,7 +358,7 @@ Zicsr_csrrw_cg_cp_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x21, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -373,7 +373,7 @@ Zicsr_csrrw_cg_cp_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -393,7 +393,7 @@ Zicsr_csrrw_cg_cp_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -407,7 +407,7 @@ Zicsr_csrrw_cg_cp_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x22, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -422,7 +422,7 @@ Zicsr_csrrw_cg_cp_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x4, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -442,7 +442,7 @@ Zicsr_csrrw_cg_cp_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -456,7 +456,7 @@ Zicsr_csrrw_cg_cp_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x4, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -471,7 +471,7 @@ Zicsr_csrrw_cg_cp_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -491,7 +491,7 @@ Zicsr_csrrw_cg_cp_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -505,7 +505,7 @@ Zicsr_csrrw_cg_cp_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x18, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -520,7 +520,7 @@ Zicsr_csrrw_cg_cp_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -541,7 +541,7 @@ Zicsr_csrrw_cg_cp_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -555,7 +555,7 @@ Zicsr_csrrw_cg_cp_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x2, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -570,7 +570,7 @@ Zicsr_csrrw_cg_cp_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -590,7 +590,7 @@ Zicsr_csrrw_cg_cp_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -604,7 +604,7 @@ Zicsr_csrrw_cg_cp_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x8, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -619,7 +619,7 @@ Zicsr_csrrw_cg_cp_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -641,7 +641,7 @@ Zicsr_csrrw_cg_cp_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -655,7 +655,7 @@ Zicsr_csrrw_cg_cp_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x26, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -670,7 +670,7 @@ Zicsr_csrrw_cg_cp_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -690,7 +690,7 @@ Zicsr_csrrw_cg_cp_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -704,7 +704,7 @@ Zicsr_csrrw_cg_cp_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x25, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -719,7 +719,7 @@ Zicsr_csrrw_cg_cp_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -739,7 +739,7 @@ Zicsr_csrrw_cg_cp_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -753,7 +753,7 @@ Zicsr_csrrw_cg_cp_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x2, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -768,7 +768,7 @@ Zicsr_csrrw_cg_cp_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -788,7 +788,7 @@ Zicsr_csrrw_cg_cp_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -802,7 +802,7 @@ Zicsr_csrrw_cg_cp_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x21, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -817,7 +817,7 @@ Zicsr_csrrw_cg_cp_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -837,7 +837,7 @@ Zicsr_csrrw_cg_cp_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -851,7 +851,7 @@ Zicsr_csrrw_cg_cp_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x11, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -866,7 +866,7 @@ Zicsr_csrrw_cg_cp_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -886,7 +886,7 @@ Zicsr_csrrw_cg_cp_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -900,7 +900,7 @@ Zicsr_csrrw_cg_cp_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x15, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -915,7 +915,7 @@ Zicsr_csrrw_cg_cp_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -935,7 +935,7 @@ Zicsr_csrrw_cg_cp_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -949,7 +949,7 @@ Zicsr_csrrw_cg_cp_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x12, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -964,7 +964,7 @@ Zicsr_csrrw_cg_cp_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -984,7 +984,7 @@ Zicsr_csrrw_cg_cp_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -998,7 +998,7 @@ Zicsr_csrrw_cg_cp_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x13, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1013,7 +1013,7 @@ Zicsr_csrrw_cg_cp_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1033,7 +1033,7 @@ Zicsr_csrrw_cg_cp_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1047,7 +1047,7 @@ Zicsr_csrrw_cg_cp_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x1, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1062,7 +1062,7 @@ Zicsr_csrrw_cg_cp_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1082,7 +1082,7 @@ Zicsr_csrrw_cg_cp_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1096,7 +1096,7 @@ Zicsr_csrrw_cg_cp_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x22, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1111,7 +1111,7 @@ Zicsr_csrrw_cg_cp_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1131,7 +1131,7 @@ Zicsr_csrrw_cg_cp_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1145,7 +1145,7 @@ Zicsr_csrrw_cg_cp_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x27, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1160,7 +1160,7 @@ Zicsr_csrrw_cg_cp_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1180,7 +1180,7 @@ Zicsr_csrrw_cg_cp_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1194,7 +1194,7 @@ Zicsr_csrrw_cg_cp_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x28, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1209,7 +1209,7 @@ Zicsr_csrrw_cg_cp_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1229,7 +1229,7 @@ Zicsr_csrrw_cg_cp_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1243,7 +1243,7 @@ Zicsr_csrrw_cg_cp_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x19, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1258,7 +1258,7 @@ Zicsr_csrrw_cg_cp_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1278,7 +1278,7 @@ Zicsr_csrrw_cg_cp_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1292,7 +1292,7 @@ Zicsr_csrrw_cg_cp_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x11, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1307,7 +1307,7 @@ Zicsr_csrrw_cg_cp_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1327,7 +1327,7 @@ Zicsr_csrrw_cg_cp_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1341,7 +1341,7 @@ Zicsr_csrrw_cg_cp_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x13, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1356,7 +1356,7 @@ Zicsr_csrrw_cg_cp_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1376,7 +1376,7 @@ Zicsr_csrrw_cg_cp_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1390,7 +1390,7 @@ Zicsr_csrrw_cg_cp_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x3, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1405,7 +1405,7 @@ Zicsr_csrrw_cg_cp_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1425,7 +1425,7 @@ Zicsr_csrrw_cg_cp_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1439,7 +1439,7 @@ Zicsr_csrrw_cg_cp_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x25, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1454,7 +1454,7 @@ Zicsr_csrrw_cg_cp_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1474,7 +1474,7 @@ Zicsr_csrrw_cg_cp_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1488,7 +1488,7 @@ Zicsr_csrrw_cg_cp_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x19, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1503,7 +1503,7 @@ Zicsr_csrrw_cg_cp_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1523,7 +1523,7 @@ Zicsr_csrrw_cg_cp_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1537,7 +1537,7 @@ Zicsr_csrrw_cg_cp_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x20, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1552,7 +1552,7 @@ Zicsr_csrrw_cg_cp_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1573,7 +1573,7 @@ Zicsr_csrrw_cg_cp_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1587,7 +1587,7 @@ Zicsr_csrrw_cg_cp_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x20, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1602,7 +1602,7 @@ Zicsr_csrrw_cg_cp_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1626,7 +1626,7 @@ Zicsr_csrrw_cg_cp_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1640,7 +1640,7 @@ Zicsr_csrrw_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1655,7 +1655,7 @@ Zicsr_csrrw_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1675,7 +1675,7 @@ Zicsr_csrrw_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1689,7 +1689,7 @@ Zicsr_csrrw_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x1, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1704,7 +1704,7 @@ Zicsr_csrrw_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1724,7 +1724,7 @@ Zicsr_csrrw_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1738,7 +1738,7 @@ Zicsr_csrrw_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x2, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1753,7 +1753,7 @@ Zicsr_csrrw_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1773,7 +1773,7 @@ Zicsr_csrrw_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1787,7 +1787,7 @@ Zicsr_csrrw_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x3, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1802,7 +1802,7 @@ Zicsr_csrrw_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1824,7 +1824,7 @@ Zicsr_csrrw_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1838,7 +1838,7 @@ Zicsr_csrrw_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x4, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1853,7 +1853,7 @@ Zicsr_csrrw_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1873,7 +1873,7 @@ Zicsr_csrrw_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1887,7 +1887,7 @@ Zicsr_csrrw_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x5, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1902,7 +1902,7 @@ Zicsr_csrrw_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1923,7 +1923,7 @@ Zicsr_csrrw_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1937,7 +1937,7 @@ Zicsr_csrrw_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x6, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1952,7 +1952,7 @@ Zicsr_csrrw_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1974,7 +1974,7 @@ Zicsr_csrrw_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1988,7 +1988,7 @@ Zicsr_csrrw_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x7, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2003,7 +2003,7 @@ Zicsr_csrrw_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2023,7 +2023,7 @@ Zicsr_csrrw_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2037,7 +2037,7 @@ Zicsr_csrrw_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x8, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2052,7 +2052,7 @@ Zicsr_csrrw_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2072,7 +2072,7 @@ Zicsr_csrrw_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2086,7 +2086,7 @@ Zicsr_csrrw_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x9, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2101,7 +2101,7 @@ Zicsr_csrrw_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2121,7 +2121,7 @@ Zicsr_csrrw_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2135,7 +2135,7 @@ Zicsr_csrrw_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x10, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2150,7 +2150,7 @@ Zicsr_csrrw_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2170,7 +2170,7 @@ Zicsr_csrrw_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2184,7 +2184,7 @@ Zicsr_csrrw_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x11, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2199,7 +2199,7 @@ Zicsr_csrrw_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2219,7 +2219,7 @@ Zicsr_csrrw_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2233,7 +2233,7 @@ Zicsr_csrrw_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x12, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2248,7 +2248,7 @@ Zicsr_csrrw_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2268,7 +2268,7 @@ Zicsr_csrrw_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2282,7 +2282,7 @@ Zicsr_csrrw_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x13, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2297,7 +2297,7 @@ Zicsr_csrrw_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2317,7 +2317,7 @@ Zicsr_csrrw_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2331,7 +2331,7 @@ Zicsr_csrrw_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x14, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2346,7 +2346,7 @@ Zicsr_csrrw_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2366,7 +2366,7 @@ Zicsr_csrrw_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2380,7 +2380,7 @@ Zicsr_csrrw_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x15, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2395,7 +2395,7 @@ Zicsr_csrrw_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2416,7 +2416,7 @@ Zicsr_csrrw_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2430,7 +2430,7 @@ Zicsr_csrrw_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x16, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2445,7 +2445,7 @@ Zicsr_csrrw_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2465,7 +2465,7 @@ Zicsr_csrrw_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2479,7 +2479,7 @@ Zicsr_csrrw_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x17, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2494,7 +2494,7 @@ Zicsr_csrrw_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2514,7 +2514,7 @@ Zicsr_csrrw_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2528,7 +2528,7 @@ Zicsr_csrrw_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x18, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2543,7 +2543,7 @@ Zicsr_csrrw_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2563,7 +2563,7 @@ Zicsr_csrrw_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2577,7 +2577,7 @@ Zicsr_csrrw_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x19, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2592,7 +2592,7 @@ Zicsr_csrrw_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2612,7 +2612,7 @@ Zicsr_csrrw_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2626,7 +2626,7 @@ Zicsr_csrrw_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x20, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2641,7 +2641,7 @@ Zicsr_csrrw_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2661,7 +2661,7 @@ Zicsr_csrrw_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2675,7 +2675,7 @@ Zicsr_csrrw_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x21, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2690,7 +2690,7 @@ Zicsr_csrrw_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2710,7 +2710,7 @@ Zicsr_csrrw_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2724,7 +2724,7 @@ Zicsr_csrrw_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x22, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2739,7 +2739,7 @@ Zicsr_csrrw_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2759,7 +2759,7 @@ Zicsr_csrrw_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2773,7 +2773,7 @@ Zicsr_csrrw_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x23, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2788,7 +2788,7 @@ Zicsr_csrrw_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2809,7 +2809,7 @@ Zicsr_csrrw_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2823,7 +2823,7 @@ Zicsr_csrrw_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x24, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2838,7 +2838,7 @@ Zicsr_csrrw_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2858,7 +2858,7 @@ Zicsr_csrrw_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2872,7 +2872,7 @@ Zicsr_csrrw_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x25, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2887,7 +2887,7 @@ Zicsr_csrrw_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2907,7 +2907,7 @@ Zicsr_csrrw_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2921,7 +2921,7 @@ Zicsr_csrrw_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x26, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2936,7 +2936,7 @@ Zicsr_csrrw_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2956,7 +2956,7 @@ Zicsr_csrrw_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2970,7 +2970,7 @@ Zicsr_csrrw_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x27, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2985,7 +2985,7 @@ Zicsr_csrrw_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3005,7 +3005,7 @@ Zicsr_csrrw_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3019,7 +3019,7 @@ Zicsr_csrrw_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x28, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3034,7 +3034,7 @@ Zicsr_csrrw_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3054,7 +3054,7 @@ Zicsr_csrrw_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3068,7 +3068,7 @@ Zicsr_csrrw_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x29, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3083,7 +3083,7 @@ Zicsr_csrrw_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3103,7 +3103,7 @@ Zicsr_csrrw_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3117,7 +3117,7 @@ Zicsr_csrrw_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x30, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3132,7 +3132,7 @@ Zicsr_csrrw_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3152,7 +3152,7 @@ Zicsr_csrrw_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3166,7 +3166,7 @@ Zicsr_csrrw_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x31, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3181,7 +3181,7 @@ Zicsr_csrrw_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3205,7 +3205,7 @@ Zicsr_csrrw_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3219,7 +3219,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x0:
 #elif !defined(U_SUPPORTED)
   csrrw x13, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3234,7 +3234,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x0:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3254,7 +3254,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3268,7 +3268,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x1:
 #elif !defined(U_SUPPORTED)
   csrrw x18, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3283,7 +3283,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x1:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3303,7 +3303,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3317,7 +3317,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x2:
 #elif !defined(U_SUPPORTED)
   csrrw x6, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3332,7 +3332,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x2:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3352,7 +3352,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3366,7 +3366,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x8000000000000000:
 #elif !defined(U_SUPPORTED)
   csrrw x12, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3381,7 +3381,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x8000000000000000:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3401,7 +3401,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x8000000000000000:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3415,7 +3415,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x8000000000000001:
 #elif !defined(U_SUPPORTED)
   csrrw x18, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3430,7 +3430,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x8000000000000001:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3450,7 +3450,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x8000000000000001:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3464,7 +3464,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x7fffffffffffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x13, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3479,7 +3479,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x7fffffffffffffff:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3499,7 +3499,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x7fffffffffffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3513,7 +3513,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x7ffffffffffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x24, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3528,7 +3528,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x7ffffffffffffffe:
 #elif !defined(U_SUPPORTED)
   csrrs x10, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3548,7 +3548,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x7ffffffffffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3562,7 +3562,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xffffffffffffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x25, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3577,7 +3577,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xffffffffffffffff:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3597,7 +3597,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xffffffffffffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3611,7 +3611,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xfffffffffffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x30, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3626,7 +3626,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xfffffffffffffffe:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3646,7 +3646,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xfffffffffffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3660,7 +3660,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x5bbc887763ae86f2:
 #elif !defined(U_SUPPORTED)
   csrrw x10, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3675,7 +3675,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x5bbc887763ae86f2:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3695,7 +3695,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x5bbc887763ae86f2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3709,7 +3709,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xaaaaaaaaaaaaaaaa:
 #elif !defined(U_SUPPORTED)
   csrrw x10, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3724,7 +3724,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xaaaaaaaaaaaaaaaa:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3744,7 +3744,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xaaaaaaaaaaaaaaaa:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3758,7 +3758,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x5555555555555555:
 #elif !defined(U_SUPPORTED)
   csrrw x24, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3773,7 +3773,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x5555555555555555:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3793,7 +3793,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x5555555555555555:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3807,7 +3807,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xffffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x6, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3822,7 +3822,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xffffffff:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3842,7 +3842,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xffffffff:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3856,7 +3856,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xfffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x27, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3871,7 +3871,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xfffffffe:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3891,7 +3891,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0xfffffffe:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3905,7 +3905,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x100000000:
 #elif !defined(U_SUPPORTED)
   csrrw x17, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3920,7 +3920,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x100000000:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3940,7 +3940,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x100000000:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3954,7 +3954,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x100000001:
 #elif !defined(U_SUPPORTED)
   csrrw x15, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3969,7 +3969,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x100000001:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3993,7 +3993,7 @@ Zicsr_csrrw_cg_cp_rs1_edges_0x100000001:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4007,7 +4007,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4022,7 +4022,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4042,7 +4042,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4056,7 +4056,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x1, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4071,7 +4071,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4091,7 +4091,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4105,7 +4105,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x2, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4120,7 +4120,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4140,7 +4140,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4154,7 +4154,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x3, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4169,7 +4169,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4191,7 +4191,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4205,7 +4205,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x4, mepc, x4
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4220,7 +4220,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4240,7 +4240,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4254,7 +4254,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x5, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4269,7 +4269,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4289,7 +4289,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4303,7 +4303,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x6, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4318,7 +4318,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4340,7 +4340,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4354,7 +4354,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x7, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4369,7 +4369,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4389,7 +4389,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x5
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4403,7 +4403,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x8, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4418,7 +4418,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x5, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4438,7 +4438,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4452,7 +4452,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x9, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4467,7 +4467,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4487,7 +4487,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4501,7 +4501,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x10, mepc, x10
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4516,7 +4516,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4536,7 +4536,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4550,7 +4550,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x11, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4565,7 +4565,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4587,7 +4587,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4601,7 +4601,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x12, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4616,7 +4616,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4636,7 +4636,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4650,7 +4650,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x13, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4665,7 +4665,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4686,7 +4686,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4700,7 +4700,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x14, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4715,7 +4715,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x21, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4736,7 +4736,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4750,7 +4750,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x15, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4765,7 +4765,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4786,7 +4786,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4800,7 +4800,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x16, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4815,7 +4815,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4835,7 +4835,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4849,7 +4849,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x17, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4864,7 +4864,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4884,7 +4884,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4898,7 +4898,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x18, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4913,7 +4913,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4933,7 +4933,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4947,7 +4947,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x19, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4962,7 +4962,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4983,7 +4983,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -4997,7 +4997,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x20, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5012,7 +5012,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5032,7 +5032,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5046,7 +5046,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x21, mepc, x21
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5061,7 +5061,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5081,7 +5081,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5095,7 +5095,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x22, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5110,7 +5110,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5130,7 +5130,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5144,7 +5144,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x23, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5159,7 +5159,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5179,7 +5179,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5193,7 +5193,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x24, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5208,7 +5208,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5228,7 +5228,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5242,7 +5242,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x25, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5257,7 +5257,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5278,7 +5278,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5292,7 +5292,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x26, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5307,7 +5307,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5327,7 +5327,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5341,7 +5341,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x27, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5356,7 +5356,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5376,7 +5376,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5390,7 +5390,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x28, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5405,7 +5405,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5425,7 +5425,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5439,7 +5439,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x29, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5454,7 +5454,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5474,7 +5474,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5488,7 +5488,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x30, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5503,7 +5503,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5523,7 +5523,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5537,7 +5537,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x31, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -5552,7 +5552,7 @@ Zicsr_csrrw_cg_cmp_rd_rs1_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif

--- a/tests/rv64i/Zicsr/Zicsr-csrrwi-00.S
+++ b/tests/rv64i/Zicsr/Zicsr-csrrwi-00.S
@@ -45,7 +45,7 @@ RVTEST_BEGIN
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -59,7 +59,7 @@ Zicsr_csrrwi_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrwi x0, mepc, 12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -74,7 +74,7 @@ Zicsr_csrrwi_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -93,7 +93,7 @@ Zicsr_csrrwi_cg_cp_rd_b0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -107,7 +107,7 @@ Zicsr_csrrwi_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrwi x1, mepc, 25
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -122,7 +122,7 @@ Zicsr_csrrwi_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -142,7 +142,7 @@ Zicsr_csrrwi_cg_cp_rd_b1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -156,7 +156,7 @@ Zicsr_csrrwi_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrwi x2, mepc, 6
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -171,7 +171,7 @@ Zicsr_csrrwi_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -191,7 +191,7 @@ Zicsr_csrrwi_cg_cp_rd_b2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x11
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -205,7 +205,7 @@ Zicsr_csrrwi_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrwi x3, mepc, 10
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -220,7 +220,7 @@ Zicsr_csrrwi_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrs x11, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -241,7 +241,7 @@ Zicsr_csrrwi_cg_cp_rd_b3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -255,7 +255,7 @@ Zicsr_csrrwi_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrwi x4, mepc, 2
 #elif defined(ZICNTR_SUPPORTED)
-  li x4, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x4, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -270,7 +270,7 @@ Zicsr_csrrwi_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -289,7 +289,7 @@ Zicsr_csrrwi_cg_cp_rd_b4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -303,7 +303,7 @@ Zicsr_csrrwi_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrwi x5, mepc, 19
 #elif defined(ZICNTR_SUPPORTED)
-  li x5, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x5, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -318,7 +318,7 @@ Zicsr_csrrwi_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -337,7 +337,7 @@ Zicsr_csrrwi_cg_cp_rd_b5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -351,7 +351,7 @@ Zicsr_csrrwi_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrwi x6, mepc, 10
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -366,7 +366,7 @@ Zicsr_csrrwi_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -387,7 +387,7 @@ Zicsr_csrrwi_cg_cp_rd_b6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -401,7 +401,7 @@ Zicsr_csrrwi_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrwi x7, mepc, 7
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -416,7 +416,7 @@ Zicsr_csrrwi_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -435,7 +435,7 @@ Zicsr_csrrwi_cg_cp_rd_b7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -449,7 +449,7 @@ Zicsr_csrrwi_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrwi x8, mepc, 25
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -464,7 +464,7 @@ Zicsr_csrrwi_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -483,7 +483,7 @@ Zicsr_csrrwi_cg_cp_rd_b8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -497,7 +497,7 @@ Zicsr_csrrwi_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrwi x9, mepc, 2
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -512,7 +512,7 @@ Zicsr_csrrwi_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -531,7 +531,7 @@ Zicsr_csrrwi_cg_cp_rd_b9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -545,7 +545,7 @@ Zicsr_csrrwi_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrwi x10, mepc, 28
 #elif defined(ZICNTR_SUPPORTED)
-  li x10, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x10, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -560,7 +560,7 @@ Zicsr_csrrwi_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -579,7 +579,7 @@ Zicsr_csrrwi_cg_cp_rd_b10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -593,7 +593,7 @@ Zicsr_csrrwi_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrwi x11, mepc, 31
 #elif defined(ZICNTR_SUPPORTED)
-  li x11, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x11, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -608,7 +608,7 @@ Zicsr_csrrwi_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -627,7 +627,7 @@ Zicsr_csrrwi_cg_cp_rd_b11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -641,7 +641,7 @@ Zicsr_csrrwi_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrwi x12, mepc, 18
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -656,7 +656,7 @@ Zicsr_csrrwi_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -675,7 +675,7 @@ Zicsr_csrrwi_cg_cp_rd_b12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -689,7 +689,7 @@ Zicsr_csrrwi_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrwi x13, mepc, 19
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -704,7 +704,7 @@ Zicsr_csrrwi_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -723,7 +723,7 @@ Zicsr_csrrwi_cg_cp_rd_b13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -737,7 +737,7 @@ Zicsr_csrrwi_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrwi x14, mepc, 16
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -752,7 +752,7 @@ Zicsr_csrrwi_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -771,7 +771,7 @@ Zicsr_csrrwi_cg_cp_rd_b14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x19
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -785,7 +785,7 @@ Zicsr_csrrwi_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrwi x15, mepc, 17
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -800,7 +800,7 @@ Zicsr_csrrwi_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrs x19, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -820,7 +820,7 @@ Zicsr_csrrwi_cg_cp_rd_b15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x15
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -834,7 +834,7 @@ Zicsr_csrrwi_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrwi x16, mepc, 18
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -849,7 +849,7 @@ Zicsr_csrrwi_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrs x15, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -868,7 +868,7 @@ Zicsr_csrrwi_cg_cp_rd_b16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x14
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -882,7 +882,7 @@ Zicsr_csrrwi_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrwi x17, mepc, 15
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -897,7 +897,7 @@ Zicsr_csrrwi_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrs x14, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x14, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x14, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -916,7 +916,7 @@ Zicsr_csrrwi_cg_cp_rd_b17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -930,7 +930,7 @@ Zicsr_csrrwi_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrwi x18, mepc, 31
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -945,7 +945,7 @@ Zicsr_csrrwi_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -964,7 +964,7 @@ Zicsr_csrrwi_cg_cp_rd_b18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -978,7 +978,7 @@ Zicsr_csrrwi_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrwi x19, mepc, 22
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -993,7 +993,7 @@ Zicsr_csrrwi_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1012,7 +1012,7 @@ Zicsr_csrrwi_cg_cp_rd_b19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1026,7 +1026,7 @@ Zicsr_csrrwi_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrwi x20, mepc, 2
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1041,7 +1041,7 @@ Zicsr_csrrwi_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrs x25, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1060,7 +1060,7 @@ Zicsr_csrrwi_cg_cp_rd_b20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x7
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1074,7 +1074,7 @@ Zicsr_csrrwi_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrwi x21, mepc, 7
 #elif defined(ZICNTR_SUPPORTED)
-  li x21, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x21, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1089,7 +1089,7 @@ Zicsr_csrrwi_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrs x7, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1108,7 +1108,7 @@ Zicsr_csrrwi_cg_cp_rd_b21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1122,7 +1122,7 @@ Zicsr_csrrwi_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrwi x22, mepc, 19
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1137,7 +1137,7 @@ Zicsr_csrrwi_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1156,7 +1156,7 @@ Zicsr_csrrwi_cg_cp_rd_b22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x2
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1170,7 +1170,7 @@ Zicsr_csrrwi_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrwi x23, mepc, 18
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1185,7 +1185,7 @@ Zicsr_csrrwi_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrs x2, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x2, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x2, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1204,7 +1204,7 @@ Zicsr_csrrwi_cg_cp_rd_b23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1218,7 +1218,7 @@ Zicsr_csrrwi_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrwi x24, mepc, 4
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1233,7 +1233,7 @@ Zicsr_csrrwi_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1252,7 +1252,7 @@ Zicsr_csrrwi_cg_cp_rd_b24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x8
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1266,7 +1266,7 @@ Zicsr_csrrwi_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrwi x25, mepc, 4
 #elif defined(ZICNTR_SUPPORTED)
-  li x25, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x25, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1281,7 +1281,7 @@ Zicsr_csrrwi_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrs x8, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1300,7 +1300,7 @@ Zicsr_csrrwi_cg_cp_rd_b25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x3
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1314,7 +1314,7 @@ Zicsr_csrrwi_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrwi x26, mepc, 27
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1329,7 +1329,7 @@ Zicsr_csrrwi_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrs x3, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1348,7 +1348,7 @@ Zicsr_csrrwi_cg_cp_rd_b26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1362,7 +1362,7 @@ Zicsr_csrrwi_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrwi x27, mepc, 23
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1377,7 +1377,7 @@ Zicsr_csrrwi_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1397,7 +1397,7 @@ Zicsr_csrrwi_cg_cp_rd_b27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1411,7 +1411,7 @@ Zicsr_csrrwi_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrwi x28, mepc, 18
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1426,7 +1426,7 @@ Zicsr_csrrwi_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1445,7 +1445,7 @@ Zicsr_csrrwi_cg_cp_rd_b28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x24
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1459,7 +1459,7 @@ Zicsr_csrrwi_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrwi x29, mepc, 31
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1474,7 +1474,7 @@ Zicsr_csrrwi_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrs x24, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1493,7 +1493,7 @@ Zicsr_csrrwi_cg_cp_rd_b29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x16
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1507,7 +1507,7 @@ Zicsr_csrrwi_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrwi x30, mepc, 25
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1522,7 +1522,7 @@ Zicsr_csrrwi_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrs x16, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x16, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x16, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1541,7 +1541,7 @@ Zicsr_csrrwi_cg_cp_rd_b30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1555,7 +1555,7 @@ Zicsr_csrrwi_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrwi x31, mepc, 20
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1570,7 +1570,7 @@ Zicsr_csrrwi_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1593,7 +1593,7 @@ Zicsr_csrrwi_cg_cp_rd_b31:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1607,7 +1607,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm0:
 #elif !defined(U_SUPPORTED)
   csrrwi x18, mepc, 0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1622,7 +1622,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm0:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1641,7 +1641,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm0:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1655,7 +1655,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm1:
 #elif !defined(U_SUPPORTED)
   csrrwi x29, mepc, 1
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1670,7 +1670,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm1:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1689,7 +1689,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm1:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1703,7 +1703,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm2:
 #elif !defined(U_SUPPORTED)
   csrrwi x7, mepc, 2
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1718,7 +1718,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm2:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1737,7 +1737,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm2:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1751,7 +1751,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm3:
 #elif !defined(U_SUPPORTED)
   csrrwi x18, mepc, 3
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1766,7 +1766,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm3:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1785,7 +1785,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm3:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1799,7 +1799,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm4:
 #elif !defined(U_SUPPORTED)
   csrrwi x19, mepc, 4
 #elif defined(ZICNTR_SUPPORTED)
-  li x19, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x19, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1814,7 +1814,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm4:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1833,7 +1833,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm4:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x31
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1847,7 +1847,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm5:
 #elif !defined(U_SUPPORTED)
   csrrwi x24, mepc, 5
 #elif defined(ZICNTR_SUPPORTED)
-  li x24, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x24, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1862,7 +1862,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm5:
 #elif !defined(U_SUPPORTED)
   csrrs x31, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1881,7 +1881,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm5:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1895,7 +1895,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm6:
 #elif !defined(U_SUPPORTED)
   csrrwi x7, mepc, 6
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1910,7 +1910,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm6:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1929,7 +1929,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm6:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1943,7 +1943,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm7:
 #elif !defined(U_SUPPORTED)
   csrrwi x29, mepc, 7
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1958,7 +1958,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm7:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1977,7 +1977,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm7:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x1
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -1991,7 +1991,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm8:
 #elif !defined(U_SUPPORTED)
   csrrwi x29, mepc, 8
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2006,7 +2006,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm8:
 #elif !defined(U_SUPPORTED)
   csrrs x1, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x1, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x1, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2025,7 +2025,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm8:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2039,7 +2039,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm9:
 #elif !defined(U_SUPPORTED)
   csrrwi x7, mepc, 9
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2054,7 +2054,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm9:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2073,7 +2073,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm9:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x29
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2087,7 +2087,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm10:
 #elif !defined(U_SUPPORTED)
   csrrwi x17, mepc, 10
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2102,7 +2102,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm10:
 #elif !defined(U_SUPPORTED)
   csrrs x29, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2121,7 +2121,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm10:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2135,7 +2135,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm11:
 #elif !defined(U_SUPPORTED)
   csrrwi x26, mepc, 11
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2150,7 +2150,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm11:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2169,7 +2169,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm11:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x18
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2183,7 +2183,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm12:
 #elif !defined(U_SUPPORTED)
   csrrwi x3, mepc, 12
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2198,7 +2198,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm12:
 #elif !defined(U_SUPPORTED)
   csrrs x18, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2217,7 +2217,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm12:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x27
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2231,7 +2231,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm13:
 #elif !defined(U_SUPPORTED)
   csrrwi x8, mepc, 13
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2246,7 +2246,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm13:
 #elif !defined(U_SUPPORTED)
   csrrs x27, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x27, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x27, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2265,7 +2265,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm13:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x28
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2279,7 +2279,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm14:
 #elif !defined(U_SUPPORTED)
   csrrwi x29, mepc, 14
 #elif defined(ZICNTR_SUPPORTED)
-  li x29, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x29, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2294,7 +2294,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm14:
 #elif !defined(U_SUPPORTED)
   csrrs x28, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2313,7 +2313,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm14:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x30
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2327,7 +2327,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm15:
 #elif !defined(U_SUPPORTED)
   csrrwi x3, mepc, 15
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2342,7 +2342,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm15:
 #elif !defined(U_SUPPORTED)
   csrrs x30, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x30, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x30, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2361,7 +2361,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm15:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2375,7 +2375,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm16:
 #elif !defined(U_SUPPORTED)
   csrrwi x8, mepc, 16
 #elif defined(ZICNTR_SUPPORTED)
-  li x8, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x8, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2390,7 +2390,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm16:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2409,7 +2409,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm16:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2423,7 +2423,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm17:
 #elif !defined(U_SUPPORTED)
   csrrwi x31, mepc, 17
 #elif defined(ZICNTR_SUPPORTED)
-  li x31, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x31, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2438,7 +2438,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm17:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2457,7 +2457,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm17:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2471,7 +2471,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm18:
 #elif !defined(U_SUPPORTED)
   csrrwi x18, mepc, 18
 #elif defined(ZICNTR_SUPPORTED)
-  li x18, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x18, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2486,7 +2486,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm18:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2505,7 +2505,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm18:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2519,7 +2519,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm19:
 #elif !defined(U_SUPPORTED)
   csrrwi x6, mepc, 19
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2534,7 +2534,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm19:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2553,7 +2553,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm19:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x17
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2567,7 +2567,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm20:
 #elif !defined(U_SUPPORTED)
   csrrwi x26, mepc, 20
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2582,7 +2582,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm20:
 #elif !defined(U_SUPPORTED)
   csrrs x17, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x17, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x17, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2601,7 +2601,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm20:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2615,7 +2615,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm21:
 #elif !defined(U_SUPPORTED)
   csrrwi x12, mepc, 21
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2630,7 +2630,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm21:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2649,7 +2649,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm21:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x9
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2663,7 +2663,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm22:
 #elif !defined(U_SUPPORTED)
   csrrwi x12, mepc, 22
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2678,7 +2678,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm22:
 #elif !defined(U_SUPPORTED)
   csrrs x9, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x9, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x9, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2697,7 +2697,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm22:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x22
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2711,7 +2711,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm23:
 #elif !defined(U_SUPPORTED)
   csrrwi x26, mepc, 23
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2726,7 +2726,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm23:
 #elif !defined(U_SUPPORTED)
   csrrs x22, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x22, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x22, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2745,7 +2745,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm23:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2759,7 +2759,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm24:
 #elif !defined(U_SUPPORTED)
   csrrwi x15, mepc, 24
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2774,7 +2774,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm24:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2793,7 +2793,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm24:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x6
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2807,7 +2807,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm25:
 #elif !defined(U_SUPPORTED)
   csrrwi x0, mepc, 25
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2822,7 +2822,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm25:
 #elif !defined(U_SUPPORTED)
   csrrs x6, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x6, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x6, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2841,7 +2841,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm25:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2855,7 +2855,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm26:
 #elif !defined(U_SUPPORTED)
   csrrwi x28, mepc, 26
 #elif defined(ZICNTR_SUPPORTED)
-  li x28, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x28, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2870,7 +2870,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm26:
 #elif !defined(U_SUPPORTED)
   csrrs x0, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2889,7 +2889,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm26:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x23
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2903,7 +2903,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm27:
 #elif !defined(U_SUPPORTED)
   csrrwi x7, mepc, 27
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2918,7 +2918,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm27:
 #elif !defined(U_SUPPORTED)
   csrrs x23, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x23, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x23, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2937,7 +2937,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm27:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x20
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2951,7 +2951,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm28:
 #elif !defined(U_SUPPORTED)
   csrrwi x12, mepc, 28
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2966,7 +2966,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm28:
 #elif !defined(U_SUPPORTED)
   csrrs x20, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x20, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x20, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2985,7 +2985,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm28:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x26
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -2999,7 +2999,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm29:
 #elif !defined(U_SUPPORTED)
   csrrwi x3, mepc, 29
 #elif defined(ZICNTR_SUPPORTED)
-  li x3, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x3, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3014,7 +3014,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm29:
 #elif !defined(U_SUPPORTED)
   csrrs x26, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x26, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x26, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3033,7 +3033,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm29:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x12
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3047,7 +3047,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm30:
 #elif !defined(U_SUPPORTED)
   csrrwi x7, mepc, 30
 #elif defined(ZICNTR_SUPPORTED)
-  li x7, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x7, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3062,7 +3062,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm30:
 #elif !defined(U_SUPPORTED)
   csrrs x12, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x12, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x12, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3081,7 +3081,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm30:
 #elif !defined(U_SUPPORTED)
   csrrw x0, mepc, x13
 #elif defined(ZICNTR_SUPPORTED)
-  li x0, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x0, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3095,7 +3095,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm31:
 #elif !defined(U_SUPPORTED)
   csrrwi x15, mepc, 31
 #elif defined(ZICNTR_SUPPORTED)
-  li x15, 0 # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
+  LI(x15, 0) # avoid write to read-only instret, or inconsistent result with rs2 or rd = 0
 #else
   #error no CSR known for testing
 #endif
@@ -3110,7 +3110,7 @@ Zicsr_csrrwi_cg_cp_uimm_5_uimm31:
 #elif !defined(U_SUPPORTED)
   csrrs x13, mepc, x0
 #elif defined(ZICNTR_SUPPORTED)
-  li x13, 0 # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
+  LI(x13, 0) # avoid write to read-only instret, or inconsistent result with rs1 or rd = 0
 #else
   #error no CSR known for testing
 #endif


### PR DESCRIPTION


- add `.github/scripts/check-li-la-pseudoinstructions.sh` to flag bare `li`/`la` pseudoinstructions in `tests/` assembly files
- register hook in `.pre-commit-config.yaml` (scope: `^tests/.*\.(S|s)$`)
- update generator Python files to emit `LI()`/`LA()` macros
- convert existing `li`/`la` usages in `tests/` to `LI()`/`LA()` macros