### PR TITLE
Add ACT build step timeout

### DIFF
--- a/framework/src/act/build.py
+++ b/framework/src/act/build.py
@@ -41,6 +41,8 @@ from act.build_types import (
     SymlinkAction,
 )
 
+BUILD_STEP_TIMEOUT_SECONDS = 300
+
 
 @dataclass
 class BuildError:
@@ -66,6 +68,28 @@ class BuildResult:
 def _exception_error(task: BuildTask, e: BaseException) -> BuildError:
     """BuildError for a task that raised before producing a return code."""
     return BuildError(task_name=task.name, command=_task_str(task), returncode=-1, output=str(e))
+
+
+def _kill_subprocess_tree(pgid: int, proc: subprocess.Popen[str] | None = None) -> None:
+    """Kill a subprocess and any children in its process group."""
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(pgid, signal.SIGKILL)
+    if proc is not None:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            proc.kill()
+
+
+def _communicate_with_timeout(proc: subprocess.Popen[str], pgid: int) -> tuple[str, int]:
+    """Collect subprocess output, killing its process group if it times out."""
+    try:
+        stdout, stderr = proc.communicate(timeout=BUILD_STEP_TIMEOUT_SECONDS)
+        return stderr + stdout, proc.returncode if proc.returncode is not None else -1
+    except subprocess.TimeoutExpired:
+        _kill_subprocess_tree(pgid, proc)
+        stdout, stderr = proc.communicate()
+        output = stderr + stdout
+        timeout_msg = f"Timed out after {BUILD_STEP_TIMEOUT_SECONDS}s; process group killed."
+        return (f"{timeout_msg}\n{output}" if output else timeout_msg), -signal.SIGKILL
 
 
 def execute_task(
@@ -100,23 +124,21 @@ def execute_task(
                 else:
                     active_pgids.add(pgid)
             if kill_immediately:
-                with contextlib.suppress(ProcessLookupError, PermissionError):
-                    os.killpg(pgid, signal.SIGKILL)
-                with contextlib.suppress(ProcessLookupError, PermissionError):
-                    proc.kill()
+                _kill_subprocess_tree(pgid, proc)
+
             try:
-                stdout, stderr = proc.communicate()
+                output, returncode = _communicate_with_timeout(proc, pgid)
             finally:
                 with pgids_lock:
                     active_pgids.discard(pgid)
             if action.stdout_file is not None:
-                action.stdout_file.write_text(stderr + stdout)
-            if proc.returncode != 0:
+                action.stdout_file.write_text(output)
+            if returncode != 0:
                 return task.key, BuildError(
                     task_name=task.name,
                     command=_task_str(task),
-                    returncode=proc.returncode,
-                    output=stderr + stdout,
+                    returncode=returncode,
+                    output=output,
                     log_file=action.stdout_file,
                 )
         except OSError as e:
@@ -296,8 +318,7 @@ def build(
             shutdown_event.set()
             pgids = set(active_pgids)
         for pgid in pgids:
-            with contextlib.suppress(ProcessLookupError, PermissionError):
-                os.killpg(pgid, signal.SIGKILL)
+            _kill_subprocess_tree(pgid)
 
     def record_result(
         done_future: Future[tuple[Path, BuildError | None]], *, live: Live, executor: ThreadPoolExecutor


### PR DESCRIPTION
Add a 300-second timeout to ACT subprocess build steps. When a command times out, ACT kills the subprocess process group, preserves captured output, and reports the timeout as the task failure.

This prevents hung compiler, reference-model, objdump, or coverage simulator commands from blocking a build indefinitely.