### PR TITLE
Remove M-mode CSR access in failure code and cleanup after sail 0.13 update

### DIFF
--- a/config/cores/cve2/ci.yaml
+++ b/config/cores/cve2/ci.yaml
@@ -5,7 +5,7 @@
 ci_enabled: true
 # Sm excluded: Insufficient WARL configuration options.
 # Ssstrict excluded: blocked by https://github.com/riscv/riscv-arch-test/issues/1601
-exclude_extensions: "Sm,SsstrictSm,Zkr"
+exclude_extensions: "Sm,SsstrictSm"
 apt_packages: "autoconf flex bison help2man libfl-dev ccache"
 install_script: ".github/scripts/install-cve2.sh"
 setup_script: ".github/scripts/setup-cve2.sh"

--- a/config/cores/cve4/ci.yaml
+++ b/config/cores/cve4/ci.yaml
@@ -3,7 +3,7 @@
 # CI configuration for the cve4 family: CV32E40P and CV32E40X
 
 ci_enabled: true
-exclude_extensions: "Sm,SmF,SsstrictSm,Zkr"
+exclude_extensions: "Sm,SmF,SsstrictSm"
 # SmF: cv32e40p-rv32imcf DUT bug - https://github.com/openhwgroup/cv32e40p/issues/1060; SsstrictSm not supported
 apt_packages: "autoconf flex bison help2man libfl-dev ccache"
 install_script: ".github/scripts/install-cve4.sh"

--- a/config/cores/cvw/ci.yaml
+++ b/config/cores/cvw/ci.yaml
@@ -5,7 +5,7 @@
 
 # Remaining exclusions are CVW/Sail behavior mismatches under the current configs.
 ci_enabled: true
-exclude_extensions: "Sm,ExceptionsSvZalrsc,ExceptionsSvZaamo,Sv,Svpbmt,InterruptsS,Zkr"
+exclude_extensions: "Sm,ExceptionsSvZalrsc,ExceptionsSvZaamo,Sv,Svpbmt,InterruptsS"
 apt_packages: "autoconf flex bison help2man libfl-dev ccache"
 install_script: ".github/scripts/install-cvw.sh"
 setup_script: ".github/scripts/setup-cvw.sh"

--- a/config/cores/cvw/ci.yaml
+++ b/config/cores/cvw/ci.yaml
@@ -4,8 +4,12 @@
 # Requires Verilator and the CVW repository
 
 # Remaining exclusions are CVW/Sail behavior mismatches under the current configs.
+# Sm: Insufficient WARL configuration options.
+# Sv: https://github.com/openhwgroup/cvw/issues/1766
+# Svpbmt: unknown
+# ExceptionsSvZalrsc: Wally should produce access fault rather than misaligned fault on misaligned LRSC. https://github.com/openhwgroup/cvw/issues/1809
 ci_enabled: true
-exclude_extensions: "Sm,ExceptionsSvZalrsc,ExceptionsSvZaamo,Sv,Svpbmt,InterruptsS"
+exclude_extensions: "Sm,ExceptionsSvZalrsc,Sv,Svpbmt"
 apt_packages: "autoconf flex bison help2man libfl-dev ccache"
 install_script: ".github/scripts/install-cvw.sh"
 setup_script: ".github/scripts/setup-cvw.sh"

--- a/config/cores/cvw/cvw-rv64gc/rvmodel_macros.h
+++ b/config/cores/cvw/cvw-rv64gc/rvmodel_macros.h
@@ -99,7 +99,12 @@
 
 ##### Machine Timer #####
 
-#define RVMODEL_TIMER_INT_SOON_DELAY 100
+// Wally's mtime advances one tick per core clock, and the code between arming
+// mtimecmp and reaching the lower privilege mode (three CLINT stores plus
+// RVTEST_GOTO_LOWER_MODE) can take well over 100 cycles on a pipelined core
+// with caches.  With a delay of 100 the timer interrupt fires while still in
+// M-mode with MIE=1, so the trap records MPP=M instead of MPP=U/S.
+#define RVMODEL_TIMER_INT_SOON_DELAY 1000
 
 #define RVMODEL_MTIME_ADDRESS  0x0200BFF8  /* Address of mtime CSR */
 

--- a/config/cores/cvw/cvw-rv64gc/sail.json
+++ b/config/cores/cvw/cvw-rv64gc/sail.json
@@ -215,8 +215,13 @@
         },
         // Similarly, a misaligned AMO currently always faults, and this field
         // can specify either `"AccessFault"` or `"AlignmentException"`.
+        // Wally (mmu.sv) evaluates misaligned-AMO faults AFTER address
+        // translation: a TLB/page-walk miss produces a page fault, and only
+        // then does a cacheable region raise an access fault (non-cacheable
+        // raises an alignment fault).  Use `None` here so the misalignment
+        // decision is deferred to the per-region PMA below, matching hardware.
         "amo": {
-          "Some": "AccessFault"
+          "None": null
         },
         // A misaligned LR/SC currently always faults, and this field can specify
         // whether it generates an access fault (use `"AccessFault"`)
@@ -321,7 +326,7 @@
             "vector": {
               "Some": "AlignmentException"
             },
-            "amo": "AccessFault"
+            "amo": "AlignmentException"
           },
           "atomic_support": "AMONone",
           "misaligned_atomicity_granule_size_exp": 0,

--- a/config/imperas/ci.yaml
+++ b/config/imperas/ci.yaml
@@ -9,10 +9,9 @@
 #  - Zkr: https://github.com/riscv/sail-riscv/issues/1829
 # - InterruptsSm/S/SSm/U: Imperas does not implement interrupts
 # - Smstateen: Sail does not implement all state yet to match
-# ExceptionsZaamo: unknown
-# ExceptionsSvZaamo: unknown
-# ExceptionsSvZalrsc: unknown
-# Zama16b: unknown
-
+# - ExceptionsSvZalrsc: misaligned LR under Sv39: Imperas raises load page fault (13, translation
+#   first); Sail rv64-max config checks misaligned LR/SC pre-translation and raises load access
+#   fault (5). No Imperas parameter changes this priority.
+#
 ci_enabled: false
-exclude_extensions: "Sm,SsstrictSm,SsstrictS,SsstrictU,SsstrictV,Zkr,ExceptionsZaamo,ExceptionsSvZaamo,ExceptionsSvZalrsc,InterruptsSm,InterruptsS,InterruptsSSm,InterruptsU,Smstateen,Zama16b"
+exclude_extensions: "Sm,SsstrictSm,SsstrictS,SsstrictU,SsstrictV,Zkr,ExceptionsSvZalrsc,InterruptsSm,InterruptsS,InterruptsSSm,InterruptsU,Smstateen"

--- a/config/imperas/ci.yaml
+++ b/config/imperas/ci.yaml
@@ -3,5 +3,16 @@
 # CI configuration for Imperas simulator
 # Imperas is proprietary and cannot run in public CI.
 
+# These exclusions don't affect CI because it doesn't run, but they help tracking incomplete features
+#  - Sm: Insufficient WARL configuration options.
+#  - SsstrictSm/S/U: Sail does not yet implement hypervisor instructions/CSRs
+#  - Zkr: https://github.com/riscv/sail-riscv/issues/1829
+# - InterruptsSm/S/SSm/U: Imperas does not implement interrupts
+# - Smstateen: Sail does not implement all state yet to match
+# ExceptionsZaamo: unknown
+# ExceptionsSvZaamo: unknown
+# ExceptionsSvZalrsc: unknown
+# Zama16b: unknown
+
 ci_enabled: false
-exclude_extensions: "Zkr"
+exclude_extensions: "Sm,SsstrictSm,SsstrictS,SsstrictU,SsstrictV,Zkr,ExceptionsZaamo,ExceptionsSvZaamo,ExceptionsSvZalrsc,InterruptsSm,InterruptsS,InterruptsSSm,InterruptsU,Smstateen,Zama16b"

--- a/config/imperas/imperas-rv32gck/imperas.ic
+++ b/config/imperas/imperas-rv32gck/imperas.ic
@@ -60,6 +60,7 @@
 
 # Misaligned access (Zicclsm)
 --override cpu*/unaligned=T
+--override cpu*/Zam=T # misaligned AMOs are supported
 
 # PMP Configuration
 --override cpu*/PMP_registers=16

--- a/config/imperas/imperas-rv32gck/sail.json
+++ b/config/imperas/imperas-rv32gck/sail.json
@@ -362,8 +362,8 @@
             "amo": "AccessFault"
           },
           "atomic_support": "AMOCASQ",
-          "misaligned_atomicity_granule_size_exp": 4,
-          "vector_misaligned_atomicity_granule_size_exp": 4,
+          "misaligned_atomicity_granule_size_exp": 6,
+          "vector_misaligned_atomicity_granule_size_exp": 6,
           "reservability": "RsrvEventual",
           "supports_cbo_zero": true,
           "supports_pte_read": true,
@@ -604,7 +604,7 @@
     // cacheable main memory region is 4, otherwise you will get a
     // config validation error.
     "Zama16b": {
-      "supported": true
+      "supported": false
     },
     "Zawrs": {
       "supported": true,

--- a/config/imperas/imperas-rv32gcv/imperas.ic
+++ b/config/imperas/imperas-rv32gcv/imperas.ic
@@ -54,6 +54,7 @@
 
 # Misaligned access (Zicclsm)
 --override cpu*/unaligned=T
+--override cpu*/Zam=T # misaligned AMOs are supported (needed for Zama16b)
 
 # PMP Configuration
 --override cpu*/PMP_registers=16

--- a/config/imperas/imperas-rv32gcv/sail.json
+++ b/config/imperas/imperas-rv32gcv/sail.json
@@ -362,8 +362,8 @@
             "amo": "AccessFault"
           },
           "atomic_support": "AMOCASQ",
-          "misaligned_atomicity_granule_size_exp": 4,
-          "vector_misaligned_atomicity_granule_size_exp": 4,
+          "misaligned_atomicity_granule_size_exp": 6,
+          "vector_misaligned_atomicity_granule_size_exp": 6,
           "reservability": "RsrvEventual",
           "supports_cbo_zero": true,
           "supports_pte_read": true,
@@ -603,8 +603,9 @@
     // `misaligned_atomicity_granule_size_exp` for each coherent and
     // cacheable main memory region is 4, otherwise you will get a
     // config validation error.
+    // TODO: Update this comment globally for >= 4 when Sail is updated accordingly.
     "Zama16b": {
-      "supported": true
+      "supported": false // TODO: this should be true, but Sail 0.13 only allows true if misaligned_atomicity_granule_size_exp = 4 rather than >= 4
     },
     "Zawrs": {
       "supported": true,

--- a/config/imperas/imperas-rv64-max/imperas-rv64-max.yaml
+++ b/config/imperas/imperas-rv64-max/imperas-rv64-max.yaml
@@ -66,7 +66,7 @@ implemented_extensions:
   - { name: Svinval, version: "= 1.0.0" }
   - { name: Svnapot, version: "= 1.0.0" }
   - { name: Svpbmt, version: "= 1.0.0" }
-  - { name: Svrsw60t59b, version: "= 1.0.0" }
+  # - { name: Svrsw60t59b, version: "= 1.0.0" } # Imperas ISS does not implement Svrsw60t59b; PTE bits 60:59 remain reserved and page fault
   - { name: Svvptc, version: "= 1.0.0" }
   - { name: U, version: "= 1.0.0" }
   - { name: V, version: "= 1.0.0" }

--- a/config/imperas/imperas-rv64-max/imperas.ic
+++ b/config/imperas/imperas-rv64-max/imperas.ic
@@ -80,6 +80,7 @@
 --override cpu*/Zfh=T
 --override cpu*/Zfa=T
 --override cpu*/Zcb=T
+--override cpu*/Zcd=T
 --override cpu*/Sstc=T
 --override cpu*/Smstateen=T
 --override cpu*/Ssstateen=T

--- a/config/imperas/imperas-rv64-max/imperas.ic
+++ b/config/imperas/imperas-rv64-max/imperas.ic
@@ -88,6 +88,7 @@
 # Misaligned access (Zicclsm) is supported
 --override cpu*/unaligned=T
 --override cpu*/unaligned_low_pri=T
+--override cpu*/Zam=T # misaligned AMOs are supported (needed for Zama16b)
 
 # Timeout
 #--override cpu*/TW_time_limit=65536  # *** attempted adding this summer 2025 for interrupt tests, but it breaks WALLY-status-tw-01.elf test and tests/coverage/priv.elf.  Not in rv32gc either

--- a/config/imperas/imperas-rv64-max/sail.json
+++ b/config/imperas/imperas-rv64-max/sail.json
@@ -362,8 +362,8 @@
             "amo": "AccessFault"
           },
           "atomic_support": "AMOCASQ",
-          "misaligned_atomicity_granule_size_exp": 4,
-          "vector_misaligned_atomicity_granule_size_exp": 4,
+          "misaligned_atomicity_granule_size_exp": 6,
+          "vector_misaligned_atomicity_granule_size_exp": 6,
           "reservability": "RsrvEventual",
           "supports_cbo_zero": true,
           "supports_pte_read": true,
@@ -603,8 +603,9 @@
     // `misaligned_atomicity_granule_size_exp` for each coherent and
     // cacheable main memory region is 4, otherwise you will get a
     // config validation error.
+    // TODO: Update this comment globally for >= 4 when Sail is updated accordingly.
     "Zama16b": {
-      "supported": true
+      "supported": false // TODO: this should be true, but Sail 0.13 only allows true if misaligned_atomicity_granule_size_exp = 4 rather than >= 4
     },
     "Zawrs": {
       "supported": true,
@@ -777,8 +778,9 @@
     "Svinval": {
       "supported": true
     },
+    // Imperas ISS does not implement Svrsw60t59b; PTE bits 60:59 remain reserved and page fault
     "Svrsw60t59b": {
-      "supported": true
+      "supported": false
     },
     "Svnapot": {
       "supported": true

--- a/docs/crd/src/rva23_crd.adoc
+++ b/docs/crd/src/rva23_crd.adoc
@@ -30,7 +30,7 @@ a| * Do not test traps into M-mode except ecall from S-mode
 
 == Introduction
 
-This document describes the test requirements for a processor to be eligible for a RVA23 certificate.
+This document describes the requirements for a processor to be eligible for a RVA23 certificate.
 
 The RVA23 processor certificate is based on the https://riscv.github.io/riscv-isa-manual/snapshot/spec/#_rva23s64_profile[RVA23S64] and RVA23U64 profiles. To
 qualify for a certificate, the processor must implement the RV64I base instruction set and all of the mandatory
@@ -50,7 +50,7 @@ NOTE: While it is permitted for an implementation to also support RV32I instruct
 
 == Discussion
 
-The primary goal of RVA23 is to provide binary compatibility for S- and U-mode operating system and application code, and RVA23 only specifies profiles for these modes.  Certification deliberately avoids imposing requirements on M-mode behavior except where called out in the profile or where M-mode controls behaviors of lower privilege modes.
+The primary goal of RVA23 is to provide binary compatibility for S- and U-mode operating system and application code.  It does not impose requirements on M-mode firmware.  Certification deliberately avoids imposing requirements on M-mode behavior except where called out in the profile or where M-mode controls behaviors of lower privilege modes.
 
 === Custom M-mode
 
@@ -62,9 +62,9 @@ RVA23 does not place any specific requirements on M-mode implementations as it i
 
 === Execution Environment and Test Supervisor Binary Interface (T-SBI)
 
-RVA23S64 runs within a supervisor execution environment.  For example, an `ECALL` from supervisor mode causes a requested trap to this execution environment. Similarly, the profile indicates that Sspm requires an execution environment providing a means to select `PMLEN`.
+Nevertheless, RVA23S64 runs within a supervisor execution environment.  For example, an `ECALL` from supervisor mode causes a requested trap to this execution environment. Similarly, the profile indicates that Sspm requires an execution environment providing a means to select `PMLEN`.
 
-RVA23 certification tests require that the execution environment boot to a deterministic state that allows software to run in S-mode, and to handle traps to the execution environment that implements the T-SBI described below. If a custom M-mode execution environment does not directly implement a feature of standard M-mode in hardware, it must be able to emulate that feature in a way that is transparent to software running in lower privilege modes.  For example, if it does not support delegating interrupts to S-mode in hardware, it must accomplish the same purpose in software by trapping to the execution environment, which may in turn deliver the interrupt to S-mode.
+RVA23 requires that the execution environment boot to a deterministic state that allows software to run in S-mode, and to handle traps to the execution environment that implements the T-SBI described below. If a custom M-mode execution environment does not directly implement a feature of standard M-mode in hardware, it must be able to emulate that feature in a way that is transparent to software running in lower privilege modes.  For example, if it does not support delegating interrupts to S-mode in hardware, it must accomplish the same purpose in software by trapping to the execution environment, which may in turn deliver the interrupt to S-mode.
 
 The execution environment must provide a Test Supervisor Binary Interface (T-SBI) that allows S-mode software to make requests of the execution environment.  These requests are made by placing commands in registers and performing an `ECALL`. See the Certification Test Plan (CTP) for details. The certification suite provides a reference T-SBI implementation that runs on standard M-mode, but custom M-mode that differs significantly from standard M-mode might have to provide its own T-SBI implementation.
 
@@ -143,9 +143,11 @@ The following M-mode CSRs/fields are OUT-OF-SCOPE and not tested:
 
 === Interrupts
 
-All supervisor interrupts (SEI, STI, SSI, and LCOFI) are IN-SCOPE for testing. Hypervisor interrupts VSEI, VSTI, VSSI, and SGEI are also IN-SCOPE. Machine interrupts (MEI, MTI, MSI) are OUT-OF-SCOPE for RVA23.
+All supervisor interrupts (SEI, STI, SSI, and LCOFI) are IN-SCOPE for testing. Hypervisor interrupts VSEI, VSTI, VSSI, and SGEI are also IN-SCOPE. Machine interrupts are OUT-OF-SCOPE.
 
 LCOFI is mandatory because it is part of the Sscofpmf extension, which is required by the profile. STI and VSTI are mandatory because Sstc is a required part of the profile. The other supervisor interrupts (SEI, SSI) are optional per the supervisor specification: "Each standard interrupt type (SEI, STI, SSI, or LCOFI) may not be implemented."  SGEI is optional because GEILEN can be 0.  The other hypervisor interrupts (VSEI, VSSI) are vague in the specification but are treated as optional because their supervisor counterparts are optional.
+
+Machine interrupts (MEI, MTI, MSI) are outside the RVA23 profile and are OUT-OF-SCOPE for certification.
 
 === User Requirements
 

--- a/docs/crd/src/rva23_crd.adoc
+++ b/docs/crd/src/rva23_crd.adoc
@@ -30,7 +30,7 @@ a| * Do not test traps into M-mode except ecall from S-mode
 
 == Introduction
 
-This document describes the requirements for a processor to be eligible for a RVA23 certificate.
+This document describes the test requirements for a processor to be eligible for a RVA23 certificate.
 
 The RVA23 processor certificate is based on the https://riscv.github.io/riscv-isa-manual/snapshot/spec/#_rva23s64_profile[RVA23S64] and RVA23U64 profiles. To
 qualify for a certificate, the processor must implement the RV64I base instruction set and all of the mandatory
@@ -50,7 +50,7 @@ NOTE: While it is permitted for an implementation to also support RV32I instruct
 
 == Discussion
 
-The primary goal of RVA23 is to provide binary compatibility for S- and U-mode operating system and application code.  It does not impose requirements on M-mode firmware.  Certification deliberately avoids imposing requirements on M-mode behavior except where called out in the profile or where M-mode controls behaviors of lower privilege modes.
+The primary goal of RVA23 is to provide binary compatibility for S- and U-mode operating system and application code, and RVA23 only specifies profiles for these modes.  Certification deliberately avoids imposing requirements on M-mode behavior except where called out in the profile or where M-mode controls behaviors of lower privilege modes.
 
 === Custom M-mode
 
@@ -62,9 +62,9 @@ RVA23 does not place any specific requirements on M-mode implementations as it i
 
 === Execution Environment and Test Supervisor Binary Interface (T-SBI)
 
-Nevertheless, RVA23S64 runs within a supervisor execution environment.  For example, an `ECALL` from supervisor mode causes a requested trap to this execution environment. Similarly, the profile indicates that Sspm requires an execution environment providing a means to select `PMLEN`.
+RVA23S64 runs within a supervisor execution environment.  For example, an `ECALL` from supervisor mode causes a requested trap to this execution environment. Similarly, the profile indicates that Sspm requires an execution environment providing a means to select `PMLEN`.
 
-RVA23 requires that the execution environment boot to a deterministic state that allows software to run in S-mode, and to handle traps to the execution environment that implements the T-SBI described below. If a custom M-mode execution environment does not directly implement a feature of standard M-mode in hardware, it must be able to emulate that feature in a way that is transparent to software running in lower privilege modes.  For example, if it does not support delegating interrupts to S-mode in hardware, it must accomplish the same purpose in software by trapping to the execution environment, which may in turn deliver the interrupt to S-mode.
+RVA23 certification tests require that the execution environment boot to a deterministic state that allows software to run in S-mode, and to handle traps to the execution environment that implements the T-SBI described below. If a custom M-mode execution environment does not directly implement a feature of standard M-mode in hardware, it must be able to emulate that feature in a way that is transparent to software running in lower privilege modes.  For example, if it does not support delegating interrupts to S-mode in hardware, it must accomplish the same purpose in software by trapping to the execution environment, which may in turn deliver the interrupt to S-mode.
 
 The execution environment must provide a Test Supervisor Binary Interface (T-SBI) that allows S-mode software to make requests of the execution environment.  These requests are made by placing commands in registers and performing an `ECALL`. See the Certification Test Plan (CTP) for details. The certification suite provides a reference T-SBI implementation that runs on standard M-mode, but custom M-mode that differs significantly from standard M-mode might have to provide its own T-SBI implementation.
 
@@ -143,11 +143,9 @@ The following M-mode CSRs/fields are OUT-OF-SCOPE and not tested:
 
 === Interrupts
 
-All supervisor interrupts (SEI, STI, SSI, and LCOFI) are IN-SCOPE for testing. Hypervisor interrupts VSEI, VSTI, VSSI, and SGEI are also IN-SCOPE. Machine interrupts are OUT-OF-SCOPE.
+All supervisor interrupts (SEI, STI, SSI, and LCOFI) are IN-SCOPE for testing. Hypervisor interrupts VSEI, VSTI, VSSI, and SGEI are also IN-SCOPE. Machine interrupts (MEI, MTI, MSI) are OUT-OF-SCOPE for RVA23.
 
 LCOFI is mandatory because it is part of the Sscofpmf extension, which is required by the profile. STI and VSTI are mandatory because Sstc is a required part of the profile. The other supervisor interrupts (SEI, SSI) are optional per the supervisor specification: "Each standard interrupt type (SEI, STI, SSI, or LCOFI) may not be implemented."  SGEI is optional because GEILEN can be 0.  The other hypervisor interrupts (VSEI, VSSI) are vague in the specification but are treated as optional because their supervisor counterparts are optional.
-
-Machine interrupts (MEI, MTI, MSI) are outside the RVA23 profile and are OUT-OF-SCOPE for certification.
 
 === User Requirements
 

--- a/generators/testgen/scripts/vector_testgen_common.py
+++ b/generators/testgen/scripts/vector_testgen_common.py
@@ -2684,7 +2684,7 @@ def prepVstart(vstartval, lmul = 1, scratch = 8, scratch2 = 28, sew=8):
     writeLine(f"li x{scratch2}, {randvstart}")
     writeLine(f"remu x{scratch2}, x{scratch2}, x{vstart_reg}",           f"# x{scratch2} = randvstart % (VLMAX - 2) (0 <= x{scratch2} < VLMAX-2)")
     writeLine(f"bgt x{vstart_reg}, x0, 1f")
-    writeLine(f"addi x{scratch2}, {vstart_reg}, -1",                     f"# x{scratch2} = VLMAX - 3")
+    writeLine(f"addi x{scratch2}, x{vstart_reg}, -1",                    f"# x{scratch2} = VLMAX - 3")
     writeLine("1:")
     writeLine(f"addi x{scratch2}, x{scratch2}, 2",                       f"# 2 <= x{scratch2} < VLMAX")
     vstart_reg = scratch2  # randomized vstart value lives in scratch2 from here on

--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsZaamo.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsZaamo.py
@@ -251,7 +251,7 @@ def _generate_amo_access_fault_tests(test_data: TestData) -> list[str]:
 @add_priv_test_generator(
     "ExceptionsZaamo",
     required_extensions=["Zaamo", "Sm"],
-    march_extensions=["I", "Zicsr", "Zaamo", "Zabha", "Zacas"],
+    march_extensions=["I", "Zaamo", "Zabha", "Zacas"],
 )
 def make_exceptionszaamo(test_data: TestData) -> list[TestChunk]:
     """Main entry point for Zaamo exception test generation."""

--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsZaamo.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsZaamo.py
@@ -251,7 +251,7 @@ def _generate_amo_access_fault_tests(test_data: TestData) -> list[str]:
 @add_priv_test_generator(
     "ExceptionsZaamo",
     required_extensions=["Zaamo", "Sm"],
-    march_extensions=["I", "Zaamo", "Zabha", "Zacas"],
+    march_extensions=["Zaamo", "Zabha", "Zacas"],
 )
 def make_exceptionszaamo(test_data: TestData) -> list[TestChunk]:
     """Main entry point for Zaamo exception test generation."""

--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsZc.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsZc.py
@@ -436,7 +436,7 @@ def _generate_illegal_instruction_tests(test_data: TestData) -> list[str]:
 @add_priv_test_generator(
     "ExceptionsZc",
     required_extensions=["Sm", "Zca"],
-    march_extensions=["Zicsr", "Zca", "Zcb", "Zcd", "C", "F", "D"],
+    march_extensions=["Zca", "Zcb", "Zcd", "C", "F", "D"],
 )
 def make_exceptionszc(test_data: TestData) -> list[TestChunk]:
     """Main entry point for Zc exception test generation."""

--- a/generators/testgen/src/testgen/priv/extensions/SmV.py
+++ b/generators/testgen/src/testgen/priv/extensions/SmV.py
@@ -535,7 +535,7 @@ def _gen_vl_walking1s_sew_lmul(test_data: TestData, temp_reg: int) -> list[str]:
 @add_priv_test_generator(
     "SmV",
     required_extensions=["Sm", "I", "M", "V", "Zicsr"],
-    march_extensions=["I", "M", "V", "Zicsr"],
+    march_extensions=["I", "M", "V"],
     extra_defines=[
         "#define RVTEST_VECTOR",
         "#define RVTEST_SEW 0",

--- a/generators/testgen/src/testgen/priv/extensions/SmV.py
+++ b/generators/testgen/src/testgen/priv/extensions/SmV.py
@@ -534,8 +534,8 @@ def _gen_vl_walking1s_sew_lmul(test_data: TestData, temp_reg: int) -> list[str]:
 
 @add_priv_test_generator(
     "SmV",
-    required_extensions=["Sm", "I", "M", "V", "Zicsr"],
-    march_extensions=["I", "M", "V"],
+    required_extensions=["Sm", "M", "V", "Zicsr"],
+    march_extensions=["M", "V"],
     extra_defines=[
         "#define RVTEST_VECTOR",
         "#define RVTEST_SEW 0",

--- a/generators/testgen/src/testgen/priv/extensions/SmVF.py
+++ b/generators/testgen/src/testgen/priv/extensions/SmVF.py
@@ -156,7 +156,7 @@ def _gen_fs_off(test_data: TestData, temp_reg: int) -> list[str]:
 @add_priv_test_generator(
     "SmVF",
     required_extensions=["Sm", "I", "M", "V", "F", "Zicsr"],
-    march_extensions=["I", "M", "F", "V", "Zicsr"],
+    march_extensions=["I", "M", "F", "V"],
     extra_defines=[
         "#define RVTEST_VECTOR",
         "#define RVTEST_SEW 0",

--- a/generators/testgen/src/testgen/priv/extensions/SmVF.py
+++ b/generators/testgen/src/testgen/priv/extensions/SmVF.py
@@ -155,8 +155,8 @@ def _gen_fs_off(test_data: TestData, temp_reg: int) -> list[str]:
 
 @add_priv_test_generator(
     "SmVF",
-    required_extensions=["Sm", "I", "M", "V", "F", "Zicsr"],
-    march_extensions=["I", "M", "F", "V"],
+    required_extensions=["Sm", "M", "V", "F", "Zicsr"],
+    march_extensions=["M", "F", "V"],
     extra_defines=[
         "#define RVTEST_VECTOR",
         "#define RVTEST_SEW 0",

--- a/generators/testgen/src/testgen/priv/extensions/Smstateen.py
+++ b/generators/testgen/src/testgen/priv/extensions/Smstateen.py
@@ -6,6 +6,8 @@
 
 """Smstateen privileged extension test generator."""
 
+from __future__ import annotations
+
 from testgen.asm.csr import csr_walk_test
 from testgen.asm.helpers import comment_banner
 from testgen.constants import INDENT
@@ -568,7 +570,7 @@ def _generate_fcsr_lower_fp_instrs(test_data: TestData) -> list[str]:
 @add_priv_test_generator(
     "Smstateen",
     required_extensions=["S", "Zicsr", "Smstateen"],
-    march_extensions=["S", "Smstateen", "Zicsr", "Zcmt", "Zfinx"],
+    march_extensions=["S", "Smstateen", "Zcmt", "Zfinx"],
 )
 def make_smstateen(test_data: TestData) -> list[TestChunk]:
     """Generate tests for Smstateen state-enable extension testsuite."""

--- a/generators/testgen/src/testgen/priv/extensions/Smstateen.py
+++ b/generators/testgen/src/testgen/priv/extensions/Smstateen.py
@@ -570,7 +570,7 @@ def _generate_fcsr_lower_fp_instrs(test_data: TestData) -> list[str]:
 @add_priv_test_generator(
     "Smstateen",
     required_extensions=["S", "Zicsr", "Smstateen"],
-    march_extensions=["S", "Smstateen", "Zcmt", "Zfinx"],
+    march_extensions=["Smstateen", "Zcmt", "Zfinx"],
 )
 def make_smstateen(test_data: TestData) -> list[TestChunk]:
     """Generate tests for Smstateen state-enable extension testsuite."""

--- a/generators/testgen/src/testgen/priv/extensions/Ssccptr.py
+++ b/generators/testgen/src/testgen/priv/extensions/Ssccptr.py
@@ -148,7 +148,7 @@ def _generate_ssccptr_lw(test_data: TestData) -> list[str]:
 @add_priv_test_generator(
     "Ssccptr",
     required_extensions=["S", "Ssccptr"],
-    march_extensions=["S"],
+    march_extensions=[],
 )
 def _generate_ssccptr_main(test_data: TestData) -> list[TestChunk]:
     """Generate all Ssccptr tests running in S-mode."""

--- a/generators/testgen/src/testgen/priv/extensions/Ssstateen.py
+++ b/generators/testgen/src/testgen/priv/extensions/Ssstateen.py
@@ -452,7 +452,7 @@ def _generate_fcsr_lower_fp_instrs(test_data: TestData) -> list[str]:
 @add_priv_test_generator(
     "Ssstateen",
     required_extensions=["S", "Zicsr", "Smstateen", "Ssstateen"],
-    march_extensions=["Ssstateen", "Smstateen", "Zicsr", "Zcmt", "Zfinx"],
+    march_extensions=["Ssstateen", "Smstateen", "Zcmt", "Zfinx"],
 )
 def make_ssstateen(test_data: TestData) -> list[TestChunk]:
     """Generate tests for Ssstateen state-enable extension testsuite."""

--- a/generators/testgen/src/testgen/priv/extensions/Sstvala.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sstvala.py
@@ -284,7 +284,7 @@ def _generate_instr_page_fault_tests(test_data: TestData, covergroup: str) -> li
 @add_priv_test_generator(
     "Sstvala",
     required_extensions=["Sstvala"],
-    march_extensions=["S"],
+    march_extensions=[],
     extra_defines=[],
 )
 def _generate_sstvala_tests(test_data: TestData) -> list[TestChunk]:

--- a/generators/testgen/src/testgen/priv/extensions/Sstvala.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sstvala.py
@@ -284,7 +284,7 @@ def _generate_instr_page_fault_tests(test_data: TestData, covergroup: str) -> li
 @add_priv_test_generator(
     "Sstvala",
     required_extensions=["Sstvala"],
-    march_extensions=["S", "Zicsr"],
+    march_extensions=["S"],
     extra_defines=[],
 )
 def _generate_sstvala_tests(test_data: TestData) -> list[TestChunk]:

--- a/generators/testgen/src/testgen/priv/extensions/Ssu64xl.py
+++ b/generators/testgen/src/testgen/priv/extensions/Ssu64xl.py
@@ -70,7 +70,7 @@ def _generate_ssu64xl_tests(test_data: TestData) -> list[str]:
 @add_priv_test_generator(
     "Ssu64xl",
     required_extensions=["S", "Ssu64xl"],
-    march_extensions=[],
+    march_extensions=["S"],
 )
 def make_ssu64xl(test_data: TestData) -> list[TestChunk]:
     test_chunks: list[TestChunk] = []

--- a/generators/testgen/src/testgen/priv/extensions/Ssu64xl.py
+++ b/generators/testgen/src/testgen/priv/extensions/Ssu64xl.py
@@ -70,7 +70,7 @@ def _generate_ssu64xl_tests(test_data: TestData) -> list[str]:
 @add_priv_test_generator(
     "Ssu64xl",
     required_extensions=["S", "Ssu64xl"],
-    march_extensions=["S"],
+    march_extensions=[],
 )
 def make_ssu64xl(test_data: TestData) -> list[TestChunk]:
     test_chunks: list[TestChunk] = []

--- a/generators/testgen/src/testgen/priv/extensions/UV.py
+++ b/generators/testgen/src/testgen/priv/extensions/UV.py
@@ -68,7 +68,7 @@ def _gen_uvcsrwalk(test_data: TestData) -> list[str]:
 @add_priv_test_generator(
     "UV",
     required_extensions=["Sm", "U", "I", "M", "V", "Zicsr"],
-    march_extensions=["I", "M", "V", "Zicsr"],
+    march_extensions=["I", "M", "V"],
     extra_defines=[
         "#define RVTEST_VECTOR",
         "#define RVTEST_SEW 0",

--- a/generators/testgen/src/testgen/priv/extensions/UV.py
+++ b/generators/testgen/src/testgen/priv/extensions/UV.py
@@ -67,8 +67,8 @@ def _gen_uvcsrwalk(test_data: TestData) -> list[str]:
 
 @add_priv_test_generator(
     "UV",
-    required_extensions=["Sm", "U", "I", "M", "V", "Zicsr"],
-    march_extensions=["I", "M", "V"],
+    required_extensions=["Sm", "U", "M", "V", "Zicsr"],
+    march_extensions=["M", "V"],
     extra_defines=[
         "#define RVTEST_VECTOR",
         "#define RVTEST_SEW 0",

--- a/generators/testgen/src/testgen/priv/extensions/Zama16b.py
+++ b/generators/testgen/src/testgen/priv/extensions/Zama16b.py
@@ -359,7 +359,7 @@ def _generate_amo_tests(test_data: TestData) -> list[str]:
 @add_priv_test_generator(
     "Zama16b",
     required_extensions=["Zama16b"],
-    march_extensions=["I", "Zaamo", "Zabha", "Zacas", "F", "D", "Zfh"],
+    march_extensions=["Zaamo", "Zabha", "Zacas", "F", "D", "Zfh"],
 )
 def make_zama16b(test_data: TestData) -> list[TestChunk]:
     """Generate tests for Zama16b misaligned atomicity granule extension."""

--- a/generators/testgen/src/testgen/priv/extensions/Zama16b.py
+++ b/generators/testgen/src/testgen/priv/extensions/Zama16b.py
@@ -12,6 +12,8 @@ Verifies that misaligned loads, stores, and AMOs that do not cross a
 naturally aligned 16-byte boundary do NOT raise a misaligned fault.
 """
 
+from __future__ import annotations
+
 from testgen.asm.helpers import comment_banner, write_sigupd
 from testgen.data.state import TestData
 from testgen.data.test_chunk import TestChunk
@@ -357,7 +359,7 @@ def _generate_amo_tests(test_data: TestData) -> list[str]:
 @add_priv_test_generator(
     "Zama16b",
     required_extensions=["Zama16b"],
-    march_extensions=["I", "Zicsr", "Zaamo", "Zabha", "Zacas", "F", "D", "Zfh"],
+    march_extensions=["I", "Zaamo", "Zabha", "Zacas", "F", "D", "Zfh"],
 )
 def make_zama16b(test_data: TestData) -> list[TestChunk]:
     """Generate tests for Zama16b misaligned atomicity granule extension."""

--- a/generators/testgen/src/testgen/priv/extensions/ZicntrS.py
+++ b/generators/testgen/src/testgen/priv/extensions/ZicntrS.py
@@ -390,7 +390,7 @@ def _generate_mscounteren_access_u_tests(test_data: TestData) -> list[str]:
 @add_priv_test_generator(
     "ZicntrS",
     required_extensions=["S", "Zicntr"],
-    march_extensions=["Zicntr", "I", "Zihpm"],
+    march_extensions=["Zicntr", "Zihpm"],
 )
 def make_zicntrs(test_data: TestData) -> list[TestChunk]:
     """Generate tests for ZicntrS coverpoints"""

--- a/generators/testgen/src/testgen/priv/extensions/ZicntrS.py
+++ b/generators/testgen/src/testgen/priv/extensions/ZicntrS.py
@@ -390,7 +390,7 @@ def _generate_mscounteren_access_u_tests(test_data: TestData) -> list[str]:
 @add_priv_test_generator(
     "ZicntrS",
     required_extensions=["S", "Zicntr"],
-    march_extensions=["Zicsr", "Zicntr", "I", "Zihpm"],
+    march_extensions=["Zicntr", "I", "Zihpm"],
 )
 def make_zicntrs(test_data: TestData) -> list[TestChunk]:
     """Generate tests for ZicntrS coverpoints"""

--- a/generators/testgen/src/testgen/priv/extensions/ZicntrU.py
+++ b/generators/testgen/src/testgen/priv/extensions/ZicntrU.py
@@ -236,7 +236,7 @@ def _generate_mcounteren_access_m_tests(test_data: TestData) -> list[str]:
 @add_priv_test_generator(
     "ZicntrU",
     required_extensions=["U", "Zicntr"],
-    march_extensions=["Zicntr", "I", "Zihpm"],
+    march_extensions=["Zicntr", "Zihpm"],
 )
 def make_zicntru(test_data: TestData) -> list[TestChunk]:
     """Generate tests for ZicntrU coverpoints"""

--- a/generators/testgen/src/testgen/priv/extensions/ZicntrU.py
+++ b/generators/testgen/src/testgen/priv/extensions/ZicntrU.py
@@ -236,7 +236,7 @@ def _generate_mcounteren_access_m_tests(test_data: TestData) -> list[str]:
 @add_priv_test_generator(
     "ZicntrU",
     required_extensions=["U", "Zicntr"],
-    march_extensions=["Zicsr", "Zicntr", "I", "Zihpm"],
+    march_extensions=["Zicntr", "I", "Zihpm"],
 )
 def make_zicntru(test_data: TestData) -> list[TestChunk]:
     """Generate tests for ZicntrU coverpoints"""

--- a/generators/testgen/src/testgen/priv/extensions/ZicsrF.py
+++ b/generators/testgen/src/testgen/priv/extensions/ZicsrF.py
@@ -331,7 +331,7 @@ def _generate_instr_tests(test_data: TestData) -> list[str]:
     return lines
 
 
-@add_priv_test_generator("ZicsrF", required_extensions=["Zicsr", "F"], march_extensions=["Zicsr", "F", "D", "Zfh"])
+@add_priv_test_generator("ZicsrF", required_extensions=["Zicsr", "F"], march_extensions=["F", "D", "Zfh"])
 def make_zicsrf(test_data: TestData) -> list[TestChunk]:
     """Generate tests for ZicsrF unprivileged floating-point fcsr extension."""
     test_chunks: list[TestChunk] = []

--- a/tests/env/rvtest_failure_code.h
+++ b/tests/env/rvtest_failure_code.h
@@ -52,15 +52,12 @@
         mv DEFAULT_TEMP_REG, x9        # move scratch base into DEFAULT_TEMP_REG
         mv DEFAULT_LINK_REG, x7        # move return address into DEFAULT_LINK_REG
         # now DEFAULT_LINK_REG has the return address of jal from the failure and DEFAULT_TEMP_REG is a vacant temporary register.
-        csrr x1, mcause
-        la x9, saved_mcause
-        SREG x1, 0(x9)
-        csrr x1, mtval
-        la x9, saved_mtval
-        SREG x1, 0(x9)
-        csrr x1, mstatus
-        la x9, saved_mstatus
-        SREG x1, 0(x9)
+        # NOTE: do NOT read mcause/mtval/mstatus here.  This entry point is
+        # reached from whichever mode's trap handler detected the mismatch;
+        # when that handler runs in S/VS-mode, an M-mode CSR read traps and
+        # livelocks the reporter.  The trap handler snapshots its own mode's
+        # xEPC/xCAUSE/xTVAL/xSTATUS into saved_mepc/saved_mcause/saved_mtval/
+        # saved_mstatus before trap signature word 0 (rvtest_trap_handler.h).
         j failedtest_saveregs
 
 #ifdef F_SUPPORTED
@@ -1770,12 +1767,13 @@
         call rvmodel_halt_fail
 
 
-    # Print saved mepc, mcause, mtval, mstatus for trap failure diagnostics.
-    # mcause/mtval/mstatus were snapshotted at failedtest_trap_x7_x9 entry,
-    # before any re-trap could corrupt the live CSRs (e.g. PMP faults from
-    # rvmodel_io_write_str).  mepc was snapshotted by the trap handler before
-    # trap signature word 0, since the handler itself rewrites the live xEPC
-    # (adj_*epc_rtn) before some mismatches are detected.
+    # Print saved xepc, xcause, xtval, xstatus for trap failure diagnostics.
+    # All four were snapshotted by the trap handler before trap signature
+    # word 0, using the trapping mode's own CSRs (CSR_X* aliases): the live
+    # CSRs can't be read here because the handler rewrites xEPC
+    # (adj_*epc_rtn) before some mismatches are detected, an S/VS-mode
+    # handler can't read the M-mode CSRs at all, and any re-trap (e.g. PMP
+    # faults from rvmodel_io_write_str) would clobber them.
     # Saves and restores ra via csr_context_ret_addr so callers can use 'call'.
     failedtest_print_csr_context:
         la a2, csr_context_ret_addr
@@ -1996,13 +1994,17 @@
         .fill 2, 4, 0
     csr_context_ret_addr:                        # return address save slot for failedtest_print_csr_context
         .fill 2, 4, 0
-    saved_mepc:                                  # original xEPC saved by common_excpt_handler before adj_Mepc
+    # The four saved_m* slots hold the trapping mode's xEPC/xCAUSE/xTVAL/xSTATUS,
+    # snapshotted by the trap handler before trap signature word 0
+    # (rvtest_trap_handler.h).  Named saved_m* for historical reasons; for an
+    # S/VS-mode handler they hold that mode's CSRs, not the M-mode ones.
+    saved_mepc:
         .fill 2, 4, 0
-    saved_mcause:                                # mcause snapshotted at failedtest_trap_x7_x9 entry
+    saved_mcause:
         .fill 2, 4, 0
-    saved_mtval:                                 # mtval snapshotted at failedtest_trap_x7_x9 entry
+    saved_mtval:
         .fill 2, 4, 0
-    saved_mstatus:                               # mstatus snapshotted at failedtest_trap_x7_x9 entry
+    saved_mstatus:
         .fill 2, 4, 0
 
     ascii_buffer:
@@ -2190,13 +2192,13 @@
     xepcinstrstr:
         .string "RVCP: Instruction that trapped: "
     mepcstr:
-        .string "RVCP: MEPC:    "
+        .string "RVCP: XEPC:    "
     mcausestr:
-        .string "RVCP: MCAUSE:  "
+        .string "RVCP: XCAUSE:  "
     mtvalstr:
-        .string "RVCP: MTVAL:   "
+        .string "RVCP: XTVAL:   "
     mstatusstr:
-        .string "RVCP: MSTATUS: "
+        .string "RVCP: XSTATUS: "
     trap_sig_offset_mismatch:
         .string "\"Mismatch in trap signature pointer offset! The test likely observed an incorrect number of traps.\"";
     sv_Mvect_str:

--- a/tests/env/rvtest_failure_code.h
+++ b/tests/env/rvtest_failure_code.h
@@ -1771,8 +1771,11 @@
 
 
     # Print saved mepc, mcause, mtval, mstatus for trap failure diagnostics.
-    # Values were snapshotted at failedtest_trap_x7_x9 entry, before any re-trap
-    # could corrupt the live CSRs (e.g. PMP faults from rvmodel_io_write_str).
+    # mcause/mtval/mstatus were snapshotted at failedtest_trap_x7_x9 entry,
+    # before any re-trap could corrupt the live CSRs (e.g. PMP faults from
+    # rvmodel_io_write_str).  mepc was snapshotted by the trap handler before
+    # trap signature word 0, since the handler itself rewrites the live xEPC
+    # (adj_*epc_rtn) before some mismatches are detected.
     # Saves and restores ra via csr_context_ret_addr so callers can use 'call'.
     failedtest_print_csr_context:
         la a2, csr_context_ret_addr

--- a/tests/env/rvtest_trap_handler.h
+++ b/tests/env/rvtest_trap_handler.h
@@ -1746,6 +1746,17 @@ tsbi_instr_table:
         LREG    T3, sig_bgn_off+          0(sp)    // T3 = this mode's signature begin address
         add     T1, T1, T3                          // T1 = this mode's current trap sig write address
 
+        // Snapshot xEPC to saved_mepc before the first TRAP_SIGUPD so
+        // failedtest_print_csr_context reports THIS trap's EPC on any word's
+        // mismatch.  It must be captured here rather than at reporter entry:
+        // the exception path rewrites the live xEPC CSR (adj_\__MODE__\()epc_rtn)
+        // after word 2, and snapshotting only in common_\__MODE__\()excpt_handler
+        // (as before) left word 0/1 mismatches printing the PREVIOUS trap's EPC.
+        // T3 and T4 are dead here (both rewritten in sv_\__MODE__\()vect before use).
+        csrr    T3, CSR_XEPC
+        la      T4, saved_mepc
+        SREG    T3, 0(T4)
+
 //---------- Trap Signature Word 0: vect+mode+status ----------
 // Packed format:
 //   bits  1: 0 = mode (MMODE_SIG=3, SMODE_SIG=1, HMODE_SIG=1, VMODE_SIG=2)
@@ -1826,11 +1837,6 @@ sv_\__MODE__\()cause:
 
 common_\__MODE__\()excpt_handler:
         csrr    T3, CSR_XEPC                         // T3 = xEPC (faulting instruction address)
-        // Save original xEPC before adj_Mepc advances it past the faulting instruction.
-        // failedtest_print_csr_context reads saved_mepc; without this, any word 3+
-        // (tval/mtval2/mtinst) mismatch would show the already-adjusted EPC instead.
-        la      T2, saved_mepc
-        SREG    T3, 0(T2)
         mv      T4, sp                               // T4 = this mode's save area (for relocation lookup)
 
 // --- EPC relocation logic ---

--- a/tests/env/rvtest_trap_handler.h
+++ b/tests/env/rvtest_trap_handler.h
@@ -1746,15 +1746,31 @@ tsbi_instr_table:
         LREG    T3, sig_bgn_off+          0(sp)    // T3 = this mode's signature begin address
         add     T1, T1, T3                          // T1 = this mode's current trap sig write address
 
-        // Snapshot xEPC to saved_mepc before the first TRAP_SIGUPD so
-        // failedtest_print_csr_context reports THIS trap's EPC on any word's
-        // mismatch.  It must be captured here rather than at reporter entry:
-        // the exception path rewrites the live xEPC CSR (adj_\__MODE__\()epc_rtn)
-        // after word 2, and snapshotting only in common_\__MODE__\()excpt_handler
-        // (as before) left word 0/1 mismatches printing the PREVIOUS trap's EPC.
-        // T3 and T4 are dead here (both rewritten in sv_\__MODE__\()vect before use).
+        // Snapshot xEPC/xCAUSE/xTVAL/xSTATUS to the saved_m* slots before the
+        // first TRAP_SIGUPD so failedtest_print_csr_context reports THIS trap's
+        // CSRs on any word's mismatch.  They must be captured here rather than
+        // at reporter entry for two reasons:
+        //  1. The exception path rewrites the live xEPC CSR
+        //     (adj_\__MODE__\()epc_rtn) after word 2, so the live value can be
+        //     stale by reporting time.
+        //  2. Only the handler expansion knows its own privilege mode.  The
+        //     reporter used to read mcause/mtval/mstatus directly, which is an
+        //     illegal instruction when the failing handler runs in S/VS-mode:
+        //     the resulting trap re-entered the handler, mismatched again, and
+        //     livelocked (watchdog "trapped N times in a row").  The CSR_X*
+        //     aliases here resolve to this mode's CSRs.
+        // T3 and T4 are dead here (both rewritten in sv_\__MODE__\()vect before
+        // use); T5 has held xcause since handler entry.
         csrr    T3, CSR_XEPC
-        la      T4, saved_mepc
+        LA(T4, saved_mepc)
+        SREG    T3, 0(T4)
+        LA(T4, saved_mcause)
+        SREG    T5, 0(T4)
+        csrr    T3, CSR_XTVAL
+        LA(T4, saved_mtval)
+        SREG    T3, 0(T4)
+        csrr    T3, CSR_XSTATUS
+        LA(T4, saved_mstatus)
         SREG    T3, 0(T4)
 
 //---------- Trap Signature Word 0: vect+mode+status ----------


### PR DESCRIPTION
Fixed cvw InterruptsS by increasing RVMODEL_TIMER_INT_SOON_DELAY
Drop unnecessary Zicsr from march_extensions
Drop Zkr exclusion from DUTs that don't support Zkr
Fix xEPC snapshotting

