### PR TITLE
Handle nondeterministic mstatus.FS transitions

### DIFF
--- a/coverpoints/norm/SmF.yaml
+++ b/coverpoints/norm/SmF.yaml
@@ -39,7 +39,7 @@ normative_rule_definitions:
   # floating-point state may cause the state to transition from Initial or Clean to
   # Dirty.
   - name: mstatus_fs_imprecise
-    coverpoint: ["SmF_cg/cp_mstatus_FS_transition, SmF_cg/cp_fcsr_access"]
+    coverpoint: ["Untestable"]
 
   # dirtiness might not be tracked at all, in which case the valid FS states are Off
   # and Dirty, and an attempt to set FS to Initial or Clean causes it to be set to
@@ -51,7 +51,7 @@ normative_rule_definitions:
   # the fcsr but does not alter its contents, and FS=Initial or FS=Clean, it is
   # implementation-defined whether FS transitions to Dirty.
   - name: mstatus_fs_no_change_dirty
-    coverpoint: ["SmF_cg/cp_mstatus_FS_transition, SmF_cg/cp_fcsr_access"]
+    coverpoint: ["Untestable"]
 
   # although CSRs and instructions are associated with one privilege level, they are
   # also accessible at all higher privilege levels.

--- a/coverpoints/priv/SmF_coverage.svh
+++ b/coverpoints/priv/SmF_coverage.svh
@@ -27,40 +27,31 @@ covergroup SmF_cg with function sample(ins_t ins);
         wildcard bins csrr      = {CSRR}  iff (ins.current.rs1_val ==  0); // csrr
     }
 
-    instrs: coverpoint ins.current.insn {
-        wildcard bins fsw          = {FSW};
+    deterministic_instrs: coverpoint ins.current.insn {
         wildcard bins flw          = {FLW};
         wildcard bins fadd         = {FADD_S};
         wildcard bins fsub         = {FSUB_S};
         wildcard bins fmul         = {FMUL_S};
         wildcard bins fdiv         = {FDIV_S};
         wildcard bins fcvt_s_w     = {FCVT_S_W};
-        wildcard bins fcvt_w_s     = {FCVT_W_S};
         `ifdef D_SUPPORTED
             wildcard bins fcvt_s_d     = {FCVT_S_D};
         `endif
         wildcard bins fmadd        = {FMADD_S};
         wildcard bins fsqrt        = {FSQRT_S};
         wildcard bins fsgnj        = {FSGNJ_S};
-        wildcard bins feq          = {FEQ_S};
-        wildcard bins fmv_x_f      = {FMV_X_S};
         wildcard bins fmv_f_x      = {FMV_S_X};
-        wildcard bins fclass       = {FCLASS_S};
         wildcard bins fmin         = {FMIN_S};
         `ifdef ZFA_SUPPORTED
             wildcard bins fli          = {FLI_S};
             wildcard bins fround       = {FROUND_S};
             `ifdef UDB_MXLEN_32
                 `ifdef D_SUPPORTED
-                    wildcard bins fmvh         = {FMVH_X_D};
                     wildcard bins fmvp         = {FMVP_D_X};
                 `endif
             `endif
         `endif
         wildcard bins add          = {ADD};
-        wildcard bins csrr_fcsr    = {32'b000000000011_00000_010_?????_1110011};
-        wildcard bins csrr_frm     = {32'b000000000010_00000_010_?????_1110011};
-        wildcard bins csrr_fflags  = {32'b000000000001_00000_010_?????_1110011};
         wildcard bins csrrw_fcsr   = {32'b000000000011_?????_001_?????_1110011};
         wildcard bins csrrw_frm    = {32'b000000000010_?????_001_?????_1110011};
         wildcard bins csrrw_fflags = {32'b000000000001_?????_001_?????_1110011};
@@ -71,12 +62,34 @@ covergroup SmF_cg with function sample(ins_t ins);
         wildcard bins csrrc_frm    = {32'b000000000010_?????_011_?????_1110011};
         wildcard bins csrrc_fflags = {32'b000000000001_?????_011_?????_1110011};
     }
+    nondeterministic_instrs: coverpoint ins.current.insn {
+        wildcard bins fsw          = {FSW};
+        wildcard bins fcvt_w_s     = {FCVT_W_S};
+        wildcard bins feq          = {FEQ_S};
+        wildcard bins fmv_x_f      = {FMV_X_S};
+        wildcard bins fclass       = {FCLASS_S};
+        `ifdef ZFA_SUPPORTED
+            `ifdef UDB_MXLEN_32
+                `ifdef D_SUPPORTED
+                    wildcard bins fmvh         = {FMVH_X_D};
+                `endif
+            `endif
+        `endif
+        wildcard bins csrr_fcsr    = {32'b000000000011_00000_010_?????_1110011};
+        wildcard bins csrr_frm     = {32'b000000000010_00000_010_?????_1110011};
+        wildcard bins csrr_fflags  = {32'b000000000001_00000_010_?????_1110011};
+    }
     mstatus_FS: coverpoint ins.prev.csr[CSR_MSTATUS][14:13] {
+    }
+    mstatus_FS_off_dirty: coverpoint ins.prev.csr[CSR_MSTATUS][14:13] {
+        bins off     = {2'b00};
+        bins dirty   = {2'b11};
     }
 
     // main coverpoints
     cp_fcsr_access:           cross fcsrname, csraccesses, mstatus_FS; // superset of ZicsrF cp_fcsr_access crossing with mstatus.FS
-    cp_mstatus_FS_transition: cross instrs, mstatus_FS;
+    cp_mstatus_FS_transition: cross deterministic_instrs, mstatus_FS;
+    cp_mstatus_FS_transition_nondeterministic: cross nondeterministic_instrs, mstatus_FS_off_dirty;
 endgroup
 
 function void smf_sample(int hart, int issue, ins_t ins);

--- a/generators/testgen/src/testgen/priv/extensions/SmF.py
+++ b/generators/testgen/src/testgen/priv/extensions/SmF.py
@@ -27,6 +27,17 @@ def _gen_fs_init(fs: int, temp_reg: int) -> str:
     return "\n".join(lines)
 
 
+def _gen_fp_csr_init(csr_name: str, value: int, temp_reg: int) -> str:
+    """Initialize an FP CSR while mstatus.FS is Dirty."""
+    lines = [
+        f"LI(x{temp_reg}, {3 << 13})",
+        f"CSRS(mstatus, x{temp_reg}) # Set mstatus.FS to dirty",
+        f"LI(x{temp_reg}, {value})",
+        f"CSRW({csr_name}, x{temp_reg}) # Initialize {csr_name}",
+    ]
+    return "\n".join(lines)
+
+
 def _generate_smfcsr_tests(test_data: TestData) -> list[str]:
     """Generate CSR tests."""
     covergroup = "SmF_fcsr_cg"
@@ -97,27 +108,19 @@ def _generate_smfcsr_tests(test_data: TestData) -> list[str]:
         )
     )
 
-    insns = [
+    # For FS=Initial/Clean, instructions that do not deterministically update floating-point state
+    # can legally either leave FS unchanged or dirty it. Skip those cases.
+    nondeterministic_initial_clean_insns = [
         f"fsw f1, 0(x{scratch_reg})",
-        f"flw f0, 0(x{scratch_reg})",
-        "fadd.s f0, f1, f2",
-        "fsub.s f0, f1, f2",
-        "fmul.s f0, f1, f2",
-        "fdiv.s f0, f1, f2",
-        "fcvt.s.w f0, x0",
         f"fcvt.w.s x{temp_reg}, f0",
-        "fmadd.s f0, f1, f2, f3",
-        "fsqrt.s f0, f1",
-        "fsgnj.s f0, f1, f2",
         f"feq.s x{temp_reg}, f1, f2",
         f"fmv.x.w x{temp_reg}, f1",
-        f"fmv.w.x f0, x{temp_reg}",
         f"fclass.s x{temp_reg}, f3",
-        "fmin.s f0, f1, f2",
-        f"add x{temp_reg}, x{temp_reg}, x{temp_reg}",
         f"csrr x{temp_reg}, fcsr",
         f"csrr x{temp_reg}, frm",
         f"csrr x{temp_reg}, fflags",
+    ]
+    fp_csr_write_insns = [
         f"csrrw x{temp_reg}, fcsr, x{temp_reg}",
         f"csrrw x{temp_reg}, frm, x{temp_reg}",
         f"csrrw x{temp_reg}, fflags, x{temp_reg}",
@@ -128,6 +131,21 @@ def _generate_smfcsr_tests(test_data: TestData) -> list[str]:
         f"csrrc x{temp_reg}, frm, x{temp_reg}",
         f"csrrc x{temp_reg}, fflags, x{temp_reg}",
     ]
+    deterministic_insns = [
+        f"flw f0, 0(x{scratch_reg})",
+        "fadd.s f0, f1, f2",
+        "fsub.s f0, f1, f2",
+        "fmul.s f0, f1, f2",
+        "fdiv.s f0, f1, f2",
+        "fcvt.s.w f0, x0",
+        "fmadd.s f0, f1, f2, f3",
+        "fsqrt.s f0, f1",
+        "fsgnj.s f0, f1, f2",
+        f"fmv.w.x f0, x{temp_reg}",
+        "fmin.s f0, f1, f2",
+        f"add x{temp_reg}, x{temp_reg}, x{temp_reg}",
+    ]
+    insns = [*nondeterministic_initial_clean_insns, *fp_csr_write_insns, *deterministic_insns]
 
     lines.extend(
         [
@@ -142,11 +160,27 @@ def _generate_smfcsr_tests(test_data: TestData) -> list[str]:
     for fs in range(4):
         coverpoint_full = f"{coverpoint}_fs{fs}"
         for insn in insns:
+            if fs in (1, 2) and insn in nondeterministic_initial_clean_insns:
+                continue  # skip nondeterministic instructions for FS=1 or FS=2
+            if insn in fp_csr_write_insns:
+                if "fcsr" in insn:
+                    csr_name = "fcsr"
+                elif "frm" in insn:
+                    csr_name = "frm"
+                else:
+                    csr_name = "fflags"
+                setup_lines = [
+                    _gen_fp_csr_init(csr_name, 1 if "csrrc" in insn else 0, temp_reg),
+                    _gen_fs_init(fs, temp_reg),
+                    f"LI(x{temp_reg}, 1) # make {insn} change {csr_name}",
+                ]
+            else:
+                setup_lines = [_gen_fs_init(fs, temp_reg)]
             lines.extend(
                 [
                     "",
                     f"# Testcase: {insn} with mstatus.FS={fs}",
-                    _gen_fs_init(fs, temp_reg),
+                    *setup_lines,
                     test_data.add_testcase(f"{insn}", coverpoint_full, covergroup),
                     f"{insn} # execute instruction with mstatus.FS={fs}",
                     gen_csr_read_sigupd(temp_reg, ("mstatus", None), test_data),
@@ -172,6 +206,8 @@ def _generate_smfcsr_tests(test_data: TestData) -> list[str]:
             ]
         )
         for insn in [f"fmvh.x.d x{temp_reg}, f1", f"fmvp.d.x f0, x{temp_reg}, x{temp_reg}"]:
+            if fs in (1, 2) and insn.startswith("fmvh.x.d "):
+                continue
             lines.extend(
                 [
                     "",


### PR DESCRIPTION
Update SmF to avoid checking `mstatus.FS` when it is not deterministic:
- Test all instructions with mstatus.FS set to off or dirty
- Skip instructions that do not write to fregs or fcsrs when mstatus.FS set to initial or clean
- Initialize fcsr before writes to ensure it actually changes, which should force dirty to be set.

Fixes #1895