### PR TITLE
Guard time/timeh CSR accesses behind UDB_TIME_CSR_IMPLEMENTED

### DIFF
--- a/generators/testgen/src/testgen/priv/extensions/Sm.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sm.py
@@ -941,7 +941,7 @@ def _generate_mcsr_cntr_tests(test_data: TestData) -> list[str]:
     )
     lines.extend(
         [
-            "#ifdef RVMODEL_MTIME_ADDRESS",
+            "#if defined(RVMODEL_MTIME_ADDRESS) && defined(UDB_TIME_CSR_IMPLEMENTED)",
             f"LI(x{r1}, 42)        # value to write to mtime",
             f"LA(x{r2}, RVMODEL_MTIME_ADDRESS)        # load address of mtime",
             f"SREG x{r1}, 0(x{r2})        # write mtime = 42 using memory-mapped I/O",

--- a/generators/testgen/src/testgen/priv/extensions/SsstrictCommon.py
+++ b/generators/testgen/src/testgen/priv/extensions/SsstrictCommon.py
@@ -58,6 +58,9 @@ class RawSweep:
 SetupFn = Callable[[list[str], TestData, int], None]
 
 
+# CSRs guarded by a UDB parameter define; compiled out when the CSR is absent.
+PARAM_GUARDED_CSRS = {0xC01: "UDB_TIME_CSR_IMPLEMENTED", 0xC81: "UDB_TIME_CSR_IMPLEMENTED"}
+
 USER_CUSTOM_CSR_RANGES = (range(0x800, 0x900), range(0xCC0, 0xD00))
 S_CUSTOM_CSR_RANGES = (range(0x5C0, 0x600), range(0x9C0, 0xA00), range(0xDC0, 0xE00))
 H_CUSTOM_CSR_RANGES = (range(0x6C0, 0x700), range(0xAC0, 0xB00), range(0xEC0, 0xF00))
@@ -286,6 +289,9 @@ def _generate_csr_sweep_body(
             r1, r2, r3 = test_data.int_regs.get_registers(3)
 
             ih = hex(csr_addr)
+            guard = PARAM_GUARDED_CSRS.get(csr_addr)
+            if guard is not None:
+                lines.append(f"#ifdef {guard}")
             lines.extend(
                 [
                     f"# CSR {ih}",
@@ -304,6 +310,8 @@ def _generate_csr_sweep_body(
                     "",
                 ]
             )
+            if guard is not None:
+                lines.append("#endif")
             test_data.int_regs.return_registers([r1, r2, r3])
         _finalize_chunk(test_data, lines, test_chunks)
     return test_chunks


### PR DESCRIPTION
This PR fixes #1924 

On a DUT with `TIME_CSR_IMPLEMENTED: false`, reads of the `time` CSR raise an illegal-instruction exception, while the Sail always implements `time` when Zicntr is enabled (there is no sail config option).

- `SsstrictCommon.py`: wrap the CSR sweep blocks for `time` (0xC01) and `timeh` (0xC81) in `#ifdef UDB_TIME_CSR_IMPLEMENTED`.
- `Sm.py`: the `cp_mtime_write` testcase writes `mtime` via MMIO and reads    back the `time` CSR; it was guarded only by `RVMODEL_MTIME_ADDRESS`. A core  with a CLINT but no `time` CSR (e.g. CV32E40P, which defines   `RVMODEL_MTIME_ADDRESS` with `TIME_CSR_IMPLEMENTED: false` in its in-repo config) would hit the same DUT/Sail trap mismatch

**Follow-ups (same bug class, not addressed here)**
ZicntrS/ZicntrU read `time` in their mcounteren/scounteren walking-bit tests without a guard, and InterruptsSstc reads `time` for stimecmp setup. Certifying the trap behavior itself (instead of skipping the access) would need a sail hoption for unimplemented `time` with Zicntr otherwise present.
