### PR TITLE
Improve trap signature overflow and count diagnostics

### DIFF
--- a/framework/src/act/sig_modify.py
+++ b/framework/src/act/sig_modify.py
@@ -11,11 +11,12 @@ from pathlib import Path
 
 
 # Adds datatype to signatures.
-# Appends 'trap_sigptr' label if TRAP_CANARY is present and marks the final canary.
+# Appends labels for trap diagnostic regions and marks the final canary.
 def process_signature_file(sig_file: Path, xlen: int) -> None:
     """Add datatype directive to each line of the signature file."""
     datatype = ".word" if xlen == 32 else ".quad"
     trap_canary = "d3a91f6c" if xlen == 32 else "d3a91f6c8b47e25d"
+    final_trap_offset_canary = "7a110ff5" if xlen == 32 else "7a110ff5c0def00d"
     sig_data = sig_file.read_text()
     result_file = sig_file.with_suffix(".results")
     sig_lines = [line for line in sig_data.splitlines() if line.strip()]
@@ -24,5 +25,7 @@ def process_signature_file(sig_file: Path, xlen: int) -> None:
             if line_number == len(sig_lines) - 1:
                 outfile.write("sig_end_canary:\n")
             outfile.write(f"{datatype} 0x{line}\n")
+            if final_trap_offset_canary in line:
+                outfile.write("final_trap_sig_offset:\n")
             if trap_canary in line:
                 outfile.write("trap_sigptr:\n")

--- a/framework/src/act/sig_modify.py
+++ b/framework/src/act/sig_modify.py
@@ -11,16 +11,18 @@ from pathlib import Path
 
 
 # Adds datatype to signatures.
-# Appends 'trap_sigptr' label if TRAP_CANARY is present
+# Appends 'trap_sigptr' label if TRAP_CANARY is present and marks the final canary.
 def process_signature_file(sig_file: Path, xlen: int) -> None:
     """Add datatype directive to each line of the signature file."""
     datatype = ".word" if xlen == 32 else ".quad"
     trap_canary = "d3a91f6c" if xlen == 32 else "d3a91f6c8b47e25d"
     sig_data = sig_file.read_text()
     result_file = sig_file.with_suffix(".results")
+    sig_lines = [line for line in sig_data.splitlines() if line.strip()]
     with result_file.open("w") as outfile:
-        for line in sig_data.splitlines():
-            if line.strip():  # Skip empty lines
-                outfile.write(f"{datatype} 0x{line}\n")
-                if trap_canary in line:
-                    outfile.write("trap_sigptr:\n")
+        for line_number, line in enumerate(sig_lines):
+            if line_number == len(sig_lines) - 1:
+                outfile.write("sig_end_canary:\n")
+            outfile.write(f"{datatype} 0x{line}\n")
+            if trap_canary in line:
+                outfile.write("trap_sigptr:\n")

--- a/tests/env/rvtest_failure_code.h
+++ b/tests/env/rvtest_failure_code.h
@@ -985,11 +985,9 @@
         la x16, trap_diag_subtype
         sw x8, 0(x16)
 
-        // The actual offset was stored as the failing SIGUPD value.
-        // We need to extract it the same way integer failures do:
-        // the beq compared actual vs expected, and the ld loaded expected.
-        // For trap_sig_offset_mismatch, the value T1 (actual offset) was
-        // the value being checked. Extract from the instruction stream.
+        // Extract the compared values from the final trap-count check:
+        // the beq compared the DUT trap signature byte count against the
+        // reference byte count loaded from final_trap_sig_offset.
 
         // Extract actual value (rs2 of beq = the value being compared)
         lhu x6, -6(DEFAULT_LINK_REG)
@@ -1417,6 +1415,14 @@
     //==========================================================================
 
     failedtest_report_trap_detailed:
+        // Load subtype and dispatch. The final trap-count check has a compact
+        // report below; skip the generic trap-failure header to keep it focused.
+        lw x8, trap_diag_subtype
+
+        // ---- Subtype 9: Trap signature offset mismatch ----
+        li x9, 9
+        beq x8, x9, trap_report_offset_mismatch
+
         // Print trap failure header
         LA(a0, trap_diag_header_str)
         call rvmodel_io_write_str
@@ -1430,13 +1436,6 @@
         LA(a0, newlinestr)
         call rvmodel_io_write_str
 
-        // Load subtype and dispatch
-        lw x8, trap_diag_subtype
-
-        // ---- Subtype 9: Trap signature offset mismatch ----
-        li x9, 9
-        beq x8, x9, trap_report_offset_mismatch
-
         // ---- Subtype 0: Unknown / generic ----
         beqz x8, trap_report_generic
 
@@ -1447,11 +1446,6 @@
     // OFFSET MISMATCH: DUT generated wrong number of traps
     //--------------------------------------------------------------
     trap_report_offset_mismatch:
-        // Print "Trap Count Mismatch"
-        LA(a0, trap_diag_count_mismatch_str)
-        call rvmodel_io_write_str
-
-        // Print expected offset
         LA(a0, trap_diag_expected_offset_str)
         call rvmodel_io_write_str
         LREG a0, trap_diag_expected_offset
@@ -1460,7 +1454,6 @@
         LA(a0, ascii_buffer)
         call rvmodel_io_write_str
 
-        // Print actual offset
         LA(a0, trap_diag_actual_offset_str)
         call rvmodel_io_write_str
         LREG a0, trap_diag_actual_offset
@@ -1469,24 +1462,16 @@
         LA(a0, ascii_buffer)
         call rvmodel_io_write_str
 
-        // Determine if extra or missing traps
+        // Determine if extra or missing traps. Offsets are unsigned byte counts.
         LREG x6, trap_diag_actual_offset
         LREG x7, trap_diag_expected_offset
-        blt x6, x7, trap_report_missing_traps
+        bltu x6, x7, trap_report_missing_traps
 
     trap_report_extra_traps:
-        // DUT generated more traps than expected
         LA(a0, trap_diag_extra_traps_str)
         call rvmodel_io_write_str
 
-        // Calculate and print approximate extra trap count
-        // Each standard trap entry is 4*REGWIDTH bytes
-        LREG x6, trap_diag_actual_offset
-        LREG x7, trap_diag_expected_offset
-        sub x6, x6, x7                              # extra bytes
-        srli x6, x6, 2                               # divide by REGWIDTH (approx entries * 4/REGWIDTH)
-        // Print the byte difference as a hex number (exact entry count depends on entry size)
-        LA(a0, trap_diag_extra_bytes_str)
+        LA(a0, trap_diag_diff_bytes_str)
         call rvmodel_io_write_str
         LREG x6, trap_diag_actual_offset
         LREG x7, trap_diag_expected_offset
@@ -1496,17 +1481,15 @@
         LA(a0, ascii_buffer)
         call rvmodel_io_write_str
 
-        LA(a0, trap_diag_extra_hint_str)
+        LA(a0, trap_diag_extra_next_step_str)
         call rvmodel_io_write_str
-        call failedtest_print_csr_context
         j failedtest_report_end
 
     trap_report_missing_traps:
-        // DUT generated fewer traps than expected
         LA(a0, trap_diag_missing_traps_str)
         call rvmodel_io_write_str
 
-        LA(a0, trap_diag_extra_bytes_str)
+        LA(a0, trap_diag_diff_bytes_str)
         call rvmodel_io_write_str
         LREG x6, trap_diag_expected_offset
         LREG x7, trap_diag_actual_offset
@@ -1516,9 +1499,8 @@
         LA(a0, ascii_buffer)
         call rvmodel_io_write_str
 
-        LA(a0, trap_diag_missing_hint_str)
+        LA(a0, trap_diag_missing_next_step_str)
         call rvmodel_io_write_str
-        call failedtest_print_csr_context
         j failedtest_report_end
 
     //--------------------------------------------------------------
@@ -2202,7 +2184,7 @@
     mstatusstr:
         .string "RVCP: MSTATUS: "
     trap_sig_offset_mismatch:
-        .string "\"Mismatch in trap signature pointer offset! The test likely observed an incorrect number of traps.\"";
+        .string "\"Trap count mismatch.\"";
     sv_Mvect_str:
         .string "\"Mismatch in trap signature! Trap was being handled in M-Mode.\"";
     sv_Svect_str:
@@ -2311,27 +2293,24 @@
         .string "RVCP: ===== TRAP FAILURE DIAGNOSTICS =====\n"
     trap_diag_origstr_label:
         .string "RVCP: Failure: "
-    trap_diag_count_mismatch_str:
-        .string "RVCP: TRAP COUNT MISMATCH - DUT generated a different number of traps than the reference model.\n"
     trap_diag_expected_offset_str:
-        .string "RVCP: Expected trap signature offset: "
+        .string "RVCP: Expected trap signature byte count: "
     trap_diag_actual_offset_str:
-        .string "RVCP: Actual trap signature offset:   "
+        .string "RVCP: Actual trap signature byte count:       "
     trap_diag_extra_traps_str:
-        .string "RVCP: DIAGNOSIS: DUT generated MORE traps than expected.\n"
+        .string "RVCP: DIAGNOSIS: DUT recorded EXTRA traps.\n"
     trap_diag_missing_traps_str:
-        .string "RVCP: DIAGNOSIS: DUT generated FEWER traps than expected (missing traps).\n"
-    trap_diag_extra_bytes_str:
-        .string "RVCP: Difference in trap signature bytes: "
-    trap_diag_extra_hint_str:
+        .string "RVCP: DIAGNOSIS: DUT recorded FEWER traps (missing traps).\n"
+    trap_diag_diff_bytes_str:
+        .string "RVCP: Trap signature byte difference: "
+    trap_diag_extra_next_step_str:
         .ascii  "RVCP: HINT: Extra traps may indicate: spurious interrupts, incorrect exception\n"
         .ascii  "RVCP:       delegation, wrong privilege mode at instruction execution, or an\n"
         .asciz  "RVCP:       instruction causing a fault that should not fault on this DUT.\n"
-    trap_diag_missing_hint_str:
+    trap_diag_missing_next_step_str:
         .ascii  "RVCP: HINT: Missing traps may indicate: exception not raised when expected,\n"
         .ascii  "RVCP:       incorrect CSR state preventing trap (e.g. xIE disabled), trap\n"
         .asciz  "RVCP:       delegation causing handler in wrong mode, or PMP/page fault missed.\n"
-
     trap_diag_handler_mode_str:
         .string "RVCP: Trap handler mode: "
     trap_diag_mode_m_str:

--- a/tests/env/rvtest_failure_code.h
+++ b/tests/env/rvtest_failure_code.h
@@ -2172,6 +2172,13 @@
         .asciz "\"\nRVCP: DEBUG INFORMATION FOLLOWS\n"
     abortstr:
         .string "\"The trap handler aborted the test before normal completion!\"";
+    trap_sig_overflowstr:
+        #ifdef RVTEST_SELFCHECK
+            .string "\nRVCP: Trap signature overflow in self-check mode. DUT generated too many traps.     \n"
+        #else
+            // Keep the same byte count as the self-check string above.
+            .string "\nRVCP: Trap signature overflow in sig mode. Increase TRAP_SIGUPD_COUNT for this test.\n"
+        #endif
     testnamestr:
         .string "RVCP: Test Info: "
     newlinestr:

--- a/tests/env/rvtest_setup.h
+++ b/tests/env/rvtest_setup.h
@@ -121,8 +121,19 @@
       LA(     T1, Mtrap_sig)
       LREG    T1, 0(T1)               // Trap signature pointer
       LA(     T2, trap_sigptr)       // Base address of trap signature region
-      sub     T1, T1, T2              // Calculate offset
-      RVTEST_SIGUPD(x2, x5, x4, T1, check_trap_sig_offset, trap_sig_offset_mismatch)
+      sub     T1, T1, T2              // Calculate DUT trap signature byte count
+      LA(     T3, final_trap_sig_offset)
+    #ifdef RVTEST_SELFCHECK
+      LREG    T4, 0(T3)               // Reference trap signature byte count
+      beq     T4, T1, 1f
+    #else
+      SREG    T1, 0(T3)               // Save reference trap signature byte count
+      beq     x0, x0, 1f
+    #endif
+      jal     T2, failedtest_trap_x7_x9
+      RVTEST_WORD_PTR check_trap_sig_offset
+      RVTEST_WORD_PTR trap_sig_offset_mismatch
+    1:
   #endif
 
   // Terminate test
@@ -411,6 +422,14 @@
         CANARY
         // Initialize remaining signature region to known value for initial pass
         .fill SIGUPD_COUNT*(SIG_STRIDE>>2),4,0xdeadbeef
+
+      // Fixed diagnostic slot for the final trap signature byte count.
+      // sig_modify.py inserts the final_trap_sig_offset label after this canary
+      // in self-checking builds, where the raw signature data is included.
+      final_trap_sig_offset_canary:
+        FINAL_TRAP_OFFSET_CANARY
+      final_trap_sig_offset:
+        .fill (REGWIDTH>>2),4,0xdeadbeef
 
       // Signature region for trap handlers
       tsig_begin_canary:

--- a/tests/env/rvtest_setup.h
+++ b/tests/env/rvtest_setup.h
@@ -97,12 +97,24 @@
     #endif
 
   #ifdef STANDARD_SM_SUPPORTED
-    LI(     T4, 0xBAD0DEAD)           // T5 holds 0xBAD0DEAD if abort_test was executed
-    bne     T4, T5, check_trap_sig_offset
-    jal     T2, failedtest_trap_x7_x9
-    RVTEST_WORD_PTR abort_test
-    RVTEST_WORD_PTR abortstr
-    .word   CSR_MEPC
+    check_trap_sig_overflow:
+      LA(     T4, trap_sig_overflow)
+      bne     T4, T5, check_abort_test
+      LA(a0, failstr)
+      call rvmodel_io_write_str
+      LA(a0, trap_sig_overflowstr)
+      call rvmodel_io_write_str
+      LA(a0, endstr)
+      call rvmodel_io_write_str
+      call rvmodel_halt_fail
+
+    check_abort_test:
+      LI(     T4, 0xBAD0DEAD)           // T5 holds 0xBAD0DEAD if abort_test was executed
+      bne     T4, T5, check_trap_sig_offset
+      jal     T2, failedtest_trap_x7_x9
+      RVTEST_WORD_PTR abort_test
+      RVTEST_WORD_PTR abortstr
+      .word   CSR_MEPC
 
     // Check trap signature offset to make sure the correct number of traps occurred
     check_trap_sig_offset:
@@ -118,6 +130,11 @@
     LA(a0, successstr)
     call rvmodel_io_write_str
     call rvmodel_halt_pass
+
+  // Terminate the test with a failure message indicating the trap signature overflowed
+  trap_sig_overflow:
+    LA(T5, trap_sig_overflow)
+    j       rvtest_code_end // switch to M-mode and clean up and terminate
 
   // Terminate test with a failure message
   abort_test:

--- a/tests/env/rvtest_trap_handler.h
+++ b/tests/env/rvtest_trap_handler.h
@@ -1686,12 +1686,11 @@ tsbi_instr_table:
 //
 // This section:
 //   1. Calculates the trap signature entry size (3, 4, or 6 words)
-//   2. Pre-increments the trap signature pointer
+//   2. Pre-increments the trap signature pointer and checks for overrun
 //   3. Records: vect+mode word, xcause, xepc/xip, xtval/intID
 //   4. For exceptions: relocates xEPC and bumps past the trapping instruction
 //   5. For interrupts: dispatches to interrupt clearing routines
-//   6. Checks for trap signature overrun
-//   7. Restores registers and returns via xret
+//   6. Restores registers and returns via xret
 //==============================================================================
 
 \__MODE__\()trapsig_ptr_upd:                     // pre-update trap signature pointer
@@ -1745,6 +1744,13 @@ tsbi_instr_table:
         addi    sp, sp, 1*sv_area_sz               // undo sp adjustment
         LREG    T3, sig_bgn_off+          0(sp)    // T3 = this mode's signature begin address
         add     T1, T1, T3                          // T1 = this mode's current trap sig write address
+
+        // Check before any trap signature stores. The end canary immediately follows
+        // trap_sigptr's allocated space, so the updated write pointer may equal
+        // sig_end_canary but must never pass it.
+        LA(     T3, sig_end_canary)
+        add     T4, T1, T2                          // T4 = this mode's updated trap sig write pointer
+        bgtu    T4, T3, trap_sig_overflow           // overrun -> fail before corrupting the signature/tohost
 
 //---------- Trap Signature Word 0: vect+mode+status ----------
 // Packed format:
@@ -2038,17 +2044,8 @@ skp_\__MODE__\()tval:
   .endif
 
 1:
-// --- Check for trap signature overrun ---
-chk_\__MODE__\()trapsig_overrun:
-        addi    sp, sp, -1*sv_area_sz              // temp adjust sp (same as trap_sig_sv)
-        LREG    T4, sv_area_off+trapsig_ptr_off(sp) // T4 = updated trap sig ptr (from M-mode shared area)
-        addi    sp, sp, 1*sv_area_sz               // undo sp adjustment
-        LREG    T2, sig_bgn_off(sp)                // T2 = this mode's sig begin
-        LREG    T1, sig_seg_siz(sp)                // T1 = this mode's sig size
-
-        add     T1, T1, T2                          // T1 = sig end address
-        bgtu    T4, T1, abort_test                  // if trap sig ptr > sig end -> overrun -> abort
-
+// --- Dispatch special exception handlers ---
+dispatch_\__MODE__\()spcl_excpt_handler:
         li      T2, int_hndlr_tblsz                // T2 = offset to exception dispatch table
         j       spcl_\__MODE__\()handler           // jump to special handler dispatcher
 

--- a/tests/env/signature.h
+++ b/tests/env/signature.h
@@ -832,6 +832,18 @@
       .word TRAP_CANARY_VALUE
 #endif
 
+#if UDB_MXLEN==64
+  #define FINAL_TRAP_OFFSET_CANARY_VALUE \
+      0x7A110FF5C0DEF00D
+  #define FINAL_TRAP_OFFSET_CANARY \
+      .dword FINAL_TRAP_OFFSET_CANARY_VALUE
+#else
+  #define FINAL_TRAP_OFFSET_CANARY_VALUE \
+      0x7A110FF5
+  #define FINAL_TRAP_OFFSET_CANARY \
+      .word FINAL_TRAP_OFFSET_CANARY_VALUE
+#endif
+
 // Read _CSR into _R and record/check the signature
 #define RVTEST_SIGUPD_CSR_RD(_SIG_PTR, _LINK_REG, _TEMP_REG, _CSR, _R, _INST_PTR, _STR_PTR) \
     CSRR(_R, _CSR)                                       ;\


### PR DESCRIPTION
Check if a trap will overflow the trap signature region before writing to it. This avoids corrupting adjacent data/HTIF state when the trap signature overflows and provides a clear overflow message.

This also fixes #1640 by changing the final trap-count check to compare the DUT trap-signature byte count directly against the reference byte count. The check no longer uses the main signature pointer, so failures now report only the relevant outcome: extra traps or missing traps.

Fixes #1229
Fixes #1640

Example extra-trap failure:

```text
RVCP-SUMMARY: TEST FAILED - Test File "SsstrictSm_IllegalInstr-03.S"
RVCP: DEBUG INFORMATION FOLLOWS
RVCP: Test Info: "Trap count mismatch."
RVCP: Reference trap-signature byte count: 0x00000000
RVCP: DUT trap-signature byte count:       0x00000010
RVCP: DIAGNOSIS: DUT recorded EXTRA traps.
RVCP: Trap-signature byte difference: 0x00000010
RVCP: NEXT STEP: Compare DUT trace/log against the reference trap report and find the first unexpected trap.
RVCP: END OF DEBUG INFORMATION
```

Example missing-trap failure:

```text
RVCP-SUMMARY: TEST FAILED - Test File "SsstrictSm_IllegalInstr-03.S"
RVCP: DEBUG INFORMATION FOLLOWS
RVCP: Test Info: "Trap count mismatch."
RVCP: Reference trap-signature byte count: 0x00000020
RVCP: DUT trap-signature byte count:       0x00000010
RVCP: DIAGNOSIS: DUT recorded FEWER traps (missing traps).
RVCP: Trap-signature byte difference: 0x00000010
RVCP: NEXT STEP: Compare DUT trace/log against the reference trap report and find the first expected trap that is absent.
RVCP: END OF DEBUG INFORMATION
```
