### PR TITLE
Respect Whole Register Move LMUL in ExceptionsVx

### DIFF
--- a/generators/testgen/scripts/vector-testgen-priv.py
+++ b/generators/testgen/scripts/vector-testgen-priv.py
@@ -172,7 +172,7 @@ def make_vill(instruction):
     description = "cp_vill"
     sew = _eff_sew_for_instruction(instruction)
     instruction_data = randomizeVectorInstructionData(instruction, sew, getBaseSuiteTestCount(),
-                                                      vd_val_pointer = "vector_random", vs2_val_pointer = "vector_random", vs1_val_pointer = "vector_random")
+                                                      vd_val_pointer = "vector_random", vs2_val_pointer = "vector_random", vs1_val_pointer = "vector_random", lmul=common.getBaseLmul(instruction, sew))
 
     scratch = pickPrivScratch(instruction_data[1])
     vtype_reg = pickPrivScratch(instruction_data[1], exclude=(scratch,))


### PR DESCRIPTION
This PR passes LMUL in the vill generator for vector priv. Previously, it did not use the value derived from the instruction name (e.g. 2 for `vmv2r.v`), so it would generate illegal instructions like `vmv2r.v v21, v25`.