### PR TITLE
Remove obsolete trap routine defines

### DIFF
--- a/docs/ctp/src/abstraction.adoc
+++ b/docs/ctp/src/abstraction.adoc
@@ -249,10 +249,6 @@ testgen/src/testgen/io/templates.py format_params needs to accept STANDARD_SM_SU
 
 remove mention of RVTEST_VECTOR  from vector code
 
-DONE: replace rvtest_mtrap_routine with STANDARD_SM_SUPPORTED or many places it gets deleted
-    replace rvtest_strap_routine with S_SUPPORTED if needed
-    replace rvtest_htrap_routine with H_SUPPORTED if needed
-
 Test generator:
     Any test that lists Sm in REQUIRED_EXTENSIONS adds STANDARD_SM_SUPPORTED as a parameter
     DONE *** edit generators/testgen/src/testgen/io/templates.py/generate_defines_from_extensions to define these boot_TO_*.  DONE Drop RVTEST_FP and tweak where it was used (hopefully removed)

--- a/generators/testgen/scripts/vector_testgen_common.py
+++ b/generators/testgen/scripts/vector_testgen_common.py
@@ -1612,8 +1612,6 @@ def getPrivExtraDefines(sew):
     sewsize = sew_to_suffix[minSEW_MIN] if sew == 0 else sew_to_suffix[sew]
     vle = f"vle{minSEW_MIN}.v"
     return "\n".join([
-        "#define rvtest_mtrap_routine",
-        "#define rvtest_strap_routine",
         "#define RVTEST_PRIV_TEST",
         f"#define SEWMIN {minSEW_MIN}",
         f"#define SEWMINSIZE e{minSEW_MIN}",

--- a/tests/env/rvtest_setup.h
+++ b/tests/env/rvtest_setup.h
@@ -7,7 +7,7 @@
 /**** RVTEST_BEGIN sets up the test environment and is run before the actual test code. ****/
 /**** - sets up main entry point labels                                                 ****/
 /**** - runs model specific boot code                                                   ****/
-/**** - instantiate prologs using RVTEST_TRAP_PROLOG() if rvtests_xtrap_routine defined ****/
+/**** - instantiates trap prologs when STANDARD_SM_SUPPORTED is defined                 ****/
 /**** - initializes regs                                                                ****/
 /**** - defines rvtest_code_begin global label                                          ****/
 /*******************************************************************************************/
@@ -60,7 +60,7 @@
 /************************************* RVTEST_CODE_END *************************************/
 /**** RVTEST_CODE_END is run after the actual test code.                                ****/
 /**** - Switch to M Mode                                                                ****/
-/**** - Instantiate epilogs using RVTEST_TRAP_EPILOG() if rvtests_xtrap_routine defined ****/
+/**** - instantiates trap epilogs when STANDARD_SM_SUPPORTED is defined                 ****/
 /**** - Instantiate trap handlers for each priv mode                                    ****/
 /**** - Include headers that contain code (not macros) that would throw off the address ****/
 /**** - Terminate test with call to RVMODEL_HALT                                        ****/

--- a/tests/priv/pmp/pmp32/PMPF/pmpf_cfg_wr.S
+++ b/tests/priv/pmp/pmp32/PMPF/pmpf_cfg_wr.S
@@ -28,7 +28,6 @@
 
 #define TEST_FILE "pmpf_cfg_wr.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPS/pmps_cfg_A_off.S
+++ b/tests/priv/pmp/pmp32/PMPS/pmps_cfg_A_off.S
@@ -29,8 +29,6 @@
 
 #define TEST_FILE "pmps_cfg_A_all.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPS/pmps_cfg_XWR.S
+++ b/tests/priv/pmp/pmp32/PMPS/pmps_cfg_XWR.S
@@ -29,8 +29,6 @@
 
 #define TEST_FILE "pmps_cfg_XWR.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPS/pmps_cfg_XWR_unlocked.S
+++ b/tests/priv/pmp/pmp32/PMPS/pmps_cfg_XWR_unlocked.S
@@ -29,8 +29,6 @@
 
 #define TEST_FILE "pmps_cfg_XWR_unlocked.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPS/pmps_csr_access.S
+++ b/tests/priv/pmp/pmp32/PMPS/pmps_csr_access.S
@@ -29,8 +29,6 @@
 
 #define TEST_FILE "pmps_csr_access.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPS/pmps_mprv_check-01.S
+++ b/tests/priv/pmp/pmp32/PMPS/pmps_mprv_check-01.S
@@ -31,8 +31,6 @@
 
 #define TEST_FILE "pmps_mprv_check-01.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPS/pmps_mprv_check-02.S
+++ b/tests/priv/pmp/pmp32/PMPS/pmps_mprv_check-02.S
@@ -29,8 +29,6 @@
 
 #define TEST_FILE "pmps_mprv_check-02.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPS/pmps_na4_legal_lxwr.S
+++ b/tests/priv/pmp/pmp32/PMPS/pmps_na4_legal_lxwr.S
@@ -33,8 +33,6 @@
 
 #define TEST_FILE "pmps_na4_legal_lxwr.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPS/pmps_napot_legal_lxwr-01.S
+++ b/tests/priv/pmp/pmp32/PMPS/pmps_napot_legal_lxwr-01.S
@@ -34,8 +34,6 @@
 
 #define TEST_FILE "pmps_napot_legal_lxwr-01.S"
 #define SIGUPD_COUNT 150
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPS/pmps_napot_legal_lxwr-02.S
+++ b/tests/priv/pmp/pmp32/PMPS/pmps_napot_legal_lxwr-02.S
@@ -34,8 +34,6 @@
 
 #define TEST_FILE "pmps_napot_legal_lxwr-02.S"
 #define SIGUPD_COUNT 150
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPS/pmps_tor_legal_lxwr-01.S
+++ b/tests/priv/pmp/pmp32/PMPS/pmps_tor_legal_lxwr-01.S
@@ -32,8 +32,6 @@
 
 #define TEST_FILE "pmps_tor_legal_lxwr.S"
 #define SIGUPD_COUNT 150
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPS/pmps_tor_legal_lxwr-02.S
+++ b/tests/priv/pmp/pmp32/PMPS/pmps_tor_legal_lxwr-02.S
@@ -32,8 +32,6 @@
 
 #define TEST_FILE "pmps_tor_legal_lxwr.S"
 #define SIGUPD_COUNT 150
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-1.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-1.S
@@ -35,7 +35,6 @@
 #define SIGUPD_COUNT 2000
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-10.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-10.S
@@ -35,7 +35,6 @@
 #define SIGUPD_COUNT 2000
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-2.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-2.S
@@ -35,7 +35,6 @@
 #define SIGUPD_COUNT 2000
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-3.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-3.S
@@ -35,7 +35,6 @@
 #define SIGUPD_COUNT 2000
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-4.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-4.S
@@ -35,7 +35,6 @@
 #define SIGUPD_COUNT 2000
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-5.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-5.S
@@ -35,7 +35,6 @@
 #define SIGUPD_COUNT 2000
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-6.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-6.S
@@ -35,7 +35,6 @@
 #define SIGUPD_COUNT 2000
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-7.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-7.S
@@ -35,7 +35,6 @@
 #define SIGUPD_COUNT 2000
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-8.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-8.S
@@ -35,7 +35,6 @@
 #define SIGUPD_COUNT 2000
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-9.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk-9.S
@@ -35,7 +35,6 @@
 #define SIGUPD_COUNT 2000
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp32/PMPU/pmpu_cfg_A_off.S
+++ b/tests/priv/pmp/pmp32/PMPU/pmpu_cfg_A_off.S
@@ -29,7 +29,6 @@
 
 #define TEST_FILE "pmpu_cfg_A_all.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPU/pmpu_cfg_XWR.S
+++ b/tests/priv/pmp/pmp32/PMPU/pmpu_cfg_XWR.S
@@ -30,7 +30,6 @@
 
 #define TEST_FILE "pmpu_cfg_XWR.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPU/pmpu_cfg_XWR_unlocked.S
+++ b/tests/priv/pmp/pmp32/PMPU/pmpu_cfg_XWR_unlocked.S
@@ -30,7 +30,6 @@
 
 #define TEST_FILE "pmpu_cfg_XWR_unlocked.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPU/pmpu_csr_access.S
+++ b/tests/priv/pmp/pmp32/PMPU/pmpu_csr_access.S
@@ -29,7 +29,6 @@
 
 #define TEST_FILE "pmpu_csr_access.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPU/pmpu_mprv_check-01.S
+++ b/tests/priv/pmp/pmp32/PMPU/pmpu_mprv_check-01.S
@@ -29,7 +29,6 @@
 
 #define TEST_FILE "pmpu_mprv_check-01.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPU/pmpu_mprv_check-02.S
+++ b/tests/priv/pmp/pmp32/PMPU/pmpu_mprv_check-02.S
@@ -29,7 +29,6 @@
 
 #define TEST_FILE "pmpu_mprv_check-02.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPU/pmpu_na4_legal_lxwr.S
+++ b/tests/priv/pmp/pmp32/PMPU/pmpu_na4_legal_lxwr.S
@@ -33,7 +33,6 @@
 
 #define TEST_FILE "pmps_na4_legal_lxwr.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPU/pmpu_napot_legal_lxwr-01.S
+++ b/tests/priv/pmp/pmp32/PMPU/pmpu_napot_legal_lxwr-01.S
@@ -33,7 +33,6 @@
 
 #define TEST_FILE "pmpu_napot_legal_lxwr.S"
 #define SIGUPD_COUNT 150
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPU/pmpu_napot_legal_lxwr-02.S
+++ b/tests/priv/pmp/pmp32/PMPU/pmpu_napot_legal_lxwr-02.S
@@ -33,7 +33,6 @@
 
 #define TEST_FILE "pmps_napot_legal_lxwr.S"
 #define SIGUPD_COUNT 150
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPU/pmpu_tor_legal_lxwr-01.S
+++ b/tests/priv/pmp/pmp32/PMPU/pmpu_tor_legal_lxwr-01.S
@@ -35,7 +35,6 @@
 
 #define TEST_FILE "pmpu_tor_legal_lxwr.S"
 #define SIGUPD_COUNT 150
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPU/pmpu_tor_legal_lxwr-02.S
+++ b/tests/priv/pmp/pmp32/PMPU/pmpu_tor_legal_lxwr-02.S
@@ -34,7 +34,6 @@
 
 #define TEST_FILE "pmpu_tor_legal_lxwr.S"
 #define SIGUPD_COUNT 150
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPZaamo/pmpzaamo_cfg_wr.S
+++ b/tests/priv/pmp/pmp32/PMPZaamo/pmpzaamo_cfg_wr.S
@@ -28,7 +28,6 @@
 
 #define TEST_FILE "pmpzaamo_cfg_wr.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPZalrsc/pmpzalrsc_cfg_wr.S
+++ b/tests/priv/pmp/pmp32/PMPZalrsc/pmpzalrsc_cfg_wr.S
@@ -28,7 +28,6 @@
 
 #define TEST_FILE "pmpzalrsc_cfg_wrS"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzcb_legal_lxwr.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzcb_legal_lxwr.S
@@ -28,7 +28,6 @@
 
 #define TEST_FILE "pmpzcb_legal_lwxr.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzcd_legal_lxwr.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzcd_legal_lxwr.S
@@ -32,7 +32,6 @@
 
 #define TEST_FILE "pmpzcd_legal_lwxr.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzcf_legal_lxwr.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzcf_legal_lxwr.S
@@ -34,7 +34,6 @@
 
 #define TEST_FILE "pmpzcf_legal_lwxr.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_01.S
+++ b/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_01.S
@@ -29,7 +29,6 @@
 
 #define TEST_FILE "pmpzicbo_cbo_wr_01.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_02.S
+++ b/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_02.S
@@ -28,7 +28,6 @@
 
 #define TEST_FILE "pmpzicbo_cbo_wr_02.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_03.S
+++ b/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_cbo_wr_03.S
@@ -28,7 +28,6 @@
 
 #define TEST_FILE "pmpzicbo_cbo_wr_03.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_prefetch.S
+++ b/tests/priv/pmp/pmp32/PMPZicbo/pmpzicbo_prefetch.S
@@ -29,7 +29,6 @@
 
 #define TEST_FILE "pmpzicbo_prefetch.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPF/pmpf_cfg_wr.S
+++ b/tests/priv/pmp/pmp64/PMPF/pmpf_cfg_wr.S
@@ -28,7 +28,6 @@
 
 #define TEST_FILE "pmpf_cfg_wr.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPS/pmps_cfg_A_off.S
+++ b/tests/priv/pmp/pmp64/PMPS/pmps_cfg_A_off.S
@@ -29,8 +29,6 @@
 
 #define TEST_FILE "pmps_cfg_A_all.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPS/pmps_cfg_XWR.S
+++ b/tests/priv/pmp/pmp64/PMPS/pmps_cfg_XWR.S
@@ -29,8 +29,6 @@
 
 #define TEST_FILE "pmps_cfg_XWR.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPS/pmps_cfg_XWR_unlocked.S
+++ b/tests/priv/pmp/pmp64/PMPS/pmps_cfg_XWR_unlocked.S
@@ -30,8 +30,6 @@
 
 #define TEST_FILE "pmps_cfg_XWR_unlocked.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPS/pmps_csr_access.S
+++ b/tests/priv/pmp/pmp64/PMPS/pmps_csr_access.S
@@ -29,8 +29,6 @@
 
 #define TEST_FILE "pmps_csr_access.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPS/pmps_mprv_check-01.S
+++ b/tests/priv/pmp/pmp64/PMPS/pmps_mprv_check-01.S
@@ -29,8 +29,6 @@
 
 #define TEST_FILE "pmps_mprv_check-01.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPS/pmps_mprv_check-02.S
+++ b/tests/priv/pmp/pmp64/PMPS/pmps_mprv_check-02.S
@@ -29,8 +29,6 @@
 
 #define TEST_FILE "pmps_mprv_check-02.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPS/pmps_na4_legal_lxwr.S
+++ b/tests/priv/pmp/pmp64/PMPS/pmps_na4_legal_lxwr.S
@@ -33,8 +33,6 @@
 
 #define TEST_FILE "pmps_na4_legal_lxwr.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPS/pmps_napot_legal_lxwr-01.S
+++ b/tests/priv/pmp/pmp64/PMPS/pmps_napot_legal_lxwr-01.S
@@ -33,8 +33,6 @@
 
 #define TEST_FILE "pmps_napot_legal_lxwr.S"
 #define SIGUPD_COUNT 150
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPS/pmps_napot_legal_lxwr-02.S
+++ b/tests/priv/pmp/pmp64/PMPS/pmps_napot_legal_lxwr-02.S
@@ -33,8 +33,6 @@
 
 #define TEST_FILE "pmps_napot_legal_lxwr.S"
 #define SIGUPD_COUNT 150
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPS/pmps_tor_legal_lxwr-01.S
+++ b/tests/priv/pmp/pmp64/PMPS/pmps_tor_legal_lxwr-01.S
@@ -31,8 +31,6 @@
 
 #define TEST_FILE "pmps_tor_legal_lxwr.S"
 #define SIGUPD_COUNT 150
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPS/pmps_tor_legal_lxwr-02.S
+++ b/tests/priv/pmp/pmp64/PMPS/pmps_tor_legal_lxwr-02.S
@@ -31,8 +31,6 @@
 
 #define TEST_FILE "pmps_tor_legal_lxwr.S"
 #define SIGUPD_COUNT 150
-#define rvtest_mtrap_routine
-#define rvtest_strap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-01.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-01.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 2000
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-02.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-02.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-03.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-03.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-04.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-04.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-05.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-05.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-06.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-06.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-07.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-07.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-08.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-08.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-09.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-09.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-10.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-10.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-11.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-11.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-12.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-12.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-13.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-13.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-14.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-14.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-15.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-15.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-16.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-16.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-17.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-17.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-18.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-18.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-19.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk-19.S
@@ -37,7 +37,6 @@
 #define SIGUPD_COUNT 500
 
 // Enable trap handler
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 // Include framework macros

--- a/tests/priv/pmp/pmp64/PMPU/pmpu_cfg_A_off.S
+++ b/tests/priv/pmp/pmp64/PMPU/pmpu_cfg_A_off.S
@@ -29,7 +29,6 @@
 
 #define TEST_FILE "pmpu_cfg_A_all.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPU/pmpu_cfg_XWR.S
+++ b/tests/priv/pmp/pmp64/PMPU/pmpu_cfg_XWR.S
@@ -30,7 +30,6 @@
 
 #define TEST_FILE "pmpu_cfg_XWR.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPU/pmpu_cfg_XWR_unlocked.S
+++ b/tests/priv/pmp/pmp64/PMPU/pmpu_cfg_XWR_unlocked.S
@@ -30,7 +30,6 @@
 
 #define TEST_FILE "pmpu_cfg_XWR_unlocked.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPU/pmpu_csr_access.S
+++ b/tests/priv/pmp/pmp64/PMPU/pmpu_csr_access.S
@@ -29,7 +29,6 @@
 
 #define TEST_FILE "pmpu_csr_access.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPU/pmpu_mprv_check-01.S
+++ b/tests/priv/pmp/pmp64/PMPU/pmpu_mprv_check-01.S
@@ -29,7 +29,6 @@
 
 #define TEST_FILE "pmpu_mprv_check-01.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPU/pmpu_mprv_check-02.S
+++ b/tests/priv/pmp/pmp64/PMPU/pmpu_mprv_check-02.S
@@ -29,7 +29,6 @@
 
 #define TEST_FILE "pmps_mprv_check-02.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPU/pmpu_na4_legal_lxwr.S
+++ b/tests/priv/pmp/pmp64/PMPU/pmpu_na4_legal_lxwr.S
@@ -33,7 +33,6 @@
 
 #define TEST_FILE "pmpu_na4_legal_lxwr.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPU/pmpu_napot_legal_lxwr-01.S
+++ b/tests/priv/pmp/pmp64/PMPU/pmpu_napot_legal_lxwr-01.S
@@ -32,7 +32,6 @@
 
 #define TEST_FILE "pmpu_napot_legal_lxwr.S"
 #define SIGUPD_COUNT 150
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPU/pmpu_napot_legal_lxwr-02.S
+++ b/tests/priv/pmp/pmp64/PMPU/pmpu_napot_legal_lxwr-02.S
@@ -33,7 +33,6 @@
 
 #define TEST_FILE "pmpu_napot_legal_lxwr.S"
 #define SIGUPD_COUNT 150
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPU/pmpu_tor_legal_lxwr-01.S
+++ b/tests/priv/pmp/pmp64/PMPU/pmpu_tor_legal_lxwr-01.S
@@ -33,7 +33,6 @@
 
 #define TEST_FILE "pmpu_tor_legal_lxwr.S"
 #define SIGUPD_COUNT 150
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPU/pmpu_tor_legal_lxwr-02.S
+++ b/tests/priv/pmp/pmp64/PMPU/pmpu_tor_legal_lxwr-02.S
@@ -33,7 +33,6 @@
 
 #define TEST_FILE "pmpu_tor_legal_lxwr.S"
 #define SIGUPD_COUNT 150
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPZaamo/pmpzaamo_cfg_wr.S
+++ b/tests/priv/pmp/pmp64/PMPZaamo/pmpzaamo_cfg_wr.S
@@ -28,7 +28,6 @@
 
 #define TEST_FILE "pmpzaamo_cfg_wr.S"
 #define SIGUPD_COUNT 120
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPZalrsc/pmpzalrsc_cfg_wr.S
+++ b/tests/priv/pmp/pmp64/PMPZalrsc/pmpzalrsc_cfg_wr.S
@@ -29,7 +29,6 @@
 
 #define TEST_FILE "pmpzalrsc_cfg_wrS"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzcb_legal_lwxr.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzcb_legal_lwxr.S
@@ -28,7 +28,6 @@
 
 #define TEST_FILE "pmpzcb_legal_lwxr.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzcd_legal_lwxr.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzcd_legal_lwxr.S
@@ -28,7 +28,6 @@
 
 #define TEST_FILE "pmpzcd_legal_lwxr.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_01.S
+++ b/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_01.S
@@ -29,7 +29,6 @@
 
 #define TEST_FILE "pmpzicbo_cbo_wr_01.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_02.S
+++ b/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_02.S
@@ -28,7 +28,6 @@
 
 #define TEST_FILE "pmpzicbo_cbo_wr_02.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_03.S
+++ b/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_cbo_wr_03.S
@@ -28,7 +28,6 @@
 
 #define TEST_FILE "pmpzicbo_cbo_wr_01.S"
 #define SIGUPD_COUNT 50
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 

--- a/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_prefetch.S
+++ b/tests/priv/pmp/pmp64/PMPZicbo/pmpzicbo_prefetch.S
@@ -28,7 +28,6 @@
 
 #define TEST_FILE "pmpzicbo_prefetch.S"
 #define SIGUPD_COUNT 100
-#define rvtest_mtrap_routine
 #define RVTEST_PRIV_TEST
 
 


### PR DESCRIPTION
Removes the remaining obsolete `rvtest_*trap_routine` defines and stale references now that trap handler selection no longer uses those macros.