### PR TITLE
PMPSm tor_zero: store ret at addr 0 so execute probe returns on cores…

### DIFF
--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_tor_zero.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_tor_zero.S
@@ -57,6 +57,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4,\TEST_CASE\()_2,test_2_str)               // Signature update
 
+    LI(a4, 0x00008067)                                       // ret (jalr x0, 0(ra)): on cores where addr 0 is mapped RAM the store lands and the later execute probe at 0 must return
     LI(a5, 0)
     LA(x1, 4f)                                               // Address to be verified
     sw a4, 0(a5)                                             // word-level store test

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_tor_zero.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_tor_zero.S
@@ -57,6 +57,7 @@ RVTEST_BEGIN
     nop
     RVTEST_SIGUPD(x2, x5, x4, a4,\TEST_CASE\()_2,test_2_str)               // Signature update
 
+    LI(a4, 0x00008067)                                       // ret (jalr x0, 0(ra)): on cores where addr 0 is mapped RAM the store lands and the later execute probe at 0 must return
     LI(a5, 0)
     LA(x1, 4f)                                               // Address to be verified
     sw a4, 0(a5)                                             // word-level store test


### PR DESCRIPTION
This PR fixes #1854 
pmpsm_cfg_A_tor_zero (pmp32 and pmp64 twins) probes address 0, the architecturally implicit lower bound of PMP entry 0 in TOR mode (coverpoint cp_cfg_A_tor0). The test implicitly assumes address 0 is not backed by writable, executable memory. On cores where that is not true, like cv32e40s, the probes succeed instead of trapping: the execute probe runs the single NOP planted at 0 and falls through into zeroed memory, dying on illegal instruction. This happens on the Sail  during signature generation.


Fix: plant `ret` instead of `NOP` at address 0. The execute probe links via `jalr ra`, so `ra` holds the resume address and the planted `ret` returns exactly where the fall-through was meant to resume. This is the same encoding the test already executes at `RETURN_INSTRUCTION+8`.

Behavior:

- Writable, readable and executable memory at 0 (e.g. cv32e40s): store lands, load reads it back, execute probe returns cleanly - no trap, matching the intended semantics; the coverpoint keeps probing the TOR lower bound on every platform class.
- Address 0 not backed (e.g. cvw, main memory at 0x80000000): the store access-faults before the value lands, load and fetch fault and recover exactly as before - the fix is invisible there.
- (Known limitation, unchanged by this patch: write-protected-but-executable memory at 0 (ROM) would need a readback guard before the jump; the test was  equally broken there before.)