### PR TITLE
Allow Certain Mask Producing Operations to be Run at vl=VLEN, SEW=8, LMUL=8

### DIFF
--- a/config/whisper/ci.yaml
+++ b/config/whisper/ci.yaml
@@ -15,7 +15,7 @@
 # InterruptsSSm excluded because whisper supports M mode interrupt delegation and Sail currently only supports S mode interrupt delegation.
 ci_enabled: true
 # TODO: Remove SsstrictV when sail SsstrictV is implemented
-exclude_extensions: "S,Sm,SmV,SsstrictSm,SsstrictS,SsstrictU,ExceptionsZaamo,ExceptionsSvZalrsc,SsstrictV,Smstateen,InterruptsSSm,Zkr"
+exclude_extensions: "S,Sm,SmV,SsstrictSm,SsstrictS,SsstrictU,ExceptionsZaamo,ExceptionsSvZalrsc,SsstrictV,Smstateen,InterruptsSSm,Zkr,Vx8,Vx16,Vx32"
 install_script: ".github/scripts/install-whisper.sh"
 apt_packages: "libboost-program-options-dev"
 shards: 1

--- a/config/whisper/whisper-rv32-max/whisper.json
+++ b/config/whisper/whisper-rv32-max/whisper.json
@@ -129,7 +129,7 @@
     "trap_non_zero_vstart": true,
     "tt_clear_tval_vl_egs": true,
     "tt_fp_usum_tree_reduction": ["e16", "e32", "e64"],
-    "update_whole_mask": false
+    "update_whole_mask": true
   },
 
   "wfi_timeout": 200

--- a/config/whisper/whisper-rv64-max/whisper.json
+++ b/config/whisper/whisper-rv64-max/whisper.json
@@ -128,7 +128,7 @@
     "trap_non_zero_vstart": true,
     "tt_clear_tval_vl_egs": true,
     "tt_fp_usum_tree_reduction": ["e16", "e32", "e64"],
-    "update_whole_mask": false
+    "update_whole_mask": true
   },
 
   "wfi_timeout": 200

--- a/generators/testgen/src/testgen/asm/vector_helpers.py
+++ b/generators/testgen/src/testgen/asm/vector_helpers.py
@@ -167,9 +167,10 @@ def write_sigupd_v_len(
     # Count the number of bytes the sigupd macro will consume. This is going to be the size of the largest supported
     # VLEN * EMUL, plus 4 bytes for padding, and then rounded to the nearest multiple of 8 (+7 & ~8 achieves this).
     # This computation is mirrored in RVTEST_SIGUPD_V_ADVANCE
-    emul_for_bytes = int(max(1, lmul))
+    emul_for_bytes = int(max(1, lmul)) if not mask_producing else 8
     max_bytes = VLEN_MAX * emul_for_bytes // 8
-    test_data.test_chunk.sigupd_count += vector_sigupd_bytes(max_bytes, test_data, vdsew)
+    sig_sew = vdsew if mask_producing else 8
+    test_data.test_chunk.sigupd_count += vector_sigupd_bytes(max_bytes, test_data, sig_sew)
 
     sig_reg = test_data.int_regs.sig_reg
     link_reg = test_data.int_regs.link_reg
@@ -212,14 +213,12 @@ def write_sigupd_v_mask_prod(
     in the signature in non-self checking mode. This ensures that we can test both the behavior at vlmax
     and at the test vl, as a valid implementation can do either.
     """
-    assert params.sew is not None, "SEW must be set for vector tests"
-    assert params.lmul is not None, "LMUL must be set for vector tests"
     assert test_data.test_chunk is not None, "No active test chunk — call begin_test_chunk() first"
 
     # We cannot consider only taking an eew=1 worth of bytes here due to the way RVTEST_SIGUPD_V_ADVANCE works
-    emul_for_bytes = int(params.lmul) if params.lmul is not None and params.lmul >= 1 else 1
+    emul_for_bytes = 8
     worst_bytes = VLEN_MAX * emul_for_bytes // 8
-    sig_stride = max(test_data.xlen, test_data.flen, params.sew) // 8
+    sig_stride = max(test_data.xlen, test_data.flen, 8) // 8
     offset_bytes = (worst_bytes + 4 + 7) & ~7
     test_data.test_chunk.sigupd_count += max(1, (offset_bytes + sig_stride - 1) // sig_stride)
 
@@ -228,8 +227,9 @@ def write_sigupd_v_mask_prod(
     temp_reg = test_data.int_regs.temp_reg
 
     return [
-        "# RVTEST_SIGUPD_VLMAX_MASK_PROD(_SIG_PTR, _LINK_REG, _TEMP_REG, _VR, _VD_EEW, _LMUL)",
-        f"RVTEST_SIGUPD_VLMAX_MASK_PROD(x{sig_reg}, x{link_reg}, x{temp_reg}, v{params.vd}, {params.sew}, 1)",
+        f"# Special SIGUPD variant that stores a mask in SIGRUN mode and no-ops in SELFCHECK mode. x{sig_reg} is the",
+        f"# signature pointer, x{link_reg} is the link register, x{temp_reg} is a temp register, and v{params.vd} is the result of the operation",
+        f"RVTEST_SIGUPD_VLMAX_MASK_PROD(x{sig_reg}, x{link_reg}, x{temp_reg}, v{params.vd})",
     ]
 
 
@@ -341,6 +341,42 @@ def prep_base_v(
     return lines, vl_register_or_imm
 
 
+def set_lower_xreg_bits(num_bits_reg: int, test_data: TestData) -> list[str]:
+    """
+    Builds a mask register with the lowest n bits set, where n is held in num_bits_reg.
+
+    Uses the same technique as
+    """
+
+    temp_reg, temp_reg2 = test_data.int_regs.get_registers(2, exclude_regs=[0])
+    temp_v = test_data.vec_regs.get_register()
+
+    code = [
+        "# Calculate the mask value by hand: start with a single whole register zeroed out",
+        f"vsetvli x{temp_reg}, x0, e8, m1, ta, ma",
+        f"vmv.v.i v{temp_v}, 0",
+        "vsetivli x0, 1, e8, m1, tu, ma",
+        "# Calculate which bit is the barrier between the ones and zeros",
+        f"andi x{temp_reg}, x{num_bits_reg}, 0x7",
+        f"addi x{temp_reg2}, x0, 1",
+        f"sll x{temp_reg}, x{temp_reg2}, x{temp_reg}",
+        "# Get something of the form 0b0011111 to prepare for a slideup",
+        f"addi x{temp_reg}, x{temp_reg}, -1",
+        f"vmv.v.x v{temp_v}, x{temp_reg}",
+        f"vsetvli x{temp_reg}, x0, e8, m1, ta, ma",
+        "# Prepare and execute a slide up, filling 0xff",
+        f"LI (x{temp_reg}, 0xff)",
+        f"vmv.v.x v0, x{temp_reg}",
+        f"srli x{temp_reg}, x{num_bits_reg}, 3",
+        f"vslideup.vx v0, v{temp_v}, x{temp_reg}",
+    ]
+
+    test_data.int_regs.return_registers([temp_reg, temp_reg2])
+    test_data.vec_regs.return_register(temp_v)
+
+    return code
+
+
 def prep_mask_v(
     mask_val: str | PresetMask,
     test_data: TestData,
@@ -391,31 +427,28 @@ def prep_mask_v(
     if mask_val == PresetMask.ZEROS:
         lines = [
             f"# Set mask value to zero, x{params.temp_reg} = VLMAX",
-            f"vsetvli x{params.temp_reg}, x0, e{params.sew}, m{lmul_flag}, tu, mu",
+            f"vsetvli x{params.temp_reg}, x0, e{params.sew}, m1, tu, mu",
             "vmv.v.i v0, 0",
         ]
     elif mask_val == PresetMask.ONES:
         # Note that an approach using temp_reg is flawed because vmsltu can be tail agnostic regardless of vtype
         lines = [
             f"# Set mask value to one, x{params.temp_reg} = VLMAX",
-            f"vsetvli x{params.temp_reg}, x0, e{params.sew}, m{lmul_flag}, tu, mu",
+            f"vsetvli x{params.temp_reg}, x0, e{params.sew}, m1, tu, mu",
             "# Sign extension makes the vector all ones",
             "vmv.v.i v0, -1",
         ]
     elif mask_val == PresetMask.VLMAX_M1_ONES:
+        assert params.temp_reg is not None
         lines = [
             f"# x{params.temp_reg} = VLMAX",
             f"vsetvli x{params.temp_reg}, x0, e{params.sew}, m{lmul_flag}, tu, mu",
             f"# x{params.temp_reg} = VLMAX - 1",
             f"addi x{params.temp_reg}, x{params.temp_reg}, -1",
-            f"# v{vtmp} = [0,1,2,...]",
-            f"vid.v v{vtmp}",
-            "# Reset mask value to 0",
-            "vmv.v.i v0, 0",
-            "# v0[i] = (i < VLMAX-1) ? 1 : 0",
-            f"vmsltu.vx v0, v{vtmp}, x{params.temp_reg}",
+            *set_lower_xreg_bits(params.temp_reg, test_data),
         ]
     elif mask_val == PresetMask.VLMAX_D2_P1_ONES:
+        assert params.temp_reg is not None
         lines = [
             f"# x{params.temp_reg} = VLMAX",
             f"vsetvli x{params.temp_reg}, x0, e{params.sew}, m{lmul_flag}, tu, mu",
@@ -423,17 +456,12 @@ def prep_mask_v(
             f"srli x{params.temp_reg}, x{params.temp_reg}, 1",
             f"# x{params.temp_reg} = VLMAX / 2 + 1",
             f"addi x{params.temp_reg}, x{params.temp_reg}, 1",
-            f"# v{vtmp} = [0,1,2,...]",
-            f"vid.v v{vtmp}",
-            "# Reset mask value to 0",
-            "vmv.v.i v0, 0",
-            "# v0[i] = (i < VLMAX/2+1) ? 1 : 0",
-            f"vmsltu.vx v0, v{vtmp}, x{params.temp_reg}",
+            *set_lower_xreg_bits(params.temp_reg, test_data),
         ]
     else:  # random mask
         lines = [
-            f"# x{params.temp_reg} = VLMAX",
-            f"vsetvli x{params.temp_reg}, x0, e{params.sew}, m{lmul_flag}, tu, mu",
+            f"# x{params.temp_reg} = VLEN",
+            f"vsetvli x{params.temp_reg}, x0, e8, m8, tu, mu",
             f"LA(x{params.temp_reg}, {mask_val})",
             "# Load mask value into v0",
             f"vlm.v v0, (x{params.temp_reg})",

--- a/generators/testgen/src/testgen/asm/vector_helpers.py
+++ b/generators/testgen/src/testgen/asm/vector_helpers.py
@@ -345,7 +345,7 @@ def set_lower_xreg_bits(num_bits_reg: int, test_data: TestData) -> list[str]:
     """
     Builds a mask register with the lowest n bits set, where n is held in num_bits_reg.
 
-    Uses the same technique as
+    Uses the same calculation as the length suite sigupd macro building the tail mask.
     """
 
     temp_reg, temp_reg2 = test_data.int_regs.get_registers(2, exclude_regs=[0])

--- a/generators/testgen/src/testgen/formatters/types/mask_prod_type.py
+++ b/generators/testgen/src/testgen/formatters/types/mask_prod_type.py
@@ -93,7 +93,9 @@ def format_mmm(
     instr_str: str, test_data: TestData, params: InstructionParams
 ) -> tuple[list[str], list[str], list[str]]:
     assert params.maskval is None, "MMM-type instructions are not maskable"
-    return format_mask_producing_type(instr_str, test_data, params, "MMM", {"vd", "vs1", "vs2"}, {"vd", "vs1", "vs2"})
+    return format_mask_producing_type(
+        instr_str, test_data, params, "MMM", {"vd", "vs1", "vs2"}, {"vd", "vs1", "vs2"}, force_full_length_check=True
+    )
 
 
 @add_instruction_formatter("MVV", mvv_config)
@@ -169,7 +171,9 @@ def format_mvim(
 
 @add_instruction_formatter("MM", mm_config)
 def format_mm(instr_str: str, test_data: TestData, params: InstructionParams) -> tuple[list[str], list[str], list[str]]:
-    return format_mask_producing_type(instr_str, test_data, params, "MM", {"vd", "vs2"}, {"vd", "vs2"})
+    return format_mask_producing_type(
+        instr_str, test_data, params, "MM", {"vd", "vs2"}, {"vd", "vs2"}, force_full_length_check=True
+    )
 
 
 def format_mask_producing_type(
@@ -181,6 +185,7 @@ def format_mask_producing_type(
     mask_registers: set[str],
     *,
     no_dot_t: bool = False,
+    force_full_length_check: bool = False,
 ) -> tuple[list[str], list[str], list[str]]:
     assert params.temp_reg is not None, f"temp_reg must provided for be {type_name}-type instructions"
     assert params.sew is not None, f"sew must provided for be {type_name}-type instructions"
@@ -306,6 +311,11 @@ def format_mask_producing_type(
         if mask_reg != 0:
             recover_mask = [f"vmand.mm v0, v{mask_reg}, v{mask_reg}"]
 
+        if force_full_length_check:
+            vlmax_vsetvli = f"# The spec says for mask-logical and vmsbf, vmsif, and vmsof, that the vlmax check is run at LMUL=8, SEW=8\nvsetvli x{params.temp_reg}, x0, e8, m8, tu, mu"
+        else:
+            vlmax_vsetvli = reload_vtype(params, "x0")
+
         check = [
             *write_sigupd_v_len(test_data, params, 1, lmul=1, mask_producing=True, mask_reg=mask_reg),
             "# After a length suite sigupd, we need to do the operation as if vl=vlmax as that is a valid behavior",
@@ -313,7 +323,7 @@ def format_mask_producing_type(
             "# clobbered in the sigupd, however, in the case of a masked instruction with vd = v0, v0 was overwritten.",
             "# So, we may have to recover that value.",
             *recover_mask,
-            reload_vtype(params, "x0"),
+            vlmax_vsetvli,
             test[0],
             "# This sigupd variant saves this result to the signature in non-selfcheck mode, and no-ops in selfcheck mode",
             *write_sigupd_v_mask_prod(test_data, params),

--- a/generators/testgen/src/testgen/formatters/vector_params.py
+++ b/generators/testgen/src/testgen/formatters/vector_params.py
@@ -488,7 +488,8 @@ def generate_random_vector_params(
         and "maskval" in instr_type_config.required_params
         and params.maskval is None
     ):
-        element_count = 1 if suite == "base" else math.ceil((VLEN_MAX / sew) * lmul / sew)
+        # Generate a whole mask worth of data
+        element_count = math.ceil(VLEN_MAX / sew)
         params.maskval = f"maskval_random_{suite}_{test_count:03d}"
         test_data.register_vector_data(
             f"maskval_random_{suite}_{test_count:03d}",

--- a/tests/env/signature.h
+++ b/tests/env/signature.h
@@ -437,15 +437,17 @@
         .else; \
             csrr _TEMP_REG, vl ;\
         .endif ; \
-        /* Set vl = VLMAX for full-register comparison*/                                                            \
-        vsetvli     _LINK_REG, x0, e##_VD_EEW, m##_LMUL, ta, ma ;                                                   \
         /* Load reference from signature and compute mismatch mask */                                               \
         .if (_MASKPROD_FLAG == 1); \
             /* Mask vector comparison: Load reference from signature and compute mismatch mask */                       \
+            /* Set vl = VLMAX for full-register comparison, for masks this means SEW=8, LMUL=8, VL=VLEN*/               \
+            vsetvli     _LINK_REG, x0, e8, m8, ta, ma ;                                                                 \
             vlm.v       _VTMP, 0(_SIG_PTR)       ;   /* Load reference data with vector unit-stride mask load */        \
             vmxor.mm    _MTMP, _VR, _VTMP        ;   /* MTMP[i] = 1 if result != reference for mask registers */        \
         .else; \
             /* Data vector comparison: Load reference from signature and compute mismatch mask */                       \
+            /* Set vl = VLMAX for full-register comparison*/                                                            \
+            vsetvli     _LINK_REG, x0, e ##_VD_EEW, m ##_LMUL, ta, ma ;                                                 \
             vle##_VD_EEW##.v _VTMP, 0(_SIG_PTR)     ;                                                                   \
             vmsne.vv    _MTMP, _VR, _VTMP        ;   /* _MTMP[i] = 1 if result != reference */                          \
         .endif; \
@@ -490,7 +492,11 @@
         /* Calculate the number of elements to slide _VTMP up */ \
         srli _TEMP_REG3, _TEMP_REG, 3; /* _TEMP_REG = _TEMP_REG >> 3 (divides by 8) */ \
         vslideup.vx _MTMP3, _VTMP, _TEMP_REG3; /* Slide Up By _TEMP_REG3. rs1 is NOT truncated to SEW bytes for this instruction */ \
-        vsetvli _LINK_REG, x0, e##_VD_EEW, m##_LMUL, ta, ma ; /* Return to the previous vector settings */                                \
+        .if (_MASKPROD_FLAG == 1) ; \
+            vsetvli _LINK_REG, x0, e8, m8, ta, ma; /* Return to the previous vector settings */     \
+        .else ; \
+            vsetvli _LINK_REG, x0, e##_VD_EEW, m##_LMUL, ta, ma ; /* Return to the previous vector settings */                                \
+        .endif ; \
     5: ;\
         .if (_MASKED_FLAG == 1); \
             /* Filter the active element mask, if the operation was masked */ \
@@ -508,7 +514,7 @@
         /* Check whether instr is a mask-producing instruction */                                                                      \
         .if (_MASKPROD_FLAG == 1); \
             /* Mask vector tail agnostic(vta == 1) handling: all 1s in agnostic element is also legal */                \
-            vmv.v.v      _MTMP2, _VR              ;   /* MTMP2[i] = (VR[i] == 1) */                                      \
+            vmand.mm     _MTMP2, _VR, _VR        ;    /* MTMP2[i] = (VR[i] == 1), vmv.v.v traps */                  \
             vmandn.mm   _MTMP2, _VTMP, _MTMP2    ;   /* MTMP2[i] = tail && !(VR[i] == 1) → mismatch with all 1s */  \
             /* Check tail elements mismatches */                                                                        \
             vmand.mm    _VTMP, _VTMP, _MTMP      ;   /* VTMP[i] = tail && (vd != sig) → mismatch with signature */      \
@@ -547,7 +553,7 @@
             beqz        _LINK_REG, 3f            ;   /* If vma==0 (undisturbed), skip agnostic relaxation */            \
             .if (_MASKPROD_FLAG == 1); \
                 /* Mask vector mask agnostic(vma == 1) handling: all 1s in agnostic element is also legal */                \
-                vmv.v.v      _MTMP2, _VR              ;   /* MTMP2[i] = (VR[i] == 1) */                                      \
+                vmand.mm     _MTMP2, _VR, _VR        ;    /* MTMP2[i] = (VR[i] == 1), vmv.v.v traps */                  \
                 vmandn.mm   _MTMP2, _VTMP, _MTMP2    ;   /* MTMP2[i] = inactive && !(VR[i] == 1) → mismatch with all 1s */  \
             .else; \
                 /* Mask agnostic(vma == 1) handling: all 1s in agnostic element is also legal */                            \
@@ -630,15 +636,17 @@
         .else; \
             csrr _TEMP_REG, vl ;\
         .endif ; \
-        /* Set vl = VLMAX for full-register comparison*/                                                            \
-        vsetvli     _LINK_REG, x0, e ##_VD_EEW, m ##_LMUL, ta, ma ;                                                 \
         /* Load reference from signature and compute mismatch mask */                                               \
         .if (_MASKPROD_FLAG == 1) ; \
             /* Mask vector comparison: Load reference from signature and compute mismatch mask */                       \
+            /* Set vl = VLMAX for full-register comparison, for masks this means SEW=8, LMUL=8, VL=VLEN*/               \
+            vsetvli     _LINK_REG, x0, e8, m8, ta, ma ;                                                                 \
             vsm.v       _VR, 0(_SIG_PTR)         ;   /* Load reference data with vector unit-stride mask load */        \
             nop                                  ;                                                                      \
         .else; \
             /* Data vector comparison: Load reference from signature and compute mismatch mask */                       \
+            /* Set vl = VLMAX for full-register comparison*/                                                            \
+            vsetvli     _LINK_REG, x0, e ##_VD_EEW, m ##_LMUL, ta, ma ;                                                 \
             vse##_VD_EEW##.v _VR, 0(_SIG_PTR)    ;                                                                   \
             nop                                  ;                                                                      \
         .endif; \
@@ -665,7 +673,11 @@
         /* As, v1 = 1, this sets only the first element of vtmp to 1 */ \
         nop                                  ;                                                                      \
         /* Return to a full vector register */ \
-        nop                                  ;                                                                      \
+        .if (_MASKPROD_FLAG == 1) ; \
+            nop ; \
+        .else ; \
+            nop ; \
+        .endif ; \
         /* Set the target to be all ones at the start */ \
         LI(_LINK_REG, 0xff)                                  ;                                                                      \
         nop                                  ;                                                                      \
@@ -794,7 +806,7 @@
 #endif
 
 #ifdef RVTEST_SELFCHECK
-    #define RVTEST_SIGUPD_VLMAX_MASK_PROD(_SIG_PTR, _LINK_REG, _TEMP_REG, _VR, _VD_EEW, _LMUL) \
+    #define RVTEST_SIGUPD_VLMAX_MASK_PROD(_SIG_PTR, _LINK_REG, _TEMP_REG, _VR) \
         .option push                         ;                                                 \
         .option norvc                        ;                                                 \
         nop                                  ;                                                 \
@@ -802,10 +814,11 @@
         RVTEST_SIGUPD_V_ADVANCE_NOP          ;                                                 \
         .option pop
 #else
-    #define RVTEST_SIGUPD_VLMAX_MASK_PROD(_SIG_PTR, _LINK_REG, _TEMP_REG, _VR, _VD_EEW, _LMUL) \
+    #define RVTEST_SIGUPD_VLMAX_MASK_PROD(_SIG_PTR, _LINK_REG, _TEMP_REG, _VR) \
         .option push                                            ;                              \
         .option norvc                                           ;                              \
-        vsetvli     _LINK_REG, x0, e##_VD_EEW, m##_LMUL, ta, ma ;                              \
+        /* Store the whole mask, regardless of vl, the corresponding read uses this setting */   \
+        vsetvli     _LINK_REG, x0, e8, m8, ta, ma               ;                              \
         vsm.v _VR, 0(_SIG_PTR)                                  ;                              \
         RVTEST_SIGUPD_V_ADVANCE(_SIG_PTR, _LINK_REG, _TEMP_REG) ;                              \
         .option pop


### PR DESCRIPTION
The spec says that: 
>Furthermore, for mask-logical instructions and vmsbf.m, vmsif.m, vmsof.m mask-manipulation instructions, any element in the tail of the result can be written with the value the mask-producing operation would have calculated with vl=VLEN, SEW=8, and LMUL=8 (i.e., all bits of the mask register can be overwritten).

This patch adds support for running those operations an additional time at vl=VLEN, SEW=8, and LMUL=8, and fixes #1958.

This required a change to sigupd to accommodate always loading and storing masks at their full length, and required a change to mask calculation so that beyond VL, results are consistent between Sail and a DUT setting all ones in a tail-agnostic policy. 

It also updates the whisper config to always test this case. 