### PR TITLE
Fix Zkr seed entropy branch labels

### DIFF
--- a/generators/testgen/src/testgen/priv/extensions/Zkr.py
+++ b/generators/testgen/src/testgen/priv/extensions/Zkr.py
@@ -231,16 +231,16 @@ def _generate_seed_entropy_zero_non_es16_tests(test_data: TestData) -> list[str]
             f"LI(x{entropy_reg}, 0xFFFF)",
             "# Check OPST value",
             f"LI(x{cmp_reg}, 0x2)",
-            f"bne x{opst_reg}, x{cmp_reg}, 1f",
+            f"bne x{opst_reg}, x{cmp_reg}, .Lzkr_seed_entropy_non_es16",
             "# SIGUPD 0x0BADBEEF if OPST is ES16",
             f"LI(x{cmp_reg}, 0xB0BA)",
             write_sigupd(cmp_reg, test_data),
-            "j 2f",
-            "1:",
+            "j .Lzkr_seed_entropy_done",
+            ".Lzkr_seed_entropy_non_es16:",
             "# If OPST is not ES16",
             f"and x{entropy_reg}, x{entropy_reg}, x{read_reg}",
             write_sigupd(entropy_reg, test_data),
-            "2:",
+            ".Lzkr_seed_entropy_done:",
         ]
     )
 


### PR DESCRIPTION
The Zkr seed entropy generator used numeric local labels around RVTEST_SIGUPD calls. RVTEST_SIGUPD also defines a 1: local label, so the branch to 1f resolved into the signature update macro instead of the intended non-ES16 path.

Use named local labels for the generator control flow to avoid local-label capture.