### PR TITLE
Split CI jobs across more runners

### DIFF
--- a/config/qemu/ci.yaml
+++ b/config/qemu/ci.yaml
@@ -34,3 +34,5 @@ exclude_extensions: "Sm,S,SsstrictSm,SsstrictS,SsstrictU,Zacas,ZacasZabha,PMPSm,
 install_script: ".github/scripts/install-qemu.sh"
 apt_packages: "libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build"
 shards: 1
+config_shards:
+  qemu-rv64-max: 2

--- a/config/sail/ci.yaml
+++ b/config/sail/ci.yaml
@@ -6,3 +6,12 @@ ci_enabled: true
 # exclude SsstrictSm because of Sail sys_control being fixed in 0.13 release
 exclude_extensions: "SsstrictSm"
 shards: 1
+config_shards:
+  sail-RVA22S64-optional: 2
+  sail-RVA23S64: 2
+  sail-RVA23S64-optional: 2
+  sail-RVB23S64-optional: 2
+  sail-rv32-max: 3
+  sail-rv32-max-clang: 3
+  sail-rv64-max: 3
+  sail-rv64-max-clang: 3

--- a/config/whisper/ci.yaml
+++ b/config/whisper/ci.yaml
@@ -20,3 +20,6 @@ ci_enabled: true
 exclude_extensions: "S,Sm,SmV,SsstrictSm,SsstrictS,SsstrictU,ExceptionsZalrsc,ExceptionsZaamo,Svadu,SvaduPMP,Zalrsc,ExceptionsSvZaamo,ExceptionsSvZalrsc,SsstrictV,Smstateen"
 install_script: ".github/scripts/install-whisper.sh"
 apt_packages: "libboost-program-options-dev"
+shards: 1
+config_shards:
+  whisper-rv64-max: 2


### PR DESCRIPTION
Now that vector is enabled in CI, the runtime was starting to creep up again. This should get it back down under 15 minutes again.