### PR TITLE
Fix ACT build-plan edge cases

### DIFF
--- a/framework/src/act/act.py
+++ b/framework/src/act/act.py
@@ -130,6 +130,7 @@ def run_act(
                 debug,
                 fast,
                 verbose,
+                dry_run,
             )
         )
 

--- a/framework/src/act/build_plan.py
+++ b/framework/src/act/build_plan.py
@@ -210,7 +210,8 @@ def gen_compile_tasks(
             # Derive nm executable from objdump executable (e.g. riscv64-unknown-elf-objdump -> riscv64-unknown-elf-nm)
             nm_exe: Path | None = None
             if config.objdump_exe is not None:
-                candidate = Path(str(config.objdump_exe).replace("objdump", "nm"))
+                objdump_exe = config.objdump_exe
+                candidate = objdump_exe.with_name(objdump_exe.name.replace("objdump", "nm"))
                 if candidate.exists():
                     nm_exe = candidate
             tasks.append(
@@ -308,7 +309,7 @@ def gen_rvvi_tasks(
         tasks.append(
             BuildTask(
                 outputs=(objdump_link,),
-                deps=(elf,),
+                deps=(objdump_orig_file,),
                 action=SymlinkAction(src=objdump_orig_file, dst=objdump_link),
             )
         )
@@ -355,6 +356,7 @@ def gen_coverage_tasks(
     env_header_dir: Path,
     coverage_simulator: CoverageSimulator,
     verbose: bool = False,
+    dry_run: bool = False,
 ) -> list[BuildTask]:
     """Generate BuildTasks for coverage UCDB generation, reports, and summary merging."""
     tasks: list[BuildTask] = []
@@ -394,14 +396,15 @@ def gen_coverage_tasks(
         # Write tracelist file, but only when its contents actually change so its mtime
         # reflects real changes. This lets us include it in extra_inputs below without
         # forcing a coverage rebuild on every run.
-        tracelist_file.parent.mkdir(parents=True, exist_ok=True)
-        tracelist_contents = (
-            f"# Tests for coverage group: {coverage_group}\n"
-            "# Generated automatically by riscv-arch-test act framework\n"
-            + "\n".join(str(trace) for trace in sorted(traces))
-        )
-        if not tracelist_file.exists() or tracelist_file.read_text() != tracelist_contents:
-            tracelist_file.write_text(tracelist_contents)
+        if not dry_run:
+            tracelist_file.parent.mkdir(parents=True, exist_ok=True)
+            tracelist_contents = (
+                f"# Tests for coverage group: {coverage_group}\n"
+                "# Generated automatically by riscv-arch-test act framework\n"
+                + "\n".join(str(trace) for trace in sorted(traces))
+            )
+            if not tracelist_file.exists() or tracelist_file.read_text() != tracelist_contents:
+                tracelist_file.write_text(tracelist_contents)
 
         # Coverage collection task
         coverage_tag = f"{coverage_group.stem.upper()}_COVERAGE"
@@ -441,7 +444,7 @@ def gen_coverage_tasks(
             BuildTask(
                 outputs=(simulator_artifact,),
                 deps=rvvi_deps,
-                extra_inputs=(*coverage_inputs, tracelist_file),
+                extra_inputs=coverage_inputs if dry_run else (*coverage_inputs, tracelist_file),
                 action=SubprocessAction(cmd=coverage_cmd, stdout_file=simulator_log, cwd=coverage_dir),
                 intermediate=True,
             )
@@ -491,6 +494,7 @@ def generate_build_plan(
     debug: bool = False,
     fast: bool = False,
     verbose: bool = False,
+    dry_run: bool = False,
 ) -> list[BuildTask]:
     """Build the full DAG of tasks for a single config."""
     if coverage_enabled and config.ref_model_type != RefModelType.SAIL:
@@ -574,6 +578,7 @@ def generate_build_plan(
                 tests_dir / "env",
                 coverage_simulator,
                 verbose,
+                dry_run,
             )
         )
 


### PR DESCRIPTION
Fix a few ACT build-plan edge cases.

The trap-report `nm` path is now derived by rewriting only the `objdump` executable name, so parent directories containing `objdump` are left untouched.

RVVI coverage objdump symlinks now depend on the actual objdump output rather than only the ELF.

Coverage tracelist files are no longer written during `--dry-run`.