### PR TITLE
Harden CI and developer checks

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -9,7 +9,7 @@ description: Set up mise and cache uv packages, optionally caching UDB gems
 
 inputs:
   udb-gems:
-    description: Cache UDB gems and set BUNDLE_PATH (for jobs that run UDB via act)
+    description: Cache UDB gems and configure Bundler's install path (for jobs that run UDB via act)
     required: false
     default: "false"
 
@@ -27,10 +27,10 @@ runs:
 
     # Install UDB gems into a dedicated directory so they can be cached
     # independently of the mise-managed Ruby installation.
-    - name: Set BUNDLE_PATH
+    - name: Configure Bundler path
       if: inputs.udb-gems == 'true'
       shell: bash
-      run: echo "BUNDLE_PATH=$GITHUB_WORKSPACE/.bundle-gems" >> "$GITHUB_ENV"
+      run: bundle config set --global path "${GITHUB_WORKSPACE}/.bundle-gems"
 
     # ~/.cache/udb holds the z3/espresso binaries that the udb gem downloads
     # at install time; a restored gem cache skips `bundle install`, so the

--- a/.github/scripts/check-align-directive.sh
+++ b/.github/scripts/check-align-directive.sh
@@ -32,7 +32,7 @@ for f in "$@"; do
     found=1
     while IFS= read -r line; do
       echo "$f:$line"
-    done <<< "$matches"
+    done <<<"$matches"
   fi
 done
 

--- a/.github/scripts/install-cve2.sh
+++ b/.github/scripts/install-cve2.sh
@@ -37,10 +37,10 @@ git init "$INSTALL_DIR/cv32e20-dv"
 
 # 3. Verilate the rv32imc config (RTL hash pinned in sim/ExternalRepos.mk).
 make -C "$INSTALL_DIR/cv32e20-dv/sim/core" \
-    verilate \
-    TEST=certification \
-    -j"$(nproc)"
+  verilate \
+  TEST=certification \
+  -j"$(nproc)"
 
 # 4. Install the cv32e20 per-test wrapper.
 install -m 0755 "$INSTALL_DIR/cv32e20-dv/.github/scripts/run-cv32e20.sh" \
-                "$INSTALL_DIR/bin/run-cv32e20.sh"
+  "$INSTALL_DIR/bin/run-cv32e20.sh"

--- a/.github/scripts/install-cve4.sh
+++ b/.github/scripts/install-cve4.sh
@@ -12,7 +12,7 @@ CVE4_DV_REPO="https://github.com/openhwgroup/cv32e40p-dv-review.git"
 CVE4_DV_COMMIT="1726d14796601884d54d9b0f699128800e2dcf55"
 CVE40X_DV_REPO="https://github.com/openhwgroup/cv32e40x-dv.git"
 CVE40X_DV_COMMIT="93ce70f1ae2ab2e66716e0c5648d27e67e161c2f"
-CVE40X_CORE_HASH="18c88fd78a37f270c8301c552f5fd0f564d0ab20"  # pin cv32e40x RTL
+CVE40X_CORE_HASH="18c88fd78a37f270c8301c552f5fd0f564d0ab20" # pin cv32e40x RTL
 VERILATOR_VERSION="v5.042"
 
 mkdir -p "$INSTALL_DIR/bin"
@@ -41,27 +41,27 @@ git init "$INSTALL_DIR/cv32e40p-dv"
 
 # 3. Build a Verilator binary per cv32e40p config (TEST = certification_<config>).
 make -C "$INSTALL_DIR/cv32e40p-dv/sim/core" \
-    verilate \
-    CV_CORE_CONFIG=rv32imcf \
-    TEST=certification_rv32imcf \
-    -j"$(nproc)"
+  verilate \
+  CV_CORE_CONFIG=rv32imcf \
+  TEST=certification_rv32imcf \
+  -j"$(nproc)"
 
 make -C "$INSTALL_DIR/cv32e40p-dv/sim/core" \
-    verilate \
-    CV_CORE_CONFIG=rv32imc \
-    TEST=certification_rv32imc \
-    -j"$(nproc)"
+  verilate \
+  CV_CORE_CONFIG=rv32imc \
+  TEST=certification_rv32imc \
+  -j"$(nproc)"
 
 # v1.0.0_rv32imc also clones the pinned v1.0.0 RTL (Makefile handles it).
 make -C "$INSTALL_DIR/cv32e40p-dv/sim/core" \
-    verilate \
-    CV_CORE_CONFIG=v1.0.0_rv32imc \
-    TEST=certification_v1.0.0_rv32imc \
-    -j"$(nproc)"
+  verilate \
+  CV_CORE_CONFIG=v1.0.0_rv32imc \
+  TEST=certification_v1.0.0_rv32imc \
+  -j"$(nproc)"
 
 # 4. Drop the per-test wrapper into $INSTALL_DIR/bin for easy invocation from CI
 install -m 0755 "$INSTALL_DIR/cv32e40p-dv/.github/scripts/run-cve4.sh" \
-                "$INSTALL_DIR/bin/run-cve4.sh"
+  "$INSTALL_DIR/bin/run-cve4.sh"
 
 # 5. Clone cv32e40x-dv at its pinned commit (fetch by SHA, same pattern as above).
 git init "$INSTALL_DIR/cv32e40x-dv"
@@ -75,14 +75,14 @@ git init "$INSTALL_DIR/cv32e40x-dv"
 # 6. Verilate both cv32e40x configs (reuses Verilator built above; RTL pinned).
 for cfg in rv32imc rv32imcab; do
   make -C "$INSTALL_DIR/cv32e40x-dv/sim/core" \
-      verilate \
-      CV_CORE_CONFIG="$cfg" \
-      CV_CORE_HASH="$CVE40X_CORE_HASH" \
-      CV_SW_TOOLCHAIN=/usr/local \
-      CV_SW_PREFIX=riscv64-unknown-elf- \
-      -j"$(nproc)"
+    verilate \
+    CV_CORE_CONFIG="$cfg" \
+    CV_CORE_HASH="$CVE40X_CORE_HASH" \
+    CV_SW_TOOLCHAIN=/usr/local \
+    CV_SW_PREFIX=riscv64-unknown-elf- \
+    -j"$(nproc)"
 done
 
 # 7. Install the cv32e40x per-test wrapper.
 install -m 0755 "$INSTALL_DIR/cv32e40x-dv/.github/scripts/run-cv32e40x.sh" \
-                "$INSTALL_DIR/bin/run-cv32e40x.sh"
+  "$INSTALL_DIR/bin/run-cv32e40x.sh"

--- a/.github/scripts/install-cvw.sh
+++ b/.github/scripts/install-cvw.sh
@@ -33,7 +33,7 @@ git submodule update --init addins/verilog-ethernet
 # Command mirrors exactly what `wsim --sim verilator` runs (bin/wsim,
 # runVerilator) so the up-to-date check skips recompilation at run time.
 export WALLY="$INSTALL_DIR/cvw"
-export PATH="$INSTALL_DIR/bin:$PATH"   # Verilator was just `make install`ed here
+export PATH="$INSTALL_DIR/bin:$PATH" # Verilator was just `make install`ed here
 
 for WALLYCONF in rv32gc rv32imc rv64gc; do
   echo "Prebuilding Verilator model for $WALLYCONF ..."
@@ -43,8 +43,11 @@ for WALLYCONF in rv32gc rv32imc rv64gc; do
     PARAM_ARGS="" \
     DEFINE_ARGS="" \
     BUILD_HASH=""
-  test -x "$WALLY/sim/verilator/wkdir/${WALLYCONF}_testbench/Vtestbench" \
-    || { echo "ERROR: Vtestbench not produced for $WALLYCONF"; exit 1; }
+  test -x "$WALLY/sim/verilator/wkdir/${WALLYCONF}_testbench/Vtestbench" ||
+    {
+      echo "ERROR: Vtestbench not produced for $WALLYCONF"
+      exit 1
+    }
   # wsim's up-to-date check is mtime-based; ensure the prebuilt model stays
   # newer than all CVW sources after the GitHub Actions cache is restored so
   # it is reused instead of silently rebuilding.

--- a/.github/scripts/setup-cve2.sh
+++ b/.github/scripts/setup-cve2.sh
@@ -8,5 +8,5 @@ set -euo pipefail
 
 INSTALL_DIR="${1:?Usage: setup-cve2.sh <install-dir>}"
 
-echo "$INSTALL_DIR/bin" >> "$GITHUB_PATH"
-echo "CVE20_DV_ROOT=$INSTALL_DIR/cv32e20-dv" >> "$GITHUB_ENV"
+echo "$INSTALL_DIR/bin" >>"$GITHUB_PATH"
+echo "CVE20_DV_ROOT=$INSTALL_DIR/cv32e20-dv" >>"$GITHUB_ENV"

--- a/.github/scripts/setup-cve4.sh
+++ b/.github/scripts/setup-cve4.sh
@@ -8,6 +8,6 @@ set -euo pipefail
 
 INSTALL_DIR="${1:?Usage: setup-cve4.sh <install-dir>}"
 
-echo "$INSTALL_DIR/bin" >> "$GITHUB_PATH"
-echo "CVE4_DV_ROOT=$INSTALL_DIR/cv32e40p-dv" >> "$GITHUB_ENV"
-echo "CVE40X_DV_ROOT=$INSTALL_DIR/cv32e40x-dv" >> "$GITHUB_ENV"
+echo "$INSTALL_DIR/bin" >>"$GITHUB_PATH"
+echo "CVE4_DV_ROOT=$INSTALL_DIR/cv32e40p-dv" >>"$GITHUB_ENV"
+echo "CVE40X_DV_ROOT=$INSTALL_DIR/cv32e40x-dv" >>"$GITHUB_ENV"

--- a/.github/scripts/setup-cvw.sh
+++ b/.github/scripts/setup-cvw.sh
@@ -9,5 +9,5 @@ set -euo pipefail
 
 INSTALL_DIR="${1:?Usage: setup-cvw.sh <install-dir>}"
 
-echo "$INSTALL_DIR/cvw/bin" >> "$GITHUB_PATH"
-echo "WALLY=$INSTALL_DIR/cvw" >> "$GITHUB_ENV"
+echo "$INSTALL_DIR/cvw/bin" >>"$GITHUB_PATH"
+echo "WALLY=$INSTALL_DIR/cvw" >>"$GITHUB_ENV"

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up mise
         uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4

--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -74,7 +74,7 @@ jobs:
       # Generated tests (e.g. priv) are not checked in but count toward the
       # suite weights used for shard bin-packing, so generate them first.
       - name: Generate tests
-        run: make tests --jobs $(nproc)
+        run: make tests --jobs "$(nproc)"
 
       - name: Discover CI configs
         id: discover
@@ -108,22 +108,24 @@ jobs:
           MATRIX_SHARD_TOTAL: ${{ matrix.shard_total }}
         run: |
           if [ -z "${MATRIX_EXTENSIONS}" ]; then
-            echo "::notice::Shard $((${MATRIX_SHARD_INDEX} + 1))/${MATRIX_SHARD_TOTAL} for ${MATRIX_CONFIG} is empty after exclusions; skipping heavy steps."
+            echo "::notice::Shard $((MATRIX_SHARD_INDEX + 1))/${MATRIX_SHARD_TOTAL} for ${MATRIX_CONFIG} is empty after exclusions; skipping heavy steps."
           else
-            echo "Shard $((${MATRIX_SHARD_INDEX} + 1))/${MATRIX_SHARD_TOTAL} extensions: ${MATRIX_EXTENSIONS}"
+            echo "Shard $((MATRIX_SHARD_INDEX + 1))/${MATRIX_SHARD_TOTAL} extensions: ${MATRIX_EXTENSIONS}"
           fi
 
       - name: Install sail-riscv model
         if: matrix.extensions != ''
         run: |
+          runner_uname=$(uname)
+          runner_arch=$(arch)
           sudo mkdir -p /usr/local
-          curl --location https://github.com/riscv/sail-riscv/releases/download/${SAIL_VERSION}/sail-riscv-$(uname)-$(arch).tar.gz \
+          curl --location "https://github.com/riscv/sail-riscv/releases/download/${SAIL_VERSION}/sail-riscv-${runner_uname}-${runner_arch}.tar.gz" \
           | sudo tar xvz --directory=/usr/local --strip-components=1
 
       - name: Install RISC-V GCC toolchain
         if: matrix.extensions != ''
         run: |
-          curl --location https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/${RISCV_TOOLCHAIN_VERSION}/riscv64-elf-ubuntu-24.04-gcc.tar.xz \
+          curl --location "https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/${RISCV_TOOLCHAIN_VERSION}/riscv64-elf-ubuntu-24.04-gcc.tar.xz" \
           | sudo tar xvJ --directory=/usr/local --strip-components=1
 
       - name: Install Clang
@@ -154,9 +156,9 @@ jobs:
           retry 3 sudo bash /tmp/llvm.sh "$LLVM_VERSION"
           retry 3 sudo apt-get update
           retry 3 sudo apt-get install -y -o Acquire::Retries=3 \
-            clang-$LLVM_VERSION lld-$LLVM_VERSION llvm-$LLVM_VERSION
+            clang-"$LLVM_VERSION" lld-"$LLVM_VERSION" llvm-"$LLVM_VERSION"
           for tool in clang clang++ lld llvm-objdump llvm-as llvm-ar llvm-nm llvm-readelf; do
-            sudo ln -sf /usr/bin/${tool}-$LLVM_VERSION /usr/bin/${tool}
+            sudo ln -sf "/usr/bin/${tool}-${LLVM_VERSION}" "/usr/bin/${tool}"
           done
 
       - name: Install runtime dependencies
@@ -165,7 +167,8 @@ jobs:
           MATRIX_APT_PACKAGES: ${{ matrix.apt_packages }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y ${MATRIX_APT_PACKAGES}
+          read -r -a apt_packages <<< "${MATRIX_APT_PACKAGES}"
+          sudo apt-get install -y "${apt_packages[@]}"
 
       - name: Restore cached simulator
         if: matrix.extensions != '' && matrix.cache_key != ''
@@ -179,7 +182,7 @@ jobs:
         if: matrix.extensions != '' && matrix.install_script != '' && steps.cache-restore.outputs.cache-hit != 'true'
         env:
           MATRIX_INSTALL_SCRIPT: ${{ matrix.install_script }}
-        run: bash ${MATRIX_INSTALL_SCRIPT} ${{ github.workspace }}/${MATRIX_SIMULATOR}
+        run: bash "${MATRIX_INSTALL_SCRIPT}" "${GITHUB_WORKSPACE}/${MATRIX_SIMULATOR}"
 
       - name: Save cached simulator
         if: matrix.extensions != '' && matrix.cache_key != '' && steps.cache-restore.outputs.cache-hit != 'true'
@@ -190,17 +193,17 @@ jobs:
 
       - name: Add simulator to PATH
         if: matrix.extensions != '' && matrix.install_script != ''
-        run: echo "$GITHUB_WORKSPACE/${MATRIX_SIMULATOR}/bin" >> $GITHUB_PATH
+        run: echo "$GITHUB_WORKSPACE/${MATRIX_SIMULATOR}/bin" >> "$GITHUB_PATH"
 
       - name: Run setup script
         if: matrix.extensions != '' && matrix.setup_script != ''
         env:
           MATRIX_SETUP_SCRIPT: ${{ matrix.setup_script }}
-        run: bash ${MATRIX_SETUP_SCRIPT} ${{ github.workspace }}/${MATRIX_SIMULATOR}
+        run: bash "${MATRIX_SETUP_SCRIPT}" "${GITHUB_WORKSPACE}/${MATRIX_SIMULATOR}"
 
       - name: Generate tests and coverpoints
         if: matrix.extensions != ''
-        run: EXTENSIONS=${MATRIX_EXTENSIONS} make tests --jobs $(nproc)
+        run: EXTENSIONS="${MATRIX_EXTENSIONS}" make tests --jobs "$(nproc)"
 
       - name: Build ELFs
         if: matrix.extensions != ''
@@ -209,16 +212,16 @@ jobs:
           MATRIX_CONFIG_FILE: ${{ matrix.config_file }}
         run: |
           FAST=True \
-          EXTENSIONS=${MATRIX_EXTENSIONS} \
-          EXCLUDE_EXTENSIONS=${MATRIX_EXCLUDE_EXTENSIONS} \
-          CONFIG_FILES=${MATRIX_CONFIG_FILE} \
-          make elfs --jobs $(nproc)
+          EXTENSIONS="${MATRIX_EXTENSIONS}" \
+          EXCLUDE_EXTENSIONS="${MATRIX_EXCLUDE_EXTENSIONS}" \
+          CONFIG_FILES="${MATRIX_CONFIG_FILE}" \
+          make elfs --jobs "$(nproc)"
 
       - name: Run tests
         if: matrix.extensions != '' && matrix.run_cmd != ''
         run: |
           ./run_tests.py "${MATRIX_RUN_CMD}" \
-          work/${MATRIX_CONFIG}/elfs
+          "work/${MATRIX_CONFIG}/elfs"
         env:
           MATRIX_RUN_CMD: ${{ matrix.run_cmd }}
 
@@ -242,7 +245,7 @@ jobs:
         uses: ./.github/actions/setup-tools
 
       - name: Generate vector tests
-        run: make vector-tests --jobs $(nproc)
+        run: make vector-tests --jobs "$(nproc)"
 
   ctp-build:
     name: Build CTP
@@ -291,12 +294,12 @@ jobs:
 
       - name: Check for differences
         run: |
-          dirs="tests/rv32i tests/rv32e tests/rv64i tests/rv64e coverpoints/unpriv coverpoints/coverage"
-          changed=$(git diff --name-only -- $dirs)
-          untracked=$(git ls-files --others --exclude-standard -- $dirs)
+          dirs=(tests/rv32i tests/rv32e tests/rv64i tests/rv64e coverpoints/unpriv coverpoints/coverage)
+          changed=$(git diff --name-only -- "${dirs[@]}")
+          untracked=$(git ls-files --others --exclude-standard -- "${dirs[@]}")
           if [ -n "$changed" ] || [ -n "$untracked" ]; then
             echo "::error::Checked-in generated files are out of sync with the generators. Run 'make tests' and commit the results."
-            [ -n "$changed" ] && echo "Changed files:" && git diff -- $dirs
+            [ -n "$changed" ] && echo "Changed files:" && git diff -- "${dirs[@]}"
             [ -n "$untracked" ] && echo "New files:" && echo "$untracked"
             exit 1
           fi
@@ -329,13 +332,15 @@ jobs:
 
       - name: Install sail-riscv model
         run: |
+          runner_uname=$(uname)
+          runner_arch=$(arch)
           sudo mkdir -p /usr/local
-          curl --location https://github.com/riscv/sail-riscv/releases/download/${SAIL_VERSION}/sail-riscv-$(uname)-$(arch).tar.gz \
+          curl --location "https://github.com/riscv/sail-riscv/releases/download/${SAIL_VERSION}/sail-riscv-${runner_uname}-${runner_arch}.tar.gz" \
           | sudo tar xvz --directory=/usr/local --strip-components=1
 
       - name: Install RISC-V GCC toolchain
         run: |
-          curl --location https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/${RISCV_TOOLCHAIN_VERSION}/riscv64-elf-ubuntu-24.04-gcc.tar.xz \
+          curl --location "https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/${RISCV_TOOLCHAIN_VERSION}/riscv64-elf-ubuntu-24.04-gcc.tar.xz" \
           | sudo tar xvJ --directory=/usr/local --strip-components=1
 
       - name: Build ELFs (exercises full act build DAG)

--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up tools
         uses: ./.github/actions/setup-tools
@@ -45,6 +47,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up tools
         uses: ./.github/actions/setup-tools
@@ -79,10 +83,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.discover-configs.outputs.matrix) }}
+    env:
+      MATRIX_CONFIG: ${{ matrix.config }}
+      MATRIX_EXTENSIONS: ${{ matrix.extensions }}
+      MATRIX_SIMULATOR: ${{ matrix.simulator }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up tools
         uses: ./.github/actions/setup-tools
@@ -90,11 +100,14 @@ jobs:
           udb-gems: "true"
 
       - name: Report shard assignment
+        env:
+          MATRIX_SHARD_INDEX: ${{ matrix.shard_index }}
+          MATRIX_SHARD_TOTAL: ${{ matrix.shard_total }}
         run: |
-          if [ -z "${{ matrix.extensions }}" ]; then
-            echo "::notice::Shard $((${{ matrix.shard_index }} + 1))/${{ matrix.shard_total }} for ${{ matrix.config }} is empty after exclusions; skipping heavy steps."
+          if [ -z "${MATRIX_EXTENSIONS}" ]; then
+            echo "::notice::Shard $((${MATRIX_SHARD_INDEX} + 1))/${MATRIX_SHARD_TOTAL} for ${MATRIX_CONFIG} is empty after exclusions; skipping heavy steps."
           else
-            echo "Shard $((${{ matrix.shard_index }} + 1))/${{ matrix.shard_total }} extensions: ${{ matrix.extensions }}"
+            echo "Shard $((${MATRIX_SHARD_INDEX} + 1))/${MATRIX_SHARD_TOTAL} extensions: ${MATRIX_EXTENSIONS}"
           fi
 
       - name: Install sail-riscv model
@@ -145,9 +158,11 @@ jobs:
 
       - name: Install runtime dependencies
         if: matrix.extensions != '' && matrix.apt_packages != ''
+        env:
+          MATRIX_APT_PACKAGES: ${{ matrix.apt_packages }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y ${{ matrix.apt_packages }}
+          sudo apt-get install -y ${MATRIX_APT_PACKAGES}
 
       - name: Restore cached simulator
         if: matrix.extensions != '' && matrix.cache_key != ''
@@ -159,7 +174,9 @@ jobs:
 
       - name: Install simulator
         if: matrix.extensions != '' && matrix.install_script != '' && steps.cache-restore.outputs.cache-hit != 'true'
-        run: bash ${{ matrix.install_script }} ${{ github.workspace }}/${{ matrix.simulator }}
+        env:
+          MATRIX_INSTALL_SCRIPT: ${{ matrix.install_script }}
+        run: bash ${MATRIX_INSTALL_SCRIPT} ${{ github.workspace }}/${MATRIX_SIMULATOR}
 
       - name: Save cached simulator
         if: matrix.extensions != '' && matrix.cache_key != '' && steps.cache-restore.outputs.cache-hit != 'true'
@@ -170,30 +187,37 @@ jobs:
 
       - name: Add simulator to PATH
         if: matrix.extensions != '' && matrix.install_script != ''
-        run: echo "$GITHUB_WORKSPACE/${{ matrix.simulator }}/bin" >> $GITHUB_PATH
+        run: echo "$GITHUB_WORKSPACE/${MATRIX_SIMULATOR}/bin" >> $GITHUB_PATH
 
       - name: Run setup script
         if: matrix.extensions != '' && matrix.setup_script != ''
-        run: bash ${{ matrix.setup_script }} ${{ github.workspace }}/${{ matrix.simulator }}
+        env:
+          MATRIX_SETUP_SCRIPT: ${{ matrix.setup_script }}
+        run: bash ${MATRIX_SETUP_SCRIPT} ${{ github.workspace }}/${MATRIX_SIMULATOR}
 
       - name: Generate tests and coverpoints
         if: matrix.extensions != ''
-        run: EXTENSIONS=${{ matrix.extensions }} make tests --jobs $(nproc)
+        run: EXTENSIONS=${MATRIX_EXTENSIONS} make tests --jobs $(nproc)
 
       - name: Build ELFs
         if: matrix.extensions != ''
+        env:
+          MATRIX_EXCLUDE_EXTENSIONS: ${{ matrix.exclude_extensions }}
+          MATRIX_CONFIG_FILE: ${{ matrix.config_file }}
         run: |
           FAST=True \
-          EXTENSIONS=${{ matrix.extensions }} \
-          EXCLUDE_EXTENSIONS=${{ matrix.exclude_extensions }} \
-          CONFIG_FILES=${{ matrix.config_file }} \
+          EXTENSIONS=${MATRIX_EXTENSIONS} \
+          EXCLUDE_EXTENSIONS=${MATRIX_EXCLUDE_EXTENSIONS} \
+          CONFIG_FILES=${MATRIX_CONFIG_FILE} \
           make elfs --jobs $(nproc)
 
       - name: Run tests
         if: matrix.extensions != '' && matrix.run_cmd != ''
         run: |
-          ./run_tests.py "${{ matrix.run_cmd }}" \
-          work/${{ matrix.config }}/elfs
+          ./run_tests.py "${MATRIX_RUN_CMD}" \
+          work/${MATRIX_CONFIG}/elfs
+        env:
+          MATRIX_RUN_CMD: ${{ matrix.run_cmd }}
 
       - name: Upload logs
         if: always() && matrix.extensions != ''
@@ -208,6 +232,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up tools
         uses: ./.github/actions/setup-tools
@@ -220,6 +246,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up tools
         uses: ./.github/actions/setup-tools
@@ -234,6 +262,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - run: git submodule update --init docs/docs-resources
 
@@ -247,6 +277,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up tools
         uses: ./.github/actions/setup-tools
@@ -278,6 +310,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Pin Python version for this job
         run: echo "${{ matrix.python-version }}" > .python-version

--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -17,6 +17,9 @@ env:
   RISCV_TOOLCHAIN_VERSION: "2026.07.15"
   LLVM_VERSION: "22"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Pre-commit (prek) check

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up mise
         uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
@@ -46,6 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - run: git submodule update --init docs/docs-resources
 
@@ -132,6 +136,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           sparse-checkout: docs/pages
+          persist-credentials: false
 
       - name: Download CTP HTML
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -98,28 +98,43 @@ jobs:
           name: crd-html
           path: ./
 
-      - name: Get current date
+      - name: Get release metadata
+        id: release_metadata
         run: |
-          echo "CURRENT_DATE=$(date +'%Y-%m-%d-%H-%M')" >> $GITHUB_ENV
-          echo "SHORT_SHA=$(echo ${GITHUB_SHA::7})" >> $GITHUB_ENV
+          current_date=$(date +'%Y-%m-%d-%H-%M')
+          short_sha=${GITHUB_SHA::7}
+          echo "current_date=$current_date" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
 
       - name: Create Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
-        with:
-          draft: false
-          prerelease: ${{ github.event_name != 'workflow_dispatch' }}
-          make_latest: true
-          tag_name: cert-docs-${{ env.CURRENT_DATE }}-${{ env.SHORT_SHA }}
-          name: "Certification Documents ${{ env.CURRENT_DATE }}: ${{ env.SHORT_SHA }}"
-          body: "Automated release of the certification documents (CTP & CRD) built on ${{ env.CURRENT_DATE }} from commit ${{ env.SHORT_SHA }}."
-          files: |
-            ctp.pdf
-            ctp.html
-            rvi20_crd.pdf
-            rvi20_crd.html
-            mc100_crd.pdf
-            mc100_crd.html
-            rva23_crd.pdf
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRERELEASE: ${{ github.event_name != 'workflow_dispatch' }}
+          CURRENT_DATE: ${{ steps.release_metadata.outputs.current_date }}
+          SHORT_SHA: ${{ steps.release_metadata.outputs.short_sha }}
+        run: |
+          tag_name="cert-docs-${CURRENT_DATE}-${SHORT_SHA}"
+          release_name="Certification Documents ${CURRENT_DATE}: ${SHORT_SHA}"
+          release_body="Automated release of the certification documents (CTP & CRD) built on ${CURRENT_DATE} from commit ${SHORT_SHA}."
+
+          release_args=(
+            --title "$release_name"
+            --notes "$release_body"
+            --latest
+          )
+          if [ "$PRERELEASE" = "true" ]; then
+            release_args+=(--prerelease)
+          fi
+
+          gh release create "$tag_name" \
+            "${release_args[@]}" \
+            ctp.pdf \
+            ctp.html \
+            rvi20_crd.pdf \
+            rvi20_crd.html \
+            mc100_crd.pdf \
+            mc100_crd.html \
+            rva23_crd.pdf \
             rva23_crd.html
 
   deploy-pages:

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -14,10 +14,7 @@ on:
       - ".github/workflows/release-docs.yml"
 
 permissions:
-  contents: write
-  actions: read
-  pages: write
-  id-token: write
+  contents: read
 
 jobs:
   build-ctp:
@@ -70,6 +67,8 @@ jobs:
   release:
     needs: [build-ctp, build-crd]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download CTP PDF
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -122,6 +121,10 @@ jobs:
   deploy-pages:
     needs: [build-ctp, build-crd]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,11 +93,9 @@ jobs:
             echo "::error::No release notes found for version '$version' in CHANGELOG.md. Add a '## [$version] - <date>' section before releasing."
             exit 1
           fi
-          {
-            echo "notes<<CHANGELOG_EOF"
-            echo "$notes"
-            echo "CHANGELOG_EOF"
-          } >> "$GITHUB_OUTPUT"
+          notes_file="$RUNNER_TEMP/release-notes.md"
+          printf "%s\n" "$notes" > "$notes_file"
+          echo "notes_file=$notes_file" >> "$GITHUB_OUTPUT"
 
       - name: Set up mise
         uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
@@ -110,16 +108,22 @@ jobs:
         run: cd docs/ctp && make -j2
 
       - name: Create Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
-        with:
-          draft: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.draft == 'true' }}
-          prerelease: false
-          make_latest: true
-          tag_name: ${{ env.VERSION }}
-          name: "${{ env.VERSION }}"
-          body: ${{ steps.notes.outputs.notes }}
-          fail_on_unmatched_files: true
-          files: |
-            docs/ctp/build/ctp.pdf
-            docs/ctp/build/ctp.html
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_DRAFT: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.draft == 'true' }}
+          RELEASE_NOTES_FILE: ${{ steps.notes.outputs.notes_file }}
+        run: |
+          release_args=(
+            --title "$VERSION"
+            --notes-file "$RELEASE_NOTES_FILE"
+            --latest
+          )
+          if [ "$RELEASE_DRAFT" = "true" ]; then
+            release_args+=(--draft)
+          fi
+
+          gh release create "$VERSION" \
+            "${release_args[@]}" \
+            docs/ctp/build/ctp.pdf \
+            docs/ctp/build/ctp.html \
             README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
         default: true
 
 permissions:
-  contents: write
+  contents: read
 
 # Serialize release creation so concurrent pushes can't race to create the same tag/release.
 concurrency:
@@ -37,8 +37,10 @@ jobs:
 
       - name: Resolve version
         id: version
+        env:
+          REQUESTED_VERSION: ${{ github.event.inputs.version }}
         run: |
-          version="${{ github.event.inputs.version }}"
+          version="$REQUESTED_VERSION"
           if [ -z "$version" ]; then
             version=$(awk -F'[][]' '/^## \[/ { print $2; exit }' CHANGELOG.md)
           fi
@@ -52,9 +54,10 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          if gh release view "${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "::notice::Release ${{ steps.version.outputs.version }} already exists; skipping."
+          if gh release view "$RELEASE_VERSION" >/dev/null 2>&1; then
+            echo "::notice::Release $RELEASE_VERSION already exists; skipping."
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -64,6 +67,8 @@ jobs:
     needs: check
     if: needs.check.outputs.exists == 'false'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       VERSION: ${{ needs.check.outputs.version }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
       exists: ${{ steps.check.outputs.exists }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Resolve version
         id: version
@@ -73,6 +75,8 @@ jobs:
       VERSION: ${{ needs.check.outputs.version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Extract release notes from CHANGELOG.md
         id: notes
@@ -97,6 +101,8 @@ jobs:
 
       - name: Set up mise
         uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
+        with:
+          cache: false # Don't cache in release workflows
 
       - run: git submodule update --init docs/docs-resources
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -3,6 +3,7 @@
 [tools]
 prek = "0.4.10"
 ruby = "3.4.10"
+shellcheck = "0.11.0"
 uv = "0.11.30"
 "gem:bundler" = "4.0.16"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,12 @@ repos:
       - id: check-toml
       - id: check-yaml
 
+  # Format pyproject.toml files
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: v2.26.0
+    hooks:
+      - id: pyproject-fmt
+
   # Ruff Python linter
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
@@ -40,7 +46,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
 
-  # Pyright Python type checker
+  # Project-local checks
   - repo: local
     hooks:
       - id: pyright
@@ -48,7 +54,6 @@ repos:
         entry: uv run pyright
         language: system
         types: [python]
-
   # Ensure uv lock file is up to date
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.11.30

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,19 @@ repos:
     hooks:
       - id: zizmor
 
+  # Shell script linting
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+
+  # Shell script formatting
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.13.1-1
+    hooks:
+      - id: shfmt
+        args: [--simplify, --indent, "2"]
+
   # Use spaces, not tabs
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,19 @@ repos:
     hooks:
       - id: uv-lock
 
+  # Check GitHub Actions workflows
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
+  # Find high-confidence security issues in GitHub Actions workflows
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.28.0
+    hooks:
+      - id: zizmor
+        args: [--min-severity=high, --min-confidence=high]
+
   # Use spaces, not tabs
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,13 @@ repos:
         entry: uv run pyright
         language: system
         types: [python]
+      - id: shellcheck
+        name: shellcheck
+        entry: mise exec -- shellcheck
+        language: system
+        types: [shell]
+        require_serial: true
+
   # Ensure uv lock file is up to date
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.11.30
@@ -65,18 +72,13 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
+        args: [-shellcheck=mise exec -- shellcheck]
 
   # Find security issues in GitHub Actions workflows
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.28.0
     hooks:
       - id: zizmor
-
-  # Shell script linting
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.11.0.1
-    hooks:
-      - id: shellcheck
 
   # Shell script formatting
   - repo: https://github.com/scop/pre-commit-shfmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ exclude: norm-rules.json
 repos:
   # Standard pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -31,14 +31,14 @@ repos:
 
   # Format pyproject.toml files
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.26.0
+    rev: d600c142bb19f521ae6a6a345f94a2efd7937759 # frozen: v2.26.0
     hooks:
       - id: pyproject-fmt
 
   # Ruff Python linter
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.22
+    rev: 2700fd5671c633760d912769c041bfcde2b9a01b # frozen: v0.15.22
     hooks:
       # Run the linter.
       - id: ruff-check
@@ -63,67 +63,61 @@ repos:
 
   # Ensure uv lock file is up to date
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.30
+    rev: 36bed8143874b34d77931e1236de048cf551e940 # frozen: 0.11.30
     hooks:
       - id: uv-lock
 
   # Check GitHub Actions workflows
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.12
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca # frozen: v1.7.12
     hooks:
       - id: actionlint
         args: [-shellcheck=mise exec -- shellcheck]
 
   # Find security issues in GitHub Actions workflows
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.28.0
+    rev: 067260dc5fe6ea86b7551bfd6f8b3ba4e6c93129 # frozen: v1.28.0
     hooks:
       - id: zizmor
 
   # Shell script formatting
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.13.1-1
+    rev: 05c1426671b9237fb5e1444dd63aa5731bec0dfb # frozen: v3.13.1-1
     hooks:
       - id: shfmt
         args: [--write, --simplify, --indent, "2"]
 
   # Use spaces, not tabs
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.6
+    rev: ad1b27d73581aa16cca06fc4a0761fc563ffe8e8 # frozen: v1.5.6
     hooks:
       - id: forbid-tabs
         exclude: '.*\.(diff|dump|patch|svg|mk)|Makefile*'
 
   # Prettier for json, yaml, markdown, etc. formatting
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.9.5
+    rev: 9337a74165b178ae2c766f60bee7252a0f06f3e8 # frozen: v3.9.5
     hooks:
       - id: prettier
 
   # Avoid common misspellings
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.3
+    rev: 57b21406f092110c18776e39b0bda50d37c945c8 # frozen: v2.4.3
     hooks:
       - id: codespell
 
   # Check links in markdown files
   - repo: https://github.com/tcort/markdown-link-check
-    rev: v3.14.2
+    rev: 3a8992dcbb083a248671812c7027b6995ef88523 # frozen: v3.14.2
     hooks:
       - id: markdown-link-check
         args: [-q, -c .markdown-link-check.config]
 
   # Validate Renovate configuration
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 43.272.3
+    rev: 87bc4ce9e2e73ac403ab97cb779dc8ede47b76ad # frozen: 43.272.3
     hooks:
       - id: renovate-config-validator
-
-  # clang-format for assembly files
-  # - repo: https://github.com/pre-commit/mirrors-clang-format
-  #   rev: "v19.1.7"
-  #   hooks:
-  #     - id: clang-format
 
   # Forbid the ambiguous `.align` assembler directive (its meaning is
   # target-dependent); require the explicit `.p2align` (power-of-two

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,12 +61,11 @@ repos:
     hooks:
       - id: actionlint
 
-  # Find high-confidence security issues in GitHub Actions workflows
+  # Find security issues in GitHub Actions workflows
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.28.0
     hooks:
       - id: zizmor
-        args: [--min-severity=high, --min-confidence=high]
 
   # Use spaces, not tabs
   - repo: https://github.com/Lucas-C/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
     rev: v3.13.1-1
     hooks:
       - id: shfmt
-        args: [--simplify, --indent, "2"]
+        args: [--write, --simplify, --indent, "2"]
 
   # Use spaces, not tabs
   - repo: https://github.com/Lucas-C/pre-commit-hooks

--- a/framework/pyproject.toml
+++ b/framework/pyproject.toml
@@ -2,26 +2,30 @@
 # act framework python project configuration file for riscv-arch-test
 # Jordan Carlin jcarlin@hmc.edu October 2025
 # SPDX-License-Identifier: Apache-2.0
+[build-system]
+build-backend = "uv_build"
+requires = [ "uv-build>=0.9.4,<0.12" ]
 
 [project]
 name = "act"
 version = "0.3.0"
 description = "RISC-V Architecture Certification Test Framework"
 readme = "../README.md"
-authors = [{ name = "Jordan Carlin", email = "jcarlin@hmc.edu" }]
+authors = [ { name = "Jordan Carlin", email = "jcarlin@hmc.edu" } ]
 requires-python = ">=3.10"
+classifiers = [
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
 dependencies = [
   "pydantic>=2.12.5",
-  "pyjson5>=2.0.0",
+  "pyjson5>=2",
   "rich>=14.3.4",
   "ruamel-yaml>=0.18.16",
   "typer>=0.23.1",
 ]
-
-[project.scripts]
-act = "act.act:main"
-
-##### BUILD #####
-[build-system]
-requires = ["uv_build>=0.9.4,<0.12.0"]
-build-backend = "uv_build"
+scripts.act = "act.act:main"

--- a/framework/src/act/data/Gemfile
+++ b/framework/src/act/data/Gemfile
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 7
 
 # By default we pull the UDB Ruby gems from rubygems.org. To develop against
 # a local riscv-unified-db checkout (e.g. to pick up unpublished changes such

--- a/framework/src/act/riscv-arch-test-vcs.sh
+++ b/framework/src/act/riscv-arch-test-vcs.sh
@@ -46,27 +46,27 @@ COMPILE_FILES=(
 
 DEFINE_ARGS=()
 for def in ${COVERAGELIST}; do
-  if [[ -n "${def}" ]]; then
+  if [[ -n ${def} ]]; then
     DEFINE_ARGS+=("+define+${def}")
   fi
 done
 
-pushd "${WKDIR}" > /dev/null
+pushd "${WKDIR}" >/dev/null
 
 # Compile
-if ! vlogan -q -full64 -sverilog "${INC_DIRS[@]}" "${DEFINE_ARGS[@]}" "${COMPILE_FILES[@]}" > vlogan.log 2>&1; then
+if ! vlogan -q -full64 -sverilog "${INC_DIRS[@]}" "${DEFINE_ARGS[@]}" "${COMPILE_FILES[@]}" >vlogan.log 2>&1; then
   echo "ERROR collecting coverage. vlogan failed; see ${WKDIR}/vlogan.log" >&2
   exit 1
 fi
 
 # Elaborate
-if ! vcs -q -full64 -sverilog testbench -o simv > vcs.log 2>&1; then
+if ! vcs -q -full64 -sverilog testbench -o simv >vcs.log 2>&1; then
   echo "ERROR collecting coverage. vcs elaboration failed; see ${WKDIR}/vcs.log" >&2
   exit 1
 fi
 
 # Simulate
-if ! ./simv -vcs_assert off +traceFileList="${TRACEFILELIST}" > simv.log 2>&1; then
+if ! ./simv -vcs_assert off +traceFileList="${TRACEFILELIST}" >simv.log 2>&1; then
   echo "ERROR collecting coverage. simv run failed; see ${WKDIR}/simv.log" >&2
   exit 1
 fi
@@ -78,4 +78,4 @@ else
   exit 1
 fi
 
-popd > /dev/null
+popd >/dev/null

--- a/generators/coverage/pyproject.toml
+++ b/generators/coverage/pyproject.toml
@@ -1,19 +1,24 @@
 # pyproject.toml
 # covergroupgen python project configuration file for riscv-arch-test
+# Jordan Carlin jcarlin@hmc.edu October 2025
 # SPDX-License-Identifier: Apache-2.0
+[build-system]
+build-backend = "uv_build"
+requires = [ "uv-build>=0.9.4,<0.12" ]
 
 [project]
 name = "covergroupgen"
 version = "0.2.0"
 description = "RISC-V Architectural Certification Covergroup Generator"
-authors = [{ name = "Jordan Carlin", email = "jcarlin@hmc.edu" }]
+authors = [ { name = "Jordan Carlin", email = "jcarlin@hmc.edu" } ]
 requires-python = ">=3.10"
-dependencies = ["typer>=0.23.1", "rich>=14.3.4"]
-
-[project.scripts]
-covergroupgen = "covergroupgen.cli:main"
-
-##### BUILD #####
-[build-system]
-requires = ["uv_build>=0.9.4,<0.12.0"]
-build-backend = "uv_build"
+classifiers = [
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
+dependencies = [ "rich>=14.3.4", "typer>=0.23.1" ]
+scripts.covergroupgen = "covergroupgen.cli:main"

--- a/generators/testgen/pyproject.toml
+++ b/generators/testgen/pyproject.toml
@@ -2,20 +2,24 @@
 # testgen python project configuration file for riscv-arch-test
 # Jordan Carlin jcarlin@hmc.edu October 2025
 # SPDX-License-Identifier: Apache-2.0
+[build-system]
+build-backend = "uv_build"
+requires = [ "uv-build>=0.9.4,<0.12" ]
 
 [project]
 name = "testgen"
 version = "0.5.0"
 description = "RISC-V Architectural Certification Test Generator"
 # readme = "README.md"
-authors = [{ name = "Jordan Carlin", email = "jcarlin@hmc.edu" }]
+authors = [ { name = "Jordan Carlin", email = "jcarlin@hmc.edu" } ]
 requires-python = ">=3.10"
-dependencies = ["typer>=0.23.1", "rich>=14.3.4"]
-
-[project.scripts]
-testgen = "testgen.cli:main"
-
-##### BUILD #####
-[build-system]
-requires = ["uv_build>=0.9.4,<0.12.0"]
-build-backend = "uv_build"
+classifiers = [
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
+dependencies = [ "rich>=14.3.4", "typer>=0.23.1" ]
+scripts.testgen = "testgen.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,15 +2,12 @@
 # Top-level python project configuration file for riscv-arch-test
 # Jordan Carlin jcarlin@hmc.edu October 2025
 # SPDX-License-Identifier: Apache-2.0
+[dependency-groups]
+dev = [ "pyright==1.1.411", "ruff==0.15.22" ]
 
 [tool.uv]
 exclude-newer = "7 days"
-
-[tool.uv.workspace]
-members = ["framework", "generators/testgen", "generators/coverage"]
-
-[dependency-groups]
-dev = ["pyright==1.1.411", "ruff==0.15.22"]
+workspace.members = [ "framework", "generators/coverage", "generators/testgen" ]
 
 ###### RUFF CONFIG #####
 [tool.ruff]
@@ -19,40 +16,36 @@ extend-exclude = [
   "docs/docs-resources",
   "generators/testgen/scripts", # Old scripts that still need to be updated
 ]
-
-[tool.ruff.lint]
-preview = true
-
 # Extra rules to enable beyond the default set
-extend-select = [
-  "ANN", # type annotation rules
+lint.extend-select = [
   "A",   # shadow builtins
-  "SIM", # Simplifications
-  "TID", # Tidy imports
-  "PTH", # Use Pathlib
+  "ANN", # type annotation rules
   "I",   # Import related rules (isort)
   "ISC", # Implicit string concatenation
+  "PTH", # Use Pathlib
+  "SIM", # Simplifications
+  "TID", # Tidy imports
 ]
-
-ignore = [
-  "RET504", # Unnecessary assignment to {name} before return statement
+lint.ignore = [
   "N",      # Naming requirements
+  "RET504", # Unnecessary assignment to {name} before return statement
 ]
-
-[tool.ty.src]
-exclude = [
-  "generators/testgen/scripts", # Old scripts that still need to be updated
-]
+lint.preview = true
 
 ##### PYRIGHT CONFIG #####
 [tool.pyright]
+pythonVersion = "3.10"
+typeCheckingMode = "standard"
 exclude = [
+  "**/.*",
   "**/__pycache__",
   "**/node_modules",
-  "**/.*",
   ".venv",
   "docs/docs-resources",
   "generators/testgen/scripts", # Old scripts that still need to be updated
 ]
-typeCheckingMode = "standard"
-pythonVersion = "3.10"
+
+[tool.ty]
+src.exclude = [
+  "generators/testgen/scripts", # Old scripts that still need to be updated
+]


### PR DESCRIPTION
Adds actionlint, zizmor, ShellCheck, shfmt, and pyproject-fmt to the prek checks.

Hardens GitHub workflows by reducing token permissions, disabling persisted checkout credentials, using gh for releases, and cleaning workflow shell snippets for ShellCheck.

Pins pre-commit hooks to frozen commit hashes and adds RubyGems cooldown for Bundler dependency resolution.