### PR TITLE
Stabilize store signature code size

### DIFF
--- a/generators/testgen/src/testgen/coverpoints/special/cp_align.py
+++ b/generators/testgen/src/testgen/coverpoints/special/cp_align.py
@@ -8,7 +8,6 @@
 """cp_align coverpoint generator."""
 
 from testgen.asm.helpers import load_int_reg, return_test_regs, write_sigupd
-from testgen.constants import INDENT
 from testgen.coverpoints.registry import add_coverpoint_generator
 from testgen.data.state import TestData
 from testgen.data.test_chunk import TestChunk
@@ -69,7 +68,6 @@ def make_align(instr_name: str, instr_type: str, coverpoint: str, test_data: Tes
                     test_data.add_testcase(f"b{alignment}", coverpoint),
                     f"{instr_name} x{params.rs2}, {params.immval}(x{test_data.int_regs.sig_reg}) # perform store",
                     f"addi x{test_data.int_regs.sig_reg}, x{test_data.int_regs.sig_reg}, {offset} # increment signature pointer",
-                    "#ifdef RVTEST_SELFCHECK",
                     f"LREG x{params.temp_reg}, -{offset}(x{test_data.int_regs.sig_reg}) # load stored value for checking",
                     write_sigupd(params.temp_reg, test_data),
                 ]
@@ -82,19 +80,7 @@ def make_align(instr_name: str, instr_type: str, coverpoint: str, test_data: Tes
                         write_sigupd(params.temp_reg, test_data),
                     ]
                 )
-            tc.code.extend(
-                [
-                    "#else",
-                    f"{instr_name} x{params.rs2}, {params.immval}(x{test_data.int_regs.sig_reg}) # repeat store so it is available for checking",
-                    f"addi x{test_data.int_regs.sig_reg}, x{test_data.int_regs.sig_reg}, {offset} # adjust base address for offset",
-                    f"{INDENT}# nops to ensure length matches SELFCHECK",
-                    "nop",
-                    "nop",
-                    "nop",
-                    "#endif",
-                    "",
-                ]
-            )
+            tc.code.append("")
 
         elif instr_type == "A":
             params = generate_random_params(test_data, instr_type, exclude_regs=[0])

--- a/generators/testgen/src/testgen/formatters/types/cfs_type.py
+++ b/generators/testgen/src/testgen/formatters/types/cfs_type.py
@@ -6,7 +6,6 @@
 ##################################
 
 from testgen.asm.helpers import load_float_reg, write_sigupd
-from testgen.constants import INDENT
 from testgen.data.params import InstructionParams
 from testgen.data.state import TestData
 from testgen.formatters.registry import InstructionTypeConfig, add_instruction_formatter
@@ -65,19 +64,10 @@ def format_cfs_type(
     check = [
         f"addi x{sig_reg}, x{sig_reg}, {params.immval} # restore base address",
         f"addi x{sig_reg}, x{sig_reg}, SIG_STRIDE # increment signature pointer",
-        "#ifdef RVTEST_SELFCHECK",
         f"LREG x{params.temp_reg}, -SIG_STRIDE(x{sig_reg}) # load stored value for checking",
         write_sigupd(params.temp_reg, test_data),
-        "#else",
-        f"{instr_name} f{params.fs2}, 0(x{sig_reg}) # repeat store so it is available for checking",
-        f"addi x{sig_reg}, x{sig_reg}, SIG_STRIDE # adjust base address for offset",
-        f"{INDENT}# nops to ensure length matches SELFCHECK",
-        "nop",
-        "nop",
-        "nop",
-        "#endif",
     ]
     assert test_data.test_chunk is not None
-    test_data.test_chunk.sigupd_count += 1
+    test_data.test_chunk.sigupd_count += 1  # Test store writes one extra signature slot
     check.append(write_sigupd(None, test_data, "fflags"))
     return (setup, test, check)

--- a/generators/testgen/src/testgen/formatters/types/cs_type.py
+++ b/generators/testgen/src/testgen/formatters/types/cs_type.py
@@ -6,7 +6,6 @@
 ##################################
 
 from testgen.asm.helpers import load_int_reg, write_sigupd
-from testgen.constants import INDENT
 from testgen.data.params import InstructionParams
 from testgen.data.state import TestData
 from testgen.formatters.registry import InstructionTypeConfig, add_instruction_formatter
@@ -66,18 +65,9 @@ def format_cs_type(
     check = [
         f"addi x{sig_reg}, x{sig_reg}, {params.immval} # restore base address",
         f"addi x{sig_reg}, x{sig_reg}, SIG_STRIDE # increment signature pointer",
-        "#ifdef RVTEST_SELFCHECK",
         f"LREG x{params.temp_reg}, -SIG_STRIDE(x{sig_reg}) # load stored value for checking",
         write_sigupd(params.temp_reg, test_data),
-        "#else",
-        f"{instr_name} x{params.rs2}, 0(x{sig_reg}) # repeat store so it is available for checking",
-        f"addi x{sig_reg}, x{sig_reg}, SIG_STRIDE # adjust base address for offset",
-        f"{INDENT}# nops to ensure length matches SELFCHECK",
-        "nop",
-        "nop",
-        "nop",
-        "#endif",
     ]
     assert test_data.test_chunk is not None
-    test_data.test_chunk.sigupd_count += 1
+    test_data.test_chunk.sigupd_count += 1  # Test store writes one extra signature slot
     return (setup, test, check)

--- a/generators/testgen/src/testgen/formatters/types/csb_type.py
+++ b/generators/testgen/src/testgen/formatters/types/csb_type.py
@@ -6,7 +6,6 @@
 ##################################
 
 from testgen.asm.helpers import load_int_reg, write_sigupd
-from testgen.constants import INDENT
 from testgen.data.params import InstructionParams
 from testgen.data.state import TestData
 from testgen.formatters.registry import InstructionTypeConfig, add_instruction_formatter
@@ -49,18 +48,9 @@ def format_csb_type(
     check = [
         f"addi x{sig_reg}, x{sig_reg}, {params.immval} # restore base address",
         f"addi x{sig_reg}, x{sig_reg}, SIG_STRIDE # increment signature pointer",
-        "#ifdef RVTEST_SELFCHECK",
         f"LREG x{params.temp_reg}, -SIG_STRIDE(x{sig_reg}) # load stored value for checking",
         write_sigupd(params.temp_reg, test_data),
-        "#else",
-        f"{instr_name} x{params.rs2}, 0(x{sig_reg}) # repeat store so it is available for checking",
-        f"addi x{sig_reg}, x{sig_reg}, SIG_STRIDE # adjust base address for offset",
-        f"{INDENT}# nops to ensure length matches SELFCHECK",
-        "nop",
-        "nop",
-        "nop",
-        "#endif",
     ]
     assert test_data.test_chunk is not None
-    test_data.test_chunk.sigupd_count += 1
+    test_data.test_chunk.sigupd_count += 1  # Test store writes one extra signature slot
     return (setup, test, check)

--- a/generators/testgen/src/testgen/formatters/types/csh_type.py
+++ b/generators/testgen/src/testgen/formatters/types/csh_type.py
@@ -6,7 +6,6 @@
 ##################################
 
 from testgen.asm.helpers import load_int_reg, write_sigupd
-from testgen.constants import INDENT
 from testgen.data.params import InstructionParams
 from testgen.data.state import TestData
 from testgen.formatters.registry import InstructionTypeConfig, add_instruction_formatter
@@ -52,18 +51,9 @@ def format_csh_type(
     check = [
         f"addi x{sig_reg}, x{sig_reg}, {params.immval} # restore base address",
         f"addi x{sig_reg}, x{sig_reg}, SIG_STRIDE # increment signature pointer",
-        "#ifdef RVTEST_SELFCHECK",
         f"LREG x{params.temp_reg}, -SIG_STRIDE(x{sig_reg}) # load stored value for checking",
         write_sigupd(params.temp_reg, test_data),
-        "#else",
-        f"{instr_name} x{params.rs2}, 0(x{sig_reg}) # repeat store so it is available for checking",
-        f"addi x{sig_reg}, x{sig_reg}, SIG_STRIDE # adjust base address for offset",
-        f"{INDENT}# nops to ensure length matches SELFCHECK",
-        "nop",
-        "nop",
-        "nop",
-        "#endif",
     ]
     assert test_data.test_chunk is not None
-    test_data.test_chunk.sigupd_count += 1
+    test_data.test_chunk.sigupd_count += 1  # Test store writes one extra signature slot
     return (setup, test, check)

--- a/generators/testgen/src/testgen/formatters/types/css_type.py
+++ b/generators/testgen/src/testgen/formatters/types/css_type.py
@@ -7,7 +7,6 @@
 ##################################
 
 from testgen.asm.helpers import load_int_reg, write_sigupd
-from testgen.constants import INDENT
 from testgen.data.params import InstructionParams
 from testgen.data.state import TestData
 from testgen.formatters.registry import InstructionTypeConfig, add_instruction_formatter
@@ -63,22 +62,9 @@ def format_css_type(
     test = [f"{instr_name} x{params.rs2}, {params.immval}(sp) # perform store"]
 
     check = [
-        "#ifdef RVTEST_SELFCHECK",
         f"LREG x{params.temp_reg}, 0(x{test_data.int_regs.sig_reg}) # load stored value for checking",
         write_sigupd(params.temp_reg, test_data),
-        "#else",
-        f"addi sp, sp, {params.immval} # remove offset from sp",
-        "addi sp, sp, SIG_STRIDE # increment signature pointer in sp",
-        f"{instr_name} x{params.rs2}, 0(sp) # repeat store so it is available for checking",
-        f"addi x{test_data.int_regs.sig_reg}, x{test_data.int_regs.sig_reg}, SIG_STRIDE # increment signature pointer",
-        f"{INDENT}# nops to ensure length matches SELFCHECK",
-        "nop",
-        "nop",
-        "#endif",
     ]
-
-    assert test_data.test_chunk is not None
-    test_data.test_chunk.sigupd_count += 1  # Extra sigupd that doesn't use the write_sigupd helper
 
     if params.rs2 != 2:
         # Return sp if it was allocated specially for this testcase

--- a/generators/testgen/src/testgen/formatters/types/css_type.py
+++ b/generators/testgen/src/testgen/formatters/types/css_type.py
@@ -63,8 +63,12 @@ def format_css_type(
 
     check = [
         f"LREG x{params.temp_reg}, 0(x{test_data.int_regs.sig_reg}) # load stored value for checking",
+        f"addi x{test_data.int_regs.sig_reg}, x{test_data.int_regs.sig_reg}, SIG_STRIDE # increment signature pointer",
         write_sigupd(params.temp_reg, test_data),
     ]
+
+    assert test_data.test_chunk is not None
+    test_data.test_chunk.sigupd_count += 1  # Test store writes one extra signature slot
 
     if params.rs2 != 2:
         # Return sp if it was allocated specially for this testcase

--- a/generators/testgen/src/testgen/formatters/types/fs_type.py
+++ b/generators/testgen/src/testgen/formatters/types/fs_type.py
@@ -6,7 +6,6 @@
 ##################################
 
 from testgen.asm.helpers import load_float_reg, write_sigupd
-from testgen.constants import INDENT
 from testgen.data.params import InstructionParams
 from testgen.data.state import TestData
 from testgen.formatters.registry import InstructionTypeConfig, add_instruction_formatter
@@ -63,19 +62,10 @@ def format_fs_type(
     check = [
         f"addi x{sig_reg}, x{sig_reg}, {params.immval} # restore base address",
         f"addi x{sig_reg}, x{sig_reg}, SIG_STRIDE # increment signature pointer",
-        "#ifdef RVTEST_SELFCHECK",
         f"LREG x{params.temp_reg}, -SIG_STRIDE(x{sig_reg}) # load stored value for checking",
         write_sigupd(params.temp_reg, test_data),
-        "#else",
-        f"{instr_name} f{params.fs2}, 0(x{sig_reg}) # repeat store so it is available for checking",
-        f"addi x{sig_reg}, x{sig_reg}, SIG_STRIDE # adjust base address for offset",
-        f"{INDENT}# nops to ensure length matches SELFCHECK",
-        "nop",
-        "nop",
-        "nop",
-        "#endif",
     ]
     assert test_data.test_chunk is not None
-    test_data.test_chunk.sigupd_count += 1
+    test_data.test_chunk.sigupd_count += 1  # Test store writes one extra signature slot
     check.append(write_sigupd(None, test_data, "fflags"))
     return (setup, test, check)

--- a/generators/testgen/src/testgen/formatters/types/s_type.py
+++ b/generators/testgen/src/testgen/formatters/types/s_type.py
@@ -6,7 +6,6 @@
 ##################################
 
 from testgen.asm.helpers import load_int_reg, write_sigupd
-from testgen.constants import INDENT
 from testgen.data.params import InstructionParams
 from testgen.data.state import TestData
 from testgen.formatters.registry import InstructionTypeConfig, add_instruction_formatter
@@ -62,18 +61,9 @@ def format_s_type(
     check = [
         f"addi x{sig_reg}, x{sig_reg}, {params.immval} # restore base address",
         f"addi x{sig_reg}, x{sig_reg}, SIG_STRIDE # increment signature pointer",
-        "#ifdef RVTEST_SELFCHECK",
         f"LREG x{params.temp_reg}, -SIG_STRIDE(x{sig_reg}) # load stored value for checking",
         write_sigupd(params.temp_reg, test_data),
-        "#else",
-        f"{instr_name} x{params.rs2}, 0(x{sig_reg}) # repeat store so it is available for checking",
-        f"addi x{sig_reg}, x{sig_reg}, SIG_STRIDE # adjust base address for offset",
-        f"{INDENT}# nops to ensure length matches SELFCHECK",
-        "nop",
-        "nop",
-        "nop",
-        "#endif",
     ]
     assert test_data.test_chunk is not None
-    test_data.test_chunk.sigupd_count += 1
+    test_data.test_chunk.sigupd_count += 1  # Test store writes one extra signature slot
     return (setup, test, check)

--- a/tests/rv32e/E/E-sb-00.S
+++ b/tests/rv32e/E/E-sb-00.S
@@ -41,18 +41,9 @@ E_sb_cg_cp_rs1_nx0_b1:
   sb x13, -1064(x1) # perform store
   addi x1, x1, -1064 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x10 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x10, E_sb_cg_cp_rs1_nx0_b1, E_sb_cg_cp_rs1_nx0_b1_str)
-#else
-  sb x13, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xa2275908
@@ -62,18 +53,9 @@ E_sb_cg_cp_rs1_nx0_b2:
   sb x15, 1926(x2) # perform store
   addi x2, x2, 1926 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, E_sb_cg_cp_rs1_nx0_b2, E_sb_cg_cp_rs1_nx0_b2_str)
-#else
-  sb x15, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x6, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
@@ -84,18 +66,9 @@ E_sb_cg_cp_rs1_nx0_b3:
   sb x14, -1040(x3) # perform store
   addi x3, x3, -1040 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x11 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x11, E_sb_cg_cp_rs1_nx0_b3, E_sb_cg_cp_rs1_nx0_b3_str)
-#else
-  sb x14, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -107,18 +80,9 @@ E_sb_cg_cp_rs1_nx0_b4:
   sb x15, -1700(x4) # perform store
   addi x4, x4, -1700 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x13 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x13, E_sb_cg_cp_rs1_nx0_b4, E_sb_cg_cp_rs1_nx0_b4_str)
-#else
-  sb x15, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x6, x10) # load rs2: x10 = 0xfb97e123
@@ -128,18 +92,9 @@ E_sb_cg_cp_rs1_nx0_b5:
   sb x10, -1056(x5) # perform store
   addi x5, x5, -1056 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x15 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x15, E_sb_cg_cp_rs1_nx0_b5, E_sb_cg_cp_rs1_nx0_b5_str)
-#else
-  sb x10, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x3, x6 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
@@ -150,18 +105,9 @@ E_sb_cg_cp_rs1_nx0_b6:
   sb x15, -1945(x6) # perform store
   addi x6, x6, -1945 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x14 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x14, E_sb_cg_cp_rs1_nx0_b6, E_sb_cg_cp_rs1_nx0_b6_str)
-#else
-  sb x15, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x7 # switch temp register to avoid conflict with test
   mv x14, x8 # switch link pointer register to avoid conflict with test
@@ -173,18 +119,9 @@ E_sb_cg_cp_rs1_nx0_b7:
   sb x15, -1425(x7) # perform store
   addi x7, x7, -1425 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x12 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x12, E_sb_cg_cp_rs1_nx0_b7, E_sb_cg_cp_rs1_nx0_b7_str)
-#else
-  sb x15, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0x868d878b
@@ -194,18 +131,9 @@ E_sb_cg_cp_rs1_nx0_b8:
   sb x2, 25(x8) # perform store
   addi x8, x8, 25 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x5 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x5, E_sb_cg_cp_rs1_nx0_b8, E_sb_cg_cp_rs1_nx0_b8_str)
-#else
-  sb x2, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0xb94836b6
@@ -215,18 +143,9 @@ E_sb_cg_cp_rs1_nx0_b9:
   sb x0, -1265(x9) # perform store
   addi x9, x9, -1265 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x1 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x1, E_sb_cg_cp_rs1_nx0_b9, E_sb_cg_cp_rs1_nx0_b9_str)
-#else
-  sb x0, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x7) # load rs2: x7 = 0x527b9d38
@@ -236,18 +155,9 @@ E_sb_cg_cp_rs1_nx0_b10:
   sb x7, -1133(x10) # perform store
   addi x10, x10, -1133 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x15, E_sb_cg_cp_rs1_nx0_b10, E_sb_cg_cp_rs1_nx0_b10_str)
-#else
-  sb x7, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x4) # load rs2: x4 = 0xc79c188a
@@ -257,18 +167,9 @@ E_sb_cg_cp_rs1_nx0_b11:
   sb x4, 110(x11) # perform store
   addi x11, x11, 110 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x5 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x5, E_sb_cg_cp_rs1_nx0_b11, E_sb_cg_cp_rs1_nx0_b11_str)
-#else
-  sb x4, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0xee7a1fec
@@ -278,18 +179,9 @@ E_sb_cg_cp_rs1_nx0_b12:
   sb x2, 1552(x12) # perform store
   addi x12, x12, 1552 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x9 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x9, E_sb_cg_cp_rs1_nx0_b12, E_sb_cg_cp_rs1_nx0_b12_str)
-#else
-  sb x2, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -301,18 +193,9 @@ E_sb_cg_cp_rs1_nx0_b13:
   sb x6, 1738(x13) # perform store
   addi x13, x13, 1738 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, E_sb_cg_cp_rs1_nx0_b13, E_sb_cg_cp_rs1_nx0_b13_str)
-#else
-  sb x6, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xd3a9df57
@@ -322,18 +205,9 @@ E_sb_cg_cp_rs1_nx0_b14:
   sb x10, 1035(x14) # perform store
   addi x14, x14, 1035 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x11 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x11, E_sb_cg_cp_rs1_nx0_b14, E_sb_cg_cp_rs1_nx0_b14_str)
-#else
-  sb x10, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x5cbf960e
@@ -343,18 +217,9 @@ E_sb_cg_cp_rs1_nx0_b15:
   sb x10, -30(x15) # perform store
   addi x15, x15, -30 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x7 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x7, E_sb_cg_cp_rs1_nx0_b15, E_sb_cg_cp_rs1_nx0_b15_str)
-#else
-  sb x10, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2
@@ -368,18 +233,9 @@ E_sb_cg_cp_rs2_b0:
   sb x0, -1464(x2) # perform store
   addi x2, x2, -1464 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x12 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x12, E_sb_cg_cp_rs2_b0, E_sb_cg_cp_rs2_b0_str)
-#else
-  sb x0, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0xd23cd067
@@ -389,18 +245,9 @@ E_sb_cg_cp_rs2_b1:
   sb x1, -1742(x8) # perform store
   addi x8, x8, -1742 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, E_sb_cg_cp_rs2_b1, E_sb_cg_cp_rs2_b1_str)
-#else
-  sb x1, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0xda48e1fc
@@ -410,18 +257,9 @@ E_sb_cg_cp_rs2_b2:
   sb x2, 1960(x14) # perform store
   addi x14, x14, 1960 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x7 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x7, E_sb_cg_cp_rs2_b2, E_sb_cg_cp_rs2_b2_str)
-#else
-  sb x2, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x9, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x3)
@@ -432,18 +270,9 @@ E_sb_cg_cp_rs2_b3:
   sb x3, -1411(x7) # perform store
   addi x7, x7, -1411 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x1 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x1, E_sb_cg_cp_rs2_b3, E_sb_cg_cp_rs2_b3_str)
-#else
-  sb x3, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x4 # switch temp register to avoid conflict with test
   mv x14, x5 # switch link pointer register to avoid conflict with test
@@ -455,18 +284,9 @@ E_sb_cg_cp_rs2_b4:
   sb x4, 483(x8) # perform store
   addi x8, x8, 483 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x11, E_sb_cg_cp_rs2_b4, E_sb_cg_cp_rs2_b4_str)
-#else
-  sb x4, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x9, x5) # load rs2: x5 = 0xfe5c6844
@@ -476,18 +296,9 @@ E_sb_cg_cp_rs2_b5:
   sb x5, 917(x7) # perform store
   addi x7, x7, 917 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x6 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x6, E_sb_cg_cp_rs2_b5, E_sb_cg_cp_rs2_b5_str)
-#else
-  sb x5, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x9, x6) # load rs2: x6 = 0x6c9cce5a
@@ -497,18 +308,9 @@ E_sb_cg_cp_rs2_b6:
   sb x6, -1742(x12) # perform store
   addi x12, x12, -1742 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x3 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x3, E_sb_cg_cp_rs2_b6, E_sb_cg_cp_rs2_b6_str)
-#else
-  sb x6, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x9, x7) # load rs2: x7 = 0x64d1f069
@@ -518,18 +320,9 @@ E_sb_cg_cp_rs2_b7:
   sb x7, 1821(x4) # perform store
   addi x4, x4, 1821 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x6 contains the expected result. x4 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x4, x14, x13, x6, E_sb_cg_cp_rs2_b7, E_sb_cg_cp_rs2_b7_str)
-#else
-  sb x7, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x9, x8) # load rs2: x8 = 0xaa6b987d
@@ -539,18 +332,9 @@ E_sb_cg_cp_rs2_b8:
   sb x8, 645(x2) # perform store
   addi x2, x2, 645 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x3 contains the expected result. x2 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x2, x14, x13, x3, E_sb_cg_cp_rs2_b8, E_sb_cg_cp_rs2_b8_str)
-#else
-  sb x8, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x15, x9 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x9)
@@ -561,18 +345,9 @@ E_sb_cg_cp_rs2_b9:
   sb x9, 1314(x10) # perform store
   addi x10, x10, 1314 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x1 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x1, E_sb_cg_cp_rs2_b9, E_sb_cg_cp_rs2_b9_str)
-#else
-  sb x9, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x1, x10 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x10)
@@ -583,18 +358,9 @@ E_sb_cg_cp_rs2_b10:
   sb x10, -278(x8) # perform store
   addi x8, x8, -278 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x7 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x7, E_sb_cg_cp_rs2_b10, E_sb_cg_cp_rs2_b10_str)
-#else
-  sb x10, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x15, x11) # load rs2: x11 = 0x164b226d
@@ -604,18 +370,9 @@ E_sb_cg_cp_rs2_b11:
   sb x11, -539(x6) # perform store
   addi x6, x6, -539 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x3 contains the expected result. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x6, x14, x13, x3, E_sb_cg_cp_rs2_b11, E_sb_cg_cp_rs2_b11_str)
-#else
-  sb x11, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rs2: x12 = 0x08d820b1
@@ -625,18 +382,9 @@ E_sb_cg_cp_rs2_b12:
   sb x12, 911(x7) # perform store
   addi x7, x7, 911 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x10 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x10, E_sb_cg_cp_rs2_b12, E_sb_cg_cp_rs2_b12_str)
-#else
-  sb x12, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -648,18 +396,9 @@ E_sb_cg_cp_rs2_b13:
   sb x13, -1057(x11) # perform store
   addi x11, x11, -1057 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, E_sb_cg_cp_rs2_b13, E_sb_cg_cp_rs2_b13_str)
-#else
-  sb x13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x15, x14) # load rs2: x14 = 0x9c331fd5
@@ -669,18 +408,9 @@ E_sb_cg_cp_rs2_b14:
   sb x14, 524(x3) # perform store
   addi x3, x3, 524 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x8 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x8, E_sb_cg_cp_rs2_b14, E_sb_cg_cp_rs2_b14_str)
-#else
-  sb x14, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x1, x15 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x15)
@@ -691,18 +421,9 @@ E_sb_cg_cp_rs2_b15:
   sb x15, -1123(x14) # perform store
   addi x14, x14, -1123 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x7 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x7, E_sb_cg_cp_rs2_b15, E_sb_cg_cp_rs2_b15_str)
-#else
-  sb x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -716,18 +437,9 @@ E_sb_cg_cp_rs2_edges_0x0:
   sb x8, 1347(x13) # perform store
   addi x13, x13, 1347 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x7 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x7, E_sb_cg_cp_rs2_edges_0x0, E_sb_cg_cp_rs2_edges_0x0_str)
-#else
-  sb x8, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x00000001
@@ -737,18 +449,9 @@ E_sb_cg_cp_rs2_edges_0x1:
   sb x15, 906(x2) # perform store
   addi x2, x2, 906 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x12 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x12, E_sb_cg_cp_rs2_edges_0x1, E_sb_cg_cp_rs2_edges_0x1_str)
-#else
-  sb x15, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x00000002
@@ -758,18 +461,9 @@ E_sb_cg_cp_rs2_edges_0x2:
   sb x11, -28(x10) # perform store
   addi x10, x10, -28 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, E_sb_cg_cp_rs2_edges_0x2, E_sb_cg_cp_rs2_edges_0x2_str)
-#else
-  sb x11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0x80000000
@@ -779,18 +473,9 @@ E_sb_cg_cp_rs2_edges_0x80000000:
   sb x2, -1022(x13) # perform store
   addi x13, x13, -1022 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, E_sb_cg_cp_rs2_edges_0x80000000, E_sb_cg_cp_rs2_edges_0x80000000_str)
-#else
-  sb x2, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x80000001
@@ -800,18 +485,9 @@ E_sb_cg_cp_rs2_edges_0x80000001:
   sb x3, 1800(x8) # perform store
   addi x8, x8, 1800 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x7 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x7, E_sb_cg_cp_rs2_edges_0x80000001, E_sb_cg_cp_rs2_edges_0x80000001_str)
-#else
-  sb x3, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x7fffffff
@@ -821,18 +497,9 @@ E_sb_cg_cp_rs2_edges_0x7fffffff:
   sb x12, -1297(x7) # perform store
   addi x7, x7, -1297 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x14 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x14, E_sb_cg_cp_rs2_edges_0x7fffffff, E_sb_cg_cp_rs2_edges_0x7fffffff_str)
-#else
-  sb x12, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x7ffffffe
@@ -842,18 +509,9 @@ E_sb_cg_cp_rs2_edges_0x7ffffffe:
   sb x10, 1604(x11) # perform store
   addi x11, x11, 1604 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, E_sb_cg_cp_rs2_edges_0x7ffffffe, E_sb_cg_cp_rs2_edges_0x7ffffffe_str)
-#else
-  sb x10, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xffffffff
@@ -863,18 +521,9 @@ E_sb_cg_cp_rs2_edges_0xffffffff:
   sb x8, -2002(x14) # perform store
   addi x14, x14, -2002 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, E_sb_cg_cp_rs2_edges_0xffffffff, E_sb_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  sb x8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xfffffffe
@@ -884,18 +533,9 @@ E_sb_cg_cp_rs2_edges_0xfffffffe:
   sb x2, -1819(x13) # perform store
   addi x13, x13, -1819 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x3 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x3, E_sb_cg_cp_rs2_edges_0xfffffffe, E_sb_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  sb x2, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x5bbc8872
@@ -905,18 +545,9 @@ E_sb_cg_cp_rs2_edges_0x5bbc8872:
   sb x6, -1920(x3) # perform store
   addi x3, x3, -1920 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x14 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x14, E_sb_cg_cp_rs2_edges_0x5bbc8872, E_sb_cg_cp_rs2_edges_0x5bbc8872_str)
-#else
-  sb x6, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xaaaaaaaa
@@ -926,18 +557,9 @@ E_sb_cg_cp_rs2_edges_0xaaaaaaaa:
   sb x14, -40(x15) # perform store
   addi x15, x15, -40 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x6 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x6, E_sb_cg_cp_rs2_edges_0xaaaaaaaa, E_sb_cg_cp_rs2_edges_0xaaaaaaaa_str)
-#else
-  sb x14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x55555555
@@ -947,18 +569,9 @@ E_sb_cg_cp_rs2_edges_0x55555555:
   sb x12, 510(x13) # perform store
   addi x13, x13, 510 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x10 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x10, E_sb_cg_cp_rs2_edges_0x55555555, E_sb_cg_cp_rs2_edges_0x55555555_str)
-#else
-  sb x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_edges
@@ -972,18 +585,9 @@ E_sb_cg_cp_imm_edges_0x0:
   sb x6, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, E_sb_cg_cp_imm_edges_0x0, E_sb_cg_cp_imm_edges_0x0_str)
-#else
-  sb x6, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xde82de47
@@ -993,18 +597,9 @@ E_sb_cg_cp_imm_edges_0x1:
   sb x13, 1(x14) # perform store
   addi x14, x14, 1 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, E_sb_cg_cp_imm_edges_0x1, E_sb_cg_cp_imm_edges_0x1_str)
-#else
-  sb x13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2)
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xd3d862b0
@@ -1014,18 +609,9 @@ E_sb_cg_cp_imm_edges_0x2:
   sb x7, 2(x2) # perform store
   addi x2, x2, 2 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x3 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x3, E_sb_cg_cp_imm_edges_0x2, E_sb_cg_cp_imm_edges_0x2_str)
-#else
-  sb x7, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 3)
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x243fd116
@@ -1035,18 +621,9 @@ E_sb_cg_cp_imm_edges_0x3:
   sb x7, 3(x8) # perform store
   addi x8, x8, 3 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x3 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x3, E_sb_cg_cp_imm_edges_0x3, E_sb_cg_cp_imm_edges_0x3_str)
-#else
-  sb x7, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 4)
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x696b7ac9
@@ -1056,18 +633,9 @@ E_sb_cg_cp_imm_edges_0x4:
   sb x3, 4(x14) # perform store
   addi x14, x14, 4 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x10 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x10, E_sb_cg_cp_imm_edges_0x4, E_sb_cg_cp_imm_edges_0x4_str)
-#else
-  sb x3, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 8)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xa18239f4
@@ -1077,18 +645,9 @@ E_sb_cg_cp_imm_edges_0x8:
   sb x8, 8(x15) # perform store
   addi x15, x15, 8 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x6 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x6, E_sb_cg_cp_imm_edges_0x8, E_sb_cg_cp_imm_edges_0x8_str)
-#else
-  sb x8, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 16)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xf13043e8
@@ -1098,18 +657,9 @@ E_sb_cg_cp_imm_edges_0x10:
   sb x13, 16(x10) # perform store
   addi x10, x10, 16 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x11 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x11, E_sb_cg_cp_imm_edges_0x10, E_sb_cg_cp_imm_edges_0x10_str)
-#else
-  sb x13, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 32)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xc105a51a
@@ -1119,18 +669,9 @@ E_sb_cg_cp_imm_edges_0x20:
   sb x11, 32(x3) # perform store
   addi x3, x3, 32 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x7 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x7, E_sb_cg_cp_imm_edges_0x20, E_sb_cg_cp_imm_edges_0x20_str)
-#else
-  sb x11, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 64)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0x5c84532d
@@ -1140,18 +681,9 @@ E_sb_cg_cp_imm_edges_0x40:
   sb x2, 64(x14) # perform store
   addi x14, x14, 64 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x11 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x11, E_sb_cg_cp_imm_edges_0x40, E_sb_cg_cp_imm_edges_0x40_str)
-#else
-  sb x2, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 128)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xf76049fb
@@ -1161,18 +693,9 @@ E_sb_cg_cp_imm_edges_0x80:
   sb x15, 128(x9) # perform store
   addi x9, x9, 128 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, E_sb_cg_cp_imm_edges_0x80, E_sb_cg_cp_imm_edges_0x80_str)
-#else
-  sb x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 256)
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xce13ae93
@@ -1182,18 +705,9 @@ E_sb_cg_cp_imm_edges_0x100:
   sb x3, 256(x8) # perform store
   addi x8, x8, 256 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, E_sb_cg_cp_imm_edges_0x100, E_sb_cg_cp_imm_edges_0x100_str)
-#else
-  sb x3, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 512)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x6ee73b9d
@@ -1203,18 +717,9 @@ E_sb_cg_cp_imm_edges_0x200:
   sb x10, 512(x2) # perform store
   addi x2, x2, 512 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, E_sb_cg_cp_imm_edges_0x200, E_sb_cg_cp_imm_edges_0x200_str)
-#else
-  sb x10, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1023)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x3facbfa9
@@ -1224,18 +729,9 @@ E_sb_cg_cp_imm_edges_0x3ff:
   sb x13, 1023(x7) # perform store
   addi x7, x7, 1023 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x3 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x3, E_sb_cg_cp_imm_edges_0x3ff, E_sb_cg_cp_imm_edges_0x3ff_str)
-#else
-  sb x13, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1024)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xb71dca8d
@@ -1245,18 +741,9 @@ E_sb_cg_cp_imm_edges_0x400:
   sb x10, 1024(x9) # perform store
   addi x9, x9, 1024 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, E_sb_cg_cp_imm_edges_0x400, E_sb_cg_cp_imm_edges_0x400_str)
-#else
-  sb x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1795)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x3a5074c2
@@ -1266,18 +753,9 @@ E_sb_cg_cp_imm_edges_0x703:
   sb x13, 1795(x3) # perform store
   addi x3, x3, 1795 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x10 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x10, E_sb_cg_cp_imm_edges_0x703, E_sb_cg_cp_imm_edges_0x703_str)
-#else
-  sb x13, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2047)
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x4d1ed345
@@ -1287,18 +765,9 @@ E_sb_cg_cp_imm_edges_0x7ff:
   sb x7, 2047(x2) # perform store
   addi x2, x2, 2047 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x9 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x9, E_sb_cg_cp_imm_edges_0x7ff, E_sb_cg_cp_imm_edges_0x7ff_str)
-#else
-  sb x7, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2048)
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0xb87296f1
@@ -1309,18 +778,9 @@ E_sb_cg_cp_imm_edges_m0x800:
   sb x9, -2048(x15) # perform store
   addi x15, x15, -2048 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x13, E_sb_cg_cp_imm_edges_m0x800, E_sb_cg_cp_imm_edges_m0x800_str)
-#else
-  sb x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2047)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xc1ebedf2
@@ -1330,18 +790,9 @@ E_sb_cg_cp_imm_edges_m0x7ff:
   sb x11, -2047(x12) # perform store
   addi x12, x12, -2047 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x6 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x6, E_sb_cg_cp_imm_edges_m0x7ff, E_sb_cg_cp_imm_edges_m0x7ff_str)
-#else
-  sb x11, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x04896ef9
@@ -1351,18 +802,9 @@ E_sb_cg_cp_imm_edges_m0x2:
   sb x11, -2(x10) # perform store
   addi x10, x10, -2 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, E_sb_cg_cp_imm_edges_m0x2, E_sb_cg_cp_imm_edges_m0x2_str)
-#else
-  sb x11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -1)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xa9467e4b
@@ -1372,18 +814,9 @@ E_sb_cg_cp_imm_edges_m0x1:
   sb x12, -1(x9) # perform store
   addi x9, x9, -1 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, E_sb_cg_cp_imm_edges_m0x1, E_sb_cg_cp_imm_edges_m0x1_str)
-#else
-  sb x12, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_align_byte
@@ -1394,168 +827,96 @@ E_sb_cg_cp_imm_edges_m0x1:
 E_sb_cg_cp_align_byte_b0:
   sb x11, 0(x9) # perform store
   addi x9, x9, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -8(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, E_sb_cg_cp_align_byte_b0, E_sb_cg_cp_align_byte_b0_str)
   LREG x6, -8(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, E_sb_cg_cp_align_byte_b0, E_sb_cg_cp_align_byte_b0_str)
-#else
-  sb x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 001)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xbb5546ad
 E_sb_cg_cp_align_byte_b1:
   sb x15, 1(x9) # perform store
   addi x9, x9, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -8(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, E_sb_cg_cp_align_byte_b1, E_sb_cg_cp_align_byte_b1_str)
   LREG x10, -8(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, E_sb_cg_cp_align_byte_b1, E_sb_cg_cp_align_byte_b1_str)
-#else
-  sb x15, 1(x9) # repeat store so it is available for checking
-  addi x9, x9, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 010)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xb7de793b
 E_sb_cg_cp_align_byte_b2:
   sb x2, 2(x9) # perform store
   addi x9, x9, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -8(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, E_sb_cg_cp_align_byte_b2, E_sb_cg_cp_align_byte_b2_str)
   LREG x15, -8(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, E_sb_cg_cp_align_byte_b2, E_sb_cg_cp_align_byte_b2_str)
-#else
-  sb x2, 2(x9) # repeat store so it is available for checking
-  addi x9, x9, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 011)
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xbe9cc00c
 E_sb_cg_cp_align_byte_b3:
   sb x7, 3(x9) # perform store
   addi x9, x9, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -8(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, E_sb_cg_cp_align_byte_b3, E_sb_cg_cp_align_byte_b3_str)
   LREG x6, -8(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, E_sb_cg_cp_align_byte_b3, E_sb_cg_cp_align_byte_b3_str)
-#else
-  sb x7, 3(x9) # repeat store so it is available for checking
-  addi x9, x9, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 100)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xc70e1ccf
 E_sb_cg_cp_align_byte_b4:
   sb x10, 4(x9) # perform store
   addi x9, x9, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -8(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, E_sb_cg_cp_align_byte_b4, E_sb_cg_cp_align_byte_b4_str)
   LREG x11, -8(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, E_sb_cg_cp_align_byte_b4, E_sb_cg_cp_align_byte_b4_str)
-#else
-  sb x10, 4(x9) # repeat store so it is available for checking
-  addi x9, x9, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 101)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xa9c06782
 E_sb_cg_cp_align_byte_b5:
   sb x11, 5(x9) # perform store
   addi x9, x9, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -8(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, E_sb_cg_cp_align_byte_b5, E_sb_cg_cp_align_byte_b5_str)
   LREG x13, -8(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, E_sb_cg_cp_align_byte_b5, E_sb_cg_cp_align_byte_b5_str)
-#else
-  sb x11, 5(x9) # repeat store so it is available for checking
-  addi x9, x9, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 110)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xaae69423
 E_sb_cg_cp_align_byte_b6:
   sb x12, 6(x9) # perform store
   addi x9, x9, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -8(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, E_sb_cg_cp_align_byte_b6, E_sb_cg_cp_align_byte_b6_str)
   LREG x6, -8(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, E_sb_cg_cp_align_byte_b6, E_sb_cg_cp_align_byte_b6_str)
-#else
-  sb x12, 6(x9) # repeat store so it is available for checking
-  addi x9, x9, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 111)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xbae4887f
 E_sb_cg_cp_align_byte_b7:
   sb x14, 7(x9) # perform store
   addi x9, x9, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -8(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, E_sb_cg_cp_align_byte_b7, E_sb_cg_cp_align_byte_b7_str)
   LREG x11, -8(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, E_sb_cg_cp_align_byte_b7, E_sb_cg_cp_align_byte_b7_str)
-#else
-  sb x14, 7(x9) # repeat store so it is available for checking
-  addi x9, x9, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 
   mv x2, x9 # restore signature pointer to default register for teardown

--- a/tests/rv32e/E/E-sh-00.S
+++ b/tests/rv32e/E/E-sh-00.S
@@ -41,18 +41,9 @@ E_sh_cg_cp_rs1_nx0_b1:
   sh x8, 289(x1) # perform store
   addi x1, x1, 289 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x15, E_sh_cg_cp_rs1_nx0_b1, E_sh_cg_cp_rs1_nx0_b1_str)
-#else
-  sh x8, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x950208d0
@@ -62,18 +53,9 @@ E_sh_cg_cp_rs1_nx0_b2:
   sh x8, -1560(x2) # perform store
   addi x2, x2, -1560 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x12 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x12, E_sh_cg_cp_rs1_nx0_b2, E_sh_cg_cp_rs1_nx0_b2_str)
-#else
-  sh x8, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x6, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
@@ -84,18 +66,9 @@ E_sh_cg_cp_rs1_nx0_b3:
   sh x10, 1834(x3) # perform store
   addi x3, x3, 1834 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x15 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x15, E_sh_cg_cp_rs1_nx0_b3, E_sh_cg_cp_rs1_nx0_b3_str)
-#else
-  sh x10, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -107,18 +80,9 @@ E_sh_cg_cp_rs1_nx0_b4:
   sh x5, -1532(x4) # perform store
   addi x4, x4, -1532 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x9 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x9, E_sh_cg_cp_rs1_nx0_b4, E_sh_cg_cp_rs1_nx0_b4_str)
-#else
-  sh x5, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x6, x11) # load rs2: x11 = 0x790a5576
@@ -128,18 +92,9 @@ E_sh_cg_cp_rs1_nx0_b5:
   sh x11, -435(x5) # perform store
   addi x5, x5, -435 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x9 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x9, E_sh_cg_cp_rs1_nx0_b5, E_sh_cg_cp_rs1_nx0_b5_str)
-#else
-  sh x11, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x1, x6 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
@@ -150,18 +105,9 @@ E_sh_cg_cp_rs1_nx0_b6:
   sh x12, 286(x6) # perform store
   addi x6, x6, 286 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x4 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x4, E_sh_cg_cp_rs1_nx0_b6, E_sh_cg_cp_rs1_nx0_b6_str)
-#else
-  sh x12, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x7 # switch temp register to avoid conflict with test
   mv x5, x8 # switch link pointer register to avoid conflict with test
@@ -173,18 +119,9 @@ E_sh_cg_cp_rs1_nx0_b7:
   sh x2, -1947(x7) # perform store
   addi x7, x7, -1947 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x10 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x10, E_sh_cg_cp_rs1_nx0_b7, E_sh_cg_cp_rs1_nx0_b7_str)
-#else
-  sh x2, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xb5cd49c6
@@ -194,18 +131,9 @@ E_sh_cg_cp_rs1_nx0_b8:
   sh x6, 1473(x8) # perform store
   addi x8, x8, 1473 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, E_sh_cg_cp_rs1_nx0_b8, E_sh_cg_cp_rs1_nx0_b8_str)
-#else
-  sh x6, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x559877e1
@@ -215,18 +143,9 @@ E_sh_cg_cp_rs1_nx0_b9:
   sh x3, 688(x9) # perform store
   addi x9, x9, 688 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, E_sh_cg_cp_rs1_nx0_b9, E_sh_cg_cp_rs1_nx0_b9_str)
-#else
-  sh x3, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x2f1a30dc
@@ -236,18 +155,9 @@ E_sh_cg_cp_rs1_nx0_b10:
   sh x12, 365(x10) # perform store
   addi x10, x10, 365 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x7 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x7, E_sh_cg_cp_rs1_nx0_b10, E_sh_cg_cp_rs1_nx0_b10_str)
-#else
-  sh x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x10746471
@@ -257,18 +167,9 @@ E_sh_cg_cp_rs1_nx0_b11:
   sh x7, 1789(x11) # perform store
   addi x11, x11, 1789 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, E_sh_cg_cp_rs1_nx0_b11, E_sh_cg_cp_rs1_nx0_b11_str)
-#else
-  sh x7, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x0f45d4d7
@@ -278,18 +179,9 @@ E_sh_cg_cp_rs1_nx0_b12:
   sh x13, 933(x12) # perform store
   addi x12, x12, 933 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, E_sh_cg_cp_rs1_nx0_b12, E_sh_cg_cp_rs1_nx0_b12_str)
-#else
-  sh x13, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xc1bbe337
@@ -299,18 +191,9 @@ E_sh_cg_cp_rs1_nx0_b13:
   sh x11, 1047(x13) # perform store
   addi x13, x13, 1047 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x3 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x3, E_sh_cg_cp_rs1_nx0_b13, E_sh_cg_cp_rs1_nx0_b13_str)
-#else
-  sh x11, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x1ccada61
@@ -320,18 +203,9 @@ E_sh_cg_cp_rs1_nx0_b14:
   sh x12, -2000(x14) # perform store
   addi x14, x14, -2000 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, E_sh_cg_cp_rs1_nx0_b14, E_sh_cg_cp_rs1_nx0_b14_str)
-#else
-  sh x12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x77e4349d
@@ -341,18 +215,9 @@ E_sh_cg_cp_rs1_nx0_b15:
   sh x11, -365(x15) # perform store
   addi x15, x15, -365 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x3 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x3, E_sh_cg_cp_rs1_nx0_b15, E_sh_cg_cp_rs1_nx0_b15_str)
-#else
-  sh x11, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2
@@ -366,18 +231,9 @@ E_sh_cg_cp_rs2_b0:
   sh x0, -352(x12) # perform store
   addi x12, x12, -352 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x3 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x3, E_sh_cg_cp_rs2_b0, E_sh_cg_cp_rs2_b0_str)
-#else
-  sh x0, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x11, x1 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x1)
@@ -388,18 +244,9 @@ E_sh_cg_cp_rs2_b1:
   sh x1, -905(x10) # perform store
   addi x10, x10, -905 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x6 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x6, E_sh_cg_cp_rs2_b1, E_sh_cg_cp_rs2_b1_str)
-#else
-  sh x1, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x11, x2) # load rs2: x2 = 0xd5d1f7a2
@@ -409,18 +256,9 @@ E_sh_cg_cp_rs2_b2:
   sh x2, -1045(x15) # perform store
   addi x15, x15, -1045 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x3 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x3, E_sh_cg_cp_rs2_b2, E_sh_cg_cp_rs2_b2_str)
-#else
-  sh x2, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x11, x3) # load rs2: x3 = 0xe34a8b9f
@@ -430,18 +268,9 @@ E_sh_cg_cp_rs2_b3:
   sh x3, -727(x12) # perform store
   addi x12, x12, -727 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x7 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x7, E_sh_cg_cp_rs2_b3, E_sh_cg_cp_rs2_b3_str)
-#else
-  sh x3, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x4 # switch temp register to avoid conflict with test
   mv x14, x5 # switch link pointer register to avoid conflict with test
@@ -453,18 +282,9 @@ E_sh_cg_cp_rs2_b4:
   sh x4, -406(x10) # perform store
   addi x10, x10, -406 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x8, E_sh_cg_cp_rs2_b4, E_sh_cg_cp_rs2_b4_str)
-#else
-  sh x4, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0x934bca1a
@@ -474,18 +294,9 @@ E_sh_cg_cp_rs2_b5:
   sh x5, -529(x7) # perform store
   addi x7, x7, -529 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x15 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x15, E_sh_cg_cp_rs2_b5, E_sh_cg_cp_rs2_b5_str)
-#else
-  sh x5, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x11, x6) # load rs2: x6 = 0xa96aa6a4
@@ -495,18 +306,9 @@ E_sh_cg_cp_rs2_b6:
   sh x6, -546(x2) # perform store
   addi x2, x2, -546 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x8 contains the expected result. x2 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x2, x14, x13, x8, E_sh_cg_cp_rs2_b6, E_sh_cg_cp_rs2_b6_str)
-#else
-  sh x6, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x11, x7) # load rs2: x7 = 0x285d6013
@@ -516,18 +318,9 @@ E_sh_cg_cp_rs2_b7:
   sh x7, -1686(x6) # perform store
   addi x6, x6, -1686 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x4 contains the expected result. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x6, x14, x13, x4, E_sh_cg_cp_rs2_b7, E_sh_cg_cp_rs2_b7_str)
-#else
-  sh x7, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x11, x8) # load rs2: x8 = 0xbe0eeb67
@@ -537,18 +330,9 @@ E_sh_cg_cp_rs2_b8:
   sh x8, -1296(x15) # perform store
   addi x15, x15, -1296 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x15, x14, x13, x10, E_sh_cg_cp_rs2_b8, E_sh_cg_cp_rs2_b8_str)
-#else
-  sh x8, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0x20bda1f4
@@ -558,18 +342,9 @@ E_sh_cg_cp_rs2_b9:
   sh x9, 1887(x7) # perform store
   addi x7, x7, 1887 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x3 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x3, E_sh_cg_cp_rs2_b9, E_sh_cg_cp_rs2_b9_str)
-#else
-  sh x9, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x11, x10) # load rs2: x10 = 0x23af2b6f
@@ -579,18 +354,9 @@ E_sh_cg_cp_rs2_b10:
   sh x10, -221(x3) # perform store
   addi x3, x3, -221 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x6 contains the expected result. x3 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x3, x14, x13, x6, E_sh_cg_cp_rs2_b10, E_sh_cg_cp_rs2_b10_str)
-#else
-  sh x10, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x12, x11 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x11)
@@ -601,18 +367,9 @@ E_sh_cg_cp_rs2_b11:
   sh x11, -827(x10) # perform store
   addi x10, x10, -827 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x8, E_sh_cg_cp_rs2_b11, E_sh_cg_cp_rs2_b11_str)
-#else
-  sh x11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x15, x12 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x12)
@@ -623,18 +380,9 @@ E_sh_cg_cp_rs2_b12:
   sh x12, -1923(x1) # perform store
   addi x1, x1, -1923 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x7 contains the expected result. x1 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x1, x14, x13, x7, E_sh_cg_cp_rs2_b12, E_sh_cg_cp_rs2_b12_str)
-#else
-  sh x12, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -646,18 +394,9 @@ E_sh_cg_cp_rs2_b13:
   sh x13, -7(x3) # perform store
   addi x3, x3, -7 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x10 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x10, E_sh_cg_cp_rs2_b13, E_sh_cg_cp_rs2_b13_str)
-#else
-  sh x13, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x15, x14) # load rs2: x14 = 0x10773afb
@@ -667,18 +406,9 @@ E_sh_cg_cp_rs2_b14:
   sh x14, -644(x7) # perform store
   addi x7, x7, -644 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x13 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x13, E_sh_cg_cp_rs2_b14, E_sh_cg_cp_rs2_b14_str)
-#else
-  sh x14, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x15 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x15)
@@ -689,18 +419,9 @@ E_sh_cg_cp_rs2_b15:
   sh x15, 655(x9) # perform store
   addi x9, x9, 655 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, E_sh_cg_cp_rs2_b15, E_sh_cg_cp_rs2_b15_str)
-#else
-  sh x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -714,18 +435,9 @@ E_sh_cg_cp_rs2_edges_0x0:
   sh x13, 800(x3) # perform store
   addi x3, x3, 800 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x14 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x14, E_sh_cg_cp_rs2_edges_0x0, E_sh_cg_cp_rs2_edges_0x0_str)
-#else
-  sh x13, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load rs2: x6 = 0x00000001
@@ -735,18 +447,9 @@ E_sh_cg_cp_rs2_edges_0x1:
   sh x6, 1338(x13) # perform store
   addi x13, x13, 1338 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, E_sh_cg_cp_rs2_edges_0x1, E_sh_cg_cp_rs2_edges_0x1_str)
-#else
-  sh x6, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
   RVTEST_TESTDATA_LOAD_INT(x2, x1) # load rs2: x1 = 0x00000002
@@ -756,18 +459,9 @@ E_sh_cg_cp_rs2_edges_0x2:
   sh x1, -206(x6) # perform store
   addi x6, x6, -206 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x15 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x15, E_sh_cg_cp_rs2_edges_0x2, E_sh_cg_cp_rs2_edges_0x2_str)
-#else
-  sh x1, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
   RVTEST_TESTDATA_LOAD_INT(x2, x9) # load rs2: x9 = 0x80000000
@@ -777,18 +471,9 @@ E_sh_cg_cp_rs2_edges_0x80000000:
   sh x9, -1522(x1) # perform store
   addi x1, x1, -1522 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x12 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x12, E_sh_cg_cp_rs2_edges_0x80000000, E_sh_cg_cp_rs2_edges_0x80000000_str)
-#else
-  sh x9, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load rs2: x11 = 0x80000001
@@ -798,18 +483,9 @@ E_sh_cg_cp_rs2_edges_0x80000001:
   sh x11, -850(x15) # perform store
   addi x15, x15, -850 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, E_sh_cg_cp_rs2_edges_0x80000001, E_sh_cg_cp_rs2_edges_0x80000001_str)
-#else
-  sh x11, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
   RVTEST_TESTDATA_LOAD_INT(x2, x1) # load rs2: x1 = 0x7fffffff
@@ -819,18 +495,9 @@ E_sh_cg_cp_rs2_edges_0x7fffffff:
   sh x1, 120(x13) # perform store
   addi x13, x13, 120 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x10 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x10, E_sh_cg_cp_rs2_edges_0x7fffffff, E_sh_cg_cp_rs2_edges_0x7fffffff_str)
-#else
-  sh x1, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
   RVTEST_TESTDATA_LOAD_INT(x2, x12) # load rs2: x12 = 0x7ffffffe
@@ -840,18 +507,9 @@ E_sh_cg_cp_rs2_edges_0x7ffffffe:
   sh x12, 823(x9) # perform store
   addi x9, x9, 823 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, E_sh_cg_cp_rs2_edges_0x7ffffffe, E_sh_cg_cp_rs2_edges_0x7ffffffe_str)
-#else
-  sh x12, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
   RVTEST_TESTDATA_LOAD_INT(x2, x3) # load rs2: x3 = 0xffffffff
@@ -861,18 +519,9 @@ E_sh_cg_cp_rs2_edges_0xffffffff:
   sh x3, 709(x13) # perform store
   addi x13, x13, 709 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x10 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x10, E_sh_cg_cp_rs2_edges_0xffffffff, E_sh_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  sh x3, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
   RVTEST_TESTDATA_LOAD_INT(x2, x7) # load rs2: x7 = 0xfffffffe
@@ -882,18 +531,9 @@ E_sh_cg_cp_rs2_edges_0xfffffffe:
   sh x7, 481(x3) # perform store
   addi x3, x3, 481 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x6 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x6, E_sh_cg_cp_rs2_edges_0xfffffffe, E_sh_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  sh x7, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
   RVTEST_TESTDATA_LOAD_INT(x2, x9) # load rs2: x9 = 0x5bbc8872
@@ -903,18 +543,9 @@ E_sh_cg_cp_rs2_edges_0x5bbc8872:
   sh x9, 616(x7) # perform store
   addi x7, x7, 616 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x12 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x12, E_sh_cg_cp_rs2_edges_0x5bbc8872, E_sh_cg_cp_rs2_edges_0x5bbc8872_str)
-#else
-  sh x9, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x2, x1) # load rs2: x1 = 0xaaaaaaaa
@@ -924,18 +555,9 @@ E_sh_cg_cp_rs2_edges_0xaaaaaaaa:
   sh x1, -886(x14) # perform store
   addi x14, x14, -886 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, E_sh_cg_cp_rs2_edges_0xaaaaaaaa, E_sh_cg_cp_rs2_edges_0xaaaaaaaa_str)
-#else
-  sh x1, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load rs2: x6 = 0x55555555
@@ -945,18 +567,9 @@ E_sh_cg_cp_rs2_edges_0x55555555:
   sh x6, 1853(x11) # perform store
   addi x11, x11, 1853 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, E_sh_cg_cp_rs2_edges_0x55555555, E_sh_cg_cp_rs2_edges_0x55555555_str)
-#else
-  sh x6, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_edges
@@ -970,18 +583,9 @@ E_sh_cg_cp_imm_edges_0x0:
   sh x6, 0(x3) # perform store
   addi x3, x3, 0 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x8 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x8, E_sh_cg_cp_imm_edges_0x0, E_sh_cg_cp_imm_edges_0x0_str)
-#else
-  sh x6, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1)
   RVTEST_TESTDATA_LOAD_INT(x2, x13) # load rs2: x13 = 0x1be5c4b2
@@ -991,18 +595,9 @@ E_sh_cg_cp_imm_edges_0x1:
   sh x13, 1(x11) # perform store
   addi x11, x11, 1 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, E_sh_cg_cp_imm_edges_0x1, E_sh_cg_cp_imm_edges_0x1_str)
-#else
-  sh x13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2)
   RVTEST_TESTDATA_LOAD_INT(x2, x3) # load rs2: x3 = 0x7b48af13
@@ -1012,18 +607,9 @@ E_sh_cg_cp_imm_edges_0x2:
   sh x3, 2(x9) # perform store
   addi x9, x9, 2 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, E_sh_cg_cp_imm_edges_0x2, E_sh_cg_cp_imm_edges_0x2_str)
-#else
-  sh x3, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 3)
   RVTEST_TESTDATA_LOAD_INT(x2, x8) # load rs2: x8 = 0xd3fb051b
@@ -1033,18 +619,9 @@ E_sh_cg_cp_imm_edges_0x3:
   sh x8, 3(x1) # perform store
   addi x1, x1, 3 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x12 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x12, E_sh_cg_cp_imm_edges_0x3, E_sh_cg_cp_imm_edges_0x3_str)
-#else
-  sh x8, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 4)
   RVTEST_TESTDATA_LOAD_INT(x2, x9) # load rs2: x9 = 0xb47389b6
@@ -1054,18 +631,9 @@ E_sh_cg_cp_imm_edges_0x4:
   sh x9, 4(x7) # perform store
   addi x7, x7, 4 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x14 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x14, E_sh_cg_cp_imm_edges_0x4, E_sh_cg_cp_imm_edges_0x4_str)
-#else
-  sh x9, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 8)
   RVTEST_TESTDATA_LOAD_INT(x2, x3) # load rs2: x3 = 0xaa43fb79
@@ -1075,18 +643,9 @@ E_sh_cg_cp_imm_edges_0x8:
   sh x3, 8(x12) # perform store
   addi x12, x12, 8 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x6 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x6, E_sh_cg_cp_imm_edges_0x8, E_sh_cg_cp_imm_edges_0x8_str)
-#else
-  sh x3, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 16)
   RVTEST_TESTDATA_LOAD_INT(x2, x7) # load rs2: x7 = 0x1cb46f5f
@@ -1096,18 +655,9 @@ E_sh_cg_cp_imm_edges_0x10:
   sh x7, 16(x9) # perform store
   addi x9, x9, 16 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x1, E_sh_cg_cp_imm_edges_0x10, E_sh_cg_cp_imm_edges_0x10_str)
-#else
-  sh x7, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 32)
   RVTEST_TESTDATA_LOAD_INT(x2, x3) # load rs2: x3 = 0x6d9949f3
@@ -1117,18 +667,9 @@ E_sh_cg_cp_imm_edges_0x20:
   sh x3, 32(x8) # perform store
   addi x8, x8, 32 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, E_sh_cg_cp_imm_edges_0x20, E_sh_cg_cp_imm_edges_0x20_str)
-#else
-  sh x3, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 64)
   RVTEST_TESTDATA_LOAD_INT(x2, x3) # load rs2: x3 = 0xe061c338
@@ -1138,18 +679,9 @@ E_sh_cg_cp_imm_edges_0x40:
   sh x3, 64(x9) # perform store
   addi x9, x9, 64 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, E_sh_cg_cp_imm_edges_0x40, E_sh_cg_cp_imm_edges_0x40_str)
-#else
-  sh x3, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 128)
   RVTEST_TESTDATA_LOAD_INT(x2, x7) # load rs2: x7 = 0x331e6fd6
@@ -1159,18 +691,9 @@ E_sh_cg_cp_imm_edges_0x80:
   sh x7, 128(x8) # perform store
   addi x8, x8, 128 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, E_sh_cg_cp_imm_edges_0x80, E_sh_cg_cp_imm_edges_0x80_str)
-#else
-  sh x7, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 256)
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load rs2: x6 = 0x5d7f02b3
@@ -1180,18 +703,9 @@ E_sh_cg_cp_imm_edges_0x100:
   sh x6, 256(x13) # perform store
   addi x13, x13, 256 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x3 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x3, E_sh_cg_cp_imm_edges_0x100, E_sh_cg_cp_imm_edges_0x100_str)
-#else
-  sh x6, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 512)
   RVTEST_TESTDATA_LOAD_INT(x2, x12) # load rs2: x12 = 0x09049e9b
@@ -1201,18 +715,9 @@ E_sh_cg_cp_imm_edges_0x200:
   sh x12, 512(x14) # perform store
   addi x14, x14, 512 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x1 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x1, E_sh_cg_cp_imm_edges_0x200, E_sh_cg_cp_imm_edges_0x200_str)
-#else
-  sh x12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1023)
   RVTEST_TESTDATA_LOAD_INT(x2, x8) # load rs2: x8 = 0x5dc414cf
@@ -1222,18 +727,9 @@ E_sh_cg_cp_imm_edges_0x3ff:
   sh x8, 1023(x11) # perform store
   addi x11, x11, 1023 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, E_sh_cg_cp_imm_edges_0x3ff, E_sh_cg_cp_imm_edges_0x3ff_str)
-#else
-  sh x8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1024)
   RVTEST_TESTDATA_LOAD_INT(x2, x9) # load rs2: x9 = 0x146b4f7c
@@ -1243,18 +739,9 @@ E_sh_cg_cp_imm_edges_0x400:
   sh x9, 1024(x10) # perform store
   addi x10, x10, 1024 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x7 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x7, E_sh_cg_cp_imm_edges_0x400, E_sh_cg_cp_imm_edges_0x400_str)
-#else
-  sh x9, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1795)
   RVTEST_TESTDATA_LOAD_INT(x2, x1) # load rs2: x1 = 0x2b243220
@@ -1264,18 +751,9 @@ E_sh_cg_cp_imm_edges_0x703:
   sh x1, 1795(x12) # perform store
   addi x12, x12, 1795 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x6 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x6, E_sh_cg_cp_imm_edges_0x703, E_sh_cg_cp_imm_edges_0x703_str)
-#else
-  sh x1, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2047)
   RVTEST_TESTDATA_LOAD_INT(x2, x1) # load rs2: x1 = 0x9e7bb89f
@@ -1285,18 +763,9 @@ E_sh_cg_cp_imm_edges_0x7ff:
   sh x1, 2047(x15) # perform store
   addi x15, x15, 2047 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x8 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x8, E_sh_cg_cp_imm_edges_0x7ff, E_sh_cg_cp_imm_edges_0x7ff_str)
-#else
-  sh x1, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2048)
   RVTEST_TESTDATA_LOAD_INT(x2, x9) # load rs2: x9 = 0x66376e41
@@ -1307,18 +776,9 @@ E_sh_cg_cp_imm_edges_m0x800:
   sh x9, -2048(x10) # perform store
   addi x10, x10, -2048 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, E_sh_cg_cp_imm_edges_m0x800, E_sh_cg_cp_imm_edges_m0x800_str)
-#else
-  sh x9, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2047)
   RVTEST_TESTDATA_LOAD_INT(x2, x8) # load rs2: x8 = 0xf8ebf302
@@ -1328,18 +788,9 @@ E_sh_cg_cp_imm_edges_m0x7ff:
   sh x8, -2047(x12) # perform store
   addi x12, x12, -2047 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x1 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x1, E_sh_cg_cp_imm_edges_m0x7ff, E_sh_cg_cp_imm_edges_m0x7ff_str)
-#else
-  sh x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2)
   RVTEST_TESTDATA_LOAD_INT(x2, x7) # load rs2: x7 = 0x37b571df
@@ -1349,18 +800,9 @@ E_sh_cg_cp_imm_edges_m0x2:
   sh x7, -2(x6) # perform store
   addi x6, x6, -2 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x13 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x13, E_sh_cg_cp_imm_edges_m0x2, E_sh_cg_cp_imm_edges_m0x2_str)
-#else
-  sh x7, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -1)
   RVTEST_TESTDATA_LOAD_INT(x2, x8) # load rs2: x8 = 0xae8cc23e
@@ -1370,18 +812,9 @@ E_sh_cg_cp_imm_edges_m0x1:
   sh x8, -1(x13) # perform store
   addi x13, x13, -1 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, E_sh_cg_cp_imm_edges_m0x1, E_sh_cg_cp_imm_edges_m0x1_str)
-#else
-  sh x8, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_align_hword
@@ -1392,84 +825,48 @@ E_sh_cg_cp_imm_edges_m0x1:
 E_sh_cg_cp_align_hword_b0:
   sh x12, 0(x13) # perform store
   addi x13, x13, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -8(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, E_sh_cg_cp_align_hword_b0, E_sh_cg_cp_align_hword_b0_str)
   LREG x8, -8(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, E_sh_cg_cp_align_hword_b0, E_sh_cg_cp_align_hword_b0_str)
-#else
-  sh x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_hword (imm[2:0] = 010)
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load rs2: x11 = 0x4441ad6e
 E_sh_cg_cp_align_hword_b2:
   sh x11, 2(x13) # perform store
   addi x13, x13, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -8(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, E_sh_cg_cp_align_hword_b2, E_sh_cg_cp_align_hword_b2_str)
   LREG x12, -8(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, E_sh_cg_cp_align_hword_b2, E_sh_cg_cp_align_hword_b2_str)
-#else
-  sh x11, 2(x13) # repeat store so it is available for checking
-  addi x13, x13, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_hword (imm[2:0] = 100)
   RVTEST_TESTDATA_LOAD_INT(x2, x1) # load rs2: x1 = 0xe0a4ba12
 E_sh_cg_cp_align_hword_b4:
   sh x1, 4(x13) # perform store
   addi x13, x13, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -8(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, E_sh_cg_cp_align_hword_b4, E_sh_cg_cp_align_hword_b4_str)
   LREG x9, -8(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, E_sh_cg_cp_align_hword_b4, E_sh_cg_cp_align_hword_b4_str)
-#else
-  sh x1, 4(x13) # repeat store so it is available for checking
-  addi x13, x13, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_hword (imm[2:0] = 110)
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load rs2: x11 = 0x143e8bf0
 E_sh_cg_cp_align_hword_b6:
   sh x11, 6(x13) # perform store
   addi x13, x13, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -8(x13) # load stored value for checking
   # Check if x7 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x7, E_sh_cg_cp_align_hword_b6, E_sh_cg_cp_align_hword_b6_str)
   LREG x7, -8(x13) # load stored value for checking
   # Check if x7 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x7, E_sh_cg_cp_align_hword_b6, E_sh_cg_cp_align_hword_b6_str)
-#else
-  sh x11, 6(x13) # repeat store so it is available for checking
-  addi x13, x13, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 
   mv x2, x13 # restore signature pointer to default register for teardown

--- a/tests/rv32e/E/E-sw-00.S
+++ b/tests/rv32e/E/E-sw-00.S
@@ -41,18 +41,9 @@ E_sw_cg_cp_rs1_nx0_b1:
   sw x13, 1402(x1) # perform store
   addi x1, x1, 1402 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x7 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x7, E_sw_cg_cp_rs1_nx0_b1, E_sw_cg_cp_rs1_nx0_b1_str)
-#else
-  sw x13, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xb49d1c5c
@@ -62,18 +53,9 @@ E_sw_cg_cp_rs1_nx0_b2:
   sw x10, -1863(x2) # perform store
   addi x2, x2, -1863 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x8 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x8, E_sw_cg_cp_rs1_nx0_b2, E_sw_cg_cp_rs1_nx0_b2_str)
-#else
-  sw x10, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x6, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
@@ -84,18 +66,9 @@ E_sw_cg_cp_rs1_nx0_b3:
   sw x7, 1618(x3) # perform store
   addi x3, x3, 1618 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x13 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x13, E_sw_cg_cp_rs1_nx0_b3, E_sw_cg_cp_rs1_nx0_b3_str)
-#else
-  sw x7, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x4 # switch temp register to avoid conflict with test
   mv x14, x5 # switch link pointer register to avoid conflict with test
@@ -107,18 +80,9 @@ E_sw_cg_cp_rs1_nx0_b4:
   sw x9, -1750(x4) # perform store
   addi x4, x4, -1750 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x1 contains the expected result. x4 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x4, x14, x13, x1, E_sw_cg_cp_rs1_nx0_b4, E_sw_cg_cp_rs1_nx0_b4_str)
-#else
-  sw x9, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x6, x3) # load rs2: x3 = 0xc7fa72a6
@@ -128,18 +92,9 @@ E_sw_cg_cp_rs1_nx0_b5:
   sw x3, -597(x5) # perform store
   addi x5, x5, -597 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x12 contains the expected result. x5 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x5, x14, x13, x12, E_sw_cg_cp_rs1_nx0_b5, E_sw_cg_cp_rs1_nx0_b5_str)
-#else
-  sw x3, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x1, x6 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
@@ -150,18 +105,9 @@ E_sw_cg_cp_rs1_nx0_b6:
   sw x0, 732(x6) # perform store
   addi x6, x6, 732 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x11 contains the expected result. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x6, x14, x13, x11, E_sw_cg_cp_rs1_nx0_b6, E_sw_cg_cp_rs1_nx0_b6_str)
-#else
-  sw x0, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x7)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x48f51cf5
@@ -171,18 +117,9 @@ E_sw_cg_cp_rs1_nx0_b7:
   sw x12, 673(x7) # perform store
   addi x7, x7, 673 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x4 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x4, E_sw_cg_cp_rs1_nx0_b7, E_sw_cg_cp_rs1_nx0_b7_str)
-#else
-  sw x12, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xc4374d5e
@@ -192,18 +129,9 @@ E_sw_cg_cp_rs1_nx0_b8:
   sw x10, 677(x8) # perform store
   addi x8, x8, 677 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x3 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x3, E_sw_cg_cp_rs1_nx0_b8, E_sw_cg_cp_rs1_nx0_b8_str)
-#else
-  sw x10, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xcac2fa9e
@@ -213,18 +141,9 @@ E_sw_cg_cp_rs1_nx0_b9:
   sw x3, 351(x9) # perform store
   addi x9, x9, 351 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x6, E_sw_cg_cp_rs1_nx0_b9, E_sw_cg_cp_rs1_nx0_b9_str)
-#else
-  sw x3, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xd34a6317
@@ -234,18 +153,9 @@ E_sw_cg_cp_rs1_nx0_b10:
   sw x12, 1622(x10) # perform store
   addi x10, x10, 1622 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x3 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x3, E_sw_cg_cp_rs1_nx0_b10, E_sw_cg_cp_rs1_nx0_b10_str)
-#else
-  sw x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xeff00a14
@@ -255,18 +165,9 @@ E_sw_cg_cp_rs1_nx0_b11:
   sw x7, 49(x11) # perform store
   addi x11, x11, 49 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x12, E_sw_cg_cp_rs1_nx0_b11, E_sw_cg_cp_rs1_nx0_b11_str)
-#else
-  sw x7, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x470e9a1f
@@ -276,18 +177,9 @@ E_sw_cg_cp_rs1_nx0_b12:
   sw x15, -637(x12) # perform store
   addi x12, x12, -637 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x9 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x9, E_sw_cg_cp_rs1_nx0_b12, E_sw_cg_cp_rs1_nx0_b12_str)
-#else
-  sw x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x13 # switch temp register to avoid conflict with test
   mv x8, x14 # switch link pointer register to avoid conflict with test
@@ -299,18 +191,9 @@ E_sw_cg_cp_rs1_nx0_b13:
   sw x4, 384(x13) # perform store
   addi x13, x13, 384 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x13, x8, x7, x11, E_sw_cg_cp_rs1_nx0_b13, E_sw_cg_cp_rs1_nx0_b13_str)
-#else
-  sw x4, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x25383a20
@@ -320,18 +203,9 @@ E_sw_cg_cp_rs1_nx0_b14:
   sw x9, -1403(x14) # perform store
   addi x14, x14, -1403 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x3 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x3, E_sw_cg_cp_rs1_nx0_b14, E_sw_cg_cp_rs1_nx0_b14_str)
-#else
-  sw x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x1, x4) # load rs2: x4 = 0xdbc2fc4c
@@ -341,18 +215,9 @@ E_sw_cg_cp_rs1_nx0_b15:
   sw x4, -194(x15) # perform store
   addi x15, x15, -194 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x5 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x15, x8, x7, x5, E_sw_cg_cp_rs1_nx0_b15, E_sw_cg_cp_rs1_nx0_b15_str)
-#else
-  sw x4, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2
@@ -366,18 +231,9 @@ E_sw_cg_cp_rs2_b0:
   sw x0, 1417(x13) # perform store
   addi x13, x13, 1417 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x3 contains the expected result. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x13, x8, x7, x3, E_sw_cg_cp_rs2_b0, E_sw_cg_cp_rs2_b0_str)
-#else
-  sw x0, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x1 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x1)
@@ -388,18 +244,9 @@ E_sw_cg_cp_rs2_b1:
   sw x1, 504(x12) # perform store
   addi x12, x12, 504 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x15 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x12, x8, x7, x15, E_sw_cg_cp_rs2_b1, E_sw_cg_cp_rs2_b1_str)
-#else
-  sw x1, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x3, x2 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x2)
@@ -410,18 +257,9 @@ E_sw_cg_cp_rs2_b2:
   sw x2, 2039(x9) # perform store
   addi x9, x9, 2039 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, E_sw_cg_cp_rs2_b2, E_sw_cg_cp_rs2_b2_str)
-#else
-  sw x2, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x12, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x3)
@@ -432,18 +270,9 @@ E_sw_cg_cp_rs2_b3:
   sw x3, -44(x5) # perform store
   addi x5, x5, -44 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x11 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x11, E_sw_cg_cp_rs2_b3, E_sw_cg_cp_rs2_b3_str)
-#else
-  sw x3, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x4)
   RVTEST_TESTDATA_LOAD_INT(x12, x4) # load rs2: x4 = 0x12f744d9
@@ -453,18 +282,9 @@ E_sw_cg_cp_rs2_b4:
   sw x4, 1332(x15) # perform store
   addi x15, x15, 1332 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x9 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x15, x8, x7, x9, E_sw_cg_cp_rs2_b4, E_sw_cg_cp_rs2_b4_str)
-#else
-  sw x4, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x12, x5) # load rs2: x5 = 0xcec1f7ec
@@ -474,18 +294,9 @@ E_sw_cg_cp_rs2_b5:
   sw x5, 342(x6) # perform store
   addi x6, x6, 342 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x14 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x14, E_sw_cg_cp_rs2_b5, E_sw_cg_cp_rs2_b5_str)
-#else
-  sw x5, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x3, x6 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x6)
@@ -496,18 +307,9 @@ E_sw_cg_cp_rs2_b6:
   sw x6, 280(x11) # perform store
   addi x11, x11, 280 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x4 contains the expected result. x11 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x11, x8, x7, x4, E_sw_cg_cp_rs2_b6, E_sw_cg_cp_rs2_b6_str)
-#else
-  sw x6, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x7 # switch temp register to avoid conflict with test
   mv x14, x8 # switch link pointer register to avoid conflict with test
@@ -519,18 +321,9 @@ E_sw_cg_cp_rs2_b7:
   sw x7, -742(x6) # perform store
   addi x6, x6, -742 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x9 contains the expected result. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x6, x14, x13, x9, E_sw_cg_cp_rs2_b7, E_sw_cg_cp_rs2_b7_str)
-#else
-  sw x7, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x12, x8) # load rs2: x8 = 0x7fcffe77
@@ -540,18 +333,9 @@ E_sw_cg_cp_rs2_b8:
   sw x8, -1867(x3) # perform store
   addi x3, x3, -1867 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x1 contains the expected result. x3 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x3, x14, x13, x1, E_sw_cg_cp_rs2_b8, E_sw_cg_cp_rs2_b8_str)
-#else
-  sw x8, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rs2: x9 = 0xbcb1ee3a
@@ -561,18 +345,9 @@ E_sw_cg_cp_rs2_b9:
   sw x9, -17(x15) # perform store
   addi x15, x15, -17 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x1 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x15, x14, x13, x1, E_sw_cg_cp_rs2_b9, E_sw_cg_cp_rs2_b9_str)
-#else
-  sw x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rs2: x10 = 0xf11bb999
@@ -582,18 +357,9 @@ E_sw_cg_cp_rs2_b10:
   sw x10, -772(x3) # perform store
   addi x3, x3, -772 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x9 contains the expected result. x3 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x3, x14, x13, x9, E_sw_cg_cp_rs2_b10, E_sw_cg_cp_rs2_b10_str)
-#else
-  sw x10, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x12, x11) # load rs2: x11 = 0x097efdf9
@@ -603,18 +369,9 @@ E_sw_cg_cp_rs2_b11:
   sw x11, 1114(x10) # perform store
   addi x10, x10, 1114 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x4 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x4, E_sw_cg_cp_rs2_b11, E_sw_cg_cp_rs2_b11_str)
-#else
-  sw x11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x15, x12 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x12)
@@ -625,18 +382,9 @@ E_sw_cg_cp_rs2_b12:
   sw x12, 15(x1) # perform store
   addi x1, x1, 15 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x1, x14, x13, x11, E_sw_cg_cp_rs2_b12, E_sw_cg_cp_rs2_b12_str)
-#else
-  sw x12, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x13 # switch temp register to avoid conflict with test
   mv x8, x14 # switch link pointer register to avoid conflict with test
@@ -648,18 +396,9 @@ E_sw_cg_cp_rs2_b13:
   sw x13, -1064(x9) # perform store
   addi x9, x9, -1064 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, E_sw_cg_cp_rs2_b13, E_sw_cg_cp_rs2_b13_str)
-#else
-  sw x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x15, x14) # load rs2: x14 = 0x697aec28
@@ -669,18 +408,9 @@ E_sw_cg_cp_rs2_b14:
   sw x14, -1416(x1) # perform store
   addi x1, x1, -1416 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x5, E_sw_cg_cp_rs2_b14, E_sw_cg_cp_rs2_b14_str)
-#else
-  sw x14, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x11, x15 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x15)
@@ -691,18 +421,9 @@ E_sw_cg_cp_rs2_b15:
   sw x15, 1875(x10) # perform store
   addi x10, x10, 1875 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x5 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x5, E_sw_cg_cp_rs2_b15, E_sw_cg_cp_rs2_b15_str)
-#else
-  sw x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -716,18 +437,9 @@ E_sw_cg_cp_rs2_edges_0x0:
   sw x12, 41(x5) # perform store
   addi x5, x5, 41 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x6 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x6, E_sw_cg_cp_rs2_edges_0x0, E_sw_cg_cp_rs2_edges_0x0_str)
-#else
-  sw x12, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
   RVTEST_TESTDATA_LOAD_INT(x11, x1) # load rs2: x1 = 0x00000001
@@ -737,18 +449,9 @@ E_sw_cg_cp_rs2_edges_0x1:
   sw x1, 345(x2) # perform store
   addi x2, x2, 345 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x13 contains the expected result. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x2, x8, x7, x13, E_sw_cg_cp_rs2_edges_0x1, E_sw_cg_cp_rs2_edges_0x1_str)
-#else
-  sw x1, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
   RVTEST_TESTDATA_LOAD_INT(x11, x6) # load rs2: x6 = 0x00000002
@@ -758,18 +461,9 @@ E_sw_cg_cp_rs2_edges_0x2:
   sw x6, 286(x14) # perform store
   addi x14, x14, 286 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x4 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x4, E_sw_cg_cp_rs2_edges_0x2, E_sw_cg_cp_rs2_edges_0x2_str)
-#else
-  sw x6, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
   RVTEST_TESTDATA_LOAD_INT(x11, x15) # load rs2: x15 = 0x80000000
@@ -779,18 +473,9 @@ E_sw_cg_cp_rs2_edges_0x80000000:
   sw x15, -2004(x9) # perform store
   addi x9, x9, -2004 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, E_sw_cg_cp_rs2_edges_0x80000000, E_sw_cg_cp_rs2_edges_0x80000000_str)
-#else
-  sw x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
   RVTEST_TESTDATA_LOAD_INT(x11, x2) # load rs2: x2 = 0x80000001
@@ -800,18 +485,9 @@ E_sw_cg_cp_rs2_edges_0x80000001:
   sw x2, 370(x12) # perform store
   addi x12, x12, 370 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x3 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x12, x8, x7, x3, E_sw_cg_cp_rs2_edges_0x80000001, E_sw_cg_cp_rs2_edges_0x80000001_str)
-#else
-  sw x2, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
   RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0x7fffffff
@@ -821,18 +497,9 @@ E_sw_cg_cp_rs2_edges_0x7fffffff:
   sw x14, -633(x6) # perform store
   addi x6, x6, -633 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x9 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x9, E_sw_cg_cp_rs2_edges_0x7fffffff, E_sw_cg_cp_rs2_edges_0x7fffffff_str)
-#else
-  sw x14, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
   RVTEST_TESTDATA_LOAD_INT(x11, x15) # load rs2: x15 = 0x7ffffffe
@@ -842,18 +509,9 @@ E_sw_cg_cp_rs2_edges_0x7ffffffe:
   sw x15, 35(x5) # perform store
   addi x5, x5, 35 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x4 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x4, E_sw_cg_cp_rs2_edges_0x7ffffffe, E_sw_cg_cp_rs2_edges_0x7ffffffe_str)
-#else
-  sw x15, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
   RVTEST_TESTDATA_LOAD_INT(x11, x10) # load rs2: x10 = 0xffffffff
@@ -863,18 +521,9 @@ E_sw_cg_cp_rs2_edges_0xffffffff:
   sw x10, -1966(x9) # perform store
   addi x9, x9, -1966 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x1 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x1, E_sw_cg_cp_rs2_edges_0xffffffff, E_sw_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  sw x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
   RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0xfffffffe
@@ -884,18 +533,9 @@ E_sw_cg_cp_rs2_edges_0xfffffffe:
   sw x14, -1348(x3) # perform store
   addi x3, x3, -1348 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x10 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x3, x8, x7, x10, E_sw_cg_cp_rs2_edges_0xfffffffe, E_sw_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  sw x14, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
   RVTEST_TESTDATA_LOAD_INT(x11, x6) # load rs2: x6 = 0x5bbc8872
@@ -905,18 +545,9 @@ E_sw_cg_cp_rs2_edges_0x5bbc8872:
   sw x6, 287(x14) # perform store
   addi x14, x14, 287 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x13, E_sw_cg_cp_rs2_edges_0x5bbc8872, E_sw_cg_cp_rs2_edges_0x5bbc8872_str)
-#else
-  sw x6, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x11, x6) # load rs2: x6 = 0xaaaaaaaa
@@ -926,18 +557,9 @@ E_sw_cg_cp_rs2_edges_0xaaaaaaaa:
   sw x6, 729(x12) # perform store
   addi x12, x12, 729 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x3 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x12, x8, x7, x3, E_sw_cg_cp_rs2_edges_0xaaaaaaaa, E_sw_cg_cp_rs2_edges_0xaaaaaaaa_str)
-#else
-  sw x6, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
   RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0x55555555
@@ -947,18 +569,9 @@ E_sw_cg_cp_rs2_edges_0x55555555:
   sw x14, -1648(x4) # perform store
   addi x4, x4, -1648 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x5 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x5, E_sw_cg_cp_rs2_edges_0x55555555, E_sw_cg_cp_rs2_edges_0x55555555_str)
-#else
-  sw x14, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_edges
@@ -972,18 +585,9 @@ E_sw_cg_cp_imm_edges_0x0:
   sw x12, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x6 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x6, E_sw_cg_cp_imm_edges_0x0, E_sw_cg_cp_imm_edges_0x0_str)
-#else
-  sw x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1)
   RVTEST_TESTDATA_LOAD_INT(x11, x12) # load rs2: x12 = 0x4f26c6f4
@@ -993,18 +597,9 @@ E_sw_cg_cp_imm_edges_0x1:
   sw x12, 1(x13) # perform store
   addi x13, x13, 1 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x3 contains the expected result. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x13, x8, x7, x3, E_sw_cg_cp_imm_edges_0x1, E_sw_cg_cp_imm_edges_0x1_str)
-#else
-  sw x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2)
   RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0x58367654
@@ -1014,18 +609,9 @@ E_sw_cg_cp_imm_edges_0x2:
   sw x4, 2(x2) # perform store
   addi x2, x2, 2 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x10 contains the expected result. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x2, x8, x7, x10, E_sw_cg_cp_imm_edges_0x2, E_sw_cg_cp_imm_edges_0x2_str)
-#else
-  sw x4, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 3)
   RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0x0f19ff31
@@ -1035,18 +621,9 @@ E_sw_cg_cp_imm_edges_0x3:
   sw x14, 3(x1) # perform store
   addi x1, x1, 3 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, E_sw_cg_cp_imm_edges_0x3, E_sw_cg_cp_imm_edges_0x3_str)
-#else
-  sw x14, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 4)
   RVTEST_TESTDATA_LOAD_INT(x11, x3) # load rs2: x3 = 0xcfbcfc7c
@@ -1056,18 +633,9 @@ E_sw_cg_cp_imm_edges_0x4:
   sw x3, 4(x14) # perform store
   addi x14, x14, 4 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x13, E_sw_cg_cp_imm_edges_0x4, E_sw_cg_cp_imm_edges_0x4_str)
-#else
-  sw x3, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 8)
   RVTEST_TESTDATA_LOAD_INT(x11, x13) # load rs2: x13 = 0x860e98b7
@@ -1077,18 +645,9 @@ E_sw_cg_cp_imm_edges_0x8:
   sw x13, 8(x4) # perform store
   addi x4, x4, 8 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x10 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x10, E_sw_cg_cp_imm_edges_0x8, E_sw_cg_cp_imm_edges_0x8_str)
-#else
-  sw x13, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 16)
   RVTEST_TESTDATA_LOAD_INT(x11, x1) # load rs2: x1 = 0x13da6910
@@ -1098,18 +657,9 @@ E_sw_cg_cp_imm_edges_0x10:
   sw x1, 16(x13) # perform store
   addi x13, x13, 16 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x6 contains the expected result. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x13, x8, x7, x6, E_sw_cg_cp_imm_edges_0x10, E_sw_cg_cp_imm_edges_0x10_str)
-#else
-  sw x1, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 32)
   RVTEST_TESTDATA_LOAD_INT(x11, x15) # load rs2: x15 = 0x3c1d5330
@@ -1119,18 +669,9 @@ E_sw_cg_cp_imm_edges_0x20:
   sw x15, 32(x9) # perform store
   addi x9, x9, 32 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, E_sw_cg_cp_imm_edges_0x20, E_sw_cg_cp_imm_edges_0x20_str)
-#else
-  sw x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 64)
   RVTEST_TESTDATA_LOAD_INT(x11, x6) # load rs2: x6 = 0xa7a8740b
@@ -1140,18 +681,9 @@ E_sw_cg_cp_imm_edges_0x40:
   sw x6, 64(x2) # perform store
   addi x2, x2, 64 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x1 contains the expected result. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x2, x8, x7, x1, E_sw_cg_cp_imm_edges_0x40, E_sw_cg_cp_imm_edges_0x40_str)
-#else
-  sw x6, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 128)
   RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0xdbad31d0
@@ -1161,18 +693,9 @@ E_sw_cg_cp_imm_edges_0x80:
   sw x14, 128(x12) # perform store
   addi x12, x12, 128 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x3 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x12, x8, x7, x3, E_sw_cg_cp_imm_edges_0x80, E_sw_cg_cp_imm_edges_0x80_str)
-#else
-  sw x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 256)
   RVTEST_TESTDATA_LOAD_INT(x11, x15) # load rs2: x15 = 0x874a85f2
@@ -1182,18 +705,9 @@ E_sw_cg_cp_imm_edges_0x100:
   sw x15, 256(x3) # perform store
   addi x3, x3, 256 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x9 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x3, x8, x7, x9, E_sw_cg_cp_imm_edges_0x100, E_sw_cg_cp_imm_edges_0x100_str)
-#else
-  sw x15, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 512)
   RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0x86a69b31
@@ -1203,18 +717,9 @@ E_sw_cg_cp_imm_edges_0x200:
   sw x14, 512(x10) # perform store
   addi x10, x10, 512 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x5 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x5, E_sw_cg_cp_imm_edges_0x200, E_sw_cg_cp_imm_edges_0x200_str)
-#else
-  sw x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1023)
   RVTEST_TESTDATA_LOAD_INT(x11, x1) # load rs2: x1 = 0x4e97669d
@@ -1224,18 +729,9 @@ E_sw_cg_cp_imm_edges_0x3ff:
   sw x1, 1023(x13) # perform store
   addi x13, x13, 1023 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x6 contains the expected result. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x13, x8, x7, x6, E_sw_cg_cp_imm_edges_0x3ff, E_sw_cg_cp_imm_edges_0x3ff_str)
-#else
-  sw x1, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1024)
   RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0xfa516d5a
@@ -1245,18 +741,9 @@ E_sw_cg_cp_imm_edges_0x400:
   sw x9, 1024(x10) # perform store
   addi x10, x10, 1024 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x15, E_sw_cg_cp_imm_edges_0x400, E_sw_cg_cp_imm_edges_0x400_str)
-#else
-  sw x9, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1795)
   RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0x7b506ebf
@@ -1266,18 +753,9 @@ E_sw_cg_cp_imm_edges_0x703:
   sw x14, 1795(x6) # perform store
   addi x6, x6, 1795 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x3 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x3, E_sw_cg_cp_imm_edges_0x703, E_sw_cg_cp_imm_edges_0x703_str)
-#else
-  sw x14, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2047)
   RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0xda1a424c
@@ -1287,18 +765,9 @@ E_sw_cg_cp_imm_edges_0x7ff:
   sw x14, 2047(x12) # perform store
   addi x12, x12, 2047 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x9 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x12, x8, x7, x9, E_sw_cg_cp_imm_edges_0x7ff, E_sw_cg_cp_imm_edges_0x7ff_str)
-#else
-  sw x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2048)
   RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0xc25f7243
@@ -1309,18 +778,9 @@ E_sw_cg_cp_imm_edges_m0x800:
   sw x5, -2048(x4) # perform store
   addi x4, x4, -2048 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x9 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x9, E_sw_cg_cp_imm_edges_m0x800, E_sw_cg_cp_imm_edges_m0x800_str)
-#else
-  sw x5, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2047)
   RVTEST_TESTDATA_LOAD_INT(x11, x3) # load rs2: x3 = 0xcbb21baf
@@ -1330,18 +790,9 @@ E_sw_cg_cp_imm_edges_m0x7ff:
   sw x3, -2047(x1) # perform store
   addi x1, x1, -2047 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x6, E_sw_cg_cp_imm_edges_m0x7ff, E_sw_cg_cp_imm_edges_m0x7ff_str)
-#else
-  sw x3, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2)
   RVTEST_TESTDATA_LOAD_INT(x11, x15) # load rs2: x15 = 0xf677cc51
@@ -1351,18 +802,9 @@ E_sw_cg_cp_imm_edges_m0x2:
   sw x15, -2(x5) # perform store
   addi x5, x5, -2 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x6 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x6, E_sw_cg_cp_imm_edges_m0x2, E_sw_cg_cp_imm_edges_m0x2_str)
-#else
-  sw x15, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -1)
   RVTEST_TESTDATA_LOAD_INT(x11, x1) # load rs2: x1 = 0x970e2313
@@ -1372,18 +814,9 @@ E_sw_cg_cp_imm_edges_m0x1:
   sw x1, -1(x4) # perform store
   addi x4, x4, -1 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x15 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x15, E_sw_cg_cp_imm_edges_m0x1, E_sw_cg_cp_imm_edges_m0x1_str)
-#else
-  sw x1, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_align_word
@@ -1394,42 +827,24 @@ E_sw_cg_cp_imm_edges_m0x1:
 E_sw_cg_cp_align_word_b0:
   sw x12, 0(x4) # perform store
   addi x4, x4, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -8(x4) # load stored value for checking
   # Check if x1 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x1, E_sw_cg_cp_align_word_b0, E_sw_cg_cp_align_word_b0_str)
   LREG x1, -8(x4) # load stored value for checking
   # Check if x1 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x1, E_sw_cg_cp_align_word_b0, E_sw_cg_cp_align_word_b0_str)
-#else
-  sw x12, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_word (imm[2:0] = 100)
   RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0xa6f52c8c
 E_sw_cg_cp_align_word_b4:
   sw x14, 4(x4) # perform store
   addi x4, x4, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -8(x4) # load stored value for checking
   # Check if x6 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x6, E_sw_cg_cp_align_word_b4, E_sw_cg_cp_align_word_b4_str)
   LREG x6, -8(x4) # load stored value for checking
   # Check if x6 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x6, E_sw_cg_cp_align_word_b4, E_sw_cg_cp_align_word_b4_str)
-#else
-  sw x14, 4(x4) # repeat store so it is available for checking
-  addi x4, x4, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 
   mv x2, x4 # restore signature pointer to default register for teardown

--- a/tests/rv32e/Zca/Zca-c.sw-00.S
+++ b/tests/rv32e/Zca/Zca-c.sw-00.S
@@ -41,18 +41,9 @@ Zca_c_sw_cg_cp_rs1_p_b8:
   c.sw x13, 24(x8) # perform store
   addi x8, x8, 24 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x15 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x15, Zca_c_sw_cg_cp_rs1_p_b8, Zca_c_sw_cg_cp_rs1_p_b8_str)
-#else
-  c.sw x13, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xa980edf0
@@ -62,18 +53,9 @@ Zca_c_sw_cg_cp_rs1_p_b9:
   c.sw x11, 96(x9) # perform store
   addi x9, x9, 96 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sw_cg_cp_rs1_p_b9, Zca_c_sw_cg_cp_rs1_p_b9_str)
-#else
-  c.sw x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x81307f54
@@ -83,18 +65,9 @@ Zca_c_sw_cg_cp_rs1_p_b10:
   c.sw x11, 96(x10) # perform store
   addi x10, x10, 96 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zca_c_sw_cg_cp_rs1_p_b10, Zca_c_sw_cg_cp_rs1_p_b10_str)
-#else
-  c.sw x11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x2d02c6e8
@@ -104,18 +77,9 @@ Zca_c_sw_cg_cp_rs1_p_b11:
   c.sw x12, 4(x11) # perform store
   addi x11, x11, 4 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_sw_cg_cp_rs1_p_b11, Zca_c_sw_cg_cp_rs1_p_b11_str)
-#else
-  c.sw x12, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x1c27445c
@@ -125,18 +89,9 @@ Zca_c_sw_cg_cp_rs1_p_b12:
   c.sw x10, 64(x12) # perform store
   addi x12, x12, 64 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zca_c_sw_cg_cp_rs1_p_b12, Zca_c_sw_cg_cp_rs1_p_b12_str)
-#else
-  c.sw x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x964fa46d
@@ -146,18 +101,9 @@ Zca_c_sw_cg_cp_rs1_p_b13:
   c.sw x8, 68(x13) # perform store
   addi x13, x13, 68 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, Zca_c_sw_cg_cp_rs1_p_b13, Zca_c_sw_cg_cp_rs1_p_b13_str)
-#else
-  c.sw x8, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x48c29810
@@ -167,18 +113,9 @@ Zca_c_sw_cg_cp_rs1_p_b14:
   c.sw x15, 92(x14) # perform store
   addi x14, x14, 92 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zca_c_sw_cg_cp_rs1_p_b14, Zca_c_sw_cg_cp_rs1_p_b14_str)
-#else
-  c.sw x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xd4733b06
@@ -188,18 +125,9 @@ Zca_c_sw_cg_cp_rs1_p_b15:
   c.sw x9, 88(x15) # perform store
   addi x15, x15, 88 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, Zca_c_sw_cg_cp_rs1_p_b15, Zca_c_sw_cg_cp_rs1_p_b15_str)
-#else
-  c.sw x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_p
@@ -213,18 +141,9 @@ Zca_c_sw_cg_cp_rs2_p_b8:
   c.sw x8, 24(x12) # perform store
   addi x12, x12, 24 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x13 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x13, Zca_c_sw_cg_cp_rs2_p_b8, Zca_c_sw_cg_cp_rs2_p_b8_str)
-#else
-  c.sw x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xd82790ad
@@ -234,18 +153,9 @@ Zca_c_sw_cg_cp_rs2_p_b9:
   c.sw x9, 40(x10) # perform store
   addi x10, x10, 40 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zca_c_sw_cg_cp_rs2_p_b9, Zca_c_sw_cg_cp_rs2_p_b9_str)
-#else
-  c.sw x9, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x10 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2_p (Test source rs2 = x10)
@@ -256,18 +166,9 @@ Zca_c_sw_cg_cp_rs2_p_b10:
   c.sw x10, 16(x9) # perform store
   addi x9, x9, 16 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sw_cg_cp_rs2_p_b10, Zca_c_sw_cg_cp_rs2_p_b10_str)
-#else
-  c.sw x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x3a943182
@@ -277,18 +178,9 @@ Zca_c_sw_cg_cp_rs2_p_b11:
   c.sw x11, 108(x14) # perform store
   addi x14, x14, 108 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zca_c_sw_cg_cp_rs2_p_b11, Zca_c_sw_cg_cp_rs2_p_b11_str)
-#else
-  c.sw x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x09f7a1dc
@@ -298,18 +190,9 @@ Zca_c_sw_cg_cp_rs2_p_b12:
   c.sw x12, 120(x13) # perform store
   addi x13, x13, 120 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x10 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x10, Zca_c_sw_cg_cp_rs2_p_b12, Zca_c_sw_cg_cp_rs2_p_b12_str)
-#else
-  c.sw x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x10, x13 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2_p (Test source rs2 = x13)
@@ -320,18 +203,9 @@ Zca_c_sw_cg_cp_rs2_p_b13:
   c.sw x13, 92(x9) # perform store
   addi x9, x9, 92 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sw_cg_cp_rs2_p_b13, Zca_c_sw_cg_cp_rs2_p_b13_str)
-#else
-  c.sw x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xadbbe3cb
@@ -341,18 +215,9 @@ Zca_c_sw_cg_cp_rs2_p_b14:
   c.sw x14, 76(x8) # perform store
   addi x8, x8, 76 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, Zca_c_sw_cg_cp_rs2_p_b14, Zca_c_sw_cg_cp_rs2_p_b14_str)
-#else
-  c.sw x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x98702264
@@ -362,18 +227,9 @@ Zca_c_sw_cg_cp_rs2_p_b15:
   c.sw x15, 36(x10) # perform store
   addi x10, x10, 36 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zca_c_sw_cg_cp_rs2_p_b15, Zca_c_sw_cg_cp_rs2_p_b15_str)
-#else
-  c.sw x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -387,18 +243,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x0:
   c.sw x13, 68(x9) # perform store
   addi x9, x9, 68 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sw_cg_cp_rs2_edges_0x0, Zca_c_sw_cg_cp_rs2_edges_0x0_str)
-#else
-  c.sw x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x00000001
@@ -408,18 +255,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x1:
   c.sw x14, 60(x10) # perform store
   addi x10, x10, 60 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0x1, Zca_c_sw_cg_cp_rs2_edges_0x1_str)
-#else
-  c.sw x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x00000002
@@ -429,18 +267,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x2:
   c.sw x12, 80(x9) # perform store
   addi x9, x9, 80 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sw_cg_cp_rs2_edges_0x2, Zca_c_sw_cg_cp_rs2_edges_0x2_str)
-#else
-  c.sw x12, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x80000000
@@ -450,18 +279,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x80000000:
   c.sw x11, 104(x13) # perform store
   addi x13, x13, 104 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0x80000000, Zca_c_sw_cg_cp_rs2_edges_0x80000000_str)
-#else
-  c.sw x11, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x80000001
@@ -471,18 +291,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x80000001:
   c.sw x15, 36(x12) # perform store
   addi x12, x12, 36 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_sw_cg_cp_rs2_edges_0x80000001, Zca_c_sw_cg_cp_rs2_edges_0x80000001_str)
-#else
-  c.sw x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x7fffffff
@@ -492,18 +303,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x7fffffff:
   c.sw x8, 124(x14) # perform store
   addi x14, x14, 124 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zca_c_sw_cg_cp_rs2_edges_0x7fffffff, Zca_c_sw_cg_cp_rs2_edges_0x7fffffff_str)
-#else
-  c.sw x8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x7ffffffe
@@ -513,18 +315,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x7ffffffe:
   c.sw x9, 44(x13) # perform store
   addi x13, x13, 44 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, Zca_c_sw_cg_cp_rs2_edges_0x7ffffffe, Zca_c_sw_cg_cp_rs2_edges_0x7ffffffe_str)
-#else
-  c.sw x9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xffffffff
@@ -534,18 +327,9 @@ Zca_c_sw_cg_cp_rs2_edges_0xffffffff:
   c.sw x15, 124(x8) # perform store
   addi x8, x8, 124 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zca_c_sw_cg_cp_rs2_edges_0xffffffff, Zca_c_sw_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  c.sw x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xfffffffe
@@ -555,18 +339,9 @@ Zca_c_sw_cg_cp_rs2_edges_0xfffffffe:
   c.sw x15, 8(x10) # perform store
   addi x10, x10, 8 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0xfffffffe, Zca_c_sw_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  c.sw x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x5bbc8872
@@ -576,18 +351,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x5bbc8872:
   c.sw x14, 24(x13) # perform store
   addi x13, x13, 24 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, Zca_c_sw_cg_cp_rs2_edges_0x5bbc8872, Zca_c_sw_cg_cp_rs2_edges_0x5bbc8872_str)
-#else
-  c.sw x14, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xaaaaaaaa
@@ -597,18 +363,9 @@ Zca_c_sw_cg_cp_rs2_edges_0xaaaaaaaa:
   c.sw x8, 44(x14) # perform store
   addi x14, x14, 44 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zca_c_sw_cg_cp_rs2_edges_0xaaaaaaaa, Zca_c_sw_cg_cp_rs2_edges_0xaaaaaaaa_str)
-#else
-  c.sw x8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x55555555
@@ -618,18 +375,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x55555555:
   c.sw x8, 28(x10) # perform store
   addi x10, x10, 28 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, Zca_c_sw_cg_cp_rs2_edges_0x55555555, Zca_c_sw_cg_cp_rs2_edges_0x55555555_str)
-#else
-  c.sw x8, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_mul
@@ -643,18 +391,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x0:
   c.sw x12, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x0, Zca_c_sw_cg_cp_imm_mul_b0x0_str)
-#else
-  c.sw x12, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=4
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x54c5a6df
@@ -664,18 +403,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x4:
   c.sw x15, 4(x9) # perform store
   addi x9, x9, 4 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x4, Zca_c_sw_cg_cp_imm_mul_b0x4_str)
-#else
-  c.sw x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=8
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xcdadf9f3
@@ -685,18 +415,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x8:
   c.sw x8, 8(x13) # perform store
   addi x13, x13, 8 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, Zca_c_sw_cg_cp_imm_mul_b0x8, Zca_c_sw_cg_cp_imm_mul_b0x8_str)
-#else
-  c.sw x8, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=12
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x9ef0eb6b
@@ -706,18 +427,9 @@ Zca_c_sw_cg_cp_imm_mul_b0xc:
   c.sw x11, 12(x10) # perform store
   addi x10, x10, 12 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0xc, Zca_c_sw_cg_cp_imm_mul_b0xc_str)
-#else
-  c.sw x11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=16
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x6dd9e2ac
@@ -727,18 +439,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x10:
   c.sw x9, 16(x13) # perform store
   addi x13, x13, 16 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, Zca_c_sw_cg_cp_imm_mul_b0x10, Zca_c_sw_cg_cp_imm_mul_b0x10_str)
-#else
-  c.sw x9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=20
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x99294280
@@ -748,18 +451,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x14:
   c.sw x12, 20(x10) # perform store
   addi x10, x10, 20 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x14, Zca_c_sw_cg_cp_imm_mul_b0x14_str)
-#else
-  c.sw x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=24
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x07eda632
@@ -769,18 +463,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x18:
   c.sw x14, 24(x12) # perform store
   addi x12, x12, 24 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x18, Zca_c_sw_cg_cp_imm_mul_b0x18_str)
-#else
-  c.sw x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=28
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xc51f04ac
@@ -790,18 +475,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x1c:
   c.sw x15, 28(x10) # perform store
   addi x10, x10, 28 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x11 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x11, Zca_c_sw_cg_cp_imm_mul_b0x1c, Zca_c_sw_cg_cp_imm_mul_b0x1c_str)
-#else
-  c.sw x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=32
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xfa076c96
@@ -811,18 +487,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x20:
   c.sw x9, 32(x11) # perform store
   addi x11, x11, 32 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x20, Zca_c_sw_cg_cp_imm_mul_b0x20_str)
-#else
-  c.sw x9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=36
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x434fa245
@@ -832,18 +499,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x24:
   c.sw x9, 36(x13) # perform store
   addi x13, x13, 36 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x24, Zca_c_sw_cg_cp_imm_mul_b0x24_str)
-#else
-  c.sw x9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=40
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xd4cb6f52
@@ -853,18 +511,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x28:
   c.sw x15, 40(x12) # perform store
   addi x12, x12, 40 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x10 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x10, Zca_c_sw_cg_cp_imm_mul_b0x28, Zca_c_sw_cg_cp_imm_mul_b0x28_str)
-#else
-  c.sw x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=44
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xc2afe81b
@@ -874,18 +523,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x2c:
   c.sw x11, 44(x14) # perform store
   addi x14, x14, 44 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zca_c_sw_cg_cp_imm_mul_b0x2c, Zca_c_sw_cg_cp_imm_mul_b0x2c_str)
-#else
-  c.sw x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=48
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x47c949f6
@@ -895,18 +535,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x30:
   c.sw x8, 48(x9) # perform store
   addi x9, x9, 48 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sw_cg_cp_imm_mul_b0x30, Zca_c_sw_cg_cp_imm_mul_b0x30_str)
-#else
-  c.sw x8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=52
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xbf9e949b
@@ -916,18 +547,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x34:
   c.sw x14, 52(x15) # perform store
   addi x15, x15, 52 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, Zca_c_sw_cg_cp_imm_mul_b0x34, Zca_c_sw_cg_cp_imm_mul_b0x34_str)
-#else
-  c.sw x14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=56
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x014e7343
@@ -937,18 +559,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x38:
   c.sw x14, 56(x8) # perform store
   addi x8, x8, 56 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x38, Zca_c_sw_cg_cp_imm_mul_b0x38_str)
-#else
-  c.sw x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=60
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xc8bd8246
@@ -958,18 +571,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x3c:
   c.sw x12, 60(x13) # perform store
   addi x13, x13, 60 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, Zca_c_sw_cg_cp_imm_mul_b0x3c, Zca_c_sw_cg_cp_imm_mul_b0x3c_str)
-#else
-  c.sw x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=64
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x26497930
@@ -979,18 +583,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x40:
   c.sw x12, 64(x8) # perform store
   addi x8, x8, 64 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, Zca_c_sw_cg_cp_imm_mul_b0x40, Zca_c_sw_cg_cp_imm_mul_b0x40_str)
-#else
-  c.sw x12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=68
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x7eac658f
@@ -1000,18 +595,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x44:
   c.sw x11, 68(x15) # perform store
   addi x15, x15, 68 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x9 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x9, Zca_c_sw_cg_cp_imm_mul_b0x44, Zca_c_sw_cg_cp_imm_mul_b0x44_str)
-#else
-  c.sw x11, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=72
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xe0865ea9
@@ -1021,18 +607,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x48:
   c.sw x9, 72(x8) # perform store
   addi x8, x8, 72 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x48, Zca_c_sw_cg_cp_imm_mul_b0x48_str)
-#else
-  c.sw x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=76
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x46275248
@@ -1042,18 +619,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x4c:
   c.sw x15, 76(x13) # perform store
   addi x13, x13, 76 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x4c, Zca_c_sw_cg_cp_imm_mul_b0x4c_str)
-#else
-  c.sw x15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=80
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x66813e8a
@@ -1063,18 +631,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x50:
   c.sw x8, 80(x11) # perform store
   addi x11, x11, 80 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_sw_cg_cp_imm_mul_b0x50, Zca_c_sw_cg_cp_imm_mul_b0x50_str)
-#else
-  c.sw x8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=84
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xf10133dd
@@ -1084,18 +643,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x54:
   c.sw x12, 84(x10) # perform store
   addi x10, x10, 84 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x9 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x9, Zca_c_sw_cg_cp_imm_mul_b0x54, Zca_c_sw_cg_cp_imm_mul_b0x54_str)
-#else
-  c.sw x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=88
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x5e8f4fc4
@@ -1105,18 +655,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x58:
   c.sw x13, 88(x9) # perform store
   addi x9, x9, 88 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sw_cg_cp_imm_mul_b0x58, Zca_c_sw_cg_cp_imm_mul_b0x58_str)
-#else
-  c.sw x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=92
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x6a7599a7
@@ -1126,18 +667,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x5c:
   c.sw x11, 92(x14) # perform store
   addi x14, x14, 92 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x5c, Zca_c_sw_cg_cp_imm_mul_b0x5c_str)
-#else
-  c.sw x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=96
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x038caa1d
@@ -1147,18 +679,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x60:
   c.sw x10, 96(x8) # perform store
   addi x8, x8, 96 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x60, Zca_c_sw_cg_cp_imm_mul_b0x60_str)
-#else
-  c.sw x10, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=100
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x36dbaa03
@@ -1168,18 +691,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x64:
   c.sw x13, 100(x11) # perform store
   addi x11, x11, 100 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x64, Zca_c_sw_cg_cp_imm_mul_b0x64_str)
-#else
-  c.sw x13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=104
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xa58a3631
@@ -1189,18 +703,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x68:
   c.sw x8, 104(x13) # perform store
   addi x13, x13, 104 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x68, Zca_c_sw_cg_cp_imm_mul_b0x68_str)
-#else
-  c.sw x8, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=108
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x41cc88af
@@ -1210,18 +715,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x6c:
   c.sw x11, 108(x12) # perform store
   addi x12, x12, 108 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x6c, Zca_c_sw_cg_cp_imm_mul_b0x6c_str)
-#else
-  c.sw x11, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=112
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xf1ef075e
@@ -1231,18 +727,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x70:
   c.sw x15, 112(x14) # perform store
   addi x14, x14, 112 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x70, Zca_c_sw_cg_cp_imm_mul_b0x70_str)
-#else
-  c.sw x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=116
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x7db92205
@@ -1252,18 +739,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x74:
   c.sw x8, 116(x12) # perform store
   addi x12, x12, 116 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x13 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x13, Zca_c_sw_cg_cp_imm_mul_b0x74, Zca_c_sw_cg_cp_imm_mul_b0x74_str)
-#else
-  c.sw x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=120
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x6d6759cc
@@ -1273,18 +751,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x78:
   c.sw x13, 120(x14) # perform store
   addi x14, x14, 120 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x78, Zca_c_sw_cg_cp_imm_mul_b0x78_str)
-#else
-  c.sw x13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=124
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xadae6b9f
@@ -1294,18 +763,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x7c:
   c.sw x12, 124(x8) # perform store
   addi x8, x8, 124 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zca_c_sw_cg_cp_imm_mul_b0x7c, Zca_c_sw_cg_cp_imm_mul_b0x7c_str)
-#else
-  c.sw x12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x8 # restore signature pointer to default register for teardown
 

--- a/tests/rv32e/Zca/Zca-c.swsp-00.S
+++ b/tests/rv32e/Zca/Zca-c.swsp-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 194
+#define SIGUPD_COUNT 102
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -39,57 +39,27 @@ RVTEST_BEGIN
   addi sp, x9, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b0:
   c.swsp x0, 32(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_swsp_cg_cp_rs2_b0, Zca_c_swsp_cg_cp_rs2_b0_str)
-#else
-  addi sp, sp, 32 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0x591f45ae
   addi sp, x9, -116  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b1:
   c.swsp x1, 116(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_swsp_cg_cp_rs2_b1, Zca_c_swsp_cg_cp_rs2_b1_str)
-#else
-  addi sp, sp, 116 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x1, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0xd0eda5be
   addi sp, x9, -168  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b2:
   c.swsp x2, 168(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_swsp_cg_cp_rs2_b2, Zca_c_swsp_cg_cp_rs2_b2_str)
-#else
-  addi sp, sp, 168 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x2, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x2, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x3)
@@ -98,19 +68,9 @@ Zca_c_swsp_cg_cp_rs2_b2:
   addi sp, x9, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b3:
   c.swsp x3, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_swsp_cg_cp_rs2_b3, Zca_c_swsp_cg_cp_rs2_b3_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -119,57 +79,27 @@ Zca_c_swsp_cg_cp_rs2_b3:
   addi sp, x9, -28  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b4:
   c.swsp x4, 28(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_b4, Zca_c_swsp_cg_cp_rs2_b4_str)
-#else
-  addi sp, sp, 28 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x4, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0xde3eab3a
   addi sp, x9, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b5:
   c.swsp x5, 232(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_b5, Zca_c_swsp_cg_cp_rs2_b5_str)
-#else
-  addi sp, sp, 232 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x6cbdaad0
   addi sp, x9, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b6:
   c.swsp x6, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_b6, Zca_c_swsp_cg_cp_rs2_b6_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x13, x7 # switch temp register to avoid conflict with test
   mv x14, x8 # switch link pointer register to avoid conflict with test
@@ -178,38 +108,18 @@ Zca_c_swsp_cg_cp_rs2_b6:
   addi sp, x9, -204  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b7:
   c.swsp x7, 204(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x15, Zca_c_swsp_cg_cp_rs2_b7, Zca_c_swsp_cg_cp_rs2_b7_str)
-#else
-  addi sp, sp, 204 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x7, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xd984615f
   addi sp, x9, -236  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b8:
   c.swsp x8, 236(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x6, Zca_c_swsp_cg_cp_rs2_b8, Zca_c_swsp_cg_cp_rs2_b8_str)
-#else
-  addi sp, sp, 236 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x8, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x10, x9 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x9)
@@ -217,19 +127,9 @@ Zca_c_swsp_cg_cp_rs2_b8:
   addi sp, x10, -140  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b9:
   c.swsp x9, 140(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x15, Zca_c_swsp_cg_cp_rs2_b9, Zca_c_swsp_cg_cp_rs2_b9_str)
-#else
-  addi sp, sp, 140 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x2, x10 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x10)
@@ -238,57 +138,27 @@ Zca_c_swsp_cg_cp_rs2_b9:
   addi sp, x15, -8  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b10:
   c.swsp x10, 8(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x15) # load stored value for checking
   # Check if x4 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x15, x14, x13, x4, Zca_c_swsp_cg_cp_rs2_b10, Zca_c_swsp_cg_cp_rs2_b10_str)
-#else
-  addi sp, sp, 8 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x49ae7932
   addi sp, x15, -72  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b11:
   c.swsp x11, 72(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x15) # load stored value for checking
   # Check if x6 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x15, x14, x13, x6, Zca_c_swsp_cg_cp_rs2_b11, Zca_c_swsp_cg_cp_rs2_b11_str)
-#else
-  addi sp, sp, 72 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xc6609195
   addi sp, x15, -88  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b12:
   c.swsp x12, 88(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x15) # load stored value for checking
   # Check if x9 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x15, x14, x13, x9, Zca_c_swsp_cg_cp_rs2_b12, Zca_c_swsp_cg_cp_rs2_b12_str)
-#else
-  addi sp, sp, 88 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x7, x13 # switch temp register to avoid conflict with test
   mv x8, x14 # switch link pointer register to avoid conflict with test
@@ -297,38 +167,18 @@ Zca_c_swsp_cg_cp_rs2_b12:
   addi sp, x15, -36  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b13:
   c.swsp x13, 36(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x15, x8, x7, x10, Zca_c_swsp_cg_cp_rs2_b13, Zca_c_swsp_cg_cp_rs2_b13_str)
-#else
-  addi sp, sp, 36 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x4c38b7b2
   addi sp, x15, -72  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b14:
   c.swsp x14, 72(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x15) # load stored value for checking
   # Check if x5 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x15, x8, x7, x5, Zca_c_swsp_cg_cp_rs2_b14, Zca_c_swsp_cg_cp_rs2_b14_str)
-#else
-  addi sp, sp, 72 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x9, x15 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x15)
@@ -336,19 +186,9 @@ Zca_c_swsp_cg_cp_rs2_b14:
   addi sp, x9, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b15:
   c.swsp x15, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_rs2_b15, Zca_c_swsp_cg_cp_rs2_b15_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -359,228 +199,108 @@ Zca_c_swsp_cg_cp_rs2_b15:
   addi sp, x9, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x0:
   c.swsp x4, 16(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_rs2_edges_0x0, Zca_c_swsp_cg_cp_rs2_edges_0x0_str)
-#else
-  addi sp, sp, 16 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x4, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x00000001
   addi sp, x9, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x1:
   c.swsp x14, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0x1, Zca_c_swsp_cg_cp_rs2_edges_0x1_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
   RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x00000002
   addi sp, x9, -44  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x2:
   c.swsp x5, 44(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x13, Zca_c_swsp_cg_cp_rs2_edges_0x2, Zca_c_swsp_cg_cp_rs2_edges_0x2_str)
-#else
-  addi sp, sp, 44 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x80000000
   addi sp, x9, -236  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x80000000:
   c.swsp x15, 236(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_edges_0x80000000, Zca_c_swsp_cg_cp_rs2_edges_0x80000000_str)
-#else
-  addi sp, sp, 236 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x80000001
   addi sp, x9, -4  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x80000001:
   c.swsp x14, 4(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x13, Zca_c_swsp_cg_cp_rs2_edges_0x80000001, Zca_c_swsp_cg_cp_rs2_edges_0x80000001_str)
-#else
-  addi sp, sp, 4 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x7fffffff
   addi sp, x9, -52  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff:
   c.swsp x6, 52(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff_str)
-#else
-  addi sp, sp, 52 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x7ffffffe
   addi sp, x9, -204  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe:
   c.swsp x5, 204(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe_str)
-#else
-  addi sp, sp, 204 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xffffffff
   addi sp, x9, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
   c.swsp x11, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xfffffffe
   addi sp, x9, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
   c.swsp x15, 240(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  addi sp, sp, 240 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x5bbc8872
   addi sp, x9, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872:
   c.swsp x13, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xaaaaaaaa
   addi sp, x9, -252  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa:
   c.swsp x11, 252(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa_str)
-#else
-  addi sp, sp, 252 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x55555555
   addi sp, x9, -228  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x55555555:
   c.swsp x3, 228(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_rs2_edges_0x55555555, Zca_c_swsp_cg_cp_rs2_edges_0x55555555_str)
-#else
-  addi sp, sp, 228 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_mul_4sp
@@ -591,1216 +311,576 @@ Zca_c_swsp_cg_cp_rs2_edges_0x55555555:
   addi sp, x9, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0:
   c.swsp x6, 0(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0_str)
-#else
-  addi sp, sp, 0 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=4
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x212852d1
   addi sp, x9, -4  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4:
   c.swsp x12, 4(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4_str)
-#else
-  addi sp, sp, 4 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=8
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xde9d49fb
   addi sp, x9, -8  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8:
   c.swsp x6, 8(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8_str)
-#else
-  addi sp, sp, 8 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=12
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x63ff9a0d
   addi sp, x9, -12  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc:
   c.swsp x3, 12(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc_str)
-#else
-  addi sp, sp, 12 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=16
   RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0xbe081e73
   addi sp, x9, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10:
   c.swsp x5, 16(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10_str)
-#else
-  addi sp, sp, 16 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=20
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xf630d861
   addi sp, x9, -20  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14:
   c.swsp x10, 20(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x9) # load stored value for checking
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14_str)
-#else
-  addi sp, sp, 20 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=24
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xb3a35dad
   addi sp, x9, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18:
   c.swsp x10, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x9) # load stored value for checking
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=28
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xf7c9a307
   addi sp, x9, -28  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c:
   c.swsp x12, 28(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c_str)
-#else
-  addi sp, sp, 28 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=32
   RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x2dc2d097
   addi sp, x9, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20:
   c.swsp x5, 32(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x9) # load stored value for checking
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20_str)
-#else
-  addi sp, sp, 32 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=36
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x6e9d4158
   addi sp, x9, -36  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24:
   c.swsp x10, 36(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24_str)
-#else
-  addi sp, sp, 36 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=40
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x926d86de
   addi sp, x9, -40  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28:
   c.swsp x13, 40(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28_str)
-#else
-  addi sp, sp, 40 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=44
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x0402a4fe
   addi sp, x9, -44  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
   c.swsp x6, 44(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c_str)
-#else
-  addi sp, sp, 44 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=48
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xb78a0b4b
   addi sp, x9, -48  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
   c.swsp x6, 48(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30_str)
-#else
-  addi sp, sp, 48 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=52
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x419d87b9
   addi sp, x9, -52  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
   c.swsp x11, 52(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34_str)
-#else
-  addi sp, sp, 52 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=56
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xdf3eea06
   addi sp, x9, -56  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
   c.swsp x15, 56(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38_str)
-#else
-  addi sp, sp, 56 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=60
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x2db624b0
   addi sp, x9, -60  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
   c.swsp x15, 60(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c_str)
-#else
-  addi sp, sp, 60 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=64
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xccf3cd83
   addi sp, x9, -64  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
   c.swsp x12, 64(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40_str)
-#else
-  addi sp, sp, 64 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=68
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x688d5237
   addi sp, x9, -68  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
   c.swsp x11, 68(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x9) # load stored value for checking
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44_str)
-#else
-  addi sp, sp, 68 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=72
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x1b13aa7d
   addi sp, x9, -72  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
   c.swsp x15, 72(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48_str)
-#else
-  addi sp, sp, 72 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=76
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x64c46502
   addi sp, x9, -76  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
   c.swsp x15, 76(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c_str)
-#else
-  addi sp, sp, 76 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=80
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x2ef80023
   addi sp, x9, -80  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
   c.swsp x6, 80(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50_str)
-#else
-  addi sp, sp, 80 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=84
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x1a9509f6
   addi sp, x9, -84  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
   c.swsp x0, 84(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x9) # load stored value for checking
   # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54_str)
-#else
-  addi sp, sp, 84 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=88
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xc18c3264
   addi sp, x9, -88  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
   c.swsp x2, 88(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58_str)
-#else
-  addi sp, sp, 88 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x2, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=92
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x80283a47
   addi sp, x9, -92  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
   c.swsp x6, 92(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c_str)
-#else
-  addi sp, sp, 92 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=96
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x068e9e00
   addi sp, x9, -96  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
   c.swsp x0, 96(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x9) # load stored value for checking
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60_str)
-#else
-  addi sp, sp, 96 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=100
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0xe87a0869
   addi sp, x9, -100  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
   c.swsp x0, 100(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64_str)
-#else
-  addi sp, sp, 100 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=104
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x25bff6fb
   addi sp, x9, -104  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
   c.swsp x12, 104(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x9) # load stored value for checking
   # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68_str)
-#else
-  addi sp, sp, 104 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=108
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x7e22c6d5
   addi sp, x9, -108  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
   c.swsp x14, 108(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c_str)
-#else
-  addi sp, sp, 108 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=112
   RVTEST_TESTDATA_LOAD_INT(x1, x4) # load rs2: x4 = 0x030293c6
   addi sp, x9, -112  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
   c.swsp x4, 112(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70_str)
-#else
-  addi sp, sp, 112 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x4, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=116
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xb4461515
   addi sp, x9, -116  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
   c.swsp x13, 116(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x9) # load stored value for checking
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74_str)
-#else
-  addi sp, sp, 116 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=120
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x2a4c1092
   addi sp, x9, -120  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
   c.swsp x6, 120(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x9) # load stored value for checking
   # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78_str)
-#else
-  addi sp, sp, 120 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=124
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x28842345
   addi sp, x9, -124  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
   c.swsp x12, 124(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c_str)
-#else
-  addi sp, sp, 124 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=128
   RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x1442f570
   addi sp, x9, -128  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
   c.swsp x5, 128(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x9) # load stored value for checking
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80_str)
-#else
-  addi sp, sp, 128 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=132
   RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x24a65a68
   addi sp, x9, -132  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
   c.swsp x5, 132(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84_str)
-#else
-  addi sp, sp, 132 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=136
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x6eefa15a
   addi sp, x9, -136  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
   c.swsp x14, 136(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x9) # load stored value for checking
   # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88_str)
-#else
-  addi sp, sp, 136 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=140
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x12412a8a
   addi sp, x9, -140  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
   c.swsp x15, 140(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c_str)
-#else
-  addi sp, sp, 140 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=144
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x1719b70c
   addi sp, x9, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
   c.swsp x10, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=148
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x5e38ff0e
   addi sp, x9, -148  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
   c.swsp x3, 148(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94_str)
-#else
-  addi sp, sp, 148 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=152
   RVTEST_TESTDATA_LOAD_INT(x1, x4) # load rs2: x4 = 0x9b99e043
   addi sp, x9, -152  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
   c.swsp x4, 152(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98_str)
-#else
-  addi sp, sp, 152 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x4, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=156
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x912f8b40
   addi sp, x9, -156  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
   c.swsp x14, 156(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c_str)
-#else
-  addi sp, sp, 156 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=160
   RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0xbe6fd0d3
   addi sp, x9, -160  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
   c.swsp x5, 160(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0_str)
-#else
-  addi sp, sp, 160 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=164
   RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0xc76e4eac
   addi sp, x9, -164  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
   c.swsp x5, 164(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x9) # load stored value for checking
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4_str)
-#else
-  addi sp, sp, 164 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=168
   RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0xfe6286b1
   addi sp, x9, -168  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
   c.swsp x5, 168(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8_str)
-#else
-  addi sp, sp, 168 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=172
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xe7279c63
   addi sp, x9, -172  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
   c.swsp x3, 172(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac_str)
-#else
-  addi sp, sp, 172 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=176
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0xf2f89694
   addi sp, x9, -176  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
   c.swsp x0, 176(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x9) # load stored value for checking
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0_str)
-#else
-  addi sp, sp, 176 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=180
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xbbddc34d
   addi sp, x9, -180  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
   c.swsp x6, 180(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4_str)
-#else
-  addi sp, sp, 180 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=184
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xff34c182
   addi sp, x9, -184  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
   c.swsp x10, 184(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8_str)
-#else
-  addi sp, sp, 184 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=188
   RVTEST_TESTDATA_LOAD_INT(x1, x4) # load rs2: x4 = 0x3dd4f217
   addi sp, x9, -188  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
   c.swsp x4, 188(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc_str)
-#else
-  addi sp, sp, 188 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x4, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=192
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xfe3a31b4
   addi sp, x9, -192  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
   c.swsp x13, 192(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0_str)
-#else
-  addi sp, sp, 192 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=196
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x1a38a42b
   addi sp, x9, -196  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
   c.swsp x10, 196(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x9) # load stored value for checking
   # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4_str)
-#else
-  addi sp, sp, 196 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=200
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xf4ac6d36
   addi sp, x9, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
   c.swsp x11, 200(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8_str)
-#else
-  addi sp, sp, 200 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=204
   RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x67a37c7e
   addi sp, x9, -204  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
   c.swsp x5, 204(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc_str)
-#else
-  addi sp, sp, 204 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=208
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x5c00883f
   addi sp, x9, -208  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
   c.swsp x13, 208(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x9) # load stored value for checking
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0_str)
-#else
-  addi sp, sp, 208 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=212
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xce57c134
   addi sp, x9, -212  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
   c.swsp x12, 212(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x9) # load stored value for checking
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4_str)
-#else
-  addi sp, sp, 212 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=216
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xd74f79ef
   addi sp, x9, -216  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
   c.swsp x6, 216(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8_str)
-#else
-  addi sp, sp, 216 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=220
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x6b889049
   addi sp, x9, -220  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
   c.swsp x6, 220(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc_str)
-#else
-  addi sp, sp, 220 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=224
   RVTEST_TESTDATA_LOAD_INT(x1, x4) # load rs2: x4 = 0x54a09b6b
   addi sp, x9, -224  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
   c.swsp x4, 224(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0_str)
-#else
-  addi sp, sp, 224 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x4, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=228
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x196dee6f
   addi sp, x9, -228  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
   c.swsp x12, 228(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4_str)
-#else
-  addi sp, sp, 228 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=232
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xcccf5ac6
   addi sp, x9, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
   c.swsp x13, 232(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8_str)
-#else
-  addi sp, sp, 232 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=236
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x0a25908f
   addi sp, x9, -236  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
   c.swsp x14, 236(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec_str)
-#else
-  addi sp, sp, 236 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=240
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x90229d22
   addi sp, x9, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
   c.swsp x3, 240(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x9) # load stored value for checking
   # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0_str)
-#else
-  addi sp, sp, 240 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=244
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x770bf921
   addi sp, x9, -244  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
   c.swsp x0, 244(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4_str)
-#else
-  addi sp, sp, 244 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=248
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xb44a4f10
   addi sp, x9, -248  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
   c.swsp x15, 248(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8_str)
-#else
-  addi sp, sp, 248 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=252
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x6e70fb89
   addi sp, x9, -252  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc:
   c.swsp x14, 252(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x9) # load stored value for checking
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc_str)
-#else
-  addi sp, sp, 252 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x2, x9 # restore signature pointer to default register for teardown
 

--- a/tests/rv32e/Zca/Zca-c.swsp-00.S
+++ b/tests/rv32e/Zca/Zca-c.swsp-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 102
+#define SIGUPD_COUNT 194
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -40,6 +40,7 @@ RVTEST_BEGIN
 Zca_c_swsp_cg_cp_rs2_b0:
   c.swsp x0, 32(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_swsp_cg_cp_rs2_b0, Zca_c_swsp_cg_cp_rs2_b0_str)
 
@@ -49,6 +50,7 @@ Zca_c_swsp_cg_cp_rs2_b0:
 Zca_c_swsp_cg_cp_rs2_b1:
   c.swsp x1, 116(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_swsp_cg_cp_rs2_b1, Zca_c_swsp_cg_cp_rs2_b1_str)
 
@@ -58,6 +60,7 @@ Zca_c_swsp_cg_cp_rs2_b1:
 Zca_c_swsp_cg_cp_rs2_b2:
   c.swsp x2, 168(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_swsp_cg_cp_rs2_b2, Zca_c_swsp_cg_cp_rs2_b2_str)
 
@@ -69,6 +72,7 @@ Zca_c_swsp_cg_cp_rs2_b2:
 Zca_c_swsp_cg_cp_rs2_b3:
   c.swsp x3, 24(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_swsp_cg_cp_rs2_b3, Zca_c_swsp_cg_cp_rs2_b3_str)
 
@@ -80,6 +84,7 @@ Zca_c_swsp_cg_cp_rs2_b3:
 Zca_c_swsp_cg_cp_rs2_b4:
   c.swsp x4, 28(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_b4, Zca_c_swsp_cg_cp_rs2_b4_str)
 
@@ -89,6 +94,7 @@ Zca_c_swsp_cg_cp_rs2_b4:
 Zca_c_swsp_cg_cp_rs2_b5:
   c.swsp x5, 232(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_b5, Zca_c_swsp_cg_cp_rs2_b5_str)
 
@@ -98,6 +104,7 @@ Zca_c_swsp_cg_cp_rs2_b5:
 Zca_c_swsp_cg_cp_rs2_b6:
   c.swsp x6, 144(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_b6, Zca_c_swsp_cg_cp_rs2_b6_str)
 
@@ -109,6 +116,7 @@ Zca_c_swsp_cg_cp_rs2_b6:
 Zca_c_swsp_cg_cp_rs2_b7:
   c.swsp x7, 204(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x15, Zca_c_swsp_cg_cp_rs2_b7, Zca_c_swsp_cg_cp_rs2_b7_str)
 
@@ -118,6 +126,7 @@ Zca_c_swsp_cg_cp_rs2_b7:
 Zca_c_swsp_cg_cp_rs2_b8:
   c.swsp x8, 236(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x6, Zca_c_swsp_cg_cp_rs2_b8, Zca_c_swsp_cg_cp_rs2_b8_str)
 
@@ -128,6 +137,7 @@ Zca_c_swsp_cg_cp_rs2_b8:
 Zca_c_swsp_cg_cp_rs2_b9:
   c.swsp x9, 140(sp) # perform store
   LREG x15, 0(x10) # load stored value for checking
+  addi x10, x10, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x15, Zca_c_swsp_cg_cp_rs2_b9, Zca_c_swsp_cg_cp_rs2_b9_str)
 
@@ -139,6 +149,7 @@ Zca_c_swsp_cg_cp_rs2_b9:
 Zca_c_swsp_cg_cp_rs2_b10:
   c.swsp x10, 8(sp) # perform store
   LREG x4, 0(x15) # load stored value for checking
+  addi x15, x15, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x15, x14, x13, x4, Zca_c_swsp_cg_cp_rs2_b10, Zca_c_swsp_cg_cp_rs2_b10_str)
 
@@ -148,6 +159,7 @@ Zca_c_swsp_cg_cp_rs2_b10:
 Zca_c_swsp_cg_cp_rs2_b11:
   c.swsp x11, 72(sp) # perform store
   LREG x6, 0(x15) # load stored value for checking
+  addi x15, x15, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x15, x14, x13, x6, Zca_c_swsp_cg_cp_rs2_b11, Zca_c_swsp_cg_cp_rs2_b11_str)
 
@@ -157,6 +169,7 @@ Zca_c_swsp_cg_cp_rs2_b11:
 Zca_c_swsp_cg_cp_rs2_b12:
   c.swsp x12, 88(sp) # perform store
   LREG x9, 0(x15) # load stored value for checking
+  addi x15, x15, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x15, x14, x13, x9, Zca_c_swsp_cg_cp_rs2_b12, Zca_c_swsp_cg_cp_rs2_b12_str)
 
@@ -168,6 +181,7 @@ Zca_c_swsp_cg_cp_rs2_b12:
 Zca_c_swsp_cg_cp_rs2_b13:
   c.swsp x13, 36(sp) # perform store
   LREG x10, 0(x15) # load stored value for checking
+  addi x15, x15, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x15, x8, x7, x10, Zca_c_swsp_cg_cp_rs2_b13, Zca_c_swsp_cg_cp_rs2_b13_str)
 
@@ -177,6 +191,7 @@ Zca_c_swsp_cg_cp_rs2_b13:
 Zca_c_swsp_cg_cp_rs2_b14:
   c.swsp x14, 72(sp) # perform store
   LREG x5, 0(x15) # load stored value for checking
+  addi x15, x15, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x15, x8, x7, x5, Zca_c_swsp_cg_cp_rs2_b14, Zca_c_swsp_cg_cp_rs2_b14_str)
 
@@ -187,6 +202,7 @@ Zca_c_swsp_cg_cp_rs2_b14:
 Zca_c_swsp_cg_cp_rs2_b15:
   c.swsp x15, 24(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_rs2_b15, Zca_c_swsp_cg_cp_rs2_b15_str)
 
@@ -200,6 +216,7 @@ Zca_c_swsp_cg_cp_rs2_b15:
 Zca_c_swsp_cg_cp_rs2_edges_0x0:
   c.swsp x4, 16(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_rs2_edges_0x0, Zca_c_swsp_cg_cp_rs2_edges_0x0_str)
 
@@ -209,6 +226,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x0:
 Zca_c_swsp_cg_cp_rs2_edges_0x1:
   c.swsp x14, 144(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0x1, Zca_c_swsp_cg_cp_rs2_edges_0x1_str)
 
@@ -218,6 +236,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x1:
 Zca_c_swsp_cg_cp_rs2_edges_0x2:
   c.swsp x5, 44(sp) # perform store
   LREG x13, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x13, Zca_c_swsp_cg_cp_rs2_edges_0x2, Zca_c_swsp_cg_cp_rs2_edges_0x2_str)
 
@@ -227,6 +246,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x2:
 Zca_c_swsp_cg_cp_rs2_edges_0x80000000:
   c.swsp x15, 236(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_edges_0x80000000, Zca_c_swsp_cg_cp_rs2_edges_0x80000000_str)
 
@@ -236,6 +256,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x80000000:
 Zca_c_swsp_cg_cp_rs2_edges_0x80000001:
   c.swsp x14, 4(sp) # perform store
   LREG x13, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x13, Zca_c_swsp_cg_cp_rs2_edges_0x80000001, Zca_c_swsp_cg_cp_rs2_edges_0x80000001_str)
 
@@ -245,6 +266,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x80000001:
 Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff:
   c.swsp x6, 52(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff_str)
 
@@ -254,6 +276,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff:
 Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe:
   c.swsp x5, 204(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe_str)
 
@@ -263,6 +286,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe:
 Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
   c.swsp x11, 144(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff_str)
 
@@ -272,6 +296,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
 Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
   c.swsp x15, 240(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe_str)
 
@@ -281,6 +306,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
 Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872:
   c.swsp x13, 144(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872_str)
 
@@ -290,6 +316,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872:
 Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa:
   c.swsp x11, 252(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa_str)
 
@@ -299,6 +326,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa:
 Zca_c_swsp_cg_cp_rs2_edges_0x55555555:
   c.swsp x3, 228(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_rs2_edges_0x55555555, Zca_c_swsp_cg_cp_rs2_edges_0x55555555_str)
 
@@ -312,6 +340,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x55555555:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0:
   c.swsp x6, 0(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0_str)
 
@@ -321,6 +350,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4:
   c.swsp x12, 4(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4_str)
 
@@ -330,6 +360,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8:
   c.swsp x6, 8(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8_str)
 
@@ -339,6 +370,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc:
   c.swsp x3, 12(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc_str)
 
@@ -348,6 +380,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10:
   c.swsp x5, 16(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10_str)
 
@@ -357,6 +390,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14:
   c.swsp x10, 20(sp) # perform store
   LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14_str)
 
@@ -366,6 +400,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18:
   c.swsp x10, 24(sp) # perform store
   LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18_str)
 
@@ -375,6 +410,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c:
   c.swsp x12, 28(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c_str)
 
@@ -384,6 +420,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20:
   c.swsp x5, 32(sp) # perform store
   LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20_str)
 
@@ -393,6 +430,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24:
   c.swsp x10, 36(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24_str)
 
@@ -402,6 +440,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28:
   c.swsp x13, 40(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28_str)
 
@@ -411,6 +450,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
   c.swsp x6, 44(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c_str)
 
@@ -420,6 +460,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
   c.swsp x6, 48(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30_str)
 
@@ -429,6 +470,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
   c.swsp x11, 52(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34_str)
 
@@ -438,6 +480,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
   c.swsp x15, 56(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38_str)
 
@@ -447,6 +490,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
   c.swsp x15, 60(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c_str)
 
@@ -456,6 +500,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
   c.swsp x12, 64(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40_str)
 
@@ -465,6 +510,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
   c.swsp x11, 68(sp) # perform store
   LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44_str)
 
@@ -474,6 +520,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
   c.swsp x15, 72(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48_str)
 
@@ -483,6 +530,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
   c.swsp x15, 76(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c_str)
 
@@ -492,6 +540,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
   c.swsp x6, 80(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50_str)
 
@@ -501,6 +550,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
   c.swsp x0, 84(sp) # perform store
   LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54_str)
 
@@ -510,6 +560,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
   c.swsp x2, 88(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58_str)
 
@@ -519,6 +570,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
   c.swsp x6, 92(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c_str)
 
@@ -528,6 +580,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
   c.swsp x0, 96(sp) # perform store
   LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60_str)
 
@@ -537,6 +590,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
   c.swsp x0, 100(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64_str)
 
@@ -546,6 +600,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
   c.swsp x12, 104(sp) # perform store
   LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68_str)
 
@@ -555,6 +610,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
   c.swsp x14, 108(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c_str)
 
@@ -564,6 +620,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
   c.swsp x4, 112(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70_str)
 
@@ -573,6 +630,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
   c.swsp x13, 116(sp) # perform store
   LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74_str)
 
@@ -582,6 +640,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
   c.swsp x6, 120(sp) # perform store
   LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78_str)
 
@@ -591,6 +650,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
   c.swsp x12, 124(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c_str)
 
@@ -600,6 +660,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
   c.swsp x5, 128(sp) # perform store
   LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80_str)
 
@@ -609,6 +670,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
   c.swsp x5, 132(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84_str)
 
@@ -618,6 +680,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
   c.swsp x14, 136(sp) # perform store
   LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88_str)
 
@@ -627,6 +690,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
   c.swsp x15, 140(sp) # perform store
   LREG x13, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c_str)
 
@@ -636,6 +700,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
   c.swsp x10, 144(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90_str)
 
@@ -645,6 +710,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
   c.swsp x3, 148(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94_str)
 
@@ -654,6 +720,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
   c.swsp x4, 152(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98_str)
 
@@ -663,6 +730,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
   c.swsp x14, 156(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c_str)
 
@@ -672,6 +740,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
   c.swsp x5, 160(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0_str)
 
@@ -681,6 +750,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
   c.swsp x5, 164(sp) # perform store
   LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4_str)
 
@@ -690,6 +760,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
   c.swsp x5, 168(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8_str)
 
@@ -699,6 +770,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
   c.swsp x3, 172(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac_str)
 
@@ -708,6 +780,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
   c.swsp x0, 176(sp) # perform store
   LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0_str)
 
@@ -717,6 +790,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
   c.swsp x6, 180(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4_str)
 
@@ -726,6 +800,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
   c.swsp x10, 184(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8_str)
 
@@ -735,6 +810,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
   c.swsp x4, 188(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc_str)
 
@@ -744,6 +820,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
   c.swsp x13, 192(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0_str)
 
@@ -753,6 +830,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
   c.swsp x10, 196(sp) # perform store
   LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4_str)
 
@@ -762,6 +840,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
   c.swsp x11, 200(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8_str)
 
@@ -771,6 +850,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
   c.swsp x5, 204(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc_str)
 
@@ -780,6 +860,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
   c.swsp x13, 208(sp) # perform store
   LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0_str)
 
@@ -789,6 +870,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
   c.swsp x12, 212(sp) # perform store
   LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4_str)
 
@@ -798,6 +880,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
   c.swsp x6, 216(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8_str)
 
@@ -807,6 +890,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
   c.swsp x6, 220(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc_str)
 
@@ -816,6 +900,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
   c.swsp x4, 224(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0_str)
 
@@ -825,6 +910,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
   c.swsp x12, 228(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4_str)
 
@@ -834,6 +920,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
   c.swsp x13, 232(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8_str)
 
@@ -843,6 +930,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
   c.swsp x14, 236(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec_str)
 
@@ -852,6 +940,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
   c.swsp x3, 240(sp) # perform store
   LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0_str)
 
@@ -861,6 +950,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
   c.swsp x0, 244(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4_str)
 
@@ -870,6 +960,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
   c.swsp x15, 248(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8_str)
 
@@ -879,6 +970,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc:
   c.swsp x14, 252(sp) # perform store
   LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc_str)
 

--- a/tests/rv32e/Zcb/Zcb-c.sb-00.S
+++ b/tests/rv32e/Zcb/Zcb-c.sb-00.S
@@ -41,18 +41,9 @@ Zcb_c_sb_cg_cp_rs1_p_b8:
   c.sb x15, 1(x8) # perform store
   addi x8, x8, 1 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zcb_c_sb_cg_cp_rs1_p_b8, Zcb_c_sb_cg_cp_rs1_p_b8_str)
-#else
-  c.sb x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xdfe42a0e
@@ -62,18 +53,9 @@ Zcb_c_sb_cg_cp_rs1_p_b9:
   c.sb x15, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zcb_c_sb_cg_cp_rs1_p_b9, Zcb_c_sb_cg_cp_rs1_p_b9_str)
-#else
-  c.sb x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xf012096f
@@ -83,18 +65,9 @@ Zcb_c_sb_cg_cp_rs1_p_b10:
   c.sb x11, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zcb_c_sb_cg_cp_rs1_p_b10, Zcb_c_sb_cg_cp_rs1_p_b10_str)
-#else
-  c.sb x11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xac88cf00
@@ -104,18 +77,9 @@ Zcb_c_sb_cg_cp_rs1_p_b11:
   c.sb x12, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, Zcb_c_sb_cg_cp_rs1_p_b11, Zcb_c_sb_cg_cp_rs1_p_b11_str)
-#else
-  c.sb x12, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x11d95231
@@ -125,18 +89,9 @@ Zcb_c_sb_cg_cp_rs1_p_b12:
   c.sb x15, 1(x12) # perform store
   addi x12, x12, 1 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zcb_c_sb_cg_cp_rs1_p_b12, Zcb_c_sb_cg_cp_rs1_p_b12_str)
-#else
-  c.sb x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xb136bb4a
@@ -146,18 +101,9 @@ Zcb_c_sb_cg_cp_rs1_p_b13:
   c.sb x10, 2(x13) # perform store
   addi x13, x13, 2 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, Zcb_c_sb_cg_cp_rs1_p_b13, Zcb_c_sb_cg_cp_rs1_p_b13_str)
-#else
-  c.sb x10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x55491316
@@ -167,18 +113,9 @@ Zcb_c_sb_cg_cp_rs1_p_b14:
   c.sb x10, 3(x14) # perform store
   addi x14, x14, 3 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zcb_c_sb_cg_cp_rs1_p_b14, Zcb_c_sb_cg_cp_rs1_p_b14_str)
-#else
-  c.sb x10, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x2721414f
@@ -188,18 +125,9 @@ Zcb_c_sb_cg_cp_rs1_p_b15:
   c.sb x9, 0(x15) # perform store
   addi x15, x15, 0 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x8 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x8, Zcb_c_sb_cg_cp_rs1_p_b15, Zcb_c_sb_cg_cp_rs1_p_b15_str)
-#else
-  c.sb x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_p
@@ -213,18 +141,9 @@ Zcb_c_sb_cg_cp_rs2_p_b8:
   c.sb x8, 0(x12) # perform store
   addi x12, x12, 0 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zcb_c_sb_cg_cp_rs2_p_b8, Zcb_c_sb_cg_cp_rs2_p_b8_str)
-#else
-  c.sb x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x428801d9
@@ -234,18 +153,9 @@ Zcb_c_sb_cg_cp_rs2_p_b9:
   c.sb x9, 2(x14) # perform store
   addi x14, x14, 2 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zcb_c_sb_cg_cp_rs2_p_b9, Zcb_c_sb_cg_cp_rs2_p_b9_str)
-#else
-  c.sb x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x6365f1e3
@@ -255,18 +165,9 @@ Zcb_c_sb_cg_cp_rs2_p_b10:
   c.sb x10, 1(x9) # perform store
   addi x9, x9, 1 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zcb_c_sb_cg_cp_rs2_p_b10, Zcb_c_sb_cg_cp_rs2_p_b10_str)
-#else
-  c.sb x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xf8f97593
@@ -276,18 +177,9 @@ Zcb_c_sb_cg_cp_rs2_p_b11:
   c.sb x11, 0(x8) # perform store
   addi x8, x8, 0 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_p_b11, Zcb_c_sb_cg_cp_rs2_p_b11_str)
-#else
-  c.sb x11, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x5a15a429
@@ -297,18 +189,9 @@ Zcb_c_sb_cg_cp_rs2_p_b12:
   c.sb x12, 3(x9) # perform store
   addi x9, x9, 3 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_p_b12, Zcb_c_sb_cg_cp_rs2_p_b12_str)
-#else
-  c.sb x12, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xefa06588
@@ -318,18 +201,9 @@ Zcb_c_sb_cg_cp_rs2_p_b13:
   c.sb x13, 1(x10) # perform store
   addi x10, x10, 1 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, Zcb_c_sb_cg_cp_rs2_p_b13, Zcb_c_sb_cg_cp_rs2_p_b13_str)
-#else
-  c.sb x13, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xcef9066a
@@ -339,18 +213,9 @@ Zcb_c_sb_cg_cp_rs2_p_b14:
   c.sb x14, 1(x11) # perform store
   addi x11, x11, 1 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_p_b14, Zcb_c_sb_cg_cp_rs2_p_b14_str)
-#else
-  c.sb x14, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x1cdd0dd0
@@ -360,18 +225,9 @@ Zcb_c_sb_cg_cp_rs2_p_b15:
   c.sb x15, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, Zcb_c_sb_cg_cp_rs2_p_b15, Zcb_c_sb_cg_cp_rs2_p_b15_str)
-#else
-  c.sb x15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -385,18 +241,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x0:
   c.sb x12, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x9 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x9, Zcb_c_sb_cg_cp_rs2_edges_0x0, Zcb_c_sb_cg_cp_rs2_edges_0x0_str)
-#else
-  c.sb x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x00000001
@@ -406,18 +253,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x1:
   c.sb x8, 2(x11) # perform store
   addi x11, x11, 2 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, Zcb_c_sb_cg_cp_rs2_edges_0x1, Zcb_c_sb_cg_cp_rs2_edges_0x1_str)
-#else
-  c.sb x8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x00000002
@@ -427,18 +265,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x2:
   c.sb x8, 2(x15) # perform store
   addi x15, x15, 2 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x9 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x9, Zcb_c_sb_cg_cp_rs2_edges_0x2, Zcb_c_sb_cg_cp_rs2_edges_0x2_str)
-#else
-  c.sb x8, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x80000000
@@ -448,18 +277,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x80000000:
   c.sb x9, 3(x8) # perform store
   addi x8, x8, 3 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zcb_c_sb_cg_cp_rs2_edges_0x80000000, Zcb_c_sb_cg_cp_rs2_edges_0x80000000_str)
-#else
-  c.sb x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x80000001
@@ -469,18 +289,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x80000001:
   c.sb x9, 3(x15) # perform store
   addi x15, x15, 3 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_edges_0x80000001, Zcb_c_sb_cg_cp_rs2_edges_0x80000001_str)
-#else
-  c.sb x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x7fffffff
@@ -490,18 +301,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x7fffffff:
   c.sb x9, 3(x11) # perform store
   addi x11, x11, 3 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, Zcb_c_sb_cg_cp_rs2_edges_0x7fffffff, Zcb_c_sb_cg_cp_rs2_edges_0x7fffffff_str)
-#else
-  c.sb x9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x7ffffffe
@@ -511,18 +313,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x7ffffffe:
   c.sb x8, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_edges_0x7ffffffe, Zcb_c_sb_cg_cp_rs2_edges_0x7ffffffe_str)
-#else
-  c.sb x8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xffffffff
@@ -532,18 +325,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0xffffffff:
   c.sb x8, 3(x15) # perform store
   addi x15, x15, 3 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x11 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x11, Zcb_c_sb_cg_cp_rs2_edges_0xffffffff, Zcb_c_sb_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  c.sb x8, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xfffffffe
@@ -553,18 +337,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0xfffffffe:
   c.sb x14, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x11 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x11, Zcb_c_sb_cg_cp_rs2_edges_0xfffffffe, Zcb_c_sb_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  c.sb x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x5bbc8872
@@ -574,18 +349,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x5bbc8872:
   c.sb x12, 2(x9) # perform store
   addi x9, x9, 2 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zcb_c_sb_cg_cp_rs2_edges_0x5bbc8872, Zcb_c_sb_cg_cp_rs2_edges_0x5bbc8872_str)
-#else
-  c.sb x12, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xaaaaaaaa
@@ -595,18 +361,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0xaaaaaaaa:
   c.sb x11, 1(x14) # perform store
   addi x14, x14, 1 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_edges_0xaaaaaaaa, Zcb_c_sb_cg_cp_rs2_edges_0xaaaaaaaa_str)
-#else
-  c.sb x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x55555555
@@ -616,18 +373,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x55555555:
   c.sb x9, 2(x15) # perform store
   addi x15, x15, 2 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_edges_0x55555555, Zcb_c_sb_cg_cp_rs2_edges_0x55555555_str)
-#else
-  c.sb x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x15 # restore signature pointer to default register for teardown
 

--- a/tests/rv32e/Zcb/Zcb-c.sh-00.S
+++ b/tests/rv32e/Zcb/Zcb-c.sh-00.S
@@ -41,18 +41,9 @@ Zcb_c_sh_cg_cp_rs1_p_b8:
   c.sh x9, 2(x8) # perform store
   addi x8, x8, 2 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, Zcb_c_sh_cg_cp_rs1_p_b8, Zcb_c_sh_cg_cp_rs1_p_b8_str)
-#else
-  c.sh x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x891c7353
@@ -62,18 +53,9 @@ Zcb_c_sh_cg_cp_rs1_p_b9:
   c.sh x14, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zcb_c_sh_cg_cp_rs1_p_b9, Zcb_c_sh_cg_cp_rs1_p_b9_str)
-#else
-  c.sh x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x7b59b968
@@ -83,18 +65,9 @@ Zcb_c_sh_cg_cp_rs1_p_b10:
   c.sh x14, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zcb_c_sh_cg_cp_rs1_p_b10, Zcb_c_sh_cg_cp_rs1_p_b10_str)
-#else
-  c.sh x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x61a7cdcc
@@ -104,18 +77,9 @@ Zcb_c_sh_cg_cp_rs1_p_b11:
   c.sh x13, 2(x11) # perform store
   addi x11, x11, 2 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, Zcb_c_sh_cg_cp_rs1_p_b11, Zcb_c_sh_cg_cp_rs1_p_b11_str)
-#else
-  c.sh x13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xb59c3971
@@ -125,18 +89,9 @@ Zcb_c_sh_cg_cp_rs1_p_b12:
   c.sh x8, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zcb_c_sh_cg_cp_rs1_p_b12, Zcb_c_sh_cg_cp_rs1_p_b12_str)
-#else
-  c.sh x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x9719fe3b
@@ -146,18 +101,9 @@ Zcb_c_sh_cg_cp_rs1_p_b13:
   c.sh x9, 2(x13) # perform store
   addi x13, x13, 2 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, Zcb_c_sh_cg_cp_rs1_p_b13, Zcb_c_sh_cg_cp_rs1_p_b13_str)
-#else
-  c.sh x9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x0151d4a1
@@ -167,18 +113,9 @@ Zcb_c_sh_cg_cp_rs1_p_b14:
   c.sh x11, 2(x14) # perform store
   addi x14, x14, 2 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, Zcb_c_sh_cg_cp_rs1_p_b14, Zcb_c_sh_cg_cp_rs1_p_b14_str)
-#else
-  c.sh x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x47d28a74
@@ -188,18 +125,9 @@ Zcb_c_sh_cg_cp_rs1_p_b15:
   c.sh x12, 2(x15) # perform store
   addi x15, x15, 2 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, Zcb_c_sh_cg_cp_rs1_p_b15, Zcb_c_sh_cg_cp_rs1_p_b15_str)
-#else
-  c.sh x12, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_p
@@ -213,18 +141,9 @@ Zcb_c_sh_cg_cp_rs2_p_b8:
   c.sh x8, 0(x12) # perform store
   addi x12, x12, 0 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x9 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x9, Zcb_c_sh_cg_cp_rs2_p_b8, Zcb_c_sh_cg_cp_rs2_p_b8_str)
-#else
-  c.sh x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x68175dfe
@@ -234,18 +153,9 @@ Zcb_c_sh_cg_cp_rs2_p_b9:
   c.sh x9, 0(x14) # perform store
   addi x14, x14, 0 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zcb_c_sh_cg_cp_rs2_p_b9, Zcb_c_sh_cg_cp_rs2_p_b9_str)
-#else
-  c.sh x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x60552e86
@@ -255,18 +165,9 @@ Zcb_c_sh_cg_cp_rs2_p_b10:
   c.sh x10, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, Zcb_c_sh_cg_cp_rs2_p_b10, Zcb_c_sh_cg_cp_rs2_p_b10_str)
-#else
-  c.sh x10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x447c61b9
@@ -276,18 +177,9 @@ Zcb_c_sh_cg_cp_rs2_p_b11:
   c.sh x11, 2(x9) # perform store
   addi x9, x9, 2 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zcb_c_sh_cg_cp_rs2_p_b11, Zcb_c_sh_cg_cp_rs2_p_b11_str)
-#else
-  c.sh x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x2b39e3d5
@@ -297,18 +189,9 @@ Zcb_c_sh_cg_cp_rs2_p_b12:
   c.sh x12, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zcb_c_sh_cg_cp_rs2_p_b12, Zcb_c_sh_cg_cp_rs2_p_b12_str)
-#else
-  c.sh x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x8cea1e27
@@ -318,18 +201,9 @@ Zcb_c_sh_cg_cp_rs2_p_b13:
   c.sh x13, 2(x15) # perform store
   addi x15, x15, 2 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, Zcb_c_sh_cg_cp_rs2_p_b13, Zcb_c_sh_cg_cp_rs2_p_b13_str)
-#else
-  c.sh x13, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xda6c4ef4
@@ -339,18 +213,9 @@ Zcb_c_sh_cg_cp_rs2_p_b14:
   c.sh x14, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x8, Zcb_c_sh_cg_cp_rs2_p_b14, Zcb_c_sh_cg_cp_rs2_p_b14_str)
-#else
-  c.sh x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x8066342e
@@ -360,18 +225,9 @@ Zcb_c_sh_cg_cp_rs2_p_b15:
   c.sh x15, 0(x8) # perform store
   addi x8, x8, 0 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zcb_c_sh_cg_cp_rs2_p_b15, Zcb_c_sh_cg_cp_rs2_p_b15_str)
-#else
-  c.sh x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -385,18 +241,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x0:
   c.sh x9, 0(x14) # perform store
   addi x14, x14, 0 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, Zcb_c_sh_cg_cp_rs2_edges_0x0, Zcb_c_sh_cg_cp_rs2_edges_0x0_str)
-#else
-  c.sh x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x00000001
@@ -406,18 +253,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x1:
   c.sh x12, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_edges_0x1, Zcb_c_sh_cg_cp_rs2_edges_0x1_str)
-#else
-  c.sh x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x00000002
@@ -427,18 +265,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x2:
   c.sh x14, 0(x8) # perform store
   addi x8, x8, 0 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zcb_c_sh_cg_cp_rs2_edges_0x2, Zcb_c_sh_cg_cp_rs2_edges_0x2_str)
-#else
-  c.sh x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x80000000
@@ -448,18 +277,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x80000000:
   c.sh x10, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zcb_c_sh_cg_cp_rs2_edges_0x80000000, Zcb_c_sh_cg_cp_rs2_edges_0x80000000_str)
-#else
-  c.sh x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x80000001
@@ -469,18 +289,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x80000001:
   c.sh x13, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x11 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x11, Zcb_c_sh_cg_cp_rs2_edges_0x80000001, Zcb_c_sh_cg_cp_rs2_edges_0x80000001_str)
-#else
-  c.sh x13, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x7fffffff
@@ -490,18 +301,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x7fffffff:
   c.sh x14, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, Zcb_c_sh_cg_cp_rs2_edges_0x7fffffff, Zcb_c_sh_cg_cp_rs2_edges_0x7fffffff_str)
-#else
-  c.sh x14, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x7ffffffe
@@ -511,18 +313,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x7ffffffe:
   c.sh x12, 2(x9) # perform store
   addi x9, x9, 2 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zcb_c_sh_cg_cp_rs2_edges_0x7ffffffe, Zcb_c_sh_cg_cp_rs2_edges_0x7ffffffe_str)
-#else
-  c.sh x12, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xffffffff
@@ -532,18 +325,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0xffffffff:
   c.sh x12, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_edges_0xffffffff, Zcb_c_sh_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  c.sh x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xfffffffe
@@ -553,18 +337,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0xfffffffe:
   c.sh x10, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x15 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_edges_0xfffffffe, Zcb_c_sh_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  c.sh x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x5bbc8872
@@ -574,18 +349,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x5bbc8872:
   c.sh x10, 2(x13) # perform store
   addi x13, x13, 2 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zcb_c_sh_cg_cp_rs2_edges_0x5bbc8872, Zcb_c_sh_cg_cp_rs2_edges_0x5bbc8872_str)
-#else
-  c.sh x10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xaaaaaaaa
@@ -595,18 +361,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0xaaaaaaaa:
   c.sh x9, 0(x15) # perform store
   addi x15, x15, 0 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, Zcb_c_sh_cg_cp_rs2_edges_0xaaaaaaaa, Zcb_c_sh_cg_cp_rs2_edges_0xaaaaaaaa_str)
-#else
-  c.sh x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x55555555
@@ -616,18 +373,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x55555555:
   c.sh x14, 0(x8) # perform store
   addi x8, x8, 0 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zcb_c_sh_cg_cp_rs2_edges_0x55555555, Zcb_c_sh_cg_cp_rs2_edges_0x55555555_str)
-#else
-  c.sh x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x8 # restore signature pointer to default register for teardown
 

--- a/tests/rv32i/D/D-fsd-00.S
+++ b/tests/rv32i/D/D-fsd-00.S
@@ -42,18 +42,9 @@ D_fsd_cg_cp_rs1_nx0_b1:
   fsd f31, -463(x1) # perform store
   addi x1, x1, -463 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x18 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x18, D_fsd_cg_cp_rs1_nx0_b1, D_fsd_cg_cp_rs1_nx0_b1_str)
-#else
-  fsd f31, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, D_fsd_cg_cp_rs1_nx0_b1, D_fsd_cg_cp_rs1_nx0_b1_str)
 
@@ -66,18 +57,9 @@ D_fsd_cg_cp_rs1_nx0_b2:
   fsd f22, 1354(x2) # perform store
   addi x2, x2, 1354 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x8 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x8, D_fsd_cg_cp_rs1_nx0_b2, D_fsd_cg_cp_rs1_nx0_b2_str)
-#else
-  fsd f22, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, D_fsd_cg_cp_rs1_nx0_b2, D_fsd_cg_cp_rs1_nx0_b2_str)
 
@@ -91,18 +73,9 @@ D_fsd_cg_cp_rs1_nx0_b3:
   fsd f6, -1274(x3) # perform store
   addi x3, x3, -1274 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x28 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x28, D_fsd_cg_cp_rs1_nx0_b3, D_fsd_cg_cp_rs1_nx0_b3_str)
-#else
-  fsd f6, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, D_fsd_cg_cp_rs1_nx0_b3, D_fsd_cg_cp_rs1_nx0_b3_str)
 
@@ -117,18 +90,9 @@ D_fsd_cg_cp_rs1_nx0_b4:
   fsd f27, -736(x4) # perform store
   addi x4, x4, -736 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x19 contains the expected result. x4 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x4, x14, x13, x19, D_fsd_cg_cp_rs1_nx0_b4, D_fsd_cg_cp_rs1_nx0_b4_str)
-#else
-  fsd f27, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x4 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x4, x14, x13, D_fsd_cg_cp_rs1_nx0_b4, D_fsd_cg_cp_rs1_nx0_b4_str)
 
@@ -141,18 +105,9 @@ D_fsd_cg_cp_rs1_nx0_b5:
   fsd f23, 883(x5) # perform store
   addi x5, x5, 883 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x21 contains the expected result. x5 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x5, x14, x13, x21, D_fsd_cg_cp_rs1_nx0_b5, D_fsd_cg_cp_rs1_nx0_b5_str)
-#else
-  fsd f23, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x5 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x5, x14, x13, D_fsd_cg_cp_rs1_nx0_b5, D_fsd_cg_cp_rs1_nx0_b5_str)
 
@@ -165,18 +120,9 @@ D_fsd_cg_cp_rs1_nx0_b6:
   fsd f21, 713(x6) # perform store
   addi x6, x6, 713 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x20 contains the expected result. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x6, x14, x13, x20, D_fsd_cg_cp_rs1_nx0_b6, D_fsd_cg_cp_rs1_nx0_b6_str)
-#else
-  fsd f21, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x14, x13, D_fsd_cg_cp_rs1_nx0_b6, D_fsd_cg_cp_rs1_nx0_b6_str)
 
@@ -189,18 +135,9 @@ D_fsd_cg_cp_rs1_nx0_b7:
   fsd f17, 930(x7) # perform store
   addi x7, x7, 930 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x20 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x20, D_fsd_cg_cp_rs1_nx0_b7, D_fsd_cg_cp_rs1_nx0_b7_str)
-#else
-  fsd f17, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x14, x13, D_fsd_cg_cp_rs1_nx0_b7, D_fsd_cg_cp_rs1_nx0_b7_str)
 
@@ -213,18 +150,9 @@ D_fsd_cg_cp_rs1_nx0_b8:
   fsd f29, -1272(x8) # perform store
   addi x8, x8, -1272 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x22 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x22, D_fsd_cg_cp_rs1_nx0_b8, D_fsd_cg_cp_rs1_nx0_b8_str)
-#else
-  fsd f29, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x14, x13, D_fsd_cg_cp_rs1_nx0_b8, D_fsd_cg_cp_rs1_nx0_b8_str)
 
@@ -237,18 +165,9 @@ D_fsd_cg_cp_rs1_nx0_b9:
   fsd f19, -1532(x9) # perform store
   addi x9, x9, -1532 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x10, D_fsd_cg_cp_rs1_nx0_b9, D_fsd_cg_cp_rs1_nx0_b9_str)
-#else
-  fsd f19, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x14, x13, D_fsd_cg_cp_rs1_nx0_b9, D_fsd_cg_cp_rs1_nx0_b9_str)
 
@@ -261,18 +180,9 @@ D_fsd_cg_cp_rs1_nx0_b10:
   fsd f14, -476(x10) # perform store
   addi x10, x10, -476 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x27 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x27, D_fsd_cg_cp_rs1_nx0_b10, D_fsd_cg_cp_rs1_nx0_b10_str)
-#else
-  fsd f14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x14, x13, D_fsd_cg_cp_rs1_nx0_b10, D_fsd_cg_cp_rs1_nx0_b10_str)
 
@@ -285,18 +195,9 @@ D_fsd_cg_cp_rs1_nx0_b11:
   fsd f22, -981(x11) # perform store
   addi x11, x11, -981 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x17 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x17, D_fsd_cg_cp_rs1_nx0_b11, D_fsd_cg_cp_rs1_nx0_b11_str)
-#else
-  fsd f22, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x14, x13, D_fsd_cg_cp_rs1_nx0_b11, D_fsd_cg_cp_rs1_nx0_b11_str)
 
@@ -309,18 +210,9 @@ D_fsd_cg_cp_rs1_nx0_b12:
   fsd f18, 174(x12) # perform store
   addi x12, x12, 174 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x9 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x9, D_fsd_cg_cp_rs1_nx0_b12, D_fsd_cg_cp_rs1_nx0_b12_str)
-#else
-  fsd f18, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x14, x13, D_fsd_cg_cp_rs1_nx0_b12, D_fsd_cg_cp_rs1_nx0_b12_str)
 
@@ -335,18 +227,9 @@ D_fsd_cg_cp_rs1_nx0_b13:
   fsd f18, -663(x13) # perform store
   addi x13, x13, -663 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, D_fsd_cg_cp_rs1_nx0_b13, D_fsd_cg_cp_rs1_nx0_b13_str)
-#else
-  fsd f18, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, D_fsd_cg_cp_rs1_nx0_b13, D_fsd_cg_cp_rs1_nx0_b13_str)
 
@@ -359,18 +242,9 @@ D_fsd_cg_cp_rs1_nx0_b14:
   fsd f1, -1118(x14) # perform store
   addi x14, x14, -1118 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x7 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x7, D_fsd_cg_cp_rs1_nx0_b14, D_fsd_cg_cp_rs1_nx0_b14_str)
-#else
-  fsd f1, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, D_fsd_cg_cp_rs1_nx0_b14, D_fsd_cg_cp_rs1_nx0_b14_str)
 
@@ -383,18 +257,9 @@ D_fsd_cg_cp_rs1_nx0_b15:
   fsd f16, 969(x15) # perform store
   addi x15, x15, 969 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x29 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x29, D_fsd_cg_cp_rs1_nx0_b15, D_fsd_cg_cp_rs1_nx0_b15_str)
-#else
-  fsd f16, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, D_fsd_cg_cp_rs1_nx0_b15, D_fsd_cg_cp_rs1_nx0_b15_str)
 
@@ -408,18 +273,9 @@ D_fsd_cg_cp_rs1_nx0_b16:
   fsd f13, 1516(x16) # perform store
   addi x16, x16, 1516 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x19 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x19, D_fsd_cg_cp_rs1_nx0_b16, D_fsd_cg_cp_rs1_nx0_b16_str)
-#else
-  fsd f13, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, D_fsd_cg_cp_rs1_nx0_b16, D_fsd_cg_cp_rs1_nx0_b16_str)
 
@@ -432,18 +288,9 @@ D_fsd_cg_cp_rs1_nx0_b17:
   fsd f26, -818(x17) # perform store
   addi x17, x17, -818 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x31 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x31, D_fsd_cg_cp_rs1_nx0_b17, D_fsd_cg_cp_rs1_nx0_b17_str)
-#else
-  fsd f26, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, D_fsd_cg_cp_rs1_nx0_b17, D_fsd_cg_cp_rs1_nx0_b17_str)
 
@@ -456,18 +303,9 @@ D_fsd_cg_cp_rs1_nx0_b18:
   fsd f10, 579(x18) # perform store
   addi x18, x18, 579 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x30 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x30, D_fsd_cg_cp_rs1_nx0_b18, D_fsd_cg_cp_rs1_nx0_b18_str)
-#else
-  fsd f10, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, D_fsd_cg_cp_rs1_nx0_b18, D_fsd_cg_cp_rs1_nx0_b18_str)
 
@@ -480,18 +318,9 @@ D_fsd_cg_cp_rs1_nx0_b19:
   fsd f10, -536(x19) # perform store
   addi x19, x19, -536 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x27 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x27, D_fsd_cg_cp_rs1_nx0_b19, D_fsd_cg_cp_rs1_nx0_b19_str)
-#else
-  fsd f10, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, D_fsd_cg_cp_rs1_nx0_b19, D_fsd_cg_cp_rs1_nx0_b19_str)
 
@@ -504,18 +333,9 @@ D_fsd_cg_cp_rs1_nx0_b20:
   fsd f2, -1456(x20) # perform store
   addi x20, x20, -1456 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x27 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x27, D_fsd_cg_cp_rs1_nx0_b20, D_fsd_cg_cp_rs1_nx0_b20_str)
-#else
-  fsd f2, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, D_fsd_cg_cp_rs1_nx0_b20, D_fsd_cg_cp_rs1_nx0_b20_str)
 
@@ -528,18 +348,9 @@ D_fsd_cg_cp_rs1_nx0_b21:
   fsd f16, -1031(x21) # perform store
   addi x21, x21, -1031 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x19 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x19, D_fsd_cg_cp_rs1_nx0_b21, D_fsd_cg_cp_rs1_nx0_b21_str)
-#else
-  fsd f16, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, D_fsd_cg_cp_rs1_nx0_b21, D_fsd_cg_cp_rs1_nx0_b21_str)
 
@@ -552,18 +363,9 @@ D_fsd_cg_cp_rs1_nx0_b22:
   fsd f22, 1980(x22) # perform store
   addi x22, x22, 1980 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x11 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x11, D_fsd_cg_cp_rs1_nx0_b22, D_fsd_cg_cp_rs1_nx0_b22_str)
-#else
-  fsd f22, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, D_fsd_cg_cp_rs1_nx0_b22, D_fsd_cg_cp_rs1_nx0_b22_str)
 
@@ -577,18 +379,9 @@ D_fsd_cg_cp_rs1_nx0_b23:
   fsd f26, -1294(x23) # perform store
   addi x23, x23, -1294 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x17 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x17, D_fsd_cg_cp_rs1_nx0_b23, D_fsd_cg_cp_rs1_nx0_b23_str)
-#else
-  fsd f26, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, D_fsd_cg_cp_rs1_nx0_b23, D_fsd_cg_cp_rs1_nx0_b23_str)
 
@@ -601,18 +394,9 @@ D_fsd_cg_cp_rs1_nx0_b24:
   fsd f27, -494(x24) # perform store
   addi x24, x24, -494 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x1 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x1, D_fsd_cg_cp_rs1_nx0_b24, D_fsd_cg_cp_rs1_nx0_b24_str)
-#else
-  fsd f27, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, D_fsd_cg_cp_rs1_nx0_b24, D_fsd_cg_cp_rs1_nx0_b24_str)
 
@@ -625,18 +409,9 @@ D_fsd_cg_cp_rs1_nx0_b25:
   fsd f25, -1587(x25) # perform store
   addi x25, x25, -1587 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x16 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x16, D_fsd_cg_cp_rs1_nx0_b25, D_fsd_cg_cp_rs1_nx0_b25_str)
-#else
-  fsd f25, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, D_fsd_cg_cp_rs1_nx0_b25, D_fsd_cg_cp_rs1_nx0_b25_str)
 
@@ -649,18 +424,9 @@ D_fsd_cg_cp_rs1_nx0_b26:
   fsd f31, -1465(x26) # perform store
   addi x26, x26, -1465 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x27 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x27, D_fsd_cg_cp_rs1_nx0_b26, D_fsd_cg_cp_rs1_nx0_b26_str)
-#else
-  fsd f31, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, D_fsd_cg_cp_rs1_nx0_b26, D_fsd_cg_cp_rs1_nx0_b26_str)
 
@@ -673,18 +439,9 @@ D_fsd_cg_cp_rs1_nx0_b27:
   fsd f5, -581(x27) # perform store
   addi x27, x27, -581 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x31 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x31, D_fsd_cg_cp_rs1_nx0_b27, D_fsd_cg_cp_rs1_nx0_b27_str)
-#else
-  fsd f5, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, D_fsd_cg_cp_rs1_nx0_b27, D_fsd_cg_cp_rs1_nx0_b27_str)
 
@@ -697,18 +454,9 @@ D_fsd_cg_cp_rs1_nx0_b28:
   fsd f5, -1764(x28) # perform store
   addi x28, x28, -1764 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x8 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x8, D_fsd_cg_cp_rs1_nx0_b28, D_fsd_cg_cp_rs1_nx0_b28_str)
-#else
-  fsd f5, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, D_fsd_cg_cp_rs1_nx0_b28, D_fsd_cg_cp_rs1_nx0_b28_str)
 
@@ -721,18 +469,9 @@ D_fsd_cg_cp_rs1_nx0_b29:
   fsd f17, 1459(x29) # perform store
   addi x29, x29, 1459 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x31 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x31, D_fsd_cg_cp_rs1_nx0_b29, D_fsd_cg_cp_rs1_nx0_b29_str)
-#else
-  fsd f17, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, D_fsd_cg_cp_rs1_nx0_b29, D_fsd_cg_cp_rs1_nx0_b29_str)
 
@@ -745,18 +484,9 @@ D_fsd_cg_cp_rs1_nx0_b30:
   fsd f24, -1509(x30) # perform store
   addi x30, x30, -1509 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x23 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x23, D_fsd_cg_cp_rs1_nx0_b30, D_fsd_cg_cp_rs1_nx0_b30_str)
-#else
-  fsd f24, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, D_fsd_cg_cp_rs1_nx0_b30, D_fsd_cg_cp_rs1_nx0_b30_str)
 
@@ -769,18 +499,9 @@ D_fsd_cg_cp_rs1_nx0_b31:
   fsd f1, 1510(x31) # perform store
   addi x31, x31, 1510 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x11 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x11, D_fsd_cg_cp_rs1_nx0_b31, D_fsd_cg_cp_rs1_nx0_b31_str)
-#else
-  fsd f1, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, D_fsd_cg_cp_rs1_nx0_b31, D_fsd_cg_cp_rs1_nx0_b31_str)
 
@@ -797,18 +518,9 @@ D_fsd_cg_cp_imm_edges_0x0:
   fsd f20, 0(x16) # perform store
   addi x16, x16, 0 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x9 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x9, D_fsd_cg_cp_imm_edges_0x0, D_fsd_cg_cp_imm_edges_0x0_str)
-#else
-  fsd f20, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, D_fsd_cg_cp_imm_edges_0x0, D_fsd_cg_cp_imm_edges_0x0_str)
 
@@ -821,18 +533,9 @@ D_fsd_cg_cp_imm_edges_0x1:
   fsd f22, 1(x30) # perform store
   addi x30, x30, 1 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x8 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x8, D_fsd_cg_cp_imm_edges_0x1, D_fsd_cg_cp_imm_edges_0x1_str)
-#else
-  fsd f22, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, D_fsd_cg_cp_imm_edges_0x1, D_fsd_cg_cp_imm_edges_0x1_str)
 
@@ -845,18 +548,9 @@ D_fsd_cg_cp_imm_edges_0x2:
   fsd f27, 2(x22) # perform store
   addi x22, x22, 2 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x15 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x15, D_fsd_cg_cp_imm_edges_0x2, D_fsd_cg_cp_imm_edges_0x2_str)
-#else
-  fsd f27, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, D_fsd_cg_cp_imm_edges_0x2, D_fsd_cg_cp_imm_edges_0x2_str)
 
@@ -869,18 +563,9 @@ D_fsd_cg_cp_imm_edges_0x3:
   fsd f15, 3(x24) # perform store
   addi x24, x24, 3 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x3 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x3, D_fsd_cg_cp_imm_edges_0x3, D_fsd_cg_cp_imm_edges_0x3_str)
-#else
-  fsd f15, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, D_fsd_cg_cp_imm_edges_0x3, D_fsd_cg_cp_imm_edges_0x3_str)
 
@@ -893,18 +578,9 @@ D_fsd_cg_cp_imm_edges_0x4:
   fsd f3, 4(x3) # perform store
   addi x3, x3, 4 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x22 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x22, D_fsd_cg_cp_imm_edges_0x4, D_fsd_cg_cp_imm_edges_0x4_str)
-#else
-  fsd f3, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, D_fsd_cg_cp_imm_edges_0x4, D_fsd_cg_cp_imm_edges_0x4_str)
 
@@ -917,18 +593,9 @@ D_fsd_cg_cp_imm_edges_0x8:
   fsd f29, 8(x15) # perform store
   addi x15, x15, 8 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x8 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x8, D_fsd_cg_cp_imm_edges_0x8, D_fsd_cg_cp_imm_edges_0x8_str)
-#else
-  fsd f29, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, D_fsd_cg_cp_imm_edges_0x8, D_fsd_cg_cp_imm_edges_0x8_str)
 
@@ -941,18 +608,9 @@ D_fsd_cg_cp_imm_edges_0x10:
   fsd f26, 16(x10) # perform store
   addi x10, x10, 16 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x17 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x17, D_fsd_cg_cp_imm_edges_0x10, D_fsd_cg_cp_imm_edges_0x10_str)
-#else
-  fsd f26, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, D_fsd_cg_cp_imm_edges_0x10, D_fsd_cg_cp_imm_edges_0x10_str)
 
@@ -965,18 +623,9 @@ D_fsd_cg_cp_imm_edges_0x20:
   fsd f14, 32(x22) # perform store
   addi x22, x22, 32 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x30 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x30, D_fsd_cg_cp_imm_edges_0x20, D_fsd_cg_cp_imm_edges_0x20_str)
-#else
-  fsd f14, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, D_fsd_cg_cp_imm_edges_0x20, D_fsd_cg_cp_imm_edges_0x20_str)
 
@@ -989,18 +638,9 @@ D_fsd_cg_cp_imm_edges_0x40:
   fsd f30, 64(x25) # perform store
   addi x25, x25, 64 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x12 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x12, D_fsd_cg_cp_imm_edges_0x40, D_fsd_cg_cp_imm_edges_0x40_str)
-#else
-  fsd f30, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, D_fsd_cg_cp_imm_edges_0x40, D_fsd_cg_cp_imm_edges_0x40_str)
 
@@ -1013,18 +653,9 @@ D_fsd_cg_cp_imm_edges_0x80:
   fsd f1, 128(x13) # perform store
   addi x13, x13, 128 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, D_fsd_cg_cp_imm_edges_0x80, D_fsd_cg_cp_imm_edges_0x80_str)
-#else
-  fsd f1, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, D_fsd_cg_cp_imm_edges_0x80, D_fsd_cg_cp_imm_edges_0x80_str)
 
@@ -1037,18 +668,9 @@ D_fsd_cg_cp_imm_edges_0x100:
   fsd f13, 256(x10) # perform store
   addi x10, x10, 256 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x24 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x24, D_fsd_cg_cp_imm_edges_0x100, D_fsd_cg_cp_imm_edges_0x100_str)
-#else
-  fsd f13, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, D_fsd_cg_cp_imm_edges_0x100, D_fsd_cg_cp_imm_edges_0x100_str)
 
@@ -1061,18 +683,9 @@ D_fsd_cg_cp_imm_edges_0x200:
   fsd f5, 512(x7) # perform store
   addi x7, x7, 512 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x24 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x24, D_fsd_cg_cp_imm_edges_0x200, D_fsd_cg_cp_imm_edges_0x200_str)
-#else
-  fsd f5, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, D_fsd_cg_cp_imm_edges_0x200, D_fsd_cg_cp_imm_edges_0x200_str)
 
@@ -1085,18 +698,9 @@ D_fsd_cg_cp_imm_edges_0x3ff:
   fsd f17, 1023(x20) # perform store
   addi x20, x20, 1023 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x14 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x14, D_fsd_cg_cp_imm_edges_0x3ff, D_fsd_cg_cp_imm_edges_0x3ff_str)
-#else
-  fsd f17, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, D_fsd_cg_cp_imm_edges_0x3ff, D_fsd_cg_cp_imm_edges_0x3ff_str)
 
@@ -1109,18 +713,9 @@ D_fsd_cg_cp_imm_edges_0x400:
   fsd f16, 1024(x24) # perform store
   addi x24, x24, 1024 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x3 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x3, D_fsd_cg_cp_imm_edges_0x400, D_fsd_cg_cp_imm_edges_0x400_str)
-#else
-  fsd f16, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, D_fsd_cg_cp_imm_edges_0x400, D_fsd_cg_cp_imm_edges_0x400_str)
 
@@ -1133,18 +728,9 @@ D_fsd_cg_cp_imm_edges_0x703:
   fsd f25, 1795(x7) # perform store
   addi x7, x7, 1795 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x11 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x11, D_fsd_cg_cp_imm_edges_0x703, D_fsd_cg_cp_imm_edges_0x703_str)
-#else
-  fsd f25, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, D_fsd_cg_cp_imm_edges_0x703, D_fsd_cg_cp_imm_edges_0x703_str)
 
@@ -1157,18 +743,9 @@ D_fsd_cg_cp_imm_edges_0x7ff:
   fsd f29, 2047(x22) # perform store
   addi x22, x22, 2047 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x8 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x8, D_fsd_cg_cp_imm_edges_0x7ff, D_fsd_cg_cp_imm_edges_0x7ff_str)
-#else
-  fsd f29, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, D_fsd_cg_cp_imm_edges_0x7ff, D_fsd_cg_cp_imm_edges_0x7ff_str)
 
@@ -1182,18 +759,9 @@ D_fsd_cg_cp_imm_edges_m0x800:
   fsd f31, -2048(x1) # perform store
   addi x1, x1, -2048 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x3 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x3, D_fsd_cg_cp_imm_edges_m0x800, D_fsd_cg_cp_imm_edges_m0x800_str)
-#else
-  fsd f31, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, D_fsd_cg_cp_imm_edges_m0x800, D_fsd_cg_cp_imm_edges_m0x800_str)
 
@@ -1206,18 +774,9 @@ D_fsd_cg_cp_imm_edges_m0x7ff:
   fsd f17, -2047(x30) # perform store
   addi x30, x30, -2047 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x7 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x7, D_fsd_cg_cp_imm_edges_m0x7ff, D_fsd_cg_cp_imm_edges_m0x7ff_str)
-#else
-  fsd f17, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, D_fsd_cg_cp_imm_edges_m0x7ff, D_fsd_cg_cp_imm_edges_m0x7ff_str)
 
@@ -1230,18 +789,9 @@ D_fsd_cg_cp_imm_edges_m0x2:
   fsd f12, -2(x13) # perform store
   addi x13, x13, -2 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x3 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x3, D_fsd_cg_cp_imm_edges_m0x2, D_fsd_cg_cp_imm_edges_m0x2_str)
-#else
-  fsd f12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, D_fsd_cg_cp_imm_edges_m0x2, D_fsd_cg_cp_imm_edges_m0x2_str)
 
@@ -1254,18 +804,9 @@ D_fsd_cg_cp_imm_edges_m0x1:
   fsd f29, -1(x25) # perform store
   addi x25, x25, -1 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x27 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x27, D_fsd_cg_cp_imm_edges_m0x1, D_fsd_cg_cp_imm_edges_m0x1_str)
-#else
-  fsd f29, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, D_fsd_cg_cp_imm_edges_m0x1, D_fsd_cg_cp_imm_edges_m0x1_str)
 
@@ -1282,18 +823,9 @@ D_fsd_cg_cp_fs2_b0:
   fsd f0, -1556(x3) # perform store
   addi x3, x3, -1556 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x17 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x17, D_fsd_cg_cp_fs2_b0, D_fsd_cg_cp_fs2_b0_str)
-#else
-  fsd f0, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, D_fsd_cg_cp_fs2_b0, D_fsd_cg_cp_fs2_b0_str)
 
@@ -1306,18 +838,9 @@ D_fsd_cg_cp_fs2_b1:
   fsd f1, -940(x20) # perform store
   addi x20, x20, -940 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x9 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x9, D_fsd_cg_cp_fs2_b1, D_fsd_cg_cp_fs2_b1_str)
-#else
-  fsd f1, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, D_fsd_cg_cp_fs2_b1, D_fsd_cg_cp_fs2_b1_str)
 
@@ -1330,18 +853,9 @@ D_fsd_cg_cp_fs2_b2:
   fsd f2, -1515(x15) # perform store
   addi x15, x15, -1515 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x18 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x18, D_fsd_cg_cp_fs2_b2, D_fsd_cg_cp_fs2_b2_str)
-#else
-  fsd f2, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, D_fsd_cg_cp_fs2_b2, D_fsd_cg_cp_fs2_b2_str)
 
@@ -1354,18 +868,9 @@ D_fsd_cg_cp_fs2_b3:
   fsd f3, 1538(x21) # perform store
   addi x21, x21, 1538 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x13 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x13, D_fsd_cg_cp_fs2_b3, D_fsd_cg_cp_fs2_b3_str)
-#else
-  fsd f3, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, D_fsd_cg_cp_fs2_b3, D_fsd_cg_cp_fs2_b3_str)
 
@@ -1378,18 +883,9 @@ D_fsd_cg_cp_fs2_b4:
   fsd f4, -945(x9) # perform store
   addi x9, x9, -945 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, D_fsd_cg_cp_fs2_b4, D_fsd_cg_cp_fs2_b4_str)
-#else
-  fsd f4, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, D_fsd_cg_cp_fs2_b4, D_fsd_cg_cp_fs2_b4_str)
 
@@ -1402,18 +898,9 @@ D_fsd_cg_cp_fs2_b5:
   fsd f5, 329(x22) # perform store
   addi x22, x22, 329 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x25 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x25, D_fsd_cg_cp_fs2_b5, D_fsd_cg_cp_fs2_b5_str)
-#else
-  fsd f5, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, D_fsd_cg_cp_fs2_b5, D_fsd_cg_cp_fs2_b5_str)
 
@@ -1426,18 +913,9 @@ D_fsd_cg_cp_fs2_b6:
   fsd f6, 281(x20) # perform store
   addi x20, x20, 281 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x17 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x17, D_fsd_cg_cp_fs2_b6, D_fsd_cg_cp_fs2_b6_str)
-#else
-  fsd f6, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, D_fsd_cg_cp_fs2_b6, D_fsd_cg_cp_fs2_b6_str)
 
@@ -1450,18 +928,9 @@ D_fsd_cg_cp_fs2_b7:
   fsd f7, 765(x8) # perform store
   addi x8, x8, 765 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, D_fsd_cg_cp_fs2_b7, D_fsd_cg_cp_fs2_b7_str)
-#else
-  fsd f7, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, D_fsd_cg_cp_fs2_b7, D_fsd_cg_cp_fs2_b7_str)
 
@@ -1474,18 +943,9 @@ D_fsd_cg_cp_fs2_b8:
   fsd f8, 1847(x3) # perform store
   addi x3, x3, 1847 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x29 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x29, D_fsd_cg_cp_fs2_b8, D_fsd_cg_cp_fs2_b8_str)
-#else
-  fsd f8, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, D_fsd_cg_cp_fs2_b8, D_fsd_cg_cp_fs2_b8_str)
 
@@ -1498,18 +958,9 @@ D_fsd_cg_cp_fs2_b9:
   fsd f9, 1278(x1) # perform store
   addi x1, x1, 1278 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x13 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x13, D_fsd_cg_cp_fs2_b9, D_fsd_cg_cp_fs2_b9_str)
-#else
-  fsd f9, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, D_fsd_cg_cp_fs2_b9, D_fsd_cg_cp_fs2_b9_str)
 
@@ -1522,18 +973,9 @@ D_fsd_cg_cp_fs2_b10:
   fsd f10, -958(x16) # perform store
   addi x16, x16, -958 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x17 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x17, D_fsd_cg_cp_fs2_b10, D_fsd_cg_cp_fs2_b10_str)
-#else
-  fsd f10, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, D_fsd_cg_cp_fs2_b10, D_fsd_cg_cp_fs2_b10_str)
 
@@ -1546,18 +988,9 @@ D_fsd_cg_cp_fs2_b11:
   fsd f11, 751(x29) # perform store
   addi x29, x29, 751 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x15 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x15, D_fsd_cg_cp_fs2_b11, D_fsd_cg_cp_fs2_b11_str)
-#else
-  fsd f11, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, D_fsd_cg_cp_fs2_b11, D_fsd_cg_cp_fs2_b11_str)
 
@@ -1570,18 +1003,9 @@ D_fsd_cg_cp_fs2_b12:
   fsd f12, 655(x15) # perform store
   addi x15, x15, 655 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, D_fsd_cg_cp_fs2_b12, D_fsd_cg_cp_fs2_b12_str)
-#else
-  fsd f12, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, D_fsd_cg_cp_fs2_b12, D_fsd_cg_cp_fs2_b12_str)
 
@@ -1594,18 +1018,9 @@ D_fsd_cg_cp_fs2_b13:
   fsd f13, 1298(x8) # perform store
   addi x8, x8, 1298 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x7 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x7, D_fsd_cg_cp_fs2_b13, D_fsd_cg_cp_fs2_b13_str)
-#else
-  fsd f13, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, D_fsd_cg_cp_fs2_b13, D_fsd_cg_cp_fs2_b13_str)
 
@@ -1618,18 +1033,9 @@ D_fsd_cg_cp_fs2_b14:
   fsd f14, 281(x18) # perform store
   addi x18, x18, 281 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x22 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x22, D_fsd_cg_cp_fs2_b14, D_fsd_cg_cp_fs2_b14_str)
-#else
-  fsd f14, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, D_fsd_cg_cp_fs2_b14, D_fsd_cg_cp_fs2_b14_str)
 
@@ -1642,18 +1048,9 @@ D_fsd_cg_cp_fs2_b15:
   fsd f15, -1672(x11) # perform store
   addi x11, x11, -1672 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x19 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x19, D_fsd_cg_cp_fs2_b15, D_fsd_cg_cp_fs2_b15_str)
-#else
-  fsd f15, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, D_fsd_cg_cp_fs2_b15, D_fsd_cg_cp_fs2_b15_str)
 
@@ -1666,18 +1063,9 @@ D_fsd_cg_cp_fs2_b16:
   fsd f16, 884(x21) # perform store
   addi x21, x21, 884 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x26 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x26, D_fsd_cg_cp_fs2_b16, D_fsd_cg_cp_fs2_b16_str)
-#else
-  fsd f16, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, D_fsd_cg_cp_fs2_b16, D_fsd_cg_cp_fs2_b16_str)
 
@@ -1690,18 +1078,9 @@ D_fsd_cg_cp_fs2_b17:
   fsd f17, 805(x29) # perform store
   addi x29, x29, 805 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x31 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x31, D_fsd_cg_cp_fs2_b17, D_fsd_cg_cp_fs2_b17_str)
-#else
-  fsd f17, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, D_fsd_cg_cp_fs2_b17, D_fsd_cg_cp_fs2_b17_str)
 
@@ -1714,18 +1093,9 @@ D_fsd_cg_cp_fs2_b18:
   fsd f18, -1721(x13) # perform store
   addi x13, x13, -1721 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, D_fsd_cg_cp_fs2_b18, D_fsd_cg_cp_fs2_b18_str)
-#else
-  fsd f18, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, D_fsd_cg_cp_fs2_b18, D_fsd_cg_cp_fs2_b18_str)
 
@@ -1738,18 +1108,9 @@ D_fsd_cg_cp_fs2_b19:
   fsd f19, -1609(x27) # perform store
   addi x27, x27, -1609 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x19 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x19, D_fsd_cg_cp_fs2_b19, D_fsd_cg_cp_fs2_b19_str)
-#else
-  fsd f19, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, D_fsd_cg_cp_fs2_b19, D_fsd_cg_cp_fs2_b19_str)
 
@@ -1762,18 +1123,9 @@ D_fsd_cg_cp_fs2_b20:
   fsd f20, 529(x7) # perform store
   addi x7, x7, 529 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x20 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x20, D_fsd_cg_cp_fs2_b20, D_fsd_cg_cp_fs2_b20_str)
-#else
-  fsd f20, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, D_fsd_cg_cp_fs2_b20, D_fsd_cg_cp_fs2_b20_str)
 
@@ -1786,18 +1138,9 @@ D_fsd_cg_cp_fs2_b21:
   fsd f21, -1239(x10) # perform store
   addi x10, x10, -1239 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x20 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x20, D_fsd_cg_cp_fs2_b21, D_fsd_cg_cp_fs2_b21_str)
-#else
-  fsd f21, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, D_fsd_cg_cp_fs2_b21, D_fsd_cg_cp_fs2_b21_str)
 
@@ -1810,18 +1153,9 @@ D_fsd_cg_cp_fs2_b22:
   fsd f22, 164(x29) # perform store
   addi x29, x29, 164 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x15 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x15, D_fsd_cg_cp_fs2_b22, D_fsd_cg_cp_fs2_b22_str)
-#else
-  fsd f22, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, D_fsd_cg_cp_fs2_b22, D_fsd_cg_cp_fs2_b22_str)
 
@@ -1834,18 +1168,9 @@ D_fsd_cg_cp_fs2_b23:
   fsd f23, -239(x28) # perform store
   addi x28, x28, -239 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x30 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x30, D_fsd_cg_cp_fs2_b23, D_fsd_cg_cp_fs2_b23_str)
-#else
-  fsd f23, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, D_fsd_cg_cp_fs2_b23, D_fsd_cg_cp_fs2_b23_str)
 
@@ -1858,18 +1183,9 @@ D_fsd_cg_cp_fs2_b24:
   fsd f24, -1837(x1) # perform store
   addi x1, x1, -1837 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x30 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x30, D_fsd_cg_cp_fs2_b24, D_fsd_cg_cp_fs2_b24_str)
-#else
-  fsd f24, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, D_fsd_cg_cp_fs2_b24, D_fsd_cg_cp_fs2_b24_str)
 
@@ -1882,18 +1198,9 @@ D_fsd_cg_cp_fs2_b25:
   fsd f25, 344(x25) # perform store
   addi x25, x25, 344 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x9 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x9, D_fsd_cg_cp_fs2_b25, D_fsd_cg_cp_fs2_b25_str)
-#else
-  fsd f25, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, D_fsd_cg_cp_fs2_b25, D_fsd_cg_cp_fs2_b25_str)
 
@@ -1906,18 +1213,9 @@ D_fsd_cg_cp_fs2_b26:
   fsd f26, 1807(x7) # perform store
   addi x7, x7, 1807 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x20 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x20, D_fsd_cg_cp_fs2_b26, D_fsd_cg_cp_fs2_b26_str)
-#else
-  fsd f26, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, D_fsd_cg_cp_fs2_b26, D_fsd_cg_cp_fs2_b26_str)
 
@@ -1930,18 +1228,9 @@ D_fsd_cg_cp_fs2_b27:
   fsd f27, 1029(x14) # perform store
   addi x14, x14, 1029 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x25 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x25, D_fsd_cg_cp_fs2_b27, D_fsd_cg_cp_fs2_b27_str)
-#else
-  fsd f27, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, D_fsd_cg_cp_fs2_b27, D_fsd_cg_cp_fs2_b27_str)
 
@@ -1954,18 +1243,9 @@ D_fsd_cg_cp_fs2_b28:
   fsd f28, -1810(x12) # perform store
   addi x12, x12, -1810 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x21 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x21, D_fsd_cg_cp_fs2_b28, D_fsd_cg_cp_fs2_b28_str)
-#else
-  fsd f28, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, D_fsd_cg_cp_fs2_b28, D_fsd_cg_cp_fs2_b28_str)
 
@@ -1978,18 +1258,9 @@ D_fsd_cg_cp_fs2_b29:
   fsd f29, -62(x23) # perform store
   addi x23, x23, -62 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x8 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x8, D_fsd_cg_cp_fs2_b29, D_fsd_cg_cp_fs2_b29_str)
-#else
-  fsd f29, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, D_fsd_cg_cp_fs2_b29, D_fsd_cg_cp_fs2_b29_str)
 
@@ -2002,18 +1273,9 @@ D_fsd_cg_cp_fs2_b30:
   fsd f30, -777(x17) # perform store
   addi x17, x17, -777 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x21 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x21, D_fsd_cg_cp_fs2_b30, D_fsd_cg_cp_fs2_b30_str)
-#else
-  fsd f30, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, D_fsd_cg_cp_fs2_b30, D_fsd_cg_cp_fs2_b30_str)
 
@@ -2026,18 +1288,9 @@ D_fsd_cg_cp_fs2_b31:
   fsd f31, -489(x9) # perform store
   addi x9, x9, -489 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x20 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x20, D_fsd_cg_cp_fs2_b31, D_fsd_cg_cp_fs2_b31_str)
-#else
-  fsd f31, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, D_fsd_cg_cp_fs2_b31, D_fsd_cg_cp_fs2_b31_str)
 
@@ -2054,18 +1307,9 @@ D_fsd_cg_cp_fs2_edges_b0x0:
   fsd f23, -865(x22) # perform store
   addi x22, x22, -865 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x20 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x20, D_fsd_cg_cp_fs2_edges_b0x0, D_fsd_cg_cp_fs2_edges_b0x0_str)
-#else
-  fsd f23, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, D_fsd_cg_cp_fs2_edges_b0x0, D_fsd_cg_cp_fs2_edges_b0x0_str)
 
@@ -2078,18 +1322,9 @@ D_fsd_cg_cp_fs2_edges_b0x80000000:
   fsd f6, -123(x30) # perform store
   addi x30, x30, -123 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x24 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x24, D_fsd_cg_cp_fs2_edges_b0x80000000, D_fsd_cg_cp_fs2_edges_b0x80000000_str)
-#else
-  fsd f6, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, D_fsd_cg_cp_fs2_edges_b0x80000000, D_fsd_cg_cp_fs2_edges_b0x80000000_str)
 
@@ -2102,18 +1337,9 @@ D_fsd_cg_cp_fs2_edges_b0x3f800000:
   fsd f26, -1308(x29) # perform store
   addi x29, x29, -1308 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x8 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x8, D_fsd_cg_cp_fs2_edges_b0x3f800000, D_fsd_cg_cp_fs2_edges_b0x3f800000_str)
-#else
-  fsd f26, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, D_fsd_cg_cp_fs2_edges_b0x3f800000, D_fsd_cg_cp_fs2_edges_b0x3f800000_str)
 
@@ -2126,18 +1352,9 @@ D_fsd_cg_cp_fs2_edges_b0xbf800000:
   fsd f31, 2018(x1) # perform store
   addi x1, x1, 2018 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x10 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x10, D_fsd_cg_cp_fs2_edges_b0xbf800000, D_fsd_cg_cp_fs2_edges_b0xbf800000_str)
-#else
-  fsd f31, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, D_fsd_cg_cp_fs2_edges_b0xbf800000, D_fsd_cg_cp_fs2_edges_b0xbf800000_str)
 
@@ -2150,18 +1367,9 @@ D_fsd_cg_cp_fs2_edges_b0x3fc00000:
   fsd f7, -727(x23) # perform store
   addi x23, x23, -727 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x22 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x22, D_fsd_cg_cp_fs2_edges_b0x3fc00000, D_fsd_cg_cp_fs2_edges_b0x3fc00000_str)
-#else
-  fsd f7, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, D_fsd_cg_cp_fs2_edges_b0x3fc00000, D_fsd_cg_cp_fs2_edges_b0x3fc00000_str)
 
@@ -2174,18 +1382,9 @@ D_fsd_cg_cp_fs2_edges_b0xbfc00000:
   fsd f2, 1915(x16) # perform store
   addi x16, x16, 1915 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x20 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x20, D_fsd_cg_cp_fs2_edges_b0xbfc00000, D_fsd_cg_cp_fs2_edges_b0xbfc00000_str)
-#else
-  fsd f2, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, D_fsd_cg_cp_fs2_edges_b0xbfc00000, D_fsd_cg_cp_fs2_edges_b0xbfc00000_str)
 
@@ -2198,18 +1397,9 @@ D_fsd_cg_cp_fs2_edges_b0x40000000:
   fsd f27, -158(x28) # perform store
   addi x28, x28, -158 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x11 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x11, D_fsd_cg_cp_fs2_edges_b0x40000000, D_fsd_cg_cp_fs2_edges_b0x40000000_str)
-#else
-  fsd f27, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, D_fsd_cg_cp_fs2_edges_b0x40000000, D_fsd_cg_cp_fs2_edges_b0x40000000_str)
 
@@ -2222,18 +1412,9 @@ D_fsd_cg_cp_fs2_edges_b0xc0000000:
   fsd f25, -1823(x7) # perform store
   addi x7, x7, -1823 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x20 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x20, D_fsd_cg_cp_fs2_edges_b0xc0000000, D_fsd_cg_cp_fs2_edges_b0xc0000000_str)
-#else
-  fsd f25, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, D_fsd_cg_cp_fs2_edges_b0xc0000000, D_fsd_cg_cp_fs2_edges_b0xc0000000_str)
 
@@ -2246,18 +1427,9 @@ D_fsd_cg_cp_fs2_edges_b0x800000:
   fsd f17, -1814(x15) # perform store
   addi x15, x15, -1814 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x1 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x1, D_fsd_cg_cp_fs2_edges_b0x800000, D_fsd_cg_cp_fs2_edges_b0x800000_str)
-#else
-  fsd f17, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, D_fsd_cg_cp_fs2_edges_b0x800000, D_fsd_cg_cp_fs2_edges_b0x800000_str)
 
@@ -2270,18 +1442,9 @@ D_fsd_cg_cp_fs2_edges_b0x80800000:
   fsd f20, 103(x16) # perform store
   addi x16, x16, 103 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x11 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x11, D_fsd_cg_cp_fs2_edges_b0x80800000, D_fsd_cg_cp_fs2_edges_b0x80800000_str)
-#else
-  fsd f20, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, D_fsd_cg_cp_fs2_edges_b0x80800000, D_fsd_cg_cp_fs2_edges_b0x80800000_str)
 
@@ -2294,18 +1457,9 @@ D_fsd_cg_cp_fs2_edges_b0x7f7fffff:
   fsd f27, 624(x1) # perform store
   addi x1, x1, 624 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x15, D_fsd_cg_cp_fs2_edges_b0x7f7fffff, D_fsd_cg_cp_fs2_edges_b0x7f7fffff_str)
-#else
-  fsd f27, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, D_fsd_cg_cp_fs2_edges_b0x7f7fffff, D_fsd_cg_cp_fs2_edges_b0x7f7fffff_str)
 
@@ -2318,18 +1472,9 @@ D_fsd_cg_cp_fs2_edges_b0xff7fffff:
   fsd f19, -642(x28) # perform store
   addi x28, x28, -642 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x15 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x15, D_fsd_cg_cp_fs2_edges_b0xff7fffff, D_fsd_cg_cp_fs2_edges_b0xff7fffff_str)
-#else
-  fsd f19, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, D_fsd_cg_cp_fs2_edges_b0xff7fffff, D_fsd_cg_cp_fs2_edges_b0xff7fffff_str)
 
@@ -2342,18 +1487,9 @@ D_fsd_cg_cp_fs2_edges_b0x7fffff:
   fsd f11, 1314(x25) # perform store
   addi x25, x25, 1314 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x19 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x19, D_fsd_cg_cp_fs2_edges_b0x7fffff, D_fsd_cg_cp_fs2_edges_b0x7fffff_str)
-#else
-  fsd f11, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, D_fsd_cg_cp_fs2_edges_b0x7fffff, D_fsd_cg_cp_fs2_edges_b0x7fffff_str)
 
@@ -2366,18 +1502,9 @@ D_fsd_cg_cp_fs2_edges_b0x807fffff:
   fsd f28, -252(x21) # perform store
   addi x21, x21, -252 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x20 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x20, D_fsd_cg_cp_fs2_edges_b0x807fffff, D_fsd_cg_cp_fs2_edges_b0x807fffff_str)
-#else
-  fsd f28, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, D_fsd_cg_cp_fs2_edges_b0x807fffff, D_fsd_cg_cp_fs2_edges_b0x807fffff_str)
 
@@ -2390,18 +1517,9 @@ D_fsd_cg_cp_fs2_edges_b0x400000:
   fsd f10, -1950(x19) # perform store
   addi x19, x19, -1950 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x3 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x3, D_fsd_cg_cp_fs2_edges_b0x400000, D_fsd_cg_cp_fs2_edges_b0x400000_str)
-#else
-  fsd f10, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, D_fsd_cg_cp_fs2_edges_b0x400000, D_fsd_cg_cp_fs2_edges_b0x400000_str)
 
@@ -2414,18 +1532,9 @@ D_fsd_cg_cp_fs2_edges_b0x80400000:
   fsd f17, 1472(x29) # perform store
   addi x29, x29, 1472 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x15 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x15, D_fsd_cg_cp_fs2_edges_b0x80400000, D_fsd_cg_cp_fs2_edges_b0x80400000_str)
-#else
-  fsd f17, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, D_fsd_cg_cp_fs2_edges_b0x80400000, D_fsd_cg_cp_fs2_edges_b0x80400000_str)
 
@@ -2438,18 +1547,9 @@ D_fsd_cg_cp_fs2_edges_b0x1:
   fsd f31, -1829(x11) # perform store
   addi x11, x11, -1829 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x28, D_fsd_cg_cp_fs2_edges_b0x1, D_fsd_cg_cp_fs2_edges_b0x1_str)
-#else
-  fsd f31, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, D_fsd_cg_cp_fs2_edges_b0x1, D_fsd_cg_cp_fs2_edges_b0x1_str)
 
@@ -2462,18 +1562,9 @@ D_fsd_cg_cp_fs2_edges_b0x80000001:
   fsd f21, -756(x17) # perform store
   addi x17, x17, -756 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x18 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x18, D_fsd_cg_cp_fs2_edges_b0x80000001, D_fsd_cg_cp_fs2_edges_b0x80000001_str)
-#else
-  fsd f21, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, D_fsd_cg_cp_fs2_edges_b0x80000001, D_fsd_cg_cp_fs2_edges_b0x80000001_str)
 
@@ -2486,18 +1577,9 @@ D_fsd_cg_cp_fs2_edges_b0x7f800000:
   fsd f30, 983(x12) # perform store
   addi x12, x12, 983 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x25 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x25, D_fsd_cg_cp_fs2_edges_b0x7f800000, D_fsd_cg_cp_fs2_edges_b0x7f800000_str)
-#else
-  fsd f30, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, D_fsd_cg_cp_fs2_edges_b0x7f800000, D_fsd_cg_cp_fs2_edges_b0x7f800000_str)
 
@@ -2510,18 +1592,9 @@ D_fsd_cg_cp_fs2_edges_b0xff800000:
   fsd f25, -352(x25) # perform store
   addi x25, x25, -352 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x13 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x13, D_fsd_cg_cp_fs2_edges_b0xff800000, D_fsd_cg_cp_fs2_edges_b0xff800000_str)
-#else
-  fsd f25, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, D_fsd_cg_cp_fs2_edges_b0xff800000, D_fsd_cg_cp_fs2_edges_b0xff800000_str)
 
@@ -2534,18 +1607,9 @@ D_fsd_cg_cp_fs2_edges_b0x7fc00000:
   fsd f20, -1295(x3) # perform store
   addi x3, x3, -1295 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x1 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x1, D_fsd_cg_cp_fs2_edges_b0x7fc00000, D_fsd_cg_cp_fs2_edges_b0x7fc00000_str)
-#else
-  fsd f20, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, D_fsd_cg_cp_fs2_edges_b0x7fc00000, D_fsd_cg_cp_fs2_edges_b0x7fc00000_str)
 
@@ -2558,18 +1622,9 @@ D_fsd_cg_cp_fs2_edges_b0x7fffffff:
   fsd f25, -894(x24) # perform store
   addi x24, x24, -894 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x22 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x22, D_fsd_cg_cp_fs2_edges_b0x7fffffff, D_fsd_cg_cp_fs2_edges_b0x7fffffff_str)
-#else
-  fsd f25, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, D_fsd_cg_cp_fs2_edges_b0x7fffffff, D_fsd_cg_cp_fs2_edges_b0x7fffffff_str)
 
@@ -2582,18 +1637,9 @@ D_fsd_cg_cp_fs2_edges_b0xffffffff:
   fsd f19, -1907(x12) # perform store
   addi x12, x12, -1907 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, D_fsd_cg_cp_fs2_edges_b0xffffffff, D_fsd_cg_cp_fs2_edges_b0xffffffff_str)
-#else
-  fsd f19, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, D_fsd_cg_cp_fs2_edges_b0xffffffff, D_fsd_cg_cp_fs2_edges_b0xffffffff_str)
 
@@ -2606,18 +1652,9 @@ D_fsd_cg_cp_fs2_edges_b0x7f800001:
   fsd f14, 1867(x30) # perform store
   addi x30, x30, 1867 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x13 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x13, D_fsd_cg_cp_fs2_edges_b0x7f800001, D_fsd_cg_cp_fs2_edges_b0x7f800001_str)
-#else
-  fsd f14, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, D_fsd_cg_cp_fs2_edges_b0x7f800001, D_fsd_cg_cp_fs2_edges_b0x7f800001_str)
 
@@ -2630,18 +1667,9 @@ D_fsd_cg_cp_fs2_edges_b0x7fbfffff:
   fsd f12, -1202(x8) # perform store
   addi x8, x8, -1202 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x19 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x19, D_fsd_cg_cp_fs2_edges_b0x7fbfffff, D_fsd_cg_cp_fs2_edges_b0x7fbfffff_str)
-#else
-  fsd f12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, D_fsd_cg_cp_fs2_edges_b0x7fbfffff, D_fsd_cg_cp_fs2_edges_b0x7fbfffff_str)
 
@@ -2654,18 +1682,9 @@ D_fsd_cg_cp_fs2_edges_b0xffbfffff:
   fsd f25, 1827(x26) # perform store
   addi x26, x26, 1827 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x21 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x21, D_fsd_cg_cp_fs2_edges_b0xffbfffff, D_fsd_cg_cp_fs2_edges_b0xffbfffff_str)
-#else
-  fsd f25, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, D_fsd_cg_cp_fs2_edges_b0xffbfffff, D_fsd_cg_cp_fs2_edges_b0xffbfffff_str)
 
@@ -2678,18 +1697,9 @@ D_fsd_cg_cp_fs2_edges_b0x7ef8654f:
   fsd f16, -502(x14) # perform store
   addi x14, x14, -502 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, D_fsd_cg_cp_fs2_edges_b0x7ef8654f, D_fsd_cg_cp_fs2_edges_b0x7ef8654f_str)
-#else
-  fsd f16, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, D_fsd_cg_cp_fs2_edges_b0x7ef8654f, D_fsd_cg_cp_fs2_edges_b0x7ef8654f_str)
 
@@ -2702,18 +1712,9 @@ D_fsd_cg_cp_fs2_edges_b0x813d9ab0:
   fsd f7, -884(x27) # perform store
   addi x27, x27, -884 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x16 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x16, D_fsd_cg_cp_fs2_edges_b0x813d9ab0, D_fsd_cg_cp_fs2_edges_b0x813d9ab0_str)
-#else
-  fsd f7, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, D_fsd_cg_cp_fs2_edges_b0x813d9ab0, D_fsd_cg_cp_fs2_edges_b0x813d9ab0_str)
 

--- a/tests/rv32i/D/D-fsw-00.S
+++ b/tests/rv32i/D/D-fsw-00.S
@@ -42,18 +42,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xffffefff00000000:
   fsw f7, 768(x28) # perform store
   addi x28, x28, 768 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x16 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x16, D_fsw_cg_cp_fs2_badNB_D_S_b0xffffefff00000000, D_fsw_cg_cp_fs2_badNB_D_S_b0xffffefff00000000_str)
-#else
-  fsw f7, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xffffefff00000000, D_fsw_cg_cp_fs2_badNB_D_S_b0xffffefff00000000_str)
 
@@ -66,18 +57,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xaaaaaaaa80000000:
   fsw f6, -788(x14) # perform store
   addi x14, x14, -788 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x6 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x6, D_fsw_cg_cp_fs2_badNB_D_S_b0xaaaaaaaa80000000, D_fsw_cg_cp_fs2_badNB_D_S_b0xaaaaaaaa80000000_str)
-#else
-  fsw f6, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xaaaaaaaa80000000, D_fsw_cg_cp_fs2_badNB_D_S_b0xaaaaaaaa80000000_str)
 
@@ -90,18 +72,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0x3f800000:
   fsw f18, -932(x25) # perform store
   addi x25, x25, -932 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x8 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x8, D_fsw_cg_cp_fs2_badNB_D_S_b0x3f800000, D_fsw_cg_cp_fs2_badNB_D_S_b0x3f800000_str)
-#else
-  fsw f18, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0x3f800000, D_fsw_cg_cp_fs2_badNB_D_S_b0x3f800000_str)
 
@@ -114,18 +87,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xdeadbeefbf800000:
   fsw f20, 1155(x14) # perform store
   addi x14, x14, 1155 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x31 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x31, D_fsw_cg_cp_fs2_badNB_D_S_b0xdeadbeefbf800000, D_fsw_cg_cp_fs2_badNB_D_S_b0xdeadbeefbf800000_str)
-#else
-  fsw f20, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xdeadbeefbf800000, D_fsw_cg_cp_fs2_badNB_D_S_b0xdeadbeefbf800000_str)
 
@@ -138,18 +102,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xa1b2c3d400800000:
   fsw f28, 463(x31) # perform store
   addi x31, x31, 463 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x15 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x15, D_fsw_cg_cp_fs2_badNB_D_S_b0xa1b2c3d400800000, D_fsw_cg_cp_fs2_badNB_D_S_b0xa1b2c3d400800000_str)
-#else
-  fsw f28, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xa1b2c3d400800000, D_fsw_cg_cp_fs2_badNB_D_S_b0xa1b2c3d400800000_str)
 
@@ -162,18 +117,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xffffffef80800000:
   fsw f3, -1407(x25) # perform store
   addi x25, x25, -1407 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x30 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x30, D_fsw_cg_cp_fs2_badNB_D_S_b0xffffffef80800000, D_fsw_cg_cp_fs2_badNB_D_S_b0xffffffef80800000_str)
-#else
-  fsw f3, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xffffffef80800000, D_fsw_cg_cp_fs2_badNB_D_S_b0xffffffef80800000_str)
 
@@ -186,18 +132,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffef7f7fffff:
   fsw f16, -422(x30) # perform store
   addi x30, x30, -422 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x16 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x16, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffef7f7fffff, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffef7f7fffff_str)
-#else
-  fsw f16, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffef7f7fffff, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffef7f7fffff_str)
 
@@ -210,18 +147,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0x7e7e7e7eff7fffff:
   fsw f31, 1263(x20) # perform store
   addi x20, x20, 1263 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x21 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x21, D_fsw_cg_cp_fs2_badNB_D_S_b0x7e7e7e7eff7fffff, D_fsw_cg_cp_fs2_badNB_D_S_b0x7e7e7e7eff7fffff_str)
-#else
-  fsw f31, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0x7e7e7e7eff7fffff, D_fsw_cg_cp_fs2_badNB_D_S_b0x7e7e7e7eff7fffff_str)
 
@@ -234,18 +162,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0x7fffffff7f800000:
   fsw f31, 349(x29) # perform store
   addi x29, x29, 349 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x13 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x13, D_fsw_cg_cp_fs2_badNB_D_S_b0x7fffffff7f800000, D_fsw_cg_cp_fs2_badNB_D_S_b0x7fffffff7f800000_str)
-#else
-  fsw f31, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0x7fffffff7f800000, D_fsw_cg_cp_fs2_badNB_D_S_b0x7fffffff7f800000_str)
 
@@ -258,18 +177,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffffeff800000:
   fsw f30, -497(x27) # perform store
   addi x27, x27, -497 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x14 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x14, D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffffeff800000, D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffffeff800000_str)
-#else
-  fsw f30, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffffeff800000, D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffffeff800000_str)
 
@@ -282,18 +192,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xfeedbee57fc00000:
   fsw f28, -651(x26) # perform store
   addi x26, x26, -651 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x21 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x21, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeedbee57fc00000, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeedbee57fc00000_str)
-#else
-  fsw f28, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeedbee57fc00000, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeedbee57fc00000_str)
 
@@ -306,18 +207,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xffc0deff7fffffff:
   fsw f7, 397(x21) # perform store
   addi x21, x21, 397 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x18 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x18, D_fsw_cg_cp_fs2_badNB_D_S_b0xffc0deff7fffffff, D_fsw_cg_cp_fs2_badNB_D_S_b0xffc0deff7fffffff_str)
-#else
-  fsw f7, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xffc0deff7fffffff, D_fsw_cg_cp_fs2_badNB_D_S_b0xffc0deff7fffffff_str)
 
@@ -330,18 +222,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffff7f800001:
   fsw f23, -266(x29) # perform store
   addi x29, x29, -266 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x10 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x10, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffff7f800001, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffff7f800001_str)
-#else
-  fsw f23, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffff7f800001, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffff7f800001_str)
 
@@ -354,18 +237,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffeff7fbfffff:
   fsw f12, -39(x8) # perform store
   addi x8, x8, -39 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffeff7fbfffff, D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffeff7fbfffff_str)
-#else
-  fsw f12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffeff7fbfffff, D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffeff7fbfffff_str)
 

--- a/tests/rv32i/F/F-fsw-00.S
+++ b/tests/rv32i/F/F-fsw-00.S
@@ -42,18 +42,9 @@ F_fsw_cg_cp_rs1_nx0_b1:
   fsw f24, 1792(x1) # perform store
   addi x1, x1, 1792 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x20 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x20, F_fsw_cg_cp_rs1_nx0_b1, F_fsw_cg_cp_rs1_nx0_b1_str)
-#else
-  fsw f24, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, F_fsw_cg_cp_rs1_nx0_b1, F_fsw_cg_cp_rs1_nx0_b1_str)
 
@@ -66,18 +57,9 @@ F_fsw_cg_cp_rs1_nx0_b2:
   fsw f18, -1294(x2) # perform store
   addi x2, x2, -1294 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, F_fsw_cg_cp_rs1_nx0_b2, F_fsw_cg_cp_rs1_nx0_b2_str)
-#else
-  fsw f18, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, F_fsw_cg_cp_rs1_nx0_b2, F_fsw_cg_cp_rs1_nx0_b2_str)
 
@@ -91,18 +73,9 @@ F_fsw_cg_cp_rs1_nx0_b3:
   fsw f13, -170(x3) # perform store
   addi x3, x3, -170 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x11 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x11, F_fsw_cg_cp_rs1_nx0_b3, F_fsw_cg_cp_rs1_nx0_b3_str)
-#else
-  fsw f13, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, F_fsw_cg_cp_rs1_nx0_b3, F_fsw_cg_cp_rs1_nx0_b3_str)
 
@@ -117,18 +90,9 @@ F_fsw_cg_cp_rs1_nx0_b4:
   fsw f20, 2014(x4) # perform store
   addi x4, x4, 2014 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x16 contains the expected result. x4 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x4, x14, x13, x16, F_fsw_cg_cp_rs1_nx0_b4, F_fsw_cg_cp_rs1_nx0_b4_str)
-#else
-  fsw f20, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x4 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x4, x14, x13, F_fsw_cg_cp_rs1_nx0_b4, F_fsw_cg_cp_rs1_nx0_b4_str)
 
@@ -141,18 +105,9 @@ F_fsw_cg_cp_rs1_nx0_b5:
   fsw f23, -3(x5) # perform store
   addi x5, x5, -3 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x22 contains the expected result. x5 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x5, x14, x13, x22, F_fsw_cg_cp_rs1_nx0_b5, F_fsw_cg_cp_rs1_nx0_b5_str)
-#else
-  fsw f23, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x5 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x5, x14, x13, F_fsw_cg_cp_rs1_nx0_b5, F_fsw_cg_cp_rs1_nx0_b5_str)
 
@@ -166,18 +121,9 @@ F_fsw_cg_cp_rs1_nx0_b6:
   fsw f17, -771(x6) # perform store
   addi x6, x6, -771 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x24 contains the expected result. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x6, x14, x13, x24, F_fsw_cg_cp_rs1_nx0_b6, F_fsw_cg_cp_rs1_nx0_b6_str)
-#else
-  fsw f17, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x14, x13, F_fsw_cg_cp_rs1_nx0_b6, F_fsw_cg_cp_rs1_nx0_b6_str)
 
@@ -190,18 +136,9 @@ F_fsw_cg_cp_rs1_nx0_b7:
   fsw f1, -1041(x7) # perform store
   addi x7, x7, -1041 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x17 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x17, F_fsw_cg_cp_rs1_nx0_b7, F_fsw_cg_cp_rs1_nx0_b7_str)
-#else
-  fsw f1, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x14, x13, F_fsw_cg_cp_rs1_nx0_b7, F_fsw_cg_cp_rs1_nx0_b7_str)
 
@@ -214,18 +151,9 @@ F_fsw_cg_cp_rs1_nx0_b8:
   fsw f8, -1964(x8) # perform store
   addi x8, x8, -1964 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x4 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x4, F_fsw_cg_cp_rs1_nx0_b8, F_fsw_cg_cp_rs1_nx0_b8_str)
-#else
-  fsw f8, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x14, x13, F_fsw_cg_cp_rs1_nx0_b8, F_fsw_cg_cp_rs1_nx0_b8_str)
 
@@ -238,18 +166,9 @@ F_fsw_cg_cp_rs1_nx0_b9:
   fsw f13, -276(x9) # perform store
   addi x9, x9, -276 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x6, F_fsw_cg_cp_rs1_nx0_b9, F_fsw_cg_cp_rs1_nx0_b9_str)
-#else
-  fsw f13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x14, x13, F_fsw_cg_cp_rs1_nx0_b9, F_fsw_cg_cp_rs1_nx0_b9_str)
 
@@ -262,18 +181,9 @@ F_fsw_cg_cp_rs1_nx0_b10:
   fsw f30, 1016(x10) # perform store
   addi x10, x10, 1016 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x30 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x30, F_fsw_cg_cp_rs1_nx0_b10, F_fsw_cg_cp_rs1_nx0_b10_str)
-#else
-  fsw f30, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x14, x13, F_fsw_cg_cp_rs1_nx0_b10, F_fsw_cg_cp_rs1_nx0_b10_str)
 
@@ -286,18 +196,9 @@ F_fsw_cg_cp_rs1_nx0_b11:
   fsw f28, 952(x11) # perform store
   addi x11, x11, 952 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x22 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x22, F_fsw_cg_cp_rs1_nx0_b11, F_fsw_cg_cp_rs1_nx0_b11_str)
-#else
-  fsw f28, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x14, x13, F_fsw_cg_cp_rs1_nx0_b11, F_fsw_cg_cp_rs1_nx0_b11_str)
 
@@ -310,18 +211,9 @@ F_fsw_cg_cp_rs1_nx0_b12:
   fsw f19, -1545(x12) # perform store
   addi x12, x12, -1545 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x24 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x24, F_fsw_cg_cp_rs1_nx0_b12, F_fsw_cg_cp_rs1_nx0_b12_str)
-#else
-  fsw f19, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x14, x13, F_fsw_cg_cp_rs1_nx0_b12, F_fsw_cg_cp_rs1_nx0_b12_str)
 
@@ -336,18 +228,9 @@ F_fsw_cg_cp_rs1_nx0_b13:
   fsw f23, 1497(x13) # perform store
   addi x13, x13, 1497 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x26 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x26, F_fsw_cg_cp_rs1_nx0_b13, F_fsw_cg_cp_rs1_nx0_b13_str)
-#else
-  fsw f23, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, F_fsw_cg_cp_rs1_nx0_b13, F_fsw_cg_cp_rs1_nx0_b13_str)
 
@@ -360,18 +243,9 @@ F_fsw_cg_cp_rs1_nx0_b14:
   fsw f2, -575(x14) # perform store
   addi x14, x14, -575 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x26 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x26, F_fsw_cg_cp_rs1_nx0_b14, F_fsw_cg_cp_rs1_nx0_b14_str)
-#else
-  fsw f2, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, F_fsw_cg_cp_rs1_nx0_b14, F_fsw_cg_cp_rs1_nx0_b14_str)
 
@@ -384,18 +258,9 @@ F_fsw_cg_cp_rs1_nx0_b15:
   fsw f1, 1387(x15) # perform store
   addi x15, x15, 1387 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x1 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x1, F_fsw_cg_cp_rs1_nx0_b15, F_fsw_cg_cp_rs1_nx0_b15_str)
-#else
-  fsw f1, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, F_fsw_cg_cp_rs1_nx0_b15, F_fsw_cg_cp_rs1_nx0_b15_str)
 
@@ -408,18 +273,9 @@ F_fsw_cg_cp_rs1_nx0_b16:
   fsw f8, -1799(x16) # perform store
   addi x16, x16, -1799 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x29 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x29, F_fsw_cg_cp_rs1_nx0_b16, F_fsw_cg_cp_rs1_nx0_b16_str)
-#else
-  fsw f8, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, F_fsw_cg_cp_rs1_nx0_b16, F_fsw_cg_cp_rs1_nx0_b16_str)
 
@@ -432,18 +288,9 @@ F_fsw_cg_cp_rs1_nx0_b17:
   fsw f0, 1354(x17) # perform store
   addi x17, x17, 1354 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x30 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x30, F_fsw_cg_cp_rs1_nx0_b17, F_fsw_cg_cp_rs1_nx0_b17_str)
-#else
-  fsw f0, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, F_fsw_cg_cp_rs1_nx0_b17, F_fsw_cg_cp_rs1_nx0_b17_str)
 
@@ -456,18 +303,9 @@ F_fsw_cg_cp_rs1_nx0_b18:
   fsw f1, 1316(x18) # perform store
   addi x18, x18, 1316 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x6, F_fsw_cg_cp_rs1_nx0_b18, F_fsw_cg_cp_rs1_nx0_b18_str)
-#else
-  fsw f1, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, F_fsw_cg_cp_rs1_nx0_b18, F_fsw_cg_cp_rs1_nx0_b18_str)
 
@@ -481,18 +319,9 @@ F_fsw_cg_cp_rs1_nx0_b19:
   fsw f31, 1623(x19) # perform store
   addi x19, x19, 1623 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x16 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x16, F_fsw_cg_cp_rs1_nx0_b19, F_fsw_cg_cp_rs1_nx0_b19_str)
-#else
-  fsw f31, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, F_fsw_cg_cp_rs1_nx0_b19, F_fsw_cg_cp_rs1_nx0_b19_str)
 
@@ -505,18 +334,9 @@ F_fsw_cg_cp_rs1_nx0_b20:
   fsw f29, 721(x20) # perform store
   addi x20, x20, 721 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x22 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x22, F_fsw_cg_cp_rs1_nx0_b20, F_fsw_cg_cp_rs1_nx0_b20_str)
-#else
-  fsw f29, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, F_fsw_cg_cp_rs1_nx0_b20, F_fsw_cg_cp_rs1_nx0_b20_str)
 
@@ -530,18 +350,9 @@ F_fsw_cg_cp_rs1_nx0_b21:
   fsw f31, -1341(x21) # perform store
   addi x21, x21, -1341 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x30 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x30, F_fsw_cg_cp_rs1_nx0_b21, F_fsw_cg_cp_rs1_nx0_b21_str)
-#else
-  fsw f31, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, F_fsw_cg_cp_rs1_nx0_b21, F_fsw_cg_cp_rs1_nx0_b21_str)
 
@@ -554,18 +365,9 @@ F_fsw_cg_cp_rs1_nx0_b22:
   fsw f19, 1664(x22) # perform store
   addi x22, x22, 1664 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x1 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x1, F_fsw_cg_cp_rs1_nx0_b22, F_fsw_cg_cp_rs1_nx0_b22_str)
-#else
-  fsw f19, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, F_fsw_cg_cp_rs1_nx0_b22, F_fsw_cg_cp_rs1_nx0_b22_str)
 
@@ -578,18 +380,9 @@ F_fsw_cg_cp_rs1_nx0_b23:
   fsw f22, 96(x23) # perform store
   addi x23, x23, 96 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x7 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x7, F_fsw_cg_cp_rs1_nx0_b23, F_fsw_cg_cp_rs1_nx0_b23_str)
-#else
-  fsw f22, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, F_fsw_cg_cp_rs1_nx0_b23, F_fsw_cg_cp_rs1_nx0_b23_str)
 
@@ -602,18 +395,9 @@ F_fsw_cg_cp_rs1_nx0_b24:
   fsw f8, 1635(x24) # perform store
   addi x24, x24, 1635 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x20 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x20, F_fsw_cg_cp_rs1_nx0_b24, F_fsw_cg_cp_rs1_nx0_b24_str)
-#else
-  fsw f8, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, F_fsw_cg_cp_rs1_nx0_b24, F_fsw_cg_cp_rs1_nx0_b24_str)
 
@@ -626,18 +410,9 @@ F_fsw_cg_cp_rs1_nx0_b25:
   fsw f28, -1392(x25) # perform store
   addi x25, x25, -1392 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x30 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x30, F_fsw_cg_cp_rs1_nx0_b25, F_fsw_cg_cp_rs1_nx0_b25_str)
-#else
-  fsw f28, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, F_fsw_cg_cp_rs1_nx0_b25, F_fsw_cg_cp_rs1_nx0_b25_str)
 
@@ -650,18 +425,9 @@ F_fsw_cg_cp_rs1_nx0_b26:
   fsw f8, -147(x26) # perform store
   addi x26, x26, -147 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x8 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x8, F_fsw_cg_cp_rs1_nx0_b26, F_fsw_cg_cp_rs1_nx0_b26_str)
-#else
-  fsw f8, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, F_fsw_cg_cp_rs1_nx0_b26, F_fsw_cg_cp_rs1_nx0_b26_str)
 
@@ -674,18 +440,9 @@ F_fsw_cg_cp_rs1_nx0_b27:
   fsw f11, -1471(x27) # perform store
   addi x27, x27, -1471 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x17 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x17, F_fsw_cg_cp_rs1_nx0_b27, F_fsw_cg_cp_rs1_nx0_b27_str)
-#else
-  fsw f11, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, F_fsw_cg_cp_rs1_nx0_b27, F_fsw_cg_cp_rs1_nx0_b27_str)
 
@@ -698,18 +455,9 @@ F_fsw_cg_cp_rs1_nx0_b28:
   fsw f30, -1154(x28) # perform store
   addi x28, x28, -1154 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x13 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x13, F_fsw_cg_cp_rs1_nx0_b28, F_fsw_cg_cp_rs1_nx0_b28_str)
-#else
-  fsw f30, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, F_fsw_cg_cp_rs1_nx0_b28, F_fsw_cg_cp_rs1_nx0_b28_str)
 
@@ -722,18 +470,9 @@ F_fsw_cg_cp_rs1_nx0_b29:
   fsw f24, -358(x29) # perform store
   addi x29, x29, -358 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x17 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x17, F_fsw_cg_cp_rs1_nx0_b29, F_fsw_cg_cp_rs1_nx0_b29_str)
-#else
-  fsw f24, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, F_fsw_cg_cp_rs1_nx0_b29, F_fsw_cg_cp_rs1_nx0_b29_str)
 
@@ -746,18 +485,9 @@ F_fsw_cg_cp_rs1_nx0_b30:
   fsw f11, -1007(x30) # perform store
   addi x30, x30, -1007 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x13 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x13, F_fsw_cg_cp_rs1_nx0_b30, F_fsw_cg_cp_rs1_nx0_b30_str)
-#else
-  fsw f11, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, F_fsw_cg_cp_rs1_nx0_b30, F_fsw_cg_cp_rs1_nx0_b30_str)
 
@@ -770,18 +500,9 @@ F_fsw_cg_cp_rs1_nx0_b31:
   fsw f1, 958(x31) # perform store
   addi x31, x31, 958 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x1 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x1, F_fsw_cg_cp_rs1_nx0_b31, F_fsw_cg_cp_rs1_nx0_b31_str)
-#else
-  fsw f1, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, F_fsw_cg_cp_rs1_nx0_b31, F_fsw_cg_cp_rs1_nx0_b31_str)
 
@@ -798,18 +519,9 @@ F_fsw_cg_cp_imm_edges_0x0:
   fsw f17, 0(x19) # perform store
   addi x19, x19, 0 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x8 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x8, F_fsw_cg_cp_imm_edges_0x0, F_fsw_cg_cp_imm_edges_0x0_str)
-#else
-  fsw f17, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, F_fsw_cg_cp_imm_edges_0x0, F_fsw_cg_cp_imm_edges_0x0_str)
 
@@ -822,18 +534,9 @@ F_fsw_cg_cp_imm_edges_0x1:
   fsw f11, 1(x29) # perform store
   addi x29, x29, 1 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x20 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x20, F_fsw_cg_cp_imm_edges_0x1, F_fsw_cg_cp_imm_edges_0x1_str)
-#else
-  fsw f11, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, F_fsw_cg_cp_imm_edges_0x1, F_fsw_cg_cp_imm_edges_0x1_str)
 
@@ -846,18 +549,9 @@ F_fsw_cg_cp_imm_edges_0x2:
   fsw f17, 2(x20) # perform store
   addi x20, x20, 2 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x17 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x17, F_fsw_cg_cp_imm_edges_0x2, F_fsw_cg_cp_imm_edges_0x2_str)
-#else
-  fsw f17, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, F_fsw_cg_cp_imm_edges_0x2, F_fsw_cg_cp_imm_edges_0x2_str)
 
@@ -870,18 +564,9 @@ F_fsw_cg_cp_imm_edges_0x3:
   fsw f13, 3(x7) # perform store
   addi x7, x7, 3 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x25 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x25, F_fsw_cg_cp_imm_edges_0x3, F_fsw_cg_cp_imm_edges_0x3_str)
-#else
-  fsw f13, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, F_fsw_cg_cp_imm_edges_0x3, F_fsw_cg_cp_imm_edges_0x3_str)
 
@@ -894,18 +579,9 @@ F_fsw_cg_cp_imm_edges_0x4:
   fsw f13, 4(x26) # perform store
   addi x26, x26, 4 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x29 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x29, F_fsw_cg_cp_imm_edges_0x4, F_fsw_cg_cp_imm_edges_0x4_str)
-#else
-  fsw f13, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, F_fsw_cg_cp_imm_edges_0x4, F_fsw_cg_cp_imm_edges_0x4_str)
 
@@ -918,18 +594,9 @@ F_fsw_cg_cp_imm_edges_0x8:
   fsw f8, 8(x29) # perform store
   addi x29, x29, 8 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x22 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x22, F_fsw_cg_cp_imm_edges_0x8, F_fsw_cg_cp_imm_edges_0x8_str)
-#else
-  fsw f8, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, F_fsw_cg_cp_imm_edges_0x8, F_fsw_cg_cp_imm_edges_0x8_str)
 
@@ -942,18 +609,9 @@ F_fsw_cg_cp_imm_edges_0x10:
   fsw f24, 16(x18) # perform store
   addi x18, x18, 16 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, F_fsw_cg_cp_imm_edges_0x10, F_fsw_cg_cp_imm_edges_0x10_str)
-#else
-  fsw f24, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, F_fsw_cg_cp_imm_edges_0x10, F_fsw_cg_cp_imm_edges_0x10_str)
 
@@ -966,18 +624,9 @@ F_fsw_cg_cp_imm_edges_0x20:
   fsw f13, 32(x31) # perform store
   addi x31, x31, 32 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x16 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x16, F_fsw_cg_cp_imm_edges_0x20, F_fsw_cg_cp_imm_edges_0x20_str)
-#else
-  fsw f13, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, F_fsw_cg_cp_imm_edges_0x20, F_fsw_cg_cp_imm_edges_0x20_str)
 
@@ -990,18 +639,9 @@ F_fsw_cg_cp_imm_edges_0x40:
   fsw f5, 64(x9) # perform store
   addi x9, x9, 64 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, F_fsw_cg_cp_imm_edges_0x40, F_fsw_cg_cp_imm_edges_0x40_str)
-#else
-  fsw f5, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, F_fsw_cg_cp_imm_edges_0x40, F_fsw_cg_cp_imm_edges_0x40_str)
 
@@ -1014,18 +654,9 @@ F_fsw_cg_cp_imm_edges_0x80:
   fsw f1, 128(x18) # perform store
   addi x18, x18, 128 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x1 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x1, F_fsw_cg_cp_imm_edges_0x80, F_fsw_cg_cp_imm_edges_0x80_str)
-#else
-  fsw f1, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, F_fsw_cg_cp_imm_edges_0x80, F_fsw_cg_cp_imm_edges_0x80_str)
 
@@ -1038,18 +669,9 @@ F_fsw_cg_cp_imm_edges_0x100:
   fsw f2, 256(x23) # perform store
   addi x23, x23, 256 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x10 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x10, F_fsw_cg_cp_imm_edges_0x100, F_fsw_cg_cp_imm_edges_0x100_str)
-#else
-  fsw f2, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, F_fsw_cg_cp_imm_edges_0x100, F_fsw_cg_cp_imm_edges_0x100_str)
 
@@ -1062,18 +684,9 @@ F_fsw_cg_cp_imm_edges_0x200:
   fsw f3, 512(x2) # perform store
   addi x2, x2, 512 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x9 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x9, F_fsw_cg_cp_imm_edges_0x200, F_fsw_cg_cp_imm_edges_0x200_str)
-#else
-  fsw f3, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, F_fsw_cg_cp_imm_edges_0x200, F_fsw_cg_cp_imm_edges_0x200_str)
 
@@ -1086,18 +699,9 @@ F_fsw_cg_cp_imm_edges_0x3ff:
   fsw f13, 1023(x7) # perform store
   addi x7, x7, 1023 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x31 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x31, F_fsw_cg_cp_imm_edges_0x3ff, F_fsw_cg_cp_imm_edges_0x3ff_str)
-#else
-  fsw f13, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, F_fsw_cg_cp_imm_edges_0x3ff, F_fsw_cg_cp_imm_edges_0x3ff_str)
 
@@ -1110,18 +714,9 @@ F_fsw_cg_cp_imm_edges_0x400:
   fsw f31, 1024(x20) # perform store
   addi x20, x20, 1024 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x15 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x15, F_fsw_cg_cp_imm_edges_0x400, F_fsw_cg_cp_imm_edges_0x400_str)
-#else
-  fsw f31, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, F_fsw_cg_cp_imm_edges_0x400, F_fsw_cg_cp_imm_edges_0x400_str)
 
@@ -1134,18 +729,9 @@ F_fsw_cg_cp_imm_edges_0x703:
   fsw f26, 1795(x28) # perform store
   addi x28, x28, 1795 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x1 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x1, F_fsw_cg_cp_imm_edges_0x703, F_fsw_cg_cp_imm_edges_0x703_str)
-#else
-  fsw f26, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, F_fsw_cg_cp_imm_edges_0x703, F_fsw_cg_cp_imm_edges_0x703_str)
 
@@ -1158,18 +744,9 @@ F_fsw_cg_cp_imm_edges_0x7ff:
   fsw f21, 2047(x14) # perform store
   addi x14, x14, 2047 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x20 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x20, F_fsw_cg_cp_imm_edges_0x7ff, F_fsw_cg_cp_imm_edges_0x7ff_str)
-#else
-  fsw f21, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, F_fsw_cg_cp_imm_edges_0x7ff, F_fsw_cg_cp_imm_edges_0x7ff_str)
 
@@ -1183,18 +760,9 @@ F_fsw_cg_cp_imm_edges_m0x800:
   fsw f12, -2048(x13) # perform store
   addi x13, x13, -2048 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x26 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x26, F_fsw_cg_cp_imm_edges_m0x800, F_fsw_cg_cp_imm_edges_m0x800_str)
-#else
-  fsw f12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, F_fsw_cg_cp_imm_edges_m0x800, F_fsw_cg_cp_imm_edges_m0x800_str)
 
@@ -1207,18 +775,9 @@ F_fsw_cg_cp_imm_edges_m0x7ff:
   fsw f22, -2047(x15) # perform store
   addi x15, x15, -2047 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x17 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x17, F_fsw_cg_cp_imm_edges_m0x7ff, F_fsw_cg_cp_imm_edges_m0x7ff_str)
-#else
-  fsw f22, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, F_fsw_cg_cp_imm_edges_m0x7ff, F_fsw_cg_cp_imm_edges_m0x7ff_str)
 
@@ -1231,18 +790,9 @@ F_fsw_cg_cp_imm_edges_m0x2:
   fsw f19, -2(x19) # perform store
   addi x19, x19, -2 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x20 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x20, F_fsw_cg_cp_imm_edges_m0x2, F_fsw_cg_cp_imm_edges_m0x2_str)
-#else
-  fsw f19, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, F_fsw_cg_cp_imm_edges_m0x2, F_fsw_cg_cp_imm_edges_m0x2_str)
 
@@ -1255,18 +805,9 @@ F_fsw_cg_cp_imm_edges_m0x1:
   fsw f27, -1(x2) # perform store
   addi x2, x2, -1 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x29 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x29, F_fsw_cg_cp_imm_edges_m0x1, F_fsw_cg_cp_imm_edges_m0x1_str)
-#else
-  fsw f27, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, F_fsw_cg_cp_imm_edges_m0x1, F_fsw_cg_cp_imm_edges_m0x1_str)
 
@@ -1283,18 +824,9 @@ F_fsw_cg_cp_fs2_b0:
   fsw f0, -417(x16) # perform store
   addi x16, x16, -417 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x14 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x14, F_fsw_cg_cp_fs2_b0, F_fsw_cg_cp_fs2_b0_str)
-#else
-  fsw f0, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, F_fsw_cg_cp_fs2_b0, F_fsw_cg_cp_fs2_b0_str)
 
@@ -1307,18 +839,9 @@ F_fsw_cg_cp_fs2_b1:
   fsw f1, 1644(x13) # perform store
   addi x13, x13, 1644 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, F_fsw_cg_cp_fs2_b1, F_fsw_cg_cp_fs2_b1_str)
-#else
-  fsw f1, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, F_fsw_cg_cp_fs2_b1, F_fsw_cg_cp_fs2_b1_str)
 
@@ -1331,18 +854,9 @@ F_fsw_cg_cp_fs2_b2:
   fsw f2, 1825(x7) # perform store
   addi x7, x7, 1825 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x11 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x11, F_fsw_cg_cp_fs2_b2, F_fsw_cg_cp_fs2_b2_str)
-#else
-  fsw f2, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, F_fsw_cg_cp_fs2_b2, F_fsw_cg_cp_fs2_b2_str)
 
@@ -1355,18 +869,9 @@ F_fsw_cg_cp_fs2_b3:
   fsw f3, -490(x26) # perform store
   addi x26, x26, -490 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x9 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x9, F_fsw_cg_cp_fs2_b3, F_fsw_cg_cp_fs2_b3_str)
-#else
-  fsw f3, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, F_fsw_cg_cp_fs2_b3, F_fsw_cg_cp_fs2_b3_str)
 
@@ -1379,18 +884,9 @@ F_fsw_cg_cp_fs2_b4:
   fsw f4, 809(x15) # perform store
   addi x15, x15, 809 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x30 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x30, F_fsw_cg_cp_fs2_b4, F_fsw_cg_cp_fs2_b4_str)
-#else
-  fsw f4, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, F_fsw_cg_cp_fs2_b4, F_fsw_cg_cp_fs2_b4_str)
 
@@ -1403,18 +899,9 @@ F_fsw_cg_cp_fs2_b5:
   fsw f5, 1060(x23) # perform store
   addi x23, x23, 1060 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x27 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x27, F_fsw_cg_cp_fs2_b5, F_fsw_cg_cp_fs2_b5_str)
-#else
-  fsw f5, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, F_fsw_cg_cp_fs2_b5, F_fsw_cg_cp_fs2_b5_str)
 
@@ -1427,18 +914,9 @@ F_fsw_cg_cp_fs2_b6:
   fsw f6, 783(x10) # perform store
   addi x10, x10, 783 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x30 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x30, F_fsw_cg_cp_fs2_b6, F_fsw_cg_cp_fs2_b6_str)
-#else
-  fsw f6, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, F_fsw_cg_cp_fs2_b6, F_fsw_cg_cp_fs2_b6_str)
 
@@ -1451,18 +929,9 @@ F_fsw_cg_cp_fs2_b7:
   fsw f7, -1469(x31) # perform store
   addi x31, x31, -1469 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x24 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x24, F_fsw_cg_cp_fs2_b7, F_fsw_cg_cp_fs2_b7_str)
-#else
-  fsw f7, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, F_fsw_cg_cp_fs2_b7, F_fsw_cg_cp_fs2_b7_str)
 
@@ -1475,18 +944,9 @@ F_fsw_cg_cp_fs2_b8:
   fsw f8, 1803(x19) # perform store
   addi x19, x19, 1803 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x14 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x14, F_fsw_cg_cp_fs2_b8, F_fsw_cg_cp_fs2_b8_str)
-#else
-  fsw f8, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, F_fsw_cg_cp_fs2_b8, F_fsw_cg_cp_fs2_b8_str)
 
@@ -1499,18 +959,9 @@ F_fsw_cg_cp_fs2_b9:
   fsw f9, 651(x23) # perform store
   addi x23, x23, 651 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x26 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x26, F_fsw_cg_cp_fs2_b9, F_fsw_cg_cp_fs2_b9_str)
-#else
-  fsw f9, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, F_fsw_cg_cp_fs2_b9, F_fsw_cg_cp_fs2_b9_str)
 
@@ -1523,18 +974,9 @@ F_fsw_cg_cp_fs2_b10:
   fsw f10, 882(x8) # perform store
   addi x8, x8, 882 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x29 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x29, F_fsw_cg_cp_fs2_b10, F_fsw_cg_cp_fs2_b10_str)
-#else
-  fsw f10, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, F_fsw_cg_cp_fs2_b10, F_fsw_cg_cp_fs2_b10_str)
 
@@ -1547,18 +989,9 @@ F_fsw_cg_cp_fs2_b11:
   fsw f11, -1757(x28) # perform store
   addi x28, x28, -1757 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x9 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x9, F_fsw_cg_cp_fs2_b11, F_fsw_cg_cp_fs2_b11_str)
-#else
-  fsw f11, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, F_fsw_cg_cp_fs2_b11, F_fsw_cg_cp_fs2_b11_str)
 
@@ -1571,18 +1004,9 @@ F_fsw_cg_cp_fs2_b12:
   fsw f12, 95(x15) # perform store
   addi x15, x15, 95 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, F_fsw_cg_cp_fs2_b12, F_fsw_cg_cp_fs2_b12_str)
-#else
-  fsw f12, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, F_fsw_cg_cp_fs2_b12, F_fsw_cg_cp_fs2_b12_str)
 
@@ -1595,18 +1019,9 @@ F_fsw_cg_cp_fs2_b13:
   fsw f13, -1069(x16) # perform store
   addi x16, x16, -1069 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x13 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x13, F_fsw_cg_cp_fs2_b13, F_fsw_cg_cp_fs2_b13_str)
-#else
-  fsw f13, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, F_fsw_cg_cp_fs2_b13, F_fsw_cg_cp_fs2_b13_str)
 
@@ -1619,18 +1034,9 @@ F_fsw_cg_cp_fs2_b14:
   fsw f14, -660(x14) # perform store
   addi x14, x14, -660 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x19 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x19, F_fsw_cg_cp_fs2_b14, F_fsw_cg_cp_fs2_b14_str)
-#else
-  fsw f14, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, F_fsw_cg_cp_fs2_b14, F_fsw_cg_cp_fs2_b14_str)
 
@@ -1643,18 +1049,9 @@ F_fsw_cg_cp_fs2_b15:
   fsw f15, -708(x15) # perform store
   addi x15, x15, -708 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x1 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x1, F_fsw_cg_cp_fs2_b15, F_fsw_cg_cp_fs2_b15_str)
-#else
-  fsw f15, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, F_fsw_cg_cp_fs2_b15, F_fsw_cg_cp_fs2_b15_str)
 
@@ -1667,18 +1064,9 @@ F_fsw_cg_cp_fs2_b16:
   fsw f16, -21(x10) # perform store
   addi x10, x10, -21 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, F_fsw_cg_cp_fs2_b16, F_fsw_cg_cp_fs2_b16_str)
-#else
-  fsw f16, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, F_fsw_cg_cp_fs2_b16, F_fsw_cg_cp_fs2_b16_str)
 
@@ -1691,18 +1079,9 @@ F_fsw_cg_cp_fs2_b17:
   fsw f17, 576(x14) # perform store
   addi x14, x14, 576 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x27 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x27, F_fsw_cg_cp_fs2_b17, F_fsw_cg_cp_fs2_b17_str)
-#else
-  fsw f17, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, F_fsw_cg_cp_fs2_b17, F_fsw_cg_cp_fs2_b17_str)
 
@@ -1715,18 +1094,9 @@ F_fsw_cg_cp_fs2_b18:
   fsw f18, 224(x29) # perform store
   addi x29, x29, 224 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x18 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x18, F_fsw_cg_cp_fs2_b18, F_fsw_cg_cp_fs2_b18_str)
-#else
-  fsw f18, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, F_fsw_cg_cp_fs2_b18, F_fsw_cg_cp_fs2_b18_str)
 
@@ -1739,18 +1109,9 @@ F_fsw_cg_cp_fs2_b19:
   fsw f19, -337(x20) # perform store
   addi x20, x20, -337 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x6 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x6, F_fsw_cg_cp_fs2_b19, F_fsw_cg_cp_fs2_b19_str)
-#else
-  fsw f19, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, F_fsw_cg_cp_fs2_b19, F_fsw_cg_cp_fs2_b19_str)
 
@@ -1763,18 +1124,9 @@ F_fsw_cg_cp_fs2_b20:
   fsw f20, 1700(x27) # perform store
   addi x27, x27, 1700 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x7 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x7, F_fsw_cg_cp_fs2_b20, F_fsw_cg_cp_fs2_b20_str)
-#else
-  fsw f20, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, F_fsw_cg_cp_fs2_b20, F_fsw_cg_cp_fs2_b20_str)
 
@@ -1787,18 +1139,9 @@ F_fsw_cg_cp_fs2_b21:
   fsw f21, 1749(x25) # perform store
   addi x25, x25, 1749 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x26 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x26, F_fsw_cg_cp_fs2_b21, F_fsw_cg_cp_fs2_b21_str)
-#else
-  fsw f21, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, F_fsw_cg_cp_fs2_b21, F_fsw_cg_cp_fs2_b21_str)
 
@@ -1811,18 +1154,9 @@ F_fsw_cg_cp_fs2_b22:
   fsw f22, 107(x30) # perform store
   addi x30, x30, 107 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x18 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x18, F_fsw_cg_cp_fs2_b22, F_fsw_cg_cp_fs2_b22_str)
-#else
-  fsw f22, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, F_fsw_cg_cp_fs2_b22, F_fsw_cg_cp_fs2_b22_str)
 
@@ -1835,18 +1169,9 @@ F_fsw_cg_cp_fs2_b23:
   fsw f23, 22(x1) # perform store
   addi x1, x1, 22 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x17 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x17, F_fsw_cg_cp_fs2_b23, F_fsw_cg_cp_fs2_b23_str)
-#else
-  fsw f23, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, F_fsw_cg_cp_fs2_b23, F_fsw_cg_cp_fs2_b23_str)
 
@@ -1859,18 +1184,9 @@ F_fsw_cg_cp_fs2_b24:
   fsw f24, -785(x8) # perform store
   addi x8, x8, -785 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, F_fsw_cg_cp_fs2_b24, F_fsw_cg_cp_fs2_b24_str)
-#else
-  fsw f24, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, F_fsw_cg_cp_fs2_b24, F_fsw_cg_cp_fs2_b24_str)
 
@@ -1883,18 +1199,9 @@ F_fsw_cg_cp_fs2_b25:
   fsw f25, 1680(x2) # perform store
   addi x2, x2, 1680 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x1 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x1, F_fsw_cg_cp_fs2_b25, F_fsw_cg_cp_fs2_b25_str)
-#else
-  fsw f25, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, F_fsw_cg_cp_fs2_b25, F_fsw_cg_cp_fs2_b25_str)
 
@@ -1907,18 +1214,9 @@ F_fsw_cg_cp_fs2_b26:
   fsw f26, -654(x29) # perform store
   addi x29, x29, -654 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x12 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x12, F_fsw_cg_cp_fs2_b26, F_fsw_cg_cp_fs2_b26_str)
-#else
-  fsw f26, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, F_fsw_cg_cp_fs2_b26, F_fsw_cg_cp_fs2_b26_str)
 
@@ -1931,18 +1229,9 @@ F_fsw_cg_cp_fs2_b27:
   fsw f27, -2033(x24) # perform store
   addi x24, x24, -2033 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x18 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x18, F_fsw_cg_cp_fs2_b27, F_fsw_cg_cp_fs2_b27_str)
-#else
-  fsw f27, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, F_fsw_cg_cp_fs2_b27, F_fsw_cg_cp_fs2_b27_str)
 
@@ -1955,18 +1244,9 @@ F_fsw_cg_cp_fs2_b28:
   fsw f28, 704(x8) # perform store
   addi x8, x8, 704 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, F_fsw_cg_cp_fs2_b28, F_fsw_cg_cp_fs2_b28_str)
-#else
-  fsw f28, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, F_fsw_cg_cp_fs2_b28, F_fsw_cg_cp_fs2_b28_str)
 
@@ -1979,18 +1259,9 @@ F_fsw_cg_cp_fs2_b29:
   fsw f29, -649(x2) # perform store
   addi x2, x2, -649 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x13 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x13, F_fsw_cg_cp_fs2_b29, F_fsw_cg_cp_fs2_b29_str)
-#else
-  fsw f29, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, F_fsw_cg_cp_fs2_b29, F_fsw_cg_cp_fs2_b29_str)
 
@@ -2003,18 +1274,9 @@ F_fsw_cg_cp_fs2_b30:
   fsw f30, -474(x18) # perform store
   addi x18, x18, -474 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, F_fsw_cg_cp_fs2_b30, F_fsw_cg_cp_fs2_b30_str)
-#else
-  fsw f30, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, F_fsw_cg_cp_fs2_b30, F_fsw_cg_cp_fs2_b30_str)
 
@@ -2027,18 +1289,9 @@ F_fsw_cg_cp_fs2_b31:
   fsw f31, 1412(x9) # perform store
   addi x9, x9, 1412 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, F_fsw_cg_cp_fs2_b31, F_fsw_cg_cp_fs2_b31_str)
-#else
-  fsw f31, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, F_fsw_cg_cp_fs2_b31, F_fsw_cg_cp_fs2_b31_str)
 
@@ -2055,18 +1308,9 @@ F_fsw_cg_cp_fs2_edges_b0x0:
   fsw f15, -1471(x21) # perform store
   addi x21, x21, -1471 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x15 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x15, F_fsw_cg_cp_fs2_edges_b0x0, F_fsw_cg_cp_fs2_edges_b0x0_str)
-#else
-  fsw f15, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, F_fsw_cg_cp_fs2_edges_b0x0, F_fsw_cg_cp_fs2_edges_b0x0_str)
 
@@ -2079,18 +1323,9 @@ F_fsw_cg_cp_fs2_edges_b0x80000000:
   fsw f9, -971(x27) # perform store
   addi x27, x27, -971 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x7 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x7, F_fsw_cg_cp_fs2_edges_b0x80000000, F_fsw_cg_cp_fs2_edges_b0x80000000_str)
-#else
-  fsw f9, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, F_fsw_cg_cp_fs2_edges_b0x80000000, F_fsw_cg_cp_fs2_edges_b0x80000000_str)
 
@@ -2103,18 +1338,9 @@ F_fsw_cg_cp_fs2_edges_b0x3f800000:
   fsw f1, -64(x18) # perform store
   addi x18, x18, -64 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x14 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x14, F_fsw_cg_cp_fs2_edges_b0x3f800000, F_fsw_cg_cp_fs2_edges_b0x3f800000_str)
-#else
-  fsw f1, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, F_fsw_cg_cp_fs2_edges_b0x3f800000, F_fsw_cg_cp_fs2_edges_b0x3f800000_str)
 
@@ -2127,18 +1353,9 @@ F_fsw_cg_cp_fs2_edges_b0xbf800000:
   fsw f22, 1044(x10) # perform store
   addi x10, x10, 1044 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, F_fsw_cg_cp_fs2_edges_b0xbf800000, F_fsw_cg_cp_fs2_edges_b0xbf800000_str)
-#else
-  fsw f22, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, F_fsw_cg_cp_fs2_edges_b0xbf800000, F_fsw_cg_cp_fs2_edges_b0xbf800000_str)
 
@@ -2151,18 +1368,9 @@ F_fsw_cg_cp_fs2_edges_b0x3fc00000:
   fsw f24, -1339(x26) # perform store
   addi x26, x26, -1339 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x20 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x20, F_fsw_cg_cp_fs2_edges_b0x3fc00000, F_fsw_cg_cp_fs2_edges_b0x3fc00000_str)
-#else
-  fsw f24, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, F_fsw_cg_cp_fs2_edges_b0x3fc00000, F_fsw_cg_cp_fs2_edges_b0x3fc00000_str)
 
@@ -2175,18 +1383,9 @@ F_fsw_cg_cp_fs2_edges_b0xbfc00000:
   fsw f2, -483(x19) # perform store
   addi x19, x19, -483 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x31 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x31, F_fsw_cg_cp_fs2_edges_b0xbfc00000, F_fsw_cg_cp_fs2_edges_b0xbfc00000_str)
-#else
-  fsw f2, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, F_fsw_cg_cp_fs2_edges_b0xbfc00000, F_fsw_cg_cp_fs2_edges_b0xbfc00000_str)
 
@@ -2199,18 +1398,9 @@ F_fsw_cg_cp_fs2_edges_b0x40000000:
   fsw f14, 926(x16) # perform store
   addi x16, x16, 926 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x26 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x26, F_fsw_cg_cp_fs2_edges_b0x40000000, F_fsw_cg_cp_fs2_edges_b0x40000000_str)
-#else
-  fsw f14, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, F_fsw_cg_cp_fs2_edges_b0x40000000, F_fsw_cg_cp_fs2_edges_b0x40000000_str)
 
@@ -2223,18 +1413,9 @@ F_fsw_cg_cp_fs2_edges_b0xc0000000:
   fsw f23, -1716(x11) # perform store
   addi x11, x11, -1716 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, F_fsw_cg_cp_fs2_edges_b0xc0000000, F_fsw_cg_cp_fs2_edges_b0xc0000000_str)
-#else
-  fsw f23, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, F_fsw_cg_cp_fs2_edges_b0xc0000000, F_fsw_cg_cp_fs2_edges_b0xc0000000_str)
 
@@ -2247,18 +1428,9 @@ F_fsw_cg_cp_fs2_edges_b0x800000:
   fsw f23, -1388(x9) # perform store
   addi x9, x9, -1388 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x23 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x23, F_fsw_cg_cp_fs2_edges_b0x800000, F_fsw_cg_cp_fs2_edges_b0x800000_str)
-#else
-  fsw f23, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, F_fsw_cg_cp_fs2_edges_b0x800000, F_fsw_cg_cp_fs2_edges_b0x800000_str)
 
@@ -2271,18 +1443,9 @@ F_fsw_cg_cp_fs2_edges_b0x80800000:
   fsw f10, -151(x22) # perform store
   addi x22, x22, -151 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x20 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x20, F_fsw_cg_cp_fs2_edges_b0x80800000, F_fsw_cg_cp_fs2_edges_b0x80800000_str)
-#else
-  fsw f10, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, F_fsw_cg_cp_fs2_edges_b0x80800000, F_fsw_cg_cp_fs2_edges_b0x80800000_str)
 
@@ -2295,18 +1458,9 @@ F_fsw_cg_cp_fs2_edges_b0x7f7fffff:
   fsw f30, 1719(x10) # perform store
   addi x10, x10, 1719 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x24 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x24, F_fsw_cg_cp_fs2_edges_b0x7f7fffff, F_fsw_cg_cp_fs2_edges_b0x7f7fffff_str)
-#else
-  fsw f30, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, F_fsw_cg_cp_fs2_edges_b0x7f7fffff, F_fsw_cg_cp_fs2_edges_b0x7f7fffff_str)
 
@@ -2319,18 +1473,9 @@ F_fsw_cg_cp_fs2_edges_b0xff7fffff:
   fsw f2, -1304(x21) # perform store
   addi x21, x21, -1304 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x13 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x13, F_fsw_cg_cp_fs2_edges_b0xff7fffff, F_fsw_cg_cp_fs2_edges_b0xff7fffff_str)
-#else
-  fsw f2, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, F_fsw_cg_cp_fs2_edges_b0xff7fffff, F_fsw_cg_cp_fs2_edges_b0xff7fffff_str)
 
@@ -2343,18 +1488,9 @@ F_fsw_cg_cp_fs2_edges_b0x7fffff:
   fsw f16, -189(x2) # perform store
   addi x2, x2, -189 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x12 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x12, F_fsw_cg_cp_fs2_edges_b0x7fffff, F_fsw_cg_cp_fs2_edges_b0x7fffff_str)
-#else
-  fsw f16, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, F_fsw_cg_cp_fs2_edges_b0x7fffff, F_fsw_cg_cp_fs2_edges_b0x7fffff_str)
 
@@ -2367,18 +1503,9 @@ F_fsw_cg_cp_fs2_edges_b0x807fffff:
   fsw f13, 571(x21) # perform store
   addi x21, x21, 571 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x27 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x27, F_fsw_cg_cp_fs2_edges_b0x807fffff, F_fsw_cg_cp_fs2_edges_b0x807fffff_str)
-#else
-  fsw f13, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, F_fsw_cg_cp_fs2_edges_b0x807fffff, F_fsw_cg_cp_fs2_edges_b0x807fffff_str)
 
@@ -2391,18 +1518,9 @@ F_fsw_cg_cp_fs2_edges_b0x400000:
   fsw f2, -688(x30) # perform store
   addi x30, x30, -688 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x10 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x10, F_fsw_cg_cp_fs2_edges_b0x400000, F_fsw_cg_cp_fs2_edges_b0x400000_str)
-#else
-  fsw f2, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, F_fsw_cg_cp_fs2_edges_b0x400000, F_fsw_cg_cp_fs2_edges_b0x400000_str)
 
@@ -2415,18 +1533,9 @@ F_fsw_cg_cp_fs2_edges_b0x80400000:
   fsw f14, -1720(x1) # perform store
   addi x1, x1, -1720 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x21 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x21, F_fsw_cg_cp_fs2_edges_b0x80400000, F_fsw_cg_cp_fs2_edges_b0x80400000_str)
-#else
-  fsw f14, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, F_fsw_cg_cp_fs2_edges_b0x80400000, F_fsw_cg_cp_fs2_edges_b0x80400000_str)
 
@@ -2439,18 +1548,9 @@ F_fsw_cg_cp_fs2_edges_b0x1:
   fsw f8, -264(x21) # perform store
   addi x21, x21, -264 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x20 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x20, F_fsw_cg_cp_fs2_edges_b0x1, F_fsw_cg_cp_fs2_edges_b0x1_str)
-#else
-  fsw f8, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, F_fsw_cg_cp_fs2_edges_b0x1, F_fsw_cg_cp_fs2_edges_b0x1_str)
 
@@ -2463,18 +1563,9 @@ F_fsw_cg_cp_fs2_edges_b0x80000001:
   fsw f3, -1359(x11) # perform store
   addi x11, x11, -1359 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x22, F_fsw_cg_cp_fs2_edges_b0x80000001, F_fsw_cg_cp_fs2_edges_b0x80000001_str)
-#else
-  fsw f3, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, F_fsw_cg_cp_fs2_edges_b0x80000001, F_fsw_cg_cp_fs2_edges_b0x80000001_str)
 
@@ -2487,18 +1578,9 @@ F_fsw_cg_cp_fs2_edges_b0x7f800000:
   fsw f25, 193(x13) # perform store
   addi x13, x13, 193 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, F_fsw_cg_cp_fs2_edges_b0x7f800000, F_fsw_cg_cp_fs2_edges_b0x7f800000_str)
-#else
-  fsw f25, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, F_fsw_cg_cp_fs2_edges_b0x7f800000, F_fsw_cg_cp_fs2_edges_b0x7f800000_str)
 
@@ -2511,18 +1593,9 @@ F_fsw_cg_cp_fs2_edges_b0xff800000:
   fsw f9, -823(x22) # perform store
   addi x22, x22, -823 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x23 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x23, F_fsw_cg_cp_fs2_edges_b0xff800000, F_fsw_cg_cp_fs2_edges_b0xff800000_str)
-#else
-  fsw f9, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, F_fsw_cg_cp_fs2_edges_b0xff800000, F_fsw_cg_cp_fs2_edges_b0xff800000_str)
 
@@ -2535,18 +1608,9 @@ F_fsw_cg_cp_fs2_edges_b0x7fc00000:
   fsw f17, 244(x28) # perform store
   addi x28, x28, 244 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x13 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x13, F_fsw_cg_cp_fs2_edges_b0x7fc00000, F_fsw_cg_cp_fs2_edges_b0x7fc00000_str)
-#else
-  fsw f17, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, F_fsw_cg_cp_fs2_edges_b0x7fc00000, F_fsw_cg_cp_fs2_edges_b0x7fc00000_str)
 
@@ -2559,18 +1623,9 @@ F_fsw_cg_cp_fs2_edges_b0x7fffffff:
   fsw f5, 442(x21) # perform store
   addi x21, x21, 442 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x29 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x29, F_fsw_cg_cp_fs2_edges_b0x7fffffff, F_fsw_cg_cp_fs2_edges_b0x7fffffff_str)
-#else
-  fsw f5, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, F_fsw_cg_cp_fs2_edges_b0x7fffffff, F_fsw_cg_cp_fs2_edges_b0x7fffffff_str)
 
@@ -2583,18 +1638,9 @@ F_fsw_cg_cp_fs2_edges_b0xffffffff:
   fsw f11, -1198(x7) # perform store
   addi x7, x7, -1198 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x15 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x15, F_fsw_cg_cp_fs2_edges_b0xffffffff, F_fsw_cg_cp_fs2_edges_b0xffffffff_str)
-#else
-  fsw f11, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, F_fsw_cg_cp_fs2_edges_b0xffffffff, F_fsw_cg_cp_fs2_edges_b0xffffffff_str)
 
@@ -2607,18 +1653,9 @@ F_fsw_cg_cp_fs2_edges_b0x7f800001:
   fsw f11, -1684(x14) # perform store
   addi x14, x14, -1684 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x31 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x31, F_fsw_cg_cp_fs2_edges_b0x7f800001, F_fsw_cg_cp_fs2_edges_b0x7f800001_str)
-#else
-  fsw f11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, F_fsw_cg_cp_fs2_edges_b0x7f800001, F_fsw_cg_cp_fs2_edges_b0x7f800001_str)
 
@@ -2631,18 +1668,9 @@ F_fsw_cg_cp_fs2_edges_b0x7fbfffff:
   fsw f26, -399(x17) # perform store
   addi x17, x17, -399 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x20 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x20, F_fsw_cg_cp_fs2_edges_b0x7fbfffff, F_fsw_cg_cp_fs2_edges_b0x7fbfffff_str)
-#else
-  fsw f26, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, F_fsw_cg_cp_fs2_edges_b0x7fbfffff, F_fsw_cg_cp_fs2_edges_b0x7fbfffff_str)
 
@@ -2655,18 +1683,9 @@ F_fsw_cg_cp_fs2_edges_b0xffbfffff:
   fsw f31, 2012(x12) # perform store
   addi x12, x12, 2012 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x16 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x16, F_fsw_cg_cp_fs2_edges_b0xffbfffff, F_fsw_cg_cp_fs2_edges_b0xffbfffff_str)
-#else
-  fsw f31, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, F_fsw_cg_cp_fs2_edges_b0xffbfffff, F_fsw_cg_cp_fs2_edges_b0xffbfffff_str)
 
@@ -2679,18 +1698,9 @@ F_fsw_cg_cp_fs2_edges_b0x7ef8654f:
   fsw f6, 698(x22) # perform store
   addi x22, x22, 698 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x16 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x16, F_fsw_cg_cp_fs2_edges_b0x7ef8654f, F_fsw_cg_cp_fs2_edges_b0x7ef8654f_str)
-#else
-  fsw f6, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, F_fsw_cg_cp_fs2_edges_b0x7ef8654f, F_fsw_cg_cp_fs2_edges_b0x7ef8654f_str)
 
@@ -2703,18 +1713,9 @@ F_fsw_cg_cp_fs2_edges_b0x813d9ab0:
   fsw f9, -2045(x24) # perform store
   addi x24, x24, -2045 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x19 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x19, F_fsw_cg_cp_fs2_edges_b0x813d9ab0, F_fsw_cg_cp_fs2_edges_b0x813d9ab0_str)
-#else
-  fsw f9, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, F_fsw_cg_cp_fs2_edges_b0x813d9ab0, F_fsw_cg_cp_fs2_edges_b0x813d9ab0_str)
 

--- a/tests/rv32i/I/I-sb-00.S
+++ b/tests/rv32i/I/I-sb-00.S
@@ -41,18 +41,9 @@ I_sb_cg_cp_rs1_nx0_b1:
   sb x21, 21(x1) # perform store
   addi x1, x1, 21 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x30 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x30, I_sb_cg_cp_rs1_nx0_b1, I_sb_cg_cp_rs1_nx0_b1_str)
-#else
-  sb x21, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x25) # load rs2: x25 = 0x74b9674b
@@ -62,18 +53,9 @@ I_sb_cg_cp_rs1_nx0_b2:
   sb x25, 1782(x2) # perform store
   addi x2, x2, 1782 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x10 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x10, I_sb_cg_cp_rs1_nx0_b2, I_sb_cg_cp_rs1_nx0_b2_str)
-#else
-  sb x25, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x30, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
@@ -84,18 +66,9 @@ I_sb_cg_cp_rs1_nx0_b3:
   sb x21, -1763(x3) # perform store
   addi x3, x3, -1763 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x10 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x10, I_sb_cg_cp_rs1_nx0_b3, I_sb_cg_cp_rs1_nx0_b3_str)
-#else
-  sb x21, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -107,18 +80,9 @@ I_sb_cg_cp_rs1_nx0_b4:
   sb x5, 791(x4) # perform store
   addi x4, x4, 791 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x9 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x9, I_sb_cg_cp_rs1_nx0_b4, I_sb_cg_cp_rs1_nx0_b4_str)
-#else
-  sb x5, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x30, x21) # load rs2: x21 = 0xb1acb555
@@ -128,18 +92,9 @@ I_sb_cg_cp_rs1_nx0_b5:
   sb x21, 1886(x5) # perform store
   addi x5, x5, 1886 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x22 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x22, I_sb_cg_cp_rs1_nx0_b5, I_sb_cg_cp_rs1_nx0_b5_str)
-#else
-  sb x21, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x30, x12) # load rs2: x12 = 0x469f2490
@@ -149,18 +104,9 @@ I_sb_cg_cp_rs1_nx0_b6:
   sb x12, 1076(x6) # perform store
   addi x6, x6, 1076 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x25, I_sb_cg_cp_rs1_nx0_b6, I_sb_cg_cp_rs1_nx0_b6_str)
-#else
-  sb x12, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x7 # switch temp register to avoid conflict with test
   mv x14, x8 # switch link pointer register to avoid conflict with test
@@ -172,18 +118,9 @@ I_sb_cg_cp_rs1_nx0_b7:
   sb x0, 519(x7) # perform store
   addi x7, x7, 519 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x26 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x26, I_sb_cg_cp_rs1_nx0_b7, I_sb_cg_cp_rs1_nx0_b7_str)
-#else
-  sb x0, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x30, x12) # load rs2: x12 = 0xcbd0956d
@@ -193,18 +130,9 @@ I_sb_cg_cp_rs1_nx0_b8:
   sb x12, 1805(x8) # perform store
   addi x8, x8, 1805 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x27 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x27, I_sb_cg_cp_rs1_nx0_b8, I_sb_cg_cp_rs1_nx0_b8_str)
-#else
-  sb x12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x30, x6) # load rs2: x6 = 0xe35fe367
@@ -214,18 +142,9 @@ I_sb_cg_cp_rs1_nx0_b9:
   sb x6, -1839(x9) # perform store
   addi x9, x9, -1839 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x28 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x28, I_sb_cg_cp_rs1_nx0_b9, I_sb_cg_cp_rs1_nx0_b9_str)
-#else
-  sb x6, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x30, x8) # load rs2: x8 = 0x058ef675
@@ -235,18 +154,9 @@ I_sb_cg_cp_rs1_nx0_b10:
   sb x8, -215(x10) # perform store
   addi x10, x10, -215 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x3 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x3, I_sb_cg_cp_rs1_nx0_b10, I_sb_cg_cp_rs1_nx0_b10_str)
-#else
-  sb x8, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x30, x19) # load rs2: x19 = 0xf8d3e2b0
@@ -256,18 +166,9 @@ I_sb_cg_cp_rs1_nx0_b11:
   sb x19, 1009(x11) # perform store
   addi x11, x11, 1009 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x5 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x5, I_sb_cg_cp_rs1_nx0_b11, I_sb_cg_cp_rs1_nx0_b11_str)
-#else
-  sb x19, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x30, x8) # load rs2: x8 = 0x97f8308b
@@ -277,18 +178,9 @@ I_sb_cg_cp_rs1_nx0_b12:
   sb x8, -1004(x12) # perform store
   addi x12, x12, -1004 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x15 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x15, I_sb_cg_cp_rs1_nx0_b12, I_sb_cg_cp_rs1_nx0_b12_str)
-#else
-  sb x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -300,18 +192,9 @@ I_sb_cg_cp_rs1_nx0_b13:
   sb x14, -414(x13) # perform store
   addi x13, x13, -414 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x22 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x22, I_sb_cg_cp_rs1_nx0_b13, I_sb_cg_cp_rs1_nx0_b13_str)
-#else
-  sb x14, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x30, x19) # load rs2: x19 = 0x3e463505
@@ -321,18 +204,9 @@ I_sb_cg_cp_rs1_nx0_b14:
   sb x19, 1824(x14) # perform store
   addi x14, x14, 1824 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x15 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x15, I_sb_cg_cp_rs1_nx0_b14, I_sb_cg_cp_rs1_nx0_b14_str)
-#else
-  sb x19, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x30, x12) # load rs2: x12 = 0xe5d296b1
@@ -342,18 +216,9 @@ I_sb_cg_cp_rs1_nx0_b15:
   sb x12, 1035(x15) # perform store
   addi x15, x15, 1035 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x23 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x23, I_sb_cg_cp_rs1_nx0_b15, I_sb_cg_cp_rs1_nx0_b15_str)
-#else
-  sb x12, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x16)
   RVTEST_TESTDATA_LOAD_INT(x30, x28) # load rs2: x28 = 0x8296325a
@@ -363,18 +228,9 @@ I_sb_cg_cp_rs1_nx0_b16:
   sb x28, -559(x16) # perform store
   addi x16, x16, -559 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x11 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x11, I_sb_cg_cp_rs1_nx0_b16, I_sb_cg_cp_rs1_nx0_b16_str)
-#else
-  sb x28, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x17)
   RVTEST_TESTDATA_LOAD_INT(x30, x13) # load rs2: x13 = 0x5e94a095
@@ -384,18 +240,9 @@ I_sb_cg_cp_rs1_nx0_b17:
   sb x13, 1273(x17) # perform store
   addi x17, x17, 1273 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x12 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x12, I_sb_cg_cp_rs1_nx0_b17, I_sb_cg_cp_rs1_nx0_b17_str)
-#else
-  sb x13, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x18)
   RVTEST_TESTDATA_LOAD_INT(x30, x28) # load rs2: x28 = 0x3bf88165
@@ -405,18 +252,9 @@ I_sb_cg_cp_rs1_nx0_b18:
   sb x28, -445(x18) # perform store
   addi x18, x18, -445 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x14 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x14, I_sb_cg_cp_rs1_nx0_b18, I_sb_cg_cp_rs1_nx0_b18_str)
-#else
-  sb x28, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x19)
   RVTEST_TESTDATA_LOAD_INT(x30, x6) # load rs2: x6 = 0x64741f3d
@@ -426,18 +264,9 @@ I_sb_cg_cp_rs1_nx0_b19:
   sb x6, -1512(x19) # perform store
   addi x19, x19, -1512 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x27 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x27, I_sb_cg_cp_rs1_nx0_b19, I_sb_cg_cp_rs1_nx0_b19_str)
-#else
-  sb x6, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x20)
   RVTEST_TESTDATA_LOAD_INT(x30, x23) # load rs2: x23 = 0x3abee8f7
@@ -447,18 +276,9 @@ I_sb_cg_cp_rs1_nx0_b20:
   sb x23, -1400(x20) # perform store
   addi x20, x20, -1400 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x13 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x13, I_sb_cg_cp_rs1_nx0_b20, I_sb_cg_cp_rs1_nx0_b20_str)
-#else
-  sb x23, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x21)
   RVTEST_TESTDATA_LOAD_INT(x30, x24) # load rs2: x24 = 0x1d89e960
@@ -468,18 +288,9 @@ I_sb_cg_cp_rs1_nx0_b21:
   sb x24, 354(x21) # perform store
   addi x21, x21, 354 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x22 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x22, I_sb_cg_cp_rs1_nx0_b21, I_sb_cg_cp_rs1_nx0_b21_str)
-#else
-  sb x24, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x22)
   RVTEST_TESTDATA_LOAD_INT(x30, x11) # load rs2: x11 = 0xece20626
@@ -489,18 +300,9 @@ I_sb_cg_cp_rs1_nx0_b22:
   sb x11, 1626(x22) # perform store
   addi x22, x22, 1626 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x9 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x9, I_sb_cg_cp_rs1_nx0_b22, I_sb_cg_cp_rs1_nx0_b22_str)
-#else
-  sb x11, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x23)
   RVTEST_TESTDATA_LOAD_INT(x30, x2) # load rs2: x2 = 0x8cc9e641
@@ -510,18 +312,9 @@ I_sb_cg_cp_rs1_nx0_b23:
   sb x2, 951(x23) # perform store
   addi x23, x23, 951 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x17 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x17, I_sb_cg_cp_rs1_nx0_b23, I_sb_cg_cp_rs1_nx0_b23_str)
-#else
-  sb x2, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x24)
   RVTEST_TESTDATA_LOAD_INT(x30, x29) # load rs2: x29 = 0x0cdf85db
@@ -531,18 +324,9 @@ I_sb_cg_cp_rs1_nx0_b24:
   sb x29, -946(x24) # perform store
   addi x24, x24, -946 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x28 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x28, I_sb_cg_cp_rs1_nx0_b24, I_sb_cg_cp_rs1_nx0_b24_str)
-#else
-  sb x29, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x25)
   RVTEST_TESTDATA_LOAD_INT(x30, x11) # load rs2: x11 = 0x2c6eab5f
@@ -552,18 +336,9 @@ I_sb_cg_cp_rs1_nx0_b25:
   sb x11, 1262(x25) # perform store
   addi x25, x25, 1262 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x22 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x22, I_sb_cg_cp_rs1_nx0_b25, I_sb_cg_cp_rs1_nx0_b25_str)
-#else
-  sb x11, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x26)
   RVTEST_TESTDATA_LOAD_INT(x30, x28) # load rs2: x28 = 0x7512b46f
@@ -573,18 +348,9 @@ I_sb_cg_cp_rs1_nx0_b26:
   sb x28, 77(x26) # perform store
   addi x26, x26, 77 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x22 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x22, I_sb_cg_cp_rs1_nx0_b26, I_sb_cg_cp_rs1_nx0_b26_str)
-#else
-  sb x28, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x27)
   RVTEST_TESTDATA_LOAD_INT(x30, x13) # load rs2: x13 = 0xb4019764
@@ -594,18 +360,9 @@ I_sb_cg_cp_rs1_nx0_b27:
   sb x13, 1282(x27) # perform store
   addi x27, x27, 1282 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x19 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x19, I_sb_cg_cp_rs1_nx0_b27, I_sb_cg_cp_rs1_nx0_b27_str)
-#else
-  sb x13, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x28)
   RVTEST_TESTDATA_LOAD_INT(x30, x20) # load rs2: x20 = 0x912c7cc4
@@ -615,18 +372,9 @@ I_sb_cg_cp_rs1_nx0_b28:
   sb x20, -712(x28) # perform store
   addi x28, x28, -712 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x9 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x9, I_sb_cg_cp_rs1_nx0_b28, I_sb_cg_cp_rs1_nx0_b28_str)
-#else
-  sb x20, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x29)
   RVTEST_TESTDATA_LOAD_INT(x30, x26) # load rs2: x26 = 0x85abcf16
@@ -636,18 +384,9 @@ I_sb_cg_cp_rs1_nx0_b29:
   sb x26, -1683(x29) # perform store
   addi x29, x29, -1683 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x3 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x3, I_sb_cg_cp_rs1_nx0_b29, I_sb_cg_cp_rs1_nx0_b29_str)
-#else
-  sb x26, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x27, x30 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x30)
@@ -658,18 +397,9 @@ I_sb_cg_cp_rs1_nx0_b30:
   sb x1, -850(x30) # perform store
   addi x30, x30, -850 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x31 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x31, I_sb_cg_cp_rs1_nx0_b30, I_sb_cg_cp_rs1_nx0_b30_str)
-#else
-  sb x1, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x31)
   RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rs2: x21 = 0xe3ecf114
@@ -679,18 +409,9 @@ I_sb_cg_cp_rs1_nx0_b31:
   sb x21, -297(x31) # perform store
   addi x31, x31, -297 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x19 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x19, I_sb_cg_cp_rs1_nx0_b31, I_sb_cg_cp_rs1_nx0_b31_str)
-#else
-  sb x21, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2
@@ -704,18 +425,9 @@ I_sb_cg_cp_rs2_b0:
   sb x0, -1464(x3) # perform store
   addi x3, x3, -1464 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x19 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x19, I_sb_cg_cp_rs2_b0, I_sb_cg_cp_rs2_b0_str)
-#else
-  sb x0, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rs2: x1 = 0xd23cd067
@@ -725,18 +437,9 @@ I_sb_cg_cp_rs2_b1:
   sb x1, -1742(x10) # perform store
   addi x10, x10, -1742 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x21 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x21, I_sb_cg_cp_rs2_b1, I_sb_cg_cp_rs2_b1_str)
-#else
-  sb x1, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x27, x2) # load rs2: x2 = 0xda48e1fc
@@ -746,18 +449,9 @@ I_sb_cg_cp_rs2_b2:
   sb x2, 1960(x1) # perform store
   addi x1, x1, 1960 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x11, I_sb_cg_cp_rs2_b2, I_sb_cg_cp_rs2_b2_str)
-#else
-  sb x2, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x27, x3) # load rs2: x3 = 0xca13d27c
@@ -767,18 +461,9 @@ I_sb_cg_cp_rs2_b3:
   sb x3, 1890(x30) # perform store
   addi x30, x30, 1890 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x7 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x7, I_sb_cg_cp_rs2_b3, I_sb_cg_cp_rs2_b3_str)
-#else
-  sb x3, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x4 # switch temp register to avoid conflict with test
   mv x14, x5 # switch link pointer register to avoid conflict with test
@@ -790,18 +475,9 @@ I_sb_cg_cp_rs2_b4:
   sb x4, -1342(x15) # perform store
   addi x15, x15, -1342 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x24 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x15, x14, x13, x24, I_sb_cg_cp_rs2_b4, I_sb_cg_cp_rs2_b4_str)
-#else
-  sb x4, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x27, x5) # load rs2: x5 = 0xd7bc459e
@@ -811,18 +487,9 @@ I_sb_cg_cp_rs2_b5:
   sb x5, -741(x26) # perform store
   addi x26, x26, -741 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x21 contains the expected result. x26 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x26, x14, x13, x21, I_sb_cg_cp_rs2_b5, I_sb_cg_cp_rs2_b5_str)
-#else
-  sb x5, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x27, x6) # load rs2: x6 = 0x7fdb7dcc
@@ -832,18 +499,9 @@ I_sb_cg_cp_rs2_b6:
   sb x6, -1543(x24) # perform store
   addi x24, x24, -1543 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x22 contains the expected result. x24 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x24, x14, x13, x22, I_sb_cg_cp_rs2_b6, I_sb_cg_cp_rs2_b6_str)
-#else
-  sb x6, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x27, x7) # load rs2: x7 = 0xb8929c43
@@ -853,18 +511,9 @@ I_sb_cg_cp_rs2_b7:
   sb x7, -431(x3) # perform store
   addi x3, x3, -431 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x19 contains the expected result. x3 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x3, x14, x13, x19, I_sb_cg_cp_rs2_b7, I_sb_cg_cp_rs2_b7_str)
-#else
-  sb x7, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load rs2: x8 = 0x44076961
@@ -874,18 +523,9 @@ I_sb_cg_cp_rs2_b8:
   sb x8, -1281(x19) # perform store
   addi x19, x19, -1281 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x21 contains the expected result. x19 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x19, x14, x13, x21, I_sb_cg_cp_rs2_b8, I_sb_cg_cp_rs2_b8_str)
-#else
-  sb x8, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x27, x9) # load rs2: x9 = 0xa6f0b722
@@ -895,18 +535,9 @@ I_sb_cg_cp_rs2_b9:
   sb x9, -1782(x11) # perform store
   addi x11, x11, -1782 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x26 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x26, I_sb_cg_cp_rs2_b9, I_sb_cg_cp_rs2_b9_str)
-#else
-  sb x9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rs2: x10 = 0xf68eb498
@@ -916,18 +547,9 @@ I_sb_cg_cp_rs2_b10:
   sb x10, 155(x23) # perform store
   addi x23, x23, 155 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x24 contains the expected result. x23 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x23, x14, x13, x24, I_sb_cg_cp_rs2_b10, I_sb_cg_cp_rs2_b10_str)
-#else
-  sb x10, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x27, x11) # load rs2: x11 = 0xb7507451
@@ -937,18 +559,9 @@ I_sb_cg_cp_rs2_b11:
   sb x11, -1659(x1) # perform store
   addi x1, x1, -1659 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x1, x14, x13, x15, I_sb_cg_cp_rs2_b11, I_sb_cg_cp_rs2_b11_str)
-#else
-  sb x11, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rs2: x12 = 0x164b226d
@@ -958,18 +571,9 @@ I_sb_cg_cp_rs2_b12:
   sb x12, -1265(x31) # perform store
   addi x31, x31, -1265 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x30 contains the expected result. x31 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x31, x14, x13, x30, I_sb_cg_cp_rs2_b12, I_sb_cg_cp_rs2_b12_str)
-#else
-  sb x12, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -981,18 +585,9 @@ I_sb_cg_cp_rs2_b13:
   sb x13, 911(x16) # perform store
   addi x16, x16, 911 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x18 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x18, I_sb_cg_cp_rs2_b13, I_sb_cg_cp_rs2_b13_str)
-#else
-  sb x13, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x27, x14) # load rs2: x14 = 0x1f8b3ca2
@@ -1002,18 +597,9 @@ I_sb_cg_cp_rs2_b14:
   sb x14, 922(x13) # perform store
   addi x13, x13, 922 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x18 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x18, I_sb_cg_cp_rs2_b14, I_sb_cg_cp_rs2_b14_str)
-#else
-  sb x14, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x27, x15) # load rs2: x15 = 0x33510ce1
@@ -1023,18 +609,9 @@ I_sb_cg_cp_rs2_b15:
   sb x15, -1972(x30) # perform store
   addi x30, x30, -1972 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x29 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x29, I_sb_cg_cp_rs2_b15, I_sb_cg_cp_rs2_b15_str)
-#else
-  sb x15, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rs2: x16 = 0xd06770ad
@@ -1044,18 +621,9 @@ I_sb_cg_cp_rs2_b16:
   sb x16, -1438(x15) # perform store
   addi x15, x15, -1438 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x26 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x26, I_sb_cg_cp_rs2_b16, I_sb_cg_cp_rs2_b16_str)
-#else
-  sb x16, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x27, x17) # load rs2: x17 = 0x918b0d6f
@@ -1065,18 +633,9 @@ I_sb_cg_cp_rs2_b17:
   sb x17, 1824(x7) # perform store
   addi x7, x7, 1824 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x23 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x23, I_sb_cg_cp_rs2_b17, I_sb_cg_cp_rs2_b17_str)
-#else
-  sb x17, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x27, x18) # load rs2: x18 = 0xbae1598d
@@ -1086,18 +645,9 @@ I_sb_cg_cp_rs2_b18:
   sb x18, -748(x17) # perform store
   addi x17, x17, -748 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x1 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x1, I_sb_cg_cp_rs2_b18, I_sb_cg_cp_rs2_b18_str)
-#else
-  sb x18, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x27, x19) # load rs2: x19 = 0x25d6dfaf
@@ -1107,18 +657,9 @@ I_sb_cg_cp_rs2_b19:
   sb x19, 6(x30) # perform store
   addi x30, x30, 6 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x12 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x12, I_sb_cg_cp_rs2_b19, I_sb_cg_cp_rs2_b19_str)
-#else
-  sb x19, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rs2: x20 = 0xa38cbd15
@@ -1128,18 +669,9 @@ I_sb_cg_cp_rs2_b20:
   sb x20, 1529(x18) # perform store
   addi x18, x18, 1529 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x7 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x7, I_sb_cg_cp_rs2_b20, I_sb_cg_cp_rs2_b20_str)
-#else
-  sb x20, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rs2: x21 = 0xf2e99703
@@ -1149,18 +681,9 @@ I_sb_cg_cp_rs2_b21:
   sb x21, -2035(x26) # perform store
   addi x26, x26, -2035 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x3 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x3, I_sb_cg_cp_rs2_b21, I_sb_cg_cp_rs2_b21_str)
-#else
-  sb x21, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x27, x22) # load rs2: x22 = 0x504da4a3
@@ -1170,18 +693,9 @@ I_sb_cg_cp_rs2_b22:
   sb x22, 671(x29) # perform store
   addi x29, x29, 671 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x12 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x12, I_sb_cg_cp_rs2_b22, I_sb_cg_cp_rs2_b22_str)
-#else
-  sb x22, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x27, x23) # load rs2: x23 = 0xfda3fabe
@@ -1191,18 +705,9 @@ I_sb_cg_cp_rs2_b23:
   sb x23, -1374(x17) # perform store
   addi x17, x17, -1374 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x12 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x12, I_sb_cg_cp_rs2_b23, I_sb_cg_cp_rs2_b23_str)
-#else
-  sb x23, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x27, x24) # load rs2: x24 = 0xbd86c1ce
@@ -1212,18 +717,9 @@ I_sb_cg_cp_rs2_b24:
   sb x24, 115(x31) # perform store
   addi x31, x31, 115 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x28 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x28, I_sb_cg_cp_rs2_b24, I_sb_cg_cp_rs2_b24_str)
-#else
-  sb x24, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x27, x25) # load rs2: x25 = 0x8282a17a
@@ -1233,18 +729,9 @@ I_sb_cg_cp_rs2_b25:
   sb x25, -1033(x17) # perform store
   addi x17, x17, -1033 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x15 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x15, I_sb_cg_cp_rs2_b25, I_sb_cg_cp_rs2_b25_str)
-#else
-  sb x25, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x27, x26) # load rs2: x26 = 0x92068e7c
@@ -1254,18 +741,9 @@ I_sb_cg_cp_rs2_b26:
   sb x26, -1969(x24) # perform store
   addi x24, x24, -1969 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x21 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x21, I_sb_cg_cp_rs2_b26, I_sb_cg_cp_rs2_b26_str)
-#else
-  sb x26, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x1, x27 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x27)
@@ -1276,18 +754,9 @@ I_sb_cg_cp_rs2_b27:
   sb x27, -1218(x23) # perform store
   addi x23, x23, -1218 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x13 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x13, I_sb_cg_cp_rs2_b27, I_sb_cg_cp_rs2_b27_str)
-#else
-  sb x27, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x90c97fc7
@@ -1297,18 +766,9 @@ I_sb_cg_cp_rs2_b28:
   sb x28, 69(x3) # perform store
   addi x3, x3, 69 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x19 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x19, I_sb_cg_cp_rs2_b28, I_sb_cg_cp_rs2_b28_str)
-#else
-  sb x28, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0xd10bb7a2
@@ -1318,18 +778,9 @@ I_sb_cg_cp_rs2_b29:
   sb x29, 1867(x21) # perform store
   addi x21, x21, 1867 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x30 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x30, I_sb_cg_cp_rs2_b29, I_sb_cg_cp_rs2_b29_str)
-#else
-  sb x29, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x6d265944
@@ -1339,18 +790,9 @@ I_sb_cg_cp_rs2_b30:
   sb x30, 1135(x8) # perform store
   addi x8, x8, 1135 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, I_sb_cg_cp_rs2_b30, I_sb_cg_cp_rs2_b30_str)
-#else
-  sb x30, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0xa944b28f
@@ -1360,18 +802,9 @@ I_sb_cg_cp_rs2_b31:
   sb x31, -1895(x16) # perform store
   addi x16, x16, -1895 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x18 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x18, I_sb_cg_cp_rs2_b31, I_sb_cg_cp_rs2_b31_str)
-#else
-  sb x31, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -1385,18 +818,9 @@ I_sb_cg_cp_rs2_edges_0x0:
   sb x12, -527(x23) # perform store
   addi x23, x23, -527 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x27 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x27, I_sb_cg_cp_rs2_edges_0x0, I_sb_cg_cp_rs2_edges_0x0_str)
-#else
-  sb x12, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x00000001
@@ -1406,18 +830,9 @@ I_sb_cg_cp_rs2_edges_0x1:
   sb x3, 1967(x17) # perform store
   addi x17, x17, 1967 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x27 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x27, I_sb_cg_cp_rs2_edges_0x1, I_sb_cg_cp_rs2_edges_0x1_str)
-#else
-  sb x3, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
   RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0x00000002
@@ -1427,18 +842,9 @@ I_sb_cg_cp_rs2_edges_0x2:
   sb x24, 673(x15) # perform store
   addi x15, x15, 673 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x3 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x3, I_sb_cg_cp_rs2_edges_0x2, I_sb_cg_cp_rs2_edges_0x2_str)
-#else
-  sb x24, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0x80000000
@@ -1448,18 +854,9 @@ I_sb_cg_cp_rs2_edges_0x80000000:
   sb x2, -1022(x23) # perform store
   addi x23, x23, -1022 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x12 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x12, I_sb_cg_cp_rs2_edges_0x80000000, I_sb_cg_cp_rs2_edges_0x80000000_str)
-#else
-  sb x2, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x80000001
@@ -1469,18 +866,9 @@ I_sb_cg_cp_rs2_edges_0x80000001:
   sb x7, -1028(x13) # perform store
   addi x13, x13, -1028 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x30 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x30, I_sb_cg_cp_rs2_edges_0x80000001, I_sb_cg_cp_rs2_edges_0x80000001_str)
-#else
-  sb x7, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x7fffffff
@@ -1490,18 +878,9 @@ I_sb_cg_cp_rs2_edges_0x7fffffff:
   sb x15, 1206(x20) # perform store
   addi x20, x20, 1206 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x12 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x12, I_sb_cg_cp_rs2_edges_0x7fffffff, I_sb_cg_cp_rs2_edges_0x7fffffff_str)
-#else
-  sb x15, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0x7ffffffe
@@ -1511,18 +890,9 @@ I_sb_cg_cp_rs2_edges_0x7ffffffe:
   sb x17, -1495(x31) # perform store
   addi x31, x31, -1495 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x15 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x15, I_sb_cg_cp_rs2_edges_0x7ffffffe, I_sb_cg_cp_rs2_edges_0x7ffffffe_str)
-#else
-  sb x17, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0xffffffff
@@ -1532,18 +902,9 @@ I_sb_cg_cp_rs2_edges_0xffffffff:
   sb x24, 499(x15) # perform store
   addi x15, x15, 499 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, I_sb_cg_cp_rs2_edges_0xffffffff, I_sb_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  sb x24, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0xfffffffe
@@ -1553,18 +914,9 @@ I_sb_cg_cp_rs2_edges_0xfffffffe:
   sb x25, 388(x12) # perform store
   addi x12, x12, 388 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x3 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x3, I_sb_cg_cp_rs2_edges_0xfffffffe, I_sb_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  sb x25, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x5bbc8872
@@ -1574,18 +926,9 @@ I_sb_cg_cp_rs2_edges_0x5bbc8872:
   sb x6, 318(x16) # perform store
   addi x16, x16, 318 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x30 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x30, I_sb_cg_cp_rs2_edges_0x5bbc8872, I_sb_cg_cp_rs2_edges_0x5bbc8872_str)
-#else
-  sb x6, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xaaaaaaaa
@@ -1595,18 +938,9 @@ I_sb_cg_cp_rs2_edges_0xaaaaaaaa:
   sb x2, 1783(x7) # perform store
   addi x7, x7, 1783 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x29 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x29, I_sb_cg_cp_rs2_edges_0xaaaaaaaa, I_sb_cg_cp_rs2_edges_0xaaaaaaaa_str)
-#else
-  sb x2, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x55555555
@@ -1616,18 +950,9 @@ I_sb_cg_cp_rs2_edges_0x55555555:
   sb x13, 1516(x3) # perform store
   addi x3, x3, 1516 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x27 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x27, I_sb_cg_cp_rs2_edges_0x55555555, I_sb_cg_cp_rs2_edges_0x55555555_str)
-#else
-  sb x13, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_edges
@@ -1641,18 +966,9 @@ I_sb_cg_cp_imm_edges_0x0:
   sb x9, 0(x17) # perform store
   addi x17, x17, 0 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x22 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x22, I_sb_cg_cp_imm_edges_0x0, I_sb_cg_cp_imm_edges_0x0_str)
-#else
-  sb x9, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1)
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0xde82de47
@@ -1662,18 +978,9 @@ I_sb_cg_cp_imm_edges_0x1:
   sb x22, 1(x23) # perform store
   addi x23, x23, 1 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x12 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x12, I_sb_cg_cp_imm_edges_0x1, I_sb_cg_cp_imm_edges_0x1_str)
-#else
-  sb x22, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xd3d862b0
@@ -1683,18 +990,9 @@ I_sb_cg_cp_imm_edges_0x2:
   sb x10, 2(x2) # perform store
   addi x2, x2, 2 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x3 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x3, I_sb_cg_cp_imm_edges_0x2, I_sb_cg_cp_imm_edges_0x2_str)
-#else
-  sb x10, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 3)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x243fd116
@@ -1704,18 +1002,9 @@ I_sb_cg_cp_imm_edges_0x3:
   sb x10, 3(x12) # perform store
   addi x12, x12, 3 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x6 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x6, I_sb_cg_cp_imm_edges_0x3, I_sb_cg_cp_imm_edges_0x3_str)
-#else
-  sb x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 4)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x696b7ac9
@@ -1725,18 +1014,9 @@ I_sb_cg_cp_imm_edges_0x4:
   sb x6, 4(x24) # perform store
   addi x24, x24, 4 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x14 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x14, I_sb_cg_cp_imm_edges_0x4, I_sb_cg_cp_imm_edges_0x4_str)
-#else
-  sb x6, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 8)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xa18239f4
@@ -1746,18 +1026,9 @@ I_sb_cg_cp_imm_edges_0x8:
   sb x13, 8(x26) # perform store
   addi x26, x26, 8 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x7 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x7, I_sb_cg_cp_imm_edges_0x8, I_sb_cg_cp_imm_edges_0x8_str)
-#else
-  sb x13, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 16)
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0xadcdd17f
@@ -1767,18 +1038,9 @@ I_sb_cg_cp_imm_edges_0x10:
   sb x31, 16(x27) # perform store
   addi x27, x27, 16 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x21 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x21, I_sb_cg_cp_imm_edges_0x10, I_sb_cg_cp_imm_edges_0x10_str)
-#else
-  sb x31, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 32)
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xe9cbf07f
@@ -1788,18 +1050,9 @@ I_sb_cg_cp_imm_edges_0x20:
   sb x7, 32(x18) # perform store
   addi x18, x18, 32 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x16 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x16, I_sb_cg_cp_imm_edges_0x20, I_sb_cg_cp_imm_edges_0x20_str)
-#else
-  sb x7, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 64)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0x5c84532d
@@ -1809,18 +1062,9 @@ I_sb_cg_cp_imm_edges_0x40:
   sb x2, 64(x12) # perform store
   addi x12, x12, 64 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x16 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x16, I_sb_cg_cp_imm_edges_0x40, I_sb_cg_cp_imm_edges_0x40_str)
-#else
-  sb x2, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 128)
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0xf76049fb
@@ -1830,18 +1074,9 @@ I_sb_cg_cp_imm_edges_0x80:
   sb x25, 128(x16) # perform store
   addi x16, x16, 128 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x9 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x9, I_sb_cg_cp_imm_edges_0x80, I_sb_cg_cp_imm_edges_0x80_str)
-#else
-  sb x25, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 256)
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xce13ae93
@@ -1851,18 +1086,9 @@ I_sb_cg_cp_imm_edges_0x100:
   sb x7, 256(x12) # perform store
   addi x12, x12, 256 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x17 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x17, I_sb_cg_cp_imm_edges_0x100, I_sb_cg_cp_imm_edges_0x100_str)
-#else
-  sb x7, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 512)
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x629bed6c
@@ -1872,18 +1098,9 @@ I_sb_cg_cp_imm_edges_0x200:
   sb x31, 512(x27) # perform store
   addi x27, x27, 512 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x14 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x14, I_sb_cg_cp_imm_edges_0x200, I_sb_cg_cp_imm_edges_0x200_str)
-#else
-  sb x31, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1023)
   RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x6ee73b9d
@@ -1893,18 +1110,9 @@ I_sb_cg_cp_imm_edges_0x3ff:
   sb x26, 1023(x12) # perform store
   addi x12, x12, 1023 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x21 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x21, I_sb_cg_cp_imm_edges_0x3ff, I_sb_cg_cp_imm_edges_0x3ff_str)
-#else
-  sb x26, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1024)
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0xc5aea379
@@ -1914,18 +1122,9 @@ I_sb_cg_cp_imm_edges_0x400:
   sb x30, 1024(x9) # perform store
   addi x9, x9, 1024 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, I_sb_cg_cp_imm_edges_0x400, I_sb_cg_cp_imm_edges_0x400_str)
-#else
-  sb x30, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1795)
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0x946fe993
@@ -1935,18 +1134,9 @@ I_sb_cg_cp_imm_edges_0x703:
   sb x19, 1795(x30) # perform store
   addi x30, x30, 1795 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x24 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x24, I_sb_cg_cp_imm_edges_0x703, I_sb_cg_cp_imm_edges_0x703_str)
-#else
-  sb x19, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2047)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xbecf5033
@@ -1956,18 +1146,9 @@ I_sb_cg_cp_imm_edges_0x7ff:
   sb x2, 2047(x15) # perform store
   addi x15, x15, 2047 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x7 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x7, I_sb_cg_cp_imm_edges_0x7ff, I_sb_cg_cp_imm_edges_0x7ff_str)
-#else
-  sb x2, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2048)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xbc734943
@@ -1978,18 +1159,9 @@ I_sb_cg_cp_imm_edges_m0x800:
   sb x8, -2048(x21) # perform store
   addi x21, x21, -2048 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x16 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x16, I_sb_cg_cp_imm_edges_m0x800, I_sb_cg_cp_imm_edges_m0x800_str)
-#else
-  sb x8, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2047)
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x7946ed14
@@ -1999,18 +1171,9 @@ I_sb_cg_cp_imm_edges_m0x7ff:
   sb x23, -2047(x11) # perform store
   addi x11, x11, -2047 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x28, I_sb_cg_cp_imm_edges_m0x7ff, I_sb_cg_cp_imm_edges_m0x7ff_str)
-#else
-  sb x23, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2)
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x86cbd37a
@@ -2020,18 +1183,9 @@ I_sb_cg_cp_imm_edges_m0x2:
   sb x7, -2(x20) # perform store
   addi x20, x20, -2 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x24 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x24, I_sb_cg_cp_imm_edges_m0x2, I_sb_cg_cp_imm_edges_m0x2_str)
-#else
-  sb x7, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -1)
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0xe56fcfec
@@ -2041,18 +1195,9 @@ I_sb_cg_cp_imm_edges_m0x1:
   sb x23, -1(x7) # perform store
   addi x7, x7, -1 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x19 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x19, I_sb_cg_cp_imm_edges_m0x1, I_sb_cg_cp_imm_edges_m0x1_str)
-#else
-  sb x23, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_align_byte
@@ -2063,168 +1208,96 @@ I_sb_cg_cp_imm_edges_m0x1:
 I_sb_cg_cp_align_byte_b0:
   sb x18, 0(x7) # perform store
   addi x7, x7, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -8(x7) # load stored value for checking
   # Check if x30 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x30, I_sb_cg_cp_align_byte_b0, I_sb_cg_cp_align_byte_b0_str)
   LREG x30, -8(x7) # load stored value for checking
   # Check if x30 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x30, I_sb_cg_cp_align_byte_b0, I_sb_cg_cp_align_byte_b0_str)
-#else
-  sb x18, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 001)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xa07c9cda
 I_sb_cg_cp_align_byte_b1:
   sb x13, 1(x7) # perform store
   addi x7, x7, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -8(x7) # load stored value for checking
   # Check if x26 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x26, I_sb_cg_cp_align_byte_b1, I_sb_cg_cp_align_byte_b1_str)
   LREG x26, -8(x7) # load stored value for checking
   # Check if x26 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x26, I_sb_cg_cp_align_byte_b1, I_sb_cg_cp_align_byte_b1_str)
-#else
-  sb x13, 1(x7) # repeat store so it is available for checking
-  addi x7, x7, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 010)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x3a196c7a
 I_sb_cg_cp_align_byte_b2:
   sb x13, 2(x7) # perform store
   addi x7, x7, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -8(x7) # load stored value for checking
   # Check if x3 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x3, I_sb_cg_cp_align_byte_b2, I_sb_cg_cp_align_byte_b2_str)
   LREG x3, -8(x7) # load stored value for checking
   # Check if x3 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x3, I_sb_cg_cp_align_byte_b2, I_sb_cg_cp_align_byte_b2_str)
-#else
-  sb x13, 2(x7) # repeat store so it is available for checking
-  addi x7, x7, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 011)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x91a7738c
 I_sb_cg_cp_align_byte_b3:
   sb x13, 3(x7) # perform store
   addi x7, x7, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -8(x7) # load stored value for checking
   # Check if x31 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x31, I_sb_cg_cp_align_byte_b3, I_sb_cg_cp_align_byte_b3_str)
   LREG x31, -8(x7) # load stored value for checking
   # Check if x31 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x31, I_sb_cg_cp_align_byte_b3, I_sb_cg_cp_align_byte_b3_str)
-#else
-  sb x13, 3(x7) # repeat store so it is available for checking
-  addi x7, x7, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 100)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xc70e1ccf
 I_sb_cg_cp_align_byte_b4:
   sb x13, 4(x7) # perform store
   addi x7, x7, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -8(x7) # load stored value for checking
   # Check if x15 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x15, I_sb_cg_cp_align_byte_b4, I_sb_cg_cp_align_byte_b4_str)
   LREG x15, -8(x7) # load stored value for checking
   # Check if x15 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x15, I_sb_cg_cp_align_byte_b4, I_sb_cg_cp_align_byte_b4_str)
-#else
-  sb x13, 4(x7) # repeat store so it is available for checking
-  addi x7, x7, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 101)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xe4834e0a
 I_sb_cg_cp_align_byte_b5:
   sb x10, 5(x7) # perform store
   addi x7, x7, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -8(x7) # load stored value for checking
   # Check if x13 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x13, I_sb_cg_cp_align_byte_b5, I_sb_cg_cp_align_byte_b5_str)
   LREG x13, -8(x7) # load stored value for checking
   # Check if x13 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x13, I_sb_cg_cp_align_byte_b5, I_sb_cg_cp_align_byte_b5_str)
-#else
-  sb x10, 5(x7) # repeat store so it is available for checking
-  addi x7, x7, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 110)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xe5341409
 I_sb_cg_cp_align_byte_b6:
   sb x10, 6(x7) # perform store
   addi x7, x7, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -8(x7) # load stored value for checking
   # Check if x9 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x9, I_sb_cg_cp_align_byte_b6, I_sb_cg_cp_align_byte_b6_str)
   LREG x9, -8(x7) # load stored value for checking
   # Check if x9 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x9, I_sb_cg_cp_align_byte_b6, I_sb_cg_cp_align_byte_b6_str)
-#else
-  sb x10, 6(x7) # repeat store so it is available for checking
-  addi x7, x7, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 111)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xbae4887f
 I_sb_cg_cp_align_byte_b7:
   sb x10, 7(x7) # perform store
   addi x7, x7, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -8(x7) # load stored value for checking
   # Check if x16 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x16, I_sb_cg_cp_align_byte_b7, I_sb_cg_cp_align_byte_b7_str)
   LREG x16, -8(x7) # load stored value for checking
   # Check if x16 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x16, I_sb_cg_cp_align_byte_b7, I_sb_cg_cp_align_byte_b7_str)
-#else
-  sb x10, 7(x7) # repeat store so it is available for checking
-  addi x7, x7, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 
   mv x2, x7 # restore signature pointer to default register for teardown

--- a/tests/rv32i/I/I-sh-00.S
+++ b/tests/rv32i/I/I-sh-00.S
@@ -41,18 +41,9 @@ I_sh_cg_cp_rs1_nx0_b1:
   sh x12, 289(x1) # perform store
   addi x1, x1, 289 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x30 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x30, I_sh_cg_cp_rs1_nx0_b1, I_sh_cg_cp_rs1_nx0_b1_str)
-#else
-  sh x12, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x950208d0
@@ -62,18 +53,9 @@ I_sh_cg_cp_rs1_nx0_b2:
   sh x12, -1560(x2) # perform store
   addi x2, x2, -1560 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x17 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x17, I_sh_cg_cp_rs1_nx0_b2, I_sh_cg_cp_rs1_nx0_b2_str)
-#else
-  sh x12, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x15, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
@@ -84,18 +66,9 @@ I_sh_cg_cp_rs1_nx0_b3:
   sh x14, 1834(x3) # perform store
   addi x3, x3, 1834 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x24 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x24, I_sh_cg_cp_rs1_nx0_b3, I_sh_cg_cp_rs1_nx0_b3_str)
-#else
-  sh x14, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -107,18 +80,9 @@ I_sh_cg_cp_rs1_nx0_b4:
   sh x11, -1532(x4) # perform store
   addi x4, x4, -1532 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x6 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x6, I_sh_cg_cp_rs1_nx0_b4, I_sh_cg_cp_rs1_nx0_b4_str)
-#else
-  sh x11, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x15, x18) # load rs2: x18 = 0x790a5576
@@ -128,18 +92,9 @@ I_sh_cg_cp_rs1_nx0_b5:
   sh x18, -902(x5) # perform store
   addi x5, x5, -902 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x26 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x26, I_sh_cg_cp_rs1_nx0_b5, I_sh_cg_cp_rs1_nx0_b5_str)
-#else
-  sh x18, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x15, x21) # load rs2: x21 = 0xb122d0a0
@@ -149,18 +104,9 @@ I_sh_cg_cp_rs1_nx0_b6:
   sh x21, -1415(x6) # perform store
   addi x6, x6, -1415 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x30 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x30, I_sh_cg_cp_rs1_nx0_b6, I_sh_cg_cp_rs1_nx0_b6_str)
-#else
-  sh x21, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x7 # switch temp register to avoid conflict with test
   mv x14, x8 # switch link pointer register to avoid conflict with test
@@ -172,18 +118,9 @@ I_sh_cg_cp_rs1_nx0_b7:
   sh x5, 286(x7) # perform store
   addi x7, x7, 286 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x24 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x24, I_sh_cg_cp_rs1_nx0_b7, I_sh_cg_cp_rs1_nx0_b7_str)
-#else
-  sh x5, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x15, x26) # load rs2: x26 = 0xcf14438c
@@ -193,18 +130,9 @@ I_sh_cg_cp_rs1_nx0_b8:
   sh x26, -1689(x8) # perform store
   addi x8, x8, -1689 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x1 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x1, I_sh_cg_cp_rs1_nx0_b8, I_sh_cg_cp_rs1_nx0_b8_str)
-#else
-  sh x26, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x15, x10) # load rs2: x10 = 0xbc29910a
@@ -214,18 +142,9 @@ I_sh_cg_cp_rs1_nx0_b9:
   sh x10, 1480(x9) # perform store
   addi x9, x9, 1480 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x7, I_sh_cg_cp_rs1_nx0_b9, I_sh_cg_cp_rs1_nx0_b9_str)
-#else
-  sh x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x15, x31) # load rs2: x31 = 0xb5ee4058
@@ -235,18 +154,9 @@ I_sh_cg_cp_rs1_nx0_b10:
   sh x31, -1595(x10) # perform store
   addi x10, x10, -1595 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x17 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x17, I_sh_cg_cp_rs1_nx0_b10, I_sh_cg_cp_rs1_nx0_b10_str)
-#else
-  sh x31, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rs2: x9 = 0xd5e61c1f
@@ -256,18 +166,9 @@ I_sh_cg_cp_rs1_nx0_b11:
   sh x9, 1696(x11) # perform store
   addi x11, x11, 1696 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x17 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x17, I_sh_cg_cp_rs1_nx0_b11, I_sh_cg_cp_rs1_nx0_b11_str)
-#else
-  sh x9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x15, x3) # load rs2: x3 = 0x0f45d4d7
@@ -277,18 +178,9 @@ I_sh_cg_cp_rs1_nx0_b12:
   sh x3, 933(x12) # perform store
   addi x12, x12, 933 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x20 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x20, I_sh_cg_cp_rs1_nx0_b12, I_sh_cg_cp_rs1_nx0_b12_str)
-#else
-  sh x3, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x13 # switch temp register to avoid conflict with test
   mv x8, x14 # switch link pointer register to avoid conflict with test
@@ -300,18 +192,9 @@ I_sh_cg_cp_rs1_nx0_b13:
   sh x1, 10(x13) # perform store
   addi x13, x13, 10 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x23 contains the expected result. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x13, x8, x7, x23, I_sh_cg_cp_rs1_nx0_b13, I_sh_cg_cp_rs1_nx0_b13_str)
-#else
-  sh x1, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x15, x27) # load rs2: x27 = 0x77e4349d
@@ -321,18 +204,9 @@ I_sh_cg_cp_rs1_nx0_b14:
   sh x27, -365(x14) # perform store
   addi x14, x14, -365 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x1 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x1, I_sh_cg_cp_rs1_nx0_b14, I_sh_cg_cp_rs1_nx0_b14_str)
-#else
-  sh x27, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x18, x15 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
@@ -343,18 +217,9 @@ I_sh_cg_cp_rs1_nx0_b15:
   sh x20, 1562(x15) # perform store
   addi x15, x15, 1562 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x5 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x15, x8, x7, x5, I_sh_cg_cp_rs1_nx0_b15, I_sh_cg_cp_rs1_nx0_b15_str)
-#else
-  sh x20, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x16)
   RVTEST_TESTDATA_LOAD_INT(x18, x30) # load rs2: x30 = 0x3e074084
@@ -364,18 +229,9 @@ I_sh_cg_cp_rs1_nx0_b16:
   sh x30, 1015(x16) # perform store
   addi x16, x16, 1015 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x17 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x16, x8, x7, x17, I_sh_cg_cp_rs1_nx0_b16, I_sh_cg_cp_rs1_nx0_b16_str)
-#else
-  sh x30, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x17)
   RVTEST_TESTDATA_LOAD_INT(x18, x22) # load rs2: x22 = 0xa0159b37
@@ -385,18 +241,9 @@ I_sh_cg_cp_rs1_nx0_b17:
   sh x22, -1881(x17) # perform store
   addi x17, x17, -1881 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x5 contains the expected result. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x17, x8, x7, x5, I_sh_cg_cp_rs1_nx0_b17, I_sh_cg_cp_rs1_nx0_b17_str)
-#else
-  sh x22, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x6, x18 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x18)
@@ -407,18 +254,9 @@ I_sh_cg_cp_rs1_nx0_b18:
   sh x22, -427(x18) # perform store
   addi x18, x18, -427 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x9 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x9, I_sh_cg_cp_rs1_nx0_b18, I_sh_cg_cp_rs1_nx0_b18_str)
-#else
-  sh x22, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x19)
   RVTEST_TESTDATA_LOAD_INT(x6, x20) # load rs2: x20 = 0xb82357e8
@@ -428,18 +266,9 @@ I_sh_cg_cp_rs1_nx0_b19:
   sh x20, 747(x19) # perform store
   addi x19, x19, 747 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x4 contains the expected result. x19 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x19, x8, x7, x4, I_sh_cg_cp_rs1_nx0_b19, I_sh_cg_cp_rs1_nx0_b19_str)
-#else
-  sh x20, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x20)
   RVTEST_TESTDATA_LOAD_INT(x6, x30) # load rs2: x30 = 0xda6dc90b
@@ -449,18 +278,9 @@ I_sh_cg_cp_rs1_nx0_b20:
   sh x30, -399(x20) # perform store
   addi x20, x20, -399 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x17 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x17, I_sh_cg_cp_rs1_nx0_b20, I_sh_cg_cp_rs1_nx0_b20_str)
-#else
-  sh x30, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x21)
   RVTEST_TESTDATA_LOAD_INT(x6, x0) # load rs2: x0 = 0x81ab99b3
@@ -470,18 +290,9 @@ I_sh_cg_cp_rs1_nx0_b21:
   sh x0, 774(x21) # perform store
   addi x21, x21, 774 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x3 contains the expected result. x21 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x21, x8, x7, x3, I_sh_cg_cp_rs1_nx0_b21, I_sh_cg_cp_rs1_nx0_b21_str)
-#else
-  sh x0, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x22)
   RVTEST_TESTDATA_LOAD_INT(x6, x15) # load rs2: x15 = 0x08541d76
@@ -491,18 +302,9 @@ I_sh_cg_cp_rs1_nx0_b22:
   sh x15, -304(x22) # perform store
   addi x22, x22, -304 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x24 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x24, I_sh_cg_cp_rs1_nx0_b22, I_sh_cg_cp_rs1_nx0_b22_str)
-#else
-  sh x15, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x23)
   RVTEST_TESTDATA_LOAD_INT(x6, x0) # load rs2: x0 = 0xf7821dd1
@@ -512,18 +314,9 @@ I_sh_cg_cp_rs1_nx0_b23:
   sh x0, -1526(x23) # perform store
   addi x23, x23, -1526 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x12 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x12, I_sh_cg_cp_rs1_nx0_b23, I_sh_cg_cp_rs1_nx0_b23_str)
-#else
-  sh x0, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x24)
   RVTEST_TESTDATA_LOAD_INT(x6, x25) # load rs2: x25 = 0xaec2d9d6
@@ -533,18 +326,9 @@ I_sh_cg_cp_rs1_nx0_b24:
   sh x25, -580(x24) # perform store
   addi x24, x24, -580 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x26 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x26, I_sh_cg_cp_rs1_nx0_b24, I_sh_cg_cp_rs1_nx0_b24_str)
-#else
-  sh x25, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x25)
   RVTEST_TESTDATA_LOAD_INT(x6, x12) # load rs2: x12 = 0xd4281687
@@ -554,18 +338,9 @@ I_sh_cg_cp_rs1_nx0_b25:
   sh x12, -571(x25) # perform store
   addi x25, x25, -571 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x17 contains the expected result. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x25, x8, x7, x17, I_sh_cg_cp_rs1_nx0_b25, I_sh_cg_cp_rs1_nx0_b25_str)
-#else
-  sh x12, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x26)
   RVTEST_TESTDATA_LOAD_INT(x6, x31) # load rs2: x31 = 0xe702d8aa
@@ -575,18 +350,9 @@ I_sh_cg_cp_rs1_nx0_b26:
   sh x31, 1304(x26) # perform store
   addi x26, x26, 1304 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x16 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x16, I_sh_cg_cp_rs1_nx0_b26, I_sh_cg_cp_rs1_nx0_b26_str)
-#else
-  sh x31, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x27)
   RVTEST_TESTDATA_LOAD_INT(x6, x21) # load rs2: x21 = 0x01e5b978
@@ -596,18 +362,9 @@ I_sh_cg_cp_rs1_nx0_b27:
   sh x21, -737(x27) # perform store
   addi x27, x27, -737 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x22 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x27, x8, x7, x22, I_sh_cg_cp_rs1_nx0_b27, I_sh_cg_cp_rs1_nx0_b27_str)
-#else
-  sh x21, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x28)
   RVTEST_TESTDATA_LOAD_INT(x6, x11) # load rs2: x11 = 0x86d2a7fa
@@ -617,18 +374,9 @@ I_sh_cg_cp_rs1_nx0_b28:
   sh x11, 1722(x28) # perform store
   addi x28, x28, 1722 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x23 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x23, I_sh_cg_cp_rs1_nx0_b28, I_sh_cg_cp_rs1_nx0_b28_str)
-#else
-  sh x11, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x29)
   RVTEST_TESTDATA_LOAD_INT(x6, x4) # load rs2: x4 = 0xf8a72a68
@@ -638,18 +386,9 @@ I_sh_cg_cp_rs1_nx0_b29:
   sh x4, 1915(x29) # perform store
   addi x29, x29, 1915 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x31 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x31, I_sh_cg_cp_rs1_nx0_b29, I_sh_cg_cp_rs1_nx0_b29_str)
-#else
-  sh x4, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x30)
   RVTEST_TESTDATA_LOAD_INT(x6, x23) # load rs2: x23 = 0xfc259537
@@ -659,18 +398,9 @@ I_sh_cg_cp_rs1_nx0_b30:
   sh x23, 20(x30) # perform store
   addi x30, x30, 20 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x19 contains the expected result. x30 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x30, x8, x7, x19, I_sh_cg_cp_rs1_nx0_b30, I_sh_cg_cp_rs1_nx0_b30_str)
-#else
-  sh x23, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x31)
   RVTEST_TESTDATA_LOAD_INT(x6, x16) # load rs2: x16 = 0x0fb52606
@@ -680,18 +410,9 @@ I_sh_cg_cp_rs1_nx0_b31:
   sh x16, 1723(x31) # perform store
   addi x31, x31, 1723 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x29 contains the expected result. x31 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x31, x8, x7, x29, I_sh_cg_cp_rs1_nx0_b31, I_sh_cg_cp_rs1_nx0_b31_str)
-#else
-  sh x16, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2
@@ -705,18 +426,9 @@ I_sh_cg_cp_rs2_b0:
   sh x0, -352(x20) # perform store
   addi x20, x20, -352 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x3 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x3, I_sh_cg_cp_rs2_b0, I_sh_cg_cp_rs2_b0_str)
-#else
-  sh x0, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x6, x1) # load rs2: x1 = 0xff157562
@@ -726,18 +438,9 @@ I_sh_cg_cp_rs2_b1:
   sh x1, -1663(x28) # perform store
   addi x28, x28, -1663 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x18 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x18, I_sh_cg_cp_rs2_b1, I_sh_cg_cp_rs2_b1_str)
-#else
-  sh x1, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x6, x2) # load rs2: x2 = 0x95575ee7
@@ -747,18 +450,9 @@ I_sh_cg_cp_rs2_b2:
   sh x2, 1111(x22) # perform store
   addi x22, x22, 1111 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x27 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x27, I_sh_cg_cp_rs2_b2, I_sh_cg_cp_rs2_b2_str)
-#else
-  sh x2, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x6, x3) # load rs2: x3 = 0x0d99a743
@@ -768,18 +462,9 @@ I_sh_cg_cp_rs2_b3:
   sh x3, 243(x27) # perform store
   addi x27, x27, 243 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x16 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x27, x8, x7, x16, I_sh_cg_cp_rs2_b3, I_sh_cg_cp_rs2_b3_str)
-#else
-  sh x3, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x4)
   RVTEST_TESTDATA_LOAD_INT(x6, x4) # load rs2: x4 = 0xe34a8b9f
@@ -789,18 +474,9 @@ I_sh_cg_cp_rs2_b4:
   sh x4, -727(x30) # perform store
   addi x30, x30, -727 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x11 contains the expected result. x30 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x30, x8, x7, x11, I_sh_cg_cp_rs2_b4, I_sh_cg_cp_rs2_b4_str)
-#else
-  sh x4, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x6, x5) # load rs2: x5 = 0x7adc0ce8
@@ -810,18 +486,9 @@ I_sh_cg_cp_rs2_b5:
   sh x5, -1034(x19) # perform store
   addi x19, x19, -1034 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x20 contains the expected result. x19 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x19, x8, x7, x20, I_sh_cg_cp_rs2_b5, I_sh_cg_cp_rs2_b5_str)
-#else
-  sh x5, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x9, x6 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x6)
@@ -832,18 +499,9 @@ I_sh_cg_cp_rs2_b6:
   sh x6, -529(x29) # perform store
   addi x29, x29, -529 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x24 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x24, I_sh_cg_cp_rs2_b6, I_sh_cg_cp_rs2_b6_str)
-#else
-  sh x6, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x7 # switch temp register to avoid conflict with test
   mv x5, x8 # switch link pointer register to avoid conflict with test
@@ -855,18 +513,9 @@ I_sh_cg_cp_rs2_b7:
   sh x7, -883(x30) # perform store
   addi x30, x30, -883 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x28 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x28, I_sh_cg_cp_rs2_b7, I_sh_cg_cp_rs2_b7_str)
-#else
-  sh x7, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x9, x8) # load rs2: x8 = 0x93061109
@@ -876,18 +525,9 @@ I_sh_cg_cp_rs2_b8:
   sh x8, 791(x25) # perform store
   addi x25, x25, 791 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x13 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x13, I_sh_cg_cp_rs2_b8, I_sh_cg_cp_rs2_b8_str)
-#else
-  sh x8, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x31, x9 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x9)
@@ -898,18 +538,9 @@ I_sh_cg_cp_rs2_b9:
   sh x9, 478(x20) # perform store
   addi x20, x20, 478 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x26 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x26, I_sh_cg_cp_rs2_b9, I_sh_cg_cp_rs2_b9_str)
-#else
-  sh x9, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x31, x10) # load rs2: x10 = 0xbcf361a2
@@ -919,18 +550,9 @@ I_sh_cg_cp_rs2_b10:
   sh x10, -874(x3) # perform store
   addi x3, x3, -874 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x1 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x1, I_sh_cg_cp_rs2_b10, I_sh_cg_cp_rs2_b10_str)
-#else
-  sh x10, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x31, x11) # load rs2: x11 = 0x6574ebc7
@@ -940,18 +562,9 @@ I_sh_cg_cp_rs2_b11:
   sh x11, -721(x29) # perform store
   addi x29, x29, -721 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x13 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x13, I_sh_cg_cp_rs2_b11, I_sh_cg_cp_rs2_b11_str)
-#else
-  sh x11, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x31, x12) # load rs2: x12 = 0x9c1cd5be
@@ -961,18 +574,9 @@ I_sh_cg_cp_rs2_b12:
   sh x12, 1187(x6) # perform store
   addi x6, x6, 1187 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x16 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x16, I_sh_cg_cp_rs2_b12, I_sh_cg_cp_rs2_b12_str)
-#else
-  sh x12, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x31, x13) # load rs2: x13 = 0x4ed951ce
@@ -982,18 +586,9 @@ I_sh_cg_cp_rs2_b13:
   sh x13, -1923(x30) # perform store
   addi x30, x30, -1923 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x26 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x26, I_sh_cg_cp_rs2_b13, I_sh_cg_cp_rs2_b13_str)
-#else
-  sh x13, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x31, x14) # load rs2: x14 = 0xc945be43
@@ -1003,18 +598,9 @@ I_sh_cg_cp_rs2_b14:
   sh x14, 279(x9) # perform store
   addi x9, x9, 279 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, I_sh_cg_cp_rs2_b14, I_sh_cg_cp_rs2_b14_str)
-#else
-  sh x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x31, x15) # load rs2: x15 = 0x34de8b17
@@ -1024,18 +610,9 @@ I_sh_cg_cp_rs2_b15:
   sh x15, 796(x22) # perform store
   addi x22, x22, 796 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x6 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x6, I_sh_cg_cp_rs2_b15, I_sh_cg_cp_rs2_b15_str)
-#else
-  sh x15, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x31, x16) # load rs2: x16 = 0x3cf8ffca
@@ -1045,18 +622,9 @@ I_sh_cg_cp_rs2_b16:
   sh x16, -1241(x8) # perform store
   addi x8, x8, -1241 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, I_sh_cg_cp_rs2_b16, I_sh_cg_cp_rs2_b16_str)
-#else
-  sh x16, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x31, x17) # load rs2: x17 = 0xd2448b7e
@@ -1066,18 +634,9 @@ I_sh_cg_cp_rs2_b17:
   sh x17, 655(x13) # perform store
   addi x13, x13, 655 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, I_sh_cg_cp_rs2_b17, I_sh_cg_cp_rs2_b17_str)
-#else
-  sh x17, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x31, x18) # load rs2: x18 = 0x8d424ad6
@@ -1087,18 +646,9 @@ I_sh_cg_cp_rs2_b18:
   sh x18, -1170(x22) # perform store
   addi x22, x22, -1170 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x10 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x10, I_sh_cg_cp_rs2_b18, I_sh_cg_cp_rs2_b18_str)
-#else
-  sh x18, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x31, x19) # load rs2: x19 = 0xc5e37c88
@@ -1108,18 +658,9 @@ I_sh_cg_cp_rs2_b19:
   sh x19, -1170(x2) # perform store
   addi x2, x2, -1170 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x11 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x11, I_sh_cg_cp_rs2_b19, I_sh_cg_cp_rs2_b19_str)
-#else
-  sh x19, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x31, x20) # load rs2: x20 = 0xabbff3fc
@@ -1129,18 +670,9 @@ I_sh_cg_cp_rs2_b20:
   sh x20, -983(x12) # perform store
   addi x12, x12, -983 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x24 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x24, I_sh_cg_cp_rs2_b20, I_sh_cg_cp_rs2_b20_str)
-#else
-  sh x20, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x31, x21) # load rs2: x21 = 0xebc553c3
@@ -1150,18 +682,9 @@ I_sh_cg_cp_rs2_b21:
   sh x21, 1361(x29) # perform store
   addi x29, x29, 1361 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x28 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x28, I_sh_cg_cp_rs2_b21, I_sh_cg_cp_rs2_b21_str)
-#else
-  sh x21, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x31, x22) # load rs2: x22 = 0x17eacd33
@@ -1171,18 +694,9 @@ I_sh_cg_cp_rs2_b22:
   sh x22, -1175(x16) # perform store
   addi x16, x16, -1175 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x26 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x26, I_sh_cg_cp_rs2_b22, I_sh_cg_cp_rs2_b22_str)
-#else
-  sh x22, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x31, x23) # load rs2: x23 = 0x48d44a74
@@ -1192,18 +706,9 @@ I_sh_cg_cp_rs2_b23:
   sh x23, 356(x19) # perform store
   addi x19, x19, 356 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x12 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x12, I_sh_cg_cp_rs2_b23, I_sh_cg_cp_rs2_b23_str)
-#else
-  sh x23, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x31, x24) # load rs2: x24 = 0x8dce2e48
@@ -1213,18 +718,9 @@ I_sh_cg_cp_rs2_b24:
   sh x24, -1359(x11) # perform store
   addi x11, x11, -1359 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, I_sh_cg_cp_rs2_b24, I_sh_cg_cp_rs2_b24_str)
-#else
-  sh x24, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x31, x25) # load rs2: x25 = 0x122aa20d
@@ -1234,18 +730,9 @@ I_sh_cg_cp_rs2_b25:
   sh x25, 1281(x16) # perform store
   addi x16, x16, 1281 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x15 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x15, I_sh_cg_cp_rs2_b25, I_sh_cg_cp_rs2_b25_str)
-#else
-  sh x25, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x31, x26) # load rs2: x26 = 0x5e577546
@@ -1255,18 +742,9 @@ I_sh_cg_cp_rs2_b26:
   sh x26, 890(x11) # perform store
   addi x11, x11, 890 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x30 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x30, I_sh_cg_cp_rs2_b26, I_sh_cg_cp_rs2_b26_str)
-#else
-  sh x26, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x31, x27) # load rs2: x27 = 0xcc769651
@@ -1276,18 +754,9 @@ I_sh_cg_cp_rs2_b27:
   sh x27, -1374(x6) # perform store
   addi x6, x6, -1374 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x12 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x12, I_sh_cg_cp_rs2_b27, I_sh_cg_cp_rs2_b27_str)
-#else
-  sh x27, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x31, x28) # load rs2: x28 = 0x38dfaac1
@@ -1297,18 +766,9 @@ I_sh_cg_cp_rs2_b28:
   sh x28, 1398(x21) # perform store
   addi x21, x21, 1398 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x30 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x30, I_sh_cg_cp_rs2_b28, I_sh_cg_cp_rs2_b28_str)
-#else
-  sh x28, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x31, x29) # load rs2: x29 = 0xbf2ebe4c
@@ -1318,18 +778,9 @@ I_sh_cg_cp_rs2_b29:
   sh x29, -109(x10) # perform store
   addi x10, x10, -109 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x9 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x9, I_sh_cg_cp_rs2_b29, I_sh_cg_cp_rs2_b29_str)
-#else
-  sh x29, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x31, x30) # load rs2: x30 = 0x692a94f6
@@ -1339,18 +790,9 @@ I_sh_cg_cp_rs2_b30:
   sh x30, 1423(x28) # perform store
   addi x28, x28, 1423 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x29 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x29, I_sh_cg_cp_rs2_b30, I_sh_cg_cp_rs2_b30_str)
-#else
-  sh x30, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x19, x31 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x31)
@@ -1361,18 +803,9 @@ I_sh_cg_cp_rs2_b31:
   sh x31, 877(x9) # perform store
   addi x9, x9, 877 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, I_sh_cg_cp_rs2_b31, I_sh_cg_cp_rs2_b31_str)
-#else
-  sh x31, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -1386,18 +819,9 @@ I_sh_cg_cp_rs2_edges_0x0:
   sh x31, 1907(x3) # perform store
   addi x3, x3, 1907 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x21 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x21, I_sh_cg_cp_rs2_edges_0x0, I_sh_cg_cp_rs2_edges_0x0_str)
-#else
-  sh x31, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
   RVTEST_TESTDATA_LOAD_INT(x19, x6) # load rs2: x6 = 0x00000001
@@ -1407,18 +831,9 @@ I_sh_cg_cp_rs2_edges_0x1:
   sh x6, 1338(x15) # perform store
   addi x15, x15, 1338 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x21 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x21, I_sh_cg_cp_rs2_edges_0x1, I_sh_cg_cp_rs2_edges_0x1_str)
-#else
-  sh x6, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
   RVTEST_TESTDATA_LOAD_INT(x19, x2) # load rs2: x2 = 0x00000002
@@ -1428,18 +843,9 @@ I_sh_cg_cp_rs2_edges_0x2:
   sh x2, -206(x7) # perform store
   addi x7, x7, -206 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x26 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x26, I_sh_cg_cp_rs2_edges_0x2, I_sh_cg_cp_rs2_edges_0x2_str)
-#else
-  sh x2, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
   RVTEST_TESTDATA_LOAD_INT(x19, x28) # load rs2: x28 = 0x80000000
@@ -1449,18 +855,9 @@ I_sh_cg_cp_rs2_edges_0x80000000:
   sh x28, 531(x2) # perform store
   addi x2, x2, 531 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x12 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x12, I_sh_cg_cp_rs2_edges_0x80000000, I_sh_cg_cp_rs2_edges_0x80000000_str)
-#else
-  sh x28, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
   RVTEST_TESTDATA_LOAD_INT(x19, x9) # load rs2: x9 = 0x80000001
@@ -1470,18 +867,9 @@ I_sh_cg_cp_rs2_edges_0x80000001:
   sh x9, -453(x6) # perform store
   addi x6, x6, -453 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x25 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x25, I_sh_cg_cp_rs2_edges_0x80000001, I_sh_cg_cp_rs2_edges_0x80000001_str)
-#else
-  sh x9, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
   RVTEST_TESTDATA_LOAD_INT(x19, x29) # load rs2: x29 = 0x7fffffff
@@ -1491,18 +879,9 @@ I_sh_cg_cp_rs2_edges_0x7fffffff:
   sh x29, 120(x8) # perform store
   addi x8, x8, 120 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x23 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x23, I_sh_cg_cp_rs2_edges_0x7fffffff, I_sh_cg_cp_rs2_edges_0x7fffffff_str)
-#else
-  sh x29, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
   RVTEST_TESTDATA_LOAD_INT(x19, x21) # load rs2: x21 = 0x7ffffffe
@@ -1512,18 +891,9 @@ I_sh_cg_cp_rs2_edges_0x7ffffffe:
   sh x21, 823(x15) # perform store
   addi x15, x15, 823 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x13, I_sh_cg_cp_rs2_edges_0x7ffffffe, I_sh_cg_cp_rs2_edges_0x7ffffffe_str)
-#else
-  sh x21, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
   RVTEST_TESTDATA_LOAD_INT(x19, x6) # load rs2: x6 = 0xffffffff
@@ -1533,18 +903,9 @@ I_sh_cg_cp_rs2_edges_0xffffffff:
   sh x6, 709(x22) # perform store
   addi x22, x22, 709 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x13 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x13, I_sh_cg_cp_rs2_edges_0xffffffff, I_sh_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  sh x6, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
   RVTEST_TESTDATA_LOAD_INT(x19, x27) # load rs2: x27 = 0xfffffffe
@@ -1554,18 +915,9 @@ I_sh_cg_cp_rs2_edges_0xfffffffe:
   sh x27, -1290(x6) # perform store
   addi x6, x6, -1290 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x9 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x9, I_sh_cg_cp_rs2_edges_0xfffffffe, I_sh_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  sh x27, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
   RVTEST_TESTDATA_LOAD_INT(x19, x15) # load rs2: x15 = 0x5bbc8872
@@ -1575,18 +927,9 @@ I_sh_cg_cp_rs2_edges_0x5bbc8872:
   sh x15, -175(x27) # perform store
   addi x27, x27, -175 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x21 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x21, I_sh_cg_cp_rs2_edges_0x5bbc8872, I_sh_cg_cp_rs2_edges_0x5bbc8872_str)
-#else
-  sh x15, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x19, x26) # load rs2: x26 = 0xaaaaaaaa
@@ -1596,18 +939,9 @@ I_sh_cg_cp_rs2_edges_0xaaaaaaaa:
   sh x26, -953(x29) # perform store
   addi x29, x29, -953 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x23 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x23, I_sh_cg_cp_rs2_edges_0xaaaaaaaa, I_sh_cg_cp_rs2_edges_0xaaaaaaaa_str)
-#else
-  sh x26, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
   RVTEST_TESTDATA_LOAD_INT(x19, x16) # load rs2: x16 = 0x55555555
@@ -1617,18 +951,9 @@ I_sh_cg_cp_rs2_edges_0x55555555:
   sh x16, 1644(x6) # perform store
   addi x6, x6, 1644 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x9 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x9, I_sh_cg_cp_rs2_edges_0x55555555, I_sh_cg_cp_rs2_edges_0x55555555_str)
-#else
-  sh x16, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_edges
@@ -1642,18 +967,9 @@ I_sh_cg_cp_imm_edges_0x0:
   sh x28, 0(x3) # perform store
   addi x3, x3, 0 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x14 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x14, I_sh_cg_cp_imm_edges_0x0, I_sh_cg_cp_imm_edges_0x0_str)
-#else
-  sh x28, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1)
   RVTEST_TESTDATA_LOAD_INT(x19, x1) # load rs2: x1 = 0xb350897d
@@ -1663,18 +979,9 @@ I_sh_cg_cp_imm_edges_0x1:
   sh x1, 1(x8) # perform store
   addi x8, x8, 1 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x27 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x27, I_sh_cg_cp_imm_edges_0x1, I_sh_cg_cp_imm_edges_0x1_str)
-#else
-  sh x1, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2)
   RVTEST_TESTDATA_LOAD_INT(x19, x2) # load rs2: x2 = 0x1a59fa2f
@@ -1684,18 +991,9 @@ I_sh_cg_cp_imm_edges_0x2:
   sh x2, 2(x16) # perform store
   addi x16, x16, 2 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x15 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x15, I_sh_cg_cp_imm_edges_0x2, I_sh_cg_cp_imm_edges_0x2_str)
-#else
-  sh x2, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 3)
   RVTEST_TESTDATA_LOAD_INT(x19, x21) # load rs2: x21 = 0x3c3e5e0e
@@ -1705,18 +1003,9 @@ I_sh_cg_cp_imm_edges_0x3:
   sh x21, 3(x6) # perform store
   addi x6, x6, 3 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x26 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x26, I_sh_cg_cp_imm_edges_0x3, I_sh_cg_cp_imm_edges_0x3_str)
-#else
-  sh x21, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 4)
   RVTEST_TESTDATA_LOAD_INT(x19, x18) # load rs2: x18 = 0x7deb8843
@@ -1726,18 +1015,9 @@ I_sh_cg_cp_imm_edges_0x4:
   sh x18, 4(x27) # perform store
   addi x27, x27, 4 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x9 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x9, I_sh_cg_cp_imm_edges_0x4, I_sh_cg_cp_imm_edges_0x4_str)
-#else
-  sh x18, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 8)
   RVTEST_TESTDATA_LOAD_INT(x19, x21) # load rs2: x21 = 0x2e8c6728
@@ -1747,18 +1027,9 @@ I_sh_cg_cp_imm_edges_0x8:
   sh x21, 8(x1) # perform store
   addi x1, x1, 8 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x11, I_sh_cg_cp_imm_edges_0x8, I_sh_cg_cp_imm_edges_0x8_str)
-#else
-  sh x21, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 16)
   RVTEST_TESTDATA_LOAD_INT(x19, x31) # load rs2: x31 = 0xe8f58d21
@@ -1768,18 +1039,9 @@ I_sh_cg_cp_imm_edges_0x10:
   sh x31, 16(x15) # perform store
   addi x15, x15, 16 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x9 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x9, I_sh_cg_cp_imm_edges_0x10, I_sh_cg_cp_imm_edges_0x10_str)
-#else
-  sh x31, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 32)
   RVTEST_TESTDATA_LOAD_INT(x19, x3) # load rs2: x3 = 0xd9c81d95
@@ -1789,18 +1051,9 @@ I_sh_cg_cp_imm_edges_0x20:
   sh x3, 32(x22) # perform store
   addi x22, x22, 32 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x30 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x30, I_sh_cg_cp_imm_edges_0x20, I_sh_cg_cp_imm_edges_0x20_str)
-#else
-  sh x3, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 64)
   RVTEST_TESTDATA_LOAD_INT(x19, x20) # load rs2: x20 = 0x8a1e5fc0
@@ -1810,18 +1063,9 @@ I_sh_cg_cp_imm_edges_0x40:
   sh x20, 64(x29) # perform store
   addi x29, x29, 64 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x12 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x12, I_sh_cg_cp_imm_edges_0x40, I_sh_cg_cp_imm_edges_0x40_str)
-#else
-  sh x20, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 128)
   RVTEST_TESTDATA_LOAD_INT(x19, x12) # load rs2: x12 = 0xa3c6d963
@@ -1831,18 +1075,9 @@ I_sh_cg_cp_imm_edges_0x80:
   sh x12, 128(x17) # perform store
   addi x17, x17, 128 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x6 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x6, I_sh_cg_cp_imm_edges_0x80, I_sh_cg_cp_imm_edges_0x80_str)
-#else
-  sh x12, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 256)
   RVTEST_TESTDATA_LOAD_INT(x19, x11) # load rs2: x11 = 0xf279e98a
@@ -1852,18 +1087,9 @@ I_sh_cg_cp_imm_edges_0x100:
   sh x11, 256(x15) # perform store
   addi x15, x15, 256 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, I_sh_cg_cp_imm_edges_0x100, I_sh_cg_cp_imm_edges_0x100_str)
-#else
-  sh x11, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 512)
   RVTEST_TESTDATA_LOAD_INT(x19, x23) # load rs2: x23 = 0xaf15dc5d
@@ -1873,18 +1099,9 @@ I_sh_cg_cp_imm_edges_0x200:
   sh x23, 512(x17) # perform store
   addi x17, x17, 512 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x8 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x8, I_sh_cg_cp_imm_edges_0x200, I_sh_cg_cp_imm_edges_0x200_str)
-#else
-  sh x23, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1023)
   RVTEST_TESTDATA_LOAD_INT(x19, x29) # load rs2: x29 = 0x6590a8f4
@@ -1894,18 +1111,9 @@ I_sh_cg_cp_imm_edges_0x3ff:
   sh x29, 1023(x14) # perform store
   addi x14, x14, 1023 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x24 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x24, I_sh_cg_cp_imm_edges_0x3ff, I_sh_cg_cp_imm_edges_0x3ff_str)
-#else
-  sh x29, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1024)
   RVTEST_TESTDATA_LOAD_INT(x19, x3) # load rs2: x3 = 0x28809ff1
@@ -1915,18 +1123,9 @@ I_sh_cg_cp_imm_edges_0x400:
   sh x3, 1024(x22) # perform store
   addi x22, x22, 1024 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x31 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x31, I_sh_cg_cp_imm_edges_0x400, I_sh_cg_cp_imm_edges_0x400_str)
-#else
-  sh x3, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1795)
   RVTEST_TESTDATA_LOAD_INT(x19, x8) # load rs2: x8 = 0xb34de811
@@ -1936,18 +1135,9 @@ I_sh_cg_cp_imm_edges_0x703:
   sh x8, 1795(x16) # perform store
   addi x16, x16, 1795 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x23 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x23, I_sh_cg_cp_imm_edges_0x703, I_sh_cg_cp_imm_edges_0x703_str)
-#else
-  sh x8, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2047)
   RVTEST_TESTDATA_LOAD_INT(x19, x30) # load rs2: x30 = 0x4280ca38
@@ -1957,18 +1147,9 @@ I_sh_cg_cp_imm_edges_0x7ff:
   sh x30, 2047(x12) # perform store
   addi x12, x12, 2047 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x3 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x3, I_sh_cg_cp_imm_edges_0x7ff, I_sh_cg_cp_imm_edges_0x7ff_str)
-#else
-  sh x30, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2048)
   RVTEST_TESTDATA_LOAD_INT(x19, x27) # load rs2: x27 = 0xaf7d709d
@@ -1979,18 +1160,9 @@ I_sh_cg_cp_imm_edges_m0x800:
   sh x27, -2048(x13) # perform store
   addi x13, x13, -2048 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x1 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x1, I_sh_cg_cp_imm_edges_m0x800, I_sh_cg_cp_imm_edges_m0x800_str)
-#else
-  sh x27, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2047)
   RVTEST_TESTDATA_LOAD_INT(x19, x10) # load rs2: x10 = 0xbe6f88a5
@@ -2000,18 +1172,9 @@ I_sh_cg_cp_imm_edges_m0x7ff:
   sh x10, -2047(x31) # perform store
   addi x31, x31, -2047 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x25 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x25, I_sh_cg_cp_imm_edges_m0x7ff, I_sh_cg_cp_imm_edges_m0x7ff_str)
-#else
-  sh x10, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2)
   RVTEST_TESTDATA_LOAD_INT(x19, x27) # load rs2: x27 = 0xb77a097d
@@ -2021,18 +1184,9 @@ I_sh_cg_cp_imm_edges_m0x2:
   sh x27, -2(x30) # perform store
   addi x30, x30, -2 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x15 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x15, I_sh_cg_cp_imm_edges_m0x2, I_sh_cg_cp_imm_edges_m0x2_str)
-#else
-  sh x27, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -1)
   RVTEST_TESTDATA_LOAD_INT(x19, x17) # load rs2: x17 = 0x2ddf1ec3
@@ -2042,18 +1196,9 @@ I_sh_cg_cp_imm_edges_m0x1:
   sh x17, -1(x25) # perform store
   addi x25, x25, -1 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x13 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x13, I_sh_cg_cp_imm_edges_m0x1, I_sh_cg_cp_imm_edges_m0x1_str)
-#else
-  sh x17, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_align_hword
@@ -2064,84 +1209,48 @@ I_sh_cg_cp_imm_edges_m0x1:
 I_sh_cg_cp_align_hword_b0:
   sh x26, 0(x25) # perform store
   addi x25, x25, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -8(x25) # load stored value for checking
   # Check if x18 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x18, I_sh_cg_cp_align_hword_b0, I_sh_cg_cp_align_hword_b0_str)
   LREG x18, -8(x25) # load stored value for checking
   # Check if x18 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x18, I_sh_cg_cp_align_hword_b0, I_sh_cg_cp_align_hword_b0_str)
-#else
-  sh x26, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_hword (imm[2:0] = 010)
   RVTEST_TESTDATA_LOAD_INT(x19, x3) # load rs2: x3 = 0xe164258b
 I_sh_cg_cp_align_hword_b2:
   sh x3, 2(x25) # perform store
   addi x25, x25, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -8(x25) # load stored value for checking
   # Check if x30 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x30, I_sh_cg_cp_align_hword_b2, I_sh_cg_cp_align_hword_b2_str)
   LREG x30, -8(x25) # load stored value for checking
   # Check if x30 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x30, I_sh_cg_cp_align_hword_b2, I_sh_cg_cp_align_hword_b2_str)
-#else
-  sh x3, 2(x25) # repeat store so it is available for checking
-  addi x25, x25, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_hword (imm[2:0] = 100)
   RVTEST_TESTDATA_LOAD_INT(x19, x15) # load rs2: x15 = 0x5d8804c7
 I_sh_cg_cp_align_hword_b4:
   sh x15, 4(x25) # perform store
   addi x25, x25, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -8(x25) # load stored value for checking
   # Check if x1 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x1, I_sh_cg_cp_align_hword_b4, I_sh_cg_cp_align_hword_b4_str)
   LREG x1, -8(x25) # load stored value for checking
   # Check if x1 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x1, I_sh_cg_cp_align_hword_b4, I_sh_cg_cp_align_hword_b4_str)
-#else
-  sh x15, 4(x25) # repeat store so it is available for checking
-  addi x25, x25, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_hword (imm[2:0] = 110)
   RVTEST_TESTDATA_LOAD_INT(x19, x30) # load rs2: x30 = 0x05ad9488
 I_sh_cg_cp_align_hword_b6:
   sh x30, 6(x25) # perform store
   addi x25, x25, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -8(x25) # load stored value for checking
   # Check if x8 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x8, I_sh_cg_cp_align_hword_b6, I_sh_cg_cp_align_hword_b6_str)
   LREG x8, -8(x25) # load stored value for checking
   # Check if x8 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x8, I_sh_cg_cp_align_hword_b6, I_sh_cg_cp_align_hword_b6_str)
-#else
-  sh x30, 6(x25) # repeat store so it is available for checking
-  addi x25, x25, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 
   mv x2, x25 # restore signature pointer to default register for teardown

--- a/tests/rv32i/I/I-sw-00.S
+++ b/tests/rv32i/I/I-sw-00.S
@@ -41,18 +41,9 @@ I_sw_cg_cp_rs1_nx0_b1:
   sw x22, -1063(x1) # perform store
   addi x1, x1, -1063 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x26 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x26, I_sw_cg_cp_rs1_nx0_b1, I_sw_cg_cp_rs1_nx0_b1_str)
-#else
-  sw x22, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x20) # load rs2: x20 = 0x4aff4fcc
@@ -62,18 +53,9 @@ I_sw_cg_cp_rs1_nx0_b2:
   sw x20, 1729(x2) # perform store
   addi x2, x2, 1729 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x11 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x11, I_sw_cg_cp_rs1_nx0_b2, I_sw_cg_cp_rs1_nx0_b2_str)
-#else
-  sw x20, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x11, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
@@ -84,18 +66,9 @@ I_sw_cg_cp_rs1_nx0_b3:
   sw x17, 1979(x3) # perform store
   addi x3, x3, 1979 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x15 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x15, I_sw_cg_cp_rs1_nx0_b3, I_sw_cg_cp_rs1_nx0_b3_str)
-#else
-  sw x17, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x4 # switch temp register to avoid conflict with test
   mv x14, x5 # switch link pointer register to avoid conflict with test
@@ -107,18 +80,9 @@ I_sw_cg_cp_rs1_nx0_b4:
   sw x31, -1847(x4) # perform store
   addi x4, x4, -1847 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x7 contains the expected result. x4 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x4, x14, x13, x7, I_sw_cg_cp_rs1_nx0_b4, I_sw_cg_cp_rs1_nx0_b4_str)
-#else
-  sw x31, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x11, x24) # load rs2: x24 = 0x82914a38
@@ -128,18 +92,9 @@ I_sw_cg_cp_rs1_nx0_b5:
   sw x24, 255(x5) # perform store
   addi x5, x5, 255 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x10 contains the expected result. x5 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x5, x14, x13, x10, I_sw_cg_cp_rs1_nx0_b5, I_sw_cg_cp_rs1_nx0_b5_str)
-#else
-  sw x24, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x11, x7) # load rs2: x7 = 0x6d86a3f6
@@ -149,18 +104,9 @@ I_sw_cg_cp_rs1_nx0_b6:
   sw x7, 231(x6) # perform store
   addi x6, x6, 231 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x16 contains the expected result. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x6, x14, x13, x16, I_sw_cg_cp_rs1_nx0_b6, I_sw_cg_cp_rs1_nx0_b6_str)
-#else
-  sw x7, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x7)
   RVTEST_TESTDATA_LOAD_INT(x11, x15) # load rs2: x15 = 0x5e06a873
@@ -170,18 +116,9 @@ I_sw_cg_cp_rs1_nx0_b7:
   sw x15, -900(x7) # perform store
   addi x7, x7, -900 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x18 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x18, I_sw_cg_cp_rs1_nx0_b7, I_sw_cg_cp_rs1_nx0_b7_str)
-#else
-  sw x15, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x11, x15) # load rs2: x15 = 0x2fc16a49
@@ -191,18 +128,9 @@ I_sw_cg_cp_rs1_nx0_b8:
   sw x15, 134(x8) # perform store
   addi x8, x8, 134 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x23 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x23, I_sw_cg_cp_rs1_nx0_b8, I_sw_cg_cp_rs1_nx0_b8_str)
-#else
-  sw x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x11, x15) # load rs2: x15 = 0x4965ec1e
@@ -212,18 +140,9 @@ I_sw_cg_cp_rs1_nx0_b9:
   sw x15, -537(x9) # perform store
   addi x9, x9, -537 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x31 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x31, I_sw_cg_cp_rs1_nx0_b9, I_sw_cg_cp_rs1_nx0_b9_str)
-#else
-  sw x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0xcafcacab
@@ -233,18 +152,9 @@ I_sw_cg_cp_rs1_nx0_b10:
   sw x4, 617(x10) # perform store
   addi x10, x10, 617 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x5 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x5, I_sw_cg_cp_rs1_nx0_b10, I_sw_cg_cp_rs1_nx0_b10_str)
-#else
-  sw x4, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x3, x11 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
@@ -255,18 +165,9 @@ I_sw_cg_cp_rs1_nx0_b11:
   sw x19, 1407(x11) # perform store
   addi x11, x11, 1407 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x15, I_sw_cg_cp_rs1_nx0_b11, I_sw_cg_cp_rs1_nx0_b11_str)
-#else
-  sw x19, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x22) # load rs2: x22 = 0xe3cbfb1c
@@ -276,18 +177,9 @@ I_sw_cg_cp_rs1_nx0_b12:
   sw x22, 1150(x12) # perform store
   addi x12, x12, 1150 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x29 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x29, I_sw_cg_cp_rs1_nx0_b12, I_sw_cg_cp_rs1_nx0_b12_str)
-#else
-  sw x22, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x13 # switch temp register to avoid conflict with test
   mv x8, x14 # switch link pointer register to avoid conflict with test
@@ -299,18 +191,9 @@ I_sw_cg_cp_rs1_nx0_b13:
   sw x6, 1642(x13) # perform store
   addi x13, x13, 1642 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x20 contains the expected result. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x13, x8, x7, x20, I_sw_cg_cp_rs1_nx0_b13, I_sw_cg_cp_rs1_nx0_b13_str)
-#else
-  sw x6, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x21) # load rs2: x21 = 0x2b4e0745
@@ -320,18 +203,9 @@ I_sw_cg_cp_rs1_nx0_b14:
   sw x21, 1068(x14) # perform store
   addi x14, x14, 1068 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x19 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x19, I_sw_cg_cp_rs1_nx0_b14, I_sw_cg_cp_rs1_nx0_b14_str)
-#else
-  sw x21, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0x716ddc81
@@ -341,18 +215,9 @@ I_sw_cg_cp_rs1_nx0_b15:
   sw x2, -1539(x15) # perform store
   addi x15, x15, -1539 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x23 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x15, x8, x7, x23, I_sw_cg_cp_rs1_nx0_b15, I_sw_cg_cp_rs1_nx0_b15_str)
-#else
-  sw x2, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x16)
   RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x9cd84540
@@ -362,18 +227,9 @@ I_sw_cg_cp_rs1_nx0_b16:
   sw x5, -525(x16) # perform store
   addi x16, x16, -525 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x19 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x16, x8, x7, x19, I_sw_cg_cp_rs1_nx0_b16, I_sw_cg_cp_rs1_nx0_b16_str)
-#else
-  sw x5, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x17)
   RVTEST_TESTDATA_LOAD_INT(x3, x24) # load rs2: x24 = 0xc81cb2a5
@@ -383,18 +239,9 @@ I_sw_cg_cp_rs1_nx0_b17:
   sw x24, -957(x17) # perform store
   addi x17, x17, -957 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x20 contains the expected result. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x17, x8, x7, x20, I_sw_cg_cp_rs1_nx0_b17, I_sw_cg_cp_rs1_nx0_b17_str)
-#else
-  sw x24, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x18)
   RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x55457b75
@@ -404,18 +251,9 @@ I_sw_cg_cp_rs1_nx0_b18:
   sw x5, -1694(x18) # perform store
   addi x18, x18, -1694 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x6 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x6, I_sw_cg_cp_rs1_nx0_b18, I_sw_cg_cp_rs1_nx0_b18_str)
-#else
-  sw x5, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x19)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x91552883
@@ -425,18 +263,9 @@ I_sw_cg_cp_rs1_nx0_b19:
   sw x15, 518(x19) # perform store
   addi x19, x19, 518 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x13 contains the expected result. x19 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x19, x8, x7, x13, I_sw_cg_cp_rs1_nx0_b19, I_sw_cg_cp_rs1_nx0_b19_str)
-#else
-  sw x15, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x20)
   RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0x40639bae
@@ -446,18 +275,9 @@ I_sw_cg_cp_rs1_nx0_b20:
   sw x0, 108(x20) # perform store
   addi x20, x20, 108 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x4 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x4, I_sw_cg_cp_rs1_nx0_b20, I_sw_cg_cp_rs1_nx0_b20_str)
-#else
-  sw x0, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x21)
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0x4c14ef26
@@ -467,18 +287,9 @@ I_sw_cg_cp_rs1_nx0_b21:
   sw x1, 482(x21) # perform store
   addi x21, x21, 482 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x27 contains the expected result. x21 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x21, x8, x7, x27, I_sw_cg_cp_rs1_nx0_b21, I_sw_cg_cp_rs1_nx0_b21_str)
-#else
-  sw x1, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x22)
   RVTEST_TESTDATA_LOAD_INT(x3, x31) # load rs2: x31 = 0x68b518a2
@@ -488,18 +299,9 @@ I_sw_cg_cp_rs1_nx0_b22:
   sw x31, 509(x22) # perform store
   addi x22, x22, 509 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x14 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x14, I_sw_cg_cp_rs1_nx0_b22, I_sw_cg_cp_rs1_nx0_b22_str)
-#else
-  sw x31, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x23)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x2ceb69f2
@@ -509,18 +311,9 @@ I_sw_cg_cp_rs1_nx0_b23:
   sw x10, -1536(x23) # perform store
   addi x23, x23, -1536 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x30 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x30, I_sw_cg_cp_rs1_nx0_b23, I_sw_cg_cp_rs1_nx0_b23_str)
-#else
-  sw x10, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x24)
   RVTEST_TESTDATA_LOAD_INT(x3, x26) # load rs2: x26 = 0x818d95f2
@@ -530,18 +323,9 @@ I_sw_cg_cp_rs1_nx0_b24:
   sw x26, 1251(x24) # perform store
   addi x24, x24, 1251 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x10 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x10, I_sw_cg_cp_rs1_nx0_b24, I_sw_cg_cp_rs1_nx0_b24_str)
-#else
-  sw x26, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x25)
   RVTEST_TESTDATA_LOAD_INT(x3, x4) # load rs2: x4 = 0xc31ad048
@@ -551,18 +335,9 @@ I_sw_cg_cp_rs1_nx0_b25:
   sw x4, -935(x25) # perform store
   addi x25, x25, -935 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x9 contains the expected result. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x25, x8, x7, x9, I_sw_cg_cp_rs1_nx0_b25, I_sw_cg_cp_rs1_nx0_b25_str)
-#else
-  sw x4, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x26)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xde9dad94
@@ -572,18 +347,9 @@ I_sw_cg_cp_rs1_nx0_b26:
   sw x14, -1403(x26) # perform store
   addi x26, x26, -1403 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x10 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x10, I_sw_cg_cp_rs1_nx0_b26, I_sw_cg_cp_rs1_nx0_b26_str)
-#else
-  sw x14, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x27)
   RVTEST_TESTDATA_LOAD_INT(x3, x28) # load rs2: x28 = 0x428ac6d1
@@ -593,18 +359,9 @@ I_sw_cg_cp_rs1_nx0_b27:
   sw x28, -123(x27) # perform store
   addi x27, x27, -123 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x6 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x27, x8, x7, x6, I_sw_cg_cp_rs1_nx0_b27, I_sw_cg_cp_rs1_nx0_b27_str)
-#else
-  sw x28, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x28)
   RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x55e31962
@@ -614,18 +371,9 @@ I_sw_cg_cp_rs1_nx0_b28:
   sw x5, 1945(x28) # perform store
   addi x28, x28, 1945 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x20 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x20, I_sw_cg_cp_rs1_nx0_b28, I_sw_cg_cp_rs1_nx0_b28_str)
-#else
-  sw x5, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x29)
   RVTEST_TESTDATA_LOAD_INT(x3, x18) # load rs2: x18 = 0x97edee76
@@ -635,18 +383,9 @@ I_sw_cg_cp_rs1_nx0_b29:
   sw x18, 525(x29) # perform store
   addi x29, x29, 525 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x10 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x10, I_sw_cg_cp_rs1_nx0_b29, I_sw_cg_cp_rs1_nx0_b29_str)
-#else
-  sw x18, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x30)
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0x02f73af5
@@ -656,18 +395,9 @@ I_sw_cg_cp_rs1_nx0_b30:
   sw x1, -1778(x30) # perform store
   addi x30, x30, -1778 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x10 contains the expected result. x30 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x30, x8, x7, x10, I_sw_cg_cp_rs1_nx0_b30, I_sw_cg_cp_rs1_nx0_b30_str)
-#else
-  sw x1, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x31)
   RVTEST_TESTDATA_LOAD_INT(x3, x27) # load rs2: x27 = 0x6397cf3b
@@ -677,18 +407,9 @@ I_sw_cg_cp_rs1_nx0_b31:
   sw x27, 1288(x31) # perform store
   addi x31, x31, 1288 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x11 contains the expected result. x31 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x31, x8, x7, x11, I_sw_cg_cp_rs1_nx0_b31, I_sw_cg_cp_rs1_nx0_b31_str)
-#else
-  sw x27, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2
@@ -702,18 +423,9 @@ I_sw_cg_cp_rs2_b0:
   sw x0, 1417(x22) # perform store
   addi x22, x22, 1417 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x1 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x1, I_sw_cg_cp_rs2_b0, I_sw_cg_cp_rs2_b0_str)
-#else
-  sw x0, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0xbe0bc484
@@ -723,18 +435,9 @@ I_sw_cg_cp_rs2_b1:
   sw x1, 911(x2) # perform store
   addi x2, x2, 911 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x18 contains the expected result. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x2, x8, x7, x18, I_sw_cg_cp_rs2_b1, I_sw_cg_cp_rs2_b1_str)
-#else
-  sw x1, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x15, x2 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x2)
@@ -745,18 +448,9 @@ I_sw_cg_cp_rs2_b2:
   sw x2, 909(x14) # perform store
   addi x14, x14, 909 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x27 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x27, I_sw_cg_cp_rs2_b2, I_sw_cg_cp_rs2_b2_str)
-#else
-  sw x2, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x26, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x3)
@@ -767,18 +461,9 @@ I_sw_cg_cp_rs2_b3:
   sw x3, 1334(x16) # perform store
   addi x16, x16, 1334 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x17 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x16, x8, x7, x17, I_sw_cg_cp_rs2_b3, I_sw_cg_cp_rs2_b3_str)
-#else
-  sw x3, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x4)
   RVTEST_TESTDATA_LOAD_INT(x26, x4) # load rs2: x4 = 0x3ba5eea0
@@ -788,18 +473,9 @@ I_sw_cg_cp_rs2_b4:
   sw x4, -1291(x12) # perform store
   addi x12, x12, -1291 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x12, x8, x7, x14, I_sw_cg_cp_rs2_b4, I_sw_cg_cp_rs2_b4_str)
-#else
-  sw x4, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x26, x5) # load rs2: x5 = 0xdb1de6f3
@@ -809,18 +485,9 @@ I_sw_cg_cp_rs2_b5:
   sw x5, -295(x1) # perform store
   addi x1, x1, -295 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, I_sw_cg_cp_rs2_b5, I_sw_cg_cp_rs2_b5_str)
-#else
-  sw x5, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x26, x6) # load rs2: x6 = 0xa8d66911
@@ -830,18 +497,9 @@ I_sw_cg_cp_rs2_b6:
   sw x6, -644(x11) # perform store
   addi x11, x11, -644 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x11, x8, x7, x14, I_sw_cg_cp_rs2_b6, I_sw_cg_cp_rs2_b6_str)
-#else
-  sw x6, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x7 # switch temp register to avoid conflict with test
   mv x14, x8 # switch link pointer register to avoid conflict with test
@@ -853,18 +511,9 @@ I_sw_cg_cp_rs2_b7:
   sw x7, -106(x1) # perform store
   addi x1, x1, -106 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x24 contains the expected result. x1 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x1, x14, x13, x24, I_sw_cg_cp_rs2_b7, I_sw_cg_cp_rs2_b7_str)
-#else
-  sw x7, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x26, x8) # load rs2: x8 = 0x2d7e476c
@@ -874,18 +523,9 @@ I_sw_cg_cp_rs2_b8:
   sw x8, -1535(x10) # perform store
   addi x10, x10, -1535 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x11 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x11, I_sw_cg_cp_rs2_b8, I_sw_cg_cp_rs2_b8_str)
-#else
-  sw x8, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x26, x9) # load rs2: x9 = 0xe68a3a54
@@ -895,18 +535,9 @@ I_sw_cg_cp_rs2_b9:
   sw x9, -690(x15) # perform store
   addi x15, x15, -690 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x25 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x15, x14, x13, x25, I_sw_cg_cp_rs2_b9, I_sw_cg_cp_rs2_b9_str)
-#else
-  sw x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x26, x10) # load rs2: x10 = 0x9f944934
@@ -916,18 +547,9 @@ I_sw_cg_cp_rs2_b10:
   sw x10, 125(x12) # perform store
   addi x12, x12, 125 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x9 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x9, I_sw_cg_cp_rs2_b10, I_sw_cg_cp_rs2_b10_str)
-#else
-  sw x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x26, x11) # load rs2: x11 = 0xbda8cd77
@@ -937,18 +559,9 @@ I_sw_cg_cp_rs2_b11:
   sw x11, -1374(x4) # perform store
   addi x4, x4, -1374 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x20 contains the expected result. x4 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x4, x14, x13, x20, I_sw_cg_cp_rs2_b11, I_sw_cg_cp_rs2_b11_str)
-#else
-  sw x11, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x26, x12) # load rs2: x12 = 0x959ea0fa
@@ -958,18 +571,9 @@ I_sw_cg_cp_rs2_b12:
   sw x12, -812(x7) # perform store
   addi x7, x7, -812 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x27 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x27, I_sw_cg_cp_rs2_b12, I_sw_cg_cp_rs2_b12_str)
-#else
-  sw x12, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -981,18 +585,9 @@ I_sw_cg_cp_rs2_b13:
   sw x13, 559(x14) # perform store
   addi x14, x14, 559 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x30 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x30, I_sw_cg_cp_rs2_b13, I_sw_cg_cp_rs2_b13_str)
-#else
-  sw x13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x10, x14 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x14)
@@ -1003,18 +598,9 @@ I_sw_cg_cp_rs2_b14:
   sw x14, -689(x11) # perform store
   addi x11, x11, -689 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x22, I_sw_cg_cp_rs2_b14, I_sw_cg_cp_rs2_b14_str)
-#else
-  sw x14, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x26, x15) # load rs2: x15 = 0x39a1a647
@@ -1024,18 +610,9 @@ I_sw_cg_cp_rs2_b15:
   sw x15, 1211(x2) # perform store
   addi x2, x2, 1211 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x6 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x6, I_sw_cg_cp_rs2_b15, I_sw_cg_cp_rs2_b15_str)
-#else
-  sw x15, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x26, x16) # load rs2: x16 = 0x8ba01616
@@ -1045,18 +622,9 @@ I_sw_cg_cp_rs2_b16:
   sw x16, 676(x29) # perform store
   addi x29, x29, 676 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x11 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x11, I_sw_cg_cp_rs2_b16, I_sw_cg_cp_rs2_b16_str)
-#else
-  sw x16, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x26, x17) # load rs2: x17 = 0x32157a98
@@ -1066,18 +634,9 @@ I_sw_cg_cp_rs2_b17:
   sw x17, 532(x20) # perform store
   addi x20, x20, 532 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x23 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x23, I_sw_cg_cp_rs2_b17, I_sw_cg_cp_rs2_b17_str)
-#else
-  sw x17, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x26, x18) # load rs2: x18 = 0x9593d54c
@@ -1087,18 +646,9 @@ I_sw_cg_cp_rs2_b18:
   sw x18, 550(x7) # perform store
   addi x7, x7, 550 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x28 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x28, I_sw_cg_cp_rs2_b18, I_sw_cg_cp_rs2_b18_str)
-#else
-  sw x18, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x26, x19) # load rs2: x19 = 0x3928116d
@@ -1108,18 +658,9 @@ I_sw_cg_cp_rs2_b19:
   sw x19, 1863(x29) # perform store
   addi x29, x29, 1863 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x24 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x24, I_sw_cg_cp_rs2_b19, I_sw_cg_cp_rs2_b19_str)
-#else
-  sw x19, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x26, x20) # load rs2: x20 = 0xdde73b94
@@ -1129,18 +670,9 @@ I_sw_cg_cp_rs2_b20:
   sw x20, -608(x11) # perform store
   addi x11, x11, -608 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x23 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x23, I_sw_cg_cp_rs2_b20, I_sw_cg_cp_rs2_b20_str)
-#else
-  sw x20, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x26, x21) # load rs2: x21 = 0x0655fb09
@@ -1150,18 +682,9 @@ I_sw_cg_cp_rs2_b21:
   sw x21, 345(x24) # perform store
   addi x24, x24, 345 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x18 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x18, I_sw_cg_cp_rs2_b21, I_sw_cg_cp_rs2_b21_str)
-#else
-  sw x21, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x26, x22) # load rs2: x22 = 0x2b2d67c8
@@ -1171,18 +694,9 @@ I_sw_cg_cp_rs2_b22:
   sw x22, 956(x17) # perform store
   addi x17, x17, 956 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x27 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x27, I_sw_cg_cp_rs2_b22, I_sw_cg_cp_rs2_b22_str)
-#else
-  sw x22, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x26, x23) # load rs2: x23 = 0x5a114ff0
@@ -1192,18 +706,9 @@ I_sw_cg_cp_rs2_b23:
   sw x23, -1079(x24) # perform store
   addi x24, x24, -1079 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x25 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x25, I_sw_cg_cp_rs2_b23, I_sw_cg_cp_rs2_b23_str)
-#else
-  sw x23, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x18, x24 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x24)
@@ -1214,18 +719,9 @@ I_sw_cg_cp_rs2_b24:
   sw x24, -1403(x21) # perform store
   addi x21, x21, -1403 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x7 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x7, I_sw_cg_cp_rs2_b24, I_sw_cg_cp_rs2_b24_str)
-#else
-  sw x24, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x26, x25) # load rs2: x25 = 0x8fd2c24d
@@ -1235,18 +731,9 @@ I_sw_cg_cp_rs2_b25:
   sw x25, -766(x6) # perform store
   addi x6, x6, -766 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x9 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x9, I_sw_cg_cp_rs2_b25, I_sw_cg_cp_rs2_b25_str)
-#else
-  sw x25, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x1, x26 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x26)
@@ -1257,18 +744,9 @@ I_sw_cg_cp_rs2_b26:
   sw x26, 1946(x28) # perform store
   addi x28, x28, 1946 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x8 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x8, I_sw_cg_cp_rs2_b26, I_sw_cg_cp_rs2_b26_str)
-#else
-  sw x26, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x204d0187
@@ -1278,18 +756,9 @@ I_sw_cg_cp_rs2_b27:
   sw x27, 494(x24) # perform store
   addi x24, x24, 494 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x16 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x16, I_sw_cg_cp_rs2_b27, I_sw_cg_cp_rs2_b27_str)
-#else
-  sw x27, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x20e059d2
@@ -1299,18 +768,9 @@ I_sw_cg_cp_rs2_b28:
   sw x28, -1844(x25) # perform store
   addi x25, x25, -1844 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x20 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x20, I_sw_cg_cp_rs2_b28, I_sw_cg_cp_rs2_b28_str)
-#else
-  sw x28, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x9cefdde0
@@ -1320,18 +780,9 @@ I_sw_cg_cp_rs2_b29:
   sw x29, 157(x24) # perform store
   addi x24, x24, 157 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x30 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x30, I_sw_cg_cp_rs2_b29, I_sw_cg_cp_rs2_b29_str)
-#else
-  sw x29, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0xe2d6837d
@@ -1341,18 +792,9 @@ I_sw_cg_cp_rs2_b30:
   sw x30, -531(x25) # perform store
   addi x25, x25, -531 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x15 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x15, I_sw_cg_cp_rs2_b30, I_sw_cg_cp_rs2_b30_str)
-#else
-  sw x30, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0xd4da5f77
@@ -1362,18 +804,9 @@ I_sw_cg_cp_rs2_b31:
   sw x31, 1879(x6) # perform store
   addi x6, x6, 1879 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x14 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x14, I_sw_cg_cp_rs2_b31, I_sw_cg_cp_rs2_b31_str)
-#else
-  sw x31, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -1387,18 +820,9 @@ I_sw_cg_cp_rs2_edges_0x0:
   sw x7, -455(x31) # perform store
   addi x31, x31, -455 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x20 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x20, I_sw_cg_cp_rs2_edges_0x0, I_sw_cg_cp_rs2_edges_0x0_str)
-#else
-  sw x7, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0x00000001
@@ -1408,18 +832,9 @@ I_sw_cg_cp_rs2_edges_0x1:
   sw x17, -1318(x12) # perform store
   addi x12, x12, -1318 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x15 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x15, I_sw_cg_cp_rs2_edges_0x1, I_sw_cg_cp_rs2_edges_0x1_str)
-#else
-  sw x17, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x00000002
@@ -1429,18 +844,9 @@ I_sw_cg_cp_rs2_edges_0x2:
   sw x28, 335(x25) # perform store
   addi x25, x25, 335 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x30 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x30, I_sw_cg_cp_rs2_edges_0x2, I_sw_cg_cp_rs2_edges_0x2_str)
-#else
-  sw x28, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
   RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x80000000
@@ -1450,18 +856,9 @@ I_sw_cg_cp_rs2_edges_0x80000000:
   sw x16, 835(x28) # perform store
   addi x28, x28, 835 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x9 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x9, I_sw_cg_cp_rs2_edges_0x80000000, I_sw_cg_cp_rs2_edges_0x80000000_str)
-#else
-  sw x16, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0x80000001
@@ -1471,18 +868,9 @@ I_sw_cg_cp_rs2_edges_0x80000001:
   sw x2, 968(x22) # perform store
   addi x22, x22, 968 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x19 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x19, I_sw_cg_cp_rs2_edges_0x80000001, I_sw_cg_cp_rs2_edges_0x80000001_str)
-#else
-  sw x2, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x7fffffff
@@ -1492,18 +880,9 @@ I_sw_cg_cp_rs2_edges_0x7fffffff:
   sw x6, 704(x18) # perform store
   addi x18, x18, 704 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, I_sw_cg_cp_rs2_edges_0x7fffffff, I_sw_cg_cp_rs2_edges_0x7fffffff_str)
-#else
-  sw x6, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x7ffffffe
@@ -1513,18 +892,9 @@ I_sw_cg_cp_rs2_edges_0x7ffffffe:
   sw x29, -1935(x24) # perform store
   addi x24, x24, -1935 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x25 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x25, I_sw_cg_cp_rs2_edges_0x7ffffffe, I_sw_cg_cp_rs2_edges_0x7ffffffe_str)
-#else
-  sw x29, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xffffffff
@@ -1534,18 +904,9 @@ I_sw_cg_cp_rs2_edges_0xffffffff:
   sw x12, -1155(x22) # perform store
   addi x22, x22, -1155 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x17 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x17, I_sw_cg_cp_rs2_edges_0xffffffff, I_sw_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  sw x12, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xfffffffe
@@ -1555,18 +916,9 @@ I_sw_cg_cp_rs2_edges_0xfffffffe:
   sw x8, 81(x14) # perform store
   addi x14, x14, 81 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x16 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x16, I_sw_cg_cp_rs2_edges_0xfffffffe, I_sw_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  sw x8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0x5bbc8872
@@ -1576,18 +928,9 @@ I_sw_cg_cp_rs2_edges_0x5bbc8872:
   sw x19, 1383(x6) # perform store
   addi x6, x6, 1383 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x16 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x16, I_sw_cg_cp_rs2_edges_0x5bbc8872, I_sw_cg_cp_rs2_edges_0x5bbc8872_str)
-#else
-  sw x19, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xaaaaaaaa
@@ -1597,18 +940,9 @@ I_sw_cg_cp_rs2_edges_0xaaaaaaaa:
   sw x12, 430(x16) # perform store
   addi x16, x16, 430 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x21 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x21, I_sw_cg_cp_rs2_edges_0xaaaaaaaa, I_sw_cg_cp_rs2_edges_0xaaaaaaaa_str)
-#else
-  sw x12, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x55555555
@@ -1618,18 +952,9 @@ I_sw_cg_cp_rs2_edges_0x55555555:
   sw x31, -713(x22) # perform store
   addi x22, x22, -713 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x6 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x6, I_sw_cg_cp_rs2_edges_0x55555555, I_sw_cg_cp_rs2_edges_0x55555555_str)
-#else
-  sw x31, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_edges
@@ -1643,18 +968,9 @@ I_sw_cg_cp_imm_edges_0x0:
   sw x17, 0(x16) # perform store
   addi x16, x16, 0 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x31 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x31, I_sw_cg_cp_imm_edges_0x0, I_sw_cg_cp_imm_edges_0x0_str)
-#else
-  sw x17, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1)
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x9c0eea91
@@ -1664,18 +980,9 @@ I_sw_cg_cp_imm_edges_0x1:
   sw x23, 1(x22) # perform store
   addi x22, x22, 1 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x28 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x28, I_sw_cg_cp_imm_edges_0x1, I_sw_cg_cp_imm_edges_0x1_str)
-#else
-  sw x23, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x991675d6
@@ -1685,18 +992,9 @@ I_sw_cg_cp_imm_edges_0x2:
   sw x6, 2(x19) # perform store
   addi x19, x19, 2 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x12 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x12, I_sw_cg_cp_imm_edges_0x2, I_sw_cg_cp_imm_edges_0x2_str)
-#else
-  sw x6, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 3)
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x58367654
@@ -1706,18 +1004,9 @@ I_sw_cg_cp_imm_edges_0x3:
   sw x23, 3(x2) # perform store
   addi x2, x2, 3 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x16 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x16, I_sw_cg_cp_imm_edges_0x3, I_sw_cg_cp_imm_edges_0x3_str)
-#else
-  sw x23, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 4)
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x0f19ff31
@@ -1727,18 +1016,9 @@ I_sw_cg_cp_imm_edges_0x4:
   sw x23, 4(x6) # perform store
   addi x6, x6, 4 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x25 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x25, I_sw_cg_cp_imm_edges_0x4, I_sw_cg_cp_imm_edges_0x4_str)
-#else
-  sw x23, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 8)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xa868e503
@@ -1748,18 +1028,9 @@ I_sw_cg_cp_imm_edges_0x8:
   sw x15, 8(x8) # perform store
   addi x8, x8, 8 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x31 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x31, I_sw_cg_cp_imm_edges_0x8, I_sw_cg_cp_imm_edges_0x8_str)
-#else
-  sw x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 16)
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x860e98b7
@@ -1769,18 +1040,9 @@ I_sw_cg_cp_imm_edges_0x10:
   sw x31, 16(x11) # perform store
   addi x11, x11, 16 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x27, I_sw_cg_cp_imm_edges_0x10, I_sw_cg_cp_imm_edges_0x10_str)
-#else
-  sw x31, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 32)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0x13da6910
@@ -1790,18 +1052,9 @@ I_sw_cg_cp_imm_edges_0x20:
   sw x2, 32(x15) # perform store
   addi x15, x15, 32 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x30 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x30, I_sw_cg_cp_imm_edges_0x20, I_sw_cg_cp_imm_edges_0x20_str)
-#else
-  sw x2, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 64)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x3c1d5330
@@ -1811,18 +1064,9 @@ I_sw_cg_cp_imm_edges_0x40:
   sw x14, 64(x9) # perform store
   addi x9, x9, 64 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x24 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x24, I_sw_cg_cp_imm_edges_0x40, I_sw_cg_cp_imm_edges_0x40_str)
-#else
-  sw x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 128)
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x141ea38a
@@ -1832,18 +1076,9 @@ I_sw_cg_cp_imm_edges_0x80:
   sw x7, 128(x29) # perform store
   addi x29, x29, 128 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x15 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x15, I_sw_cg_cp_imm_edges_0x80, I_sw_cg_cp_imm_edges_0x80_str)
-#else
-  sw x7, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 256)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x8ec858c6
@@ -1853,18 +1088,9 @@ I_sw_cg_cp_imm_edges_0x100:
   sw x8, 256(x13) # perform store
   addi x13, x13, 256 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, I_sw_cg_cp_imm_edges_0x100, I_sw_cg_cp_imm_edges_0x100_str)
-#else
-  sw x8, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 512)
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x97e8d2f6
@@ -1874,18 +1100,9 @@ I_sw_cg_cp_imm_edges_0x200:
   sw x30, 512(x7) # perform store
   addi x7, x7, 512 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x24 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x24, I_sw_cg_cp_imm_edges_0x200, I_sw_cg_cp_imm_edges_0x200_str)
-#else
-  sw x30, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1023)
   RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0x1b2c9cbe
@@ -1895,18 +1112,9 @@ I_sw_cg_cp_imm_edges_0x3ff:
   sw x17, 1023(x8) # perform store
   addi x8, x8, 1023 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x20 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x20, I_sw_cg_cp_imm_edges_0x3ff, I_sw_cg_cp_imm_edges_0x3ff_str)
-#else
-  sw x17, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1024)
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x3b6d51b2
@@ -1916,18 +1124,9 @@ I_sw_cg_cp_imm_edges_0x400:
   sw x9, 1024(x25) # perform store
   addi x25, x25, 1024 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x29 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x29, I_sw_cg_cp_imm_edges_0x400, I_sw_cg_cp_imm_edges_0x400_str)
-#else
-  sw x9, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1795)
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x6bda5c4e
@@ -1937,18 +1136,9 @@ I_sw_cg_cp_imm_edges_0x703:
   sw x27, 1795(x3) # perform store
   addi x3, x3, 1795 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x21 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x21, I_sw_cg_cp_imm_edges_0x703, I_sw_cg_cp_imm_edges_0x703_str)
-#else
-  sw x27, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2047)
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0xdb727b24
@@ -1958,18 +1148,9 @@ I_sw_cg_cp_imm_edges_0x7ff:
   sw x21, 2047(x12) # perform store
   addi x12, x12, 2047 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, I_sw_cg_cp_imm_edges_0x7ff, I_sw_cg_cp_imm_edges_0x7ff_str)
-#else
-  sw x21, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2048)
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x7b506ebf
@@ -1980,18 +1161,9 @@ I_sw_cg_cp_imm_edges_m0x800:
   sw x25, -2048(x27) # perform store
   addi x27, x27, -2048 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x7 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x7, I_sw_cg_cp_imm_edges_m0x800, I_sw_cg_cp_imm_edges_m0x800_str)
-#else
-  sw x25, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2047)
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x08c1c774
@@ -2001,18 +1173,9 @@ I_sw_cg_cp_imm_edges_m0x7ff:
   sw x31, -2047(x19) # perform store
   addi x19, x19, -2047 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x8 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x8, I_sw_cg_cp_imm_edges_m0x7ff, I_sw_cg_cp_imm_edges_m0x7ff_str)
-#else
-  sw x31, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2)
   RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rs2: x18 = 0x38eb4e13
@@ -2022,18 +1185,9 @@ I_sw_cg_cp_imm_edges_m0x2:
   sw x18, -2(x13) # perform store
   addi x13, x13, -2 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x21 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x21, I_sw_cg_cp_imm_edges_m0x2, I_sw_cg_cp_imm_edges_m0x2_str)
-#else
-  sw x18, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -1)
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x9fe8a559
@@ -2043,18 +1197,9 @@ I_sw_cg_cp_imm_edges_m0x1:
   sw x27, -1(x10) # perform store
   addi x10, x10, -1 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x7 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x7, I_sw_cg_cp_imm_edges_m0x1, I_sw_cg_cp_imm_edges_m0x1_str)
-#else
-  sw x27, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_align_word
@@ -2065,42 +1210,24 @@ I_sw_cg_cp_imm_edges_m0x1:
 I_sw_cg_cp_align_word_b0:
   sw x17, 0(x10) # perform store
   addi x10, x10, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -8(x10) # load stored value for checking
   # Check if x6 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x6, I_sw_cg_cp_align_word_b0, I_sw_cg_cp_align_word_b0_str)
   LREG x6, -8(x10) # load stored value for checking
   # Check if x6 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x6, I_sw_cg_cp_align_word_b0, I_sw_cg_cp_align_word_b0_str)
-#else
-  sw x17, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_word (imm[2:0] = 100)
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0xa6f52c8c
 I_sw_cg_cp_align_word_b4:
   sw x22, 4(x10) # perform store
   addi x10, x10, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -8(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, I_sw_cg_cp_align_word_b4, I_sw_cg_cp_align_word_b4_str)
   LREG x14, -8(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, I_sw_cg_cp_align_word_b4, I_sw_cg_cp_align_word_b4_str)
-#else
-  sw x22, 4(x10) # repeat store so it is available for checking
-  addi x10, x10, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 
   mv x2, x10 # restore signature pointer to default register for teardown

--- a/tests/rv32i/Zca/Zca-c.sw-00.S
+++ b/tests/rv32i/Zca/Zca-c.sw-00.S
@@ -41,18 +41,9 @@ Zca_c_sw_cg_cp_rs1_p_b8:
   c.sw x13, 24(x8) # perform store
   addi x8, x8, 24 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x15 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x15, Zca_c_sw_cg_cp_rs1_p_b8, Zca_c_sw_cg_cp_rs1_p_b8_str)
-#else
-  c.sw x13, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xa980edf0
@@ -62,18 +53,9 @@ Zca_c_sw_cg_cp_rs1_p_b9:
   c.sw x11, 96(x9) # perform store
   addi x9, x9, 96 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sw_cg_cp_rs1_p_b9, Zca_c_sw_cg_cp_rs1_p_b9_str)
-#else
-  c.sw x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x81307f54
@@ -83,18 +65,9 @@ Zca_c_sw_cg_cp_rs1_p_b10:
   c.sw x11, 96(x10) # perform store
   addi x10, x10, 96 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zca_c_sw_cg_cp_rs1_p_b10, Zca_c_sw_cg_cp_rs1_p_b10_str)
-#else
-  c.sw x11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x2d02c6e8
@@ -104,18 +77,9 @@ Zca_c_sw_cg_cp_rs1_p_b11:
   c.sw x12, 4(x11) # perform store
   addi x11, x11, 4 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_sw_cg_cp_rs1_p_b11, Zca_c_sw_cg_cp_rs1_p_b11_str)
-#else
-  c.sw x12, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x1c27445c
@@ -125,18 +89,9 @@ Zca_c_sw_cg_cp_rs1_p_b12:
   c.sw x10, 64(x12) # perform store
   addi x12, x12, 64 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zca_c_sw_cg_cp_rs1_p_b12, Zca_c_sw_cg_cp_rs1_p_b12_str)
-#else
-  c.sw x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x964fa46d
@@ -146,18 +101,9 @@ Zca_c_sw_cg_cp_rs1_p_b13:
   c.sw x8, 68(x13) # perform store
   addi x13, x13, 68 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, Zca_c_sw_cg_cp_rs1_p_b13, Zca_c_sw_cg_cp_rs1_p_b13_str)
-#else
-  c.sw x8, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x48c29810
@@ -167,18 +113,9 @@ Zca_c_sw_cg_cp_rs1_p_b14:
   c.sw x15, 92(x14) # perform store
   addi x14, x14, 92 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zca_c_sw_cg_cp_rs1_p_b14, Zca_c_sw_cg_cp_rs1_p_b14_str)
-#else
-  c.sw x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xd4733b06
@@ -188,18 +125,9 @@ Zca_c_sw_cg_cp_rs1_p_b15:
   c.sw x9, 88(x15) # perform store
   addi x15, x15, 88 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, Zca_c_sw_cg_cp_rs1_p_b15, Zca_c_sw_cg_cp_rs1_p_b15_str)
-#else
-  c.sw x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_p
@@ -213,18 +141,9 @@ Zca_c_sw_cg_cp_rs2_p_b8:
   c.sw x8, 24(x12) # perform store
   addi x12, x12, 24 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x13 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x13, Zca_c_sw_cg_cp_rs2_p_b8, Zca_c_sw_cg_cp_rs2_p_b8_str)
-#else
-  c.sw x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xd82790ad
@@ -234,18 +153,9 @@ Zca_c_sw_cg_cp_rs2_p_b9:
   c.sw x9, 40(x10) # perform store
   addi x10, x10, 40 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zca_c_sw_cg_cp_rs2_p_b9, Zca_c_sw_cg_cp_rs2_p_b9_str)
-#else
-  c.sw x9, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x16, x10 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2_p (Test source rs2 = x10)
@@ -256,18 +166,9 @@ Zca_c_sw_cg_cp_rs2_p_b10:
   c.sw x10, 16(x9) # perform store
   addi x9, x9, 16 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sw_cg_cp_rs2_p_b10, Zca_c_sw_cg_cp_rs2_p_b10_str)
-#else
-  c.sw x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x3a943182
@@ -277,18 +178,9 @@ Zca_c_sw_cg_cp_rs2_p_b11:
   c.sw x11, 108(x14) # perform store
   addi x14, x14, 108 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zca_c_sw_cg_cp_rs2_p_b11, Zca_c_sw_cg_cp_rs2_p_b11_str)
-#else
-  c.sw x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x09f7a1dc
@@ -298,18 +190,9 @@ Zca_c_sw_cg_cp_rs2_p_b12:
   c.sw x12, 120(x13) # perform store
   addi x13, x13, 120 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x10 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x10, Zca_c_sw_cg_cp_rs2_p_b12, Zca_c_sw_cg_cp_rs2_p_b12_str)
-#else
-  c.sw x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x16, x13 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2_p (Test source rs2 = x13)
@@ -320,18 +203,9 @@ Zca_c_sw_cg_cp_rs2_p_b13:
   c.sw x13, 92(x9) # perform store
   addi x9, x9, 92 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sw_cg_cp_rs2_p_b13, Zca_c_sw_cg_cp_rs2_p_b13_str)
-#else
-  c.sw x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xadbbe3cb
@@ -341,18 +215,9 @@ Zca_c_sw_cg_cp_rs2_p_b14:
   c.sw x14, 76(x8) # perform store
   addi x8, x8, 76 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, Zca_c_sw_cg_cp_rs2_p_b14, Zca_c_sw_cg_cp_rs2_p_b14_str)
-#else
-  c.sw x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x98702264
@@ -362,18 +227,9 @@ Zca_c_sw_cg_cp_rs2_p_b15:
   c.sw x15, 36(x10) # perform store
   addi x10, x10, 36 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zca_c_sw_cg_cp_rs2_p_b15, Zca_c_sw_cg_cp_rs2_p_b15_str)
-#else
-  c.sw x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -387,18 +243,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x0:
   c.sw x13, 68(x9) # perform store
   addi x9, x9, 68 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sw_cg_cp_rs2_edges_0x0, Zca_c_sw_cg_cp_rs2_edges_0x0_str)
-#else
-  c.sw x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x00000001
@@ -408,18 +255,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x1:
   c.sw x14, 60(x10) # perform store
   addi x10, x10, 60 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0x1, Zca_c_sw_cg_cp_rs2_edges_0x1_str)
-#else
-  c.sw x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x00000002
@@ -429,18 +267,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x2:
   c.sw x12, 80(x9) # perform store
   addi x9, x9, 80 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sw_cg_cp_rs2_edges_0x2, Zca_c_sw_cg_cp_rs2_edges_0x2_str)
-#else
-  c.sw x12, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x80000000
@@ -450,18 +279,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x80000000:
   c.sw x11, 104(x13) # perform store
   addi x13, x13, 104 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0x80000000, Zca_c_sw_cg_cp_rs2_edges_0x80000000_str)
-#else
-  c.sw x11, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x80000001
@@ -471,18 +291,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x80000001:
   c.sw x15, 36(x12) # perform store
   addi x12, x12, 36 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_sw_cg_cp_rs2_edges_0x80000001, Zca_c_sw_cg_cp_rs2_edges_0x80000001_str)
-#else
-  c.sw x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x7fffffff
@@ -492,18 +303,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x7fffffff:
   c.sw x8, 124(x14) # perform store
   addi x14, x14, 124 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zca_c_sw_cg_cp_rs2_edges_0x7fffffff, Zca_c_sw_cg_cp_rs2_edges_0x7fffffff_str)
-#else
-  c.sw x8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x7ffffffe
@@ -513,18 +315,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x7ffffffe:
   c.sw x9, 44(x13) # perform store
   addi x13, x13, 44 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, Zca_c_sw_cg_cp_rs2_edges_0x7ffffffe, Zca_c_sw_cg_cp_rs2_edges_0x7ffffffe_str)
-#else
-  c.sw x9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xffffffff
@@ -534,18 +327,9 @@ Zca_c_sw_cg_cp_rs2_edges_0xffffffff:
   c.sw x15, 124(x8) # perform store
   addi x8, x8, 124 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zca_c_sw_cg_cp_rs2_edges_0xffffffff, Zca_c_sw_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  c.sw x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xfffffffe
@@ -555,18 +339,9 @@ Zca_c_sw_cg_cp_rs2_edges_0xfffffffe:
   c.sw x15, 8(x10) # perform store
   addi x10, x10, 8 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0xfffffffe, Zca_c_sw_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  c.sw x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x5bbc8872
@@ -576,18 +351,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x5bbc8872:
   c.sw x14, 24(x13) # perform store
   addi x13, x13, 24 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, Zca_c_sw_cg_cp_rs2_edges_0x5bbc8872, Zca_c_sw_cg_cp_rs2_edges_0x5bbc8872_str)
-#else
-  c.sw x14, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xaaaaaaaa
@@ -597,18 +363,9 @@ Zca_c_sw_cg_cp_rs2_edges_0xaaaaaaaa:
   c.sw x8, 44(x14) # perform store
   addi x14, x14, 44 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zca_c_sw_cg_cp_rs2_edges_0xaaaaaaaa, Zca_c_sw_cg_cp_rs2_edges_0xaaaaaaaa_str)
-#else
-  c.sw x8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x55555555
@@ -618,18 +375,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x55555555:
   c.sw x8, 28(x10) # perform store
   addi x10, x10, 28 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, Zca_c_sw_cg_cp_rs2_edges_0x55555555, Zca_c_sw_cg_cp_rs2_edges_0x55555555_str)
-#else
-  c.sw x8, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_mul
@@ -643,18 +391,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x0:
   c.sw x12, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x0, Zca_c_sw_cg_cp_imm_mul_b0x0_str)
-#else
-  c.sw x12, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=4
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x54c5a6df
@@ -664,18 +403,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x4:
   c.sw x15, 4(x9) # perform store
   addi x9, x9, 4 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x4, Zca_c_sw_cg_cp_imm_mul_b0x4_str)
-#else
-  c.sw x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=8
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xcdadf9f3
@@ -685,18 +415,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x8:
   c.sw x8, 8(x13) # perform store
   addi x13, x13, 8 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, Zca_c_sw_cg_cp_imm_mul_b0x8, Zca_c_sw_cg_cp_imm_mul_b0x8_str)
-#else
-  c.sw x8, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=12
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x9ef0eb6b
@@ -706,18 +427,9 @@ Zca_c_sw_cg_cp_imm_mul_b0xc:
   c.sw x11, 12(x10) # perform store
   addi x10, x10, 12 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0xc, Zca_c_sw_cg_cp_imm_mul_b0xc_str)
-#else
-  c.sw x11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=16
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x6dd9e2ac
@@ -727,18 +439,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x10:
   c.sw x9, 16(x13) # perform store
   addi x13, x13, 16 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, Zca_c_sw_cg_cp_imm_mul_b0x10, Zca_c_sw_cg_cp_imm_mul_b0x10_str)
-#else
-  c.sw x9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=20
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x99294280
@@ -748,18 +451,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x14:
   c.sw x12, 20(x10) # perform store
   addi x10, x10, 20 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x14, Zca_c_sw_cg_cp_imm_mul_b0x14_str)
-#else
-  c.sw x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=24
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x07eda632
@@ -769,18 +463,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x18:
   c.sw x14, 24(x12) # perform store
   addi x12, x12, 24 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x18, Zca_c_sw_cg_cp_imm_mul_b0x18_str)
-#else
-  c.sw x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=28
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xc51f04ac
@@ -790,18 +475,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x1c:
   c.sw x15, 28(x10) # perform store
   addi x10, x10, 28 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x11 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x11, Zca_c_sw_cg_cp_imm_mul_b0x1c, Zca_c_sw_cg_cp_imm_mul_b0x1c_str)
-#else
-  c.sw x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=32
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xfa076c96
@@ -811,18 +487,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x20:
   c.sw x9, 32(x11) # perform store
   addi x11, x11, 32 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x20, Zca_c_sw_cg_cp_imm_mul_b0x20_str)
-#else
-  c.sw x9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=36
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x434fa245
@@ -832,18 +499,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x24:
   c.sw x9, 36(x13) # perform store
   addi x13, x13, 36 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x24, Zca_c_sw_cg_cp_imm_mul_b0x24_str)
-#else
-  c.sw x9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=40
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xd4cb6f52
@@ -853,18 +511,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x28:
   c.sw x15, 40(x12) # perform store
   addi x12, x12, 40 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x10 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x10, Zca_c_sw_cg_cp_imm_mul_b0x28, Zca_c_sw_cg_cp_imm_mul_b0x28_str)
-#else
-  c.sw x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=44
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xc2afe81b
@@ -874,18 +523,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x2c:
   c.sw x11, 44(x14) # perform store
   addi x14, x14, 44 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zca_c_sw_cg_cp_imm_mul_b0x2c, Zca_c_sw_cg_cp_imm_mul_b0x2c_str)
-#else
-  c.sw x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=48
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x47c949f6
@@ -895,18 +535,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x30:
   c.sw x8, 48(x9) # perform store
   addi x9, x9, 48 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sw_cg_cp_imm_mul_b0x30, Zca_c_sw_cg_cp_imm_mul_b0x30_str)
-#else
-  c.sw x8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=52
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xbf9e949b
@@ -916,18 +547,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x34:
   c.sw x14, 52(x15) # perform store
   addi x15, x15, 52 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, Zca_c_sw_cg_cp_imm_mul_b0x34, Zca_c_sw_cg_cp_imm_mul_b0x34_str)
-#else
-  c.sw x14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=56
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x014e7343
@@ -937,18 +559,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x38:
   c.sw x14, 56(x8) # perform store
   addi x8, x8, 56 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x38, Zca_c_sw_cg_cp_imm_mul_b0x38_str)
-#else
-  c.sw x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=60
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xc8bd8246
@@ -958,18 +571,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x3c:
   c.sw x12, 60(x13) # perform store
   addi x13, x13, 60 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, Zca_c_sw_cg_cp_imm_mul_b0x3c, Zca_c_sw_cg_cp_imm_mul_b0x3c_str)
-#else
-  c.sw x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=64
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x26497930
@@ -979,18 +583,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x40:
   c.sw x12, 64(x8) # perform store
   addi x8, x8, 64 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, Zca_c_sw_cg_cp_imm_mul_b0x40, Zca_c_sw_cg_cp_imm_mul_b0x40_str)
-#else
-  c.sw x12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=68
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x7eac658f
@@ -1000,18 +595,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x44:
   c.sw x11, 68(x15) # perform store
   addi x15, x15, 68 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x9 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x9, Zca_c_sw_cg_cp_imm_mul_b0x44, Zca_c_sw_cg_cp_imm_mul_b0x44_str)
-#else
-  c.sw x11, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=72
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xe0865ea9
@@ -1021,18 +607,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x48:
   c.sw x9, 72(x8) # perform store
   addi x8, x8, 72 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x48, Zca_c_sw_cg_cp_imm_mul_b0x48_str)
-#else
-  c.sw x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=76
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x46275248
@@ -1042,18 +619,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x4c:
   c.sw x15, 76(x13) # perform store
   addi x13, x13, 76 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x4c, Zca_c_sw_cg_cp_imm_mul_b0x4c_str)
-#else
-  c.sw x15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=80
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x66813e8a
@@ -1063,18 +631,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x50:
   c.sw x8, 80(x11) # perform store
   addi x11, x11, 80 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_sw_cg_cp_imm_mul_b0x50, Zca_c_sw_cg_cp_imm_mul_b0x50_str)
-#else
-  c.sw x8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=84
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xf10133dd
@@ -1084,18 +643,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x54:
   c.sw x12, 84(x10) # perform store
   addi x10, x10, 84 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x9 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x9, Zca_c_sw_cg_cp_imm_mul_b0x54, Zca_c_sw_cg_cp_imm_mul_b0x54_str)
-#else
-  c.sw x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=88
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x5e8f4fc4
@@ -1105,18 +655,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x58:
   c.sw x13, 88(x9) # perform store
   addi x9, x9, 88 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sw_cg_cp_imm_mul_b0x58, Zca_c_sw_cg_cp_imm_mul_b0x58_str)
-#else
-  c.sw x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=92
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x6a7599a7
@@ -1126,18 +667,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x5c:
   c.sw x11, 92(x14) # perform store
   addi x14, x14, 92 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x5c, Zca_c_sw_cg_cp_imm_mul_b0x5c_str)
-#else
-  c.sw x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=96
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x038caa1d
@@ -1147,18 +679,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x60:
   c.sw x10, 96(x8) # perform store
   addi x8, x8, 96 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x60, Zca_c_sw_cg_cp_imm_mul_b0x60_str)
-#else
-  c.sw x10, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=100
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x36dbaa03
@@ -1168,18 +691,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x64:
   c.sw x13, 100(x11) # perform store
   addi x11, x11, 100 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x64, Zca_c_sw_cg_cp_imm_mul_b0x64_str)
-#else
-  c.sw x13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=104
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xa58a3631
@@ -1189,18 +703,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x68:
   c.sw x8, 104(x13) # perform store
   addi x13, x13, 104 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x68, Zca_c_sw_cg_cp_imm_mul_b0x68_str)
-#else
-  c.sw x8, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=108
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x41cc88af
@@ -1210,18 +715,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x6c:
   c.sw x11, 108(x12) # perform store
   addi x12, x12, 108 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x6c, Zca_c_sw_cg_cp_imm_mul_b0x6c_str)
-#else
-  c.sw x11, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=112
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xf1ef075e
@@ -1231,18 +727,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x70:
   c.sw x15, 112(x14) # perform store
   addi x14, x14, 112 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x70, Zca_c_sw_cg_cp_imm_mul_b0x70_str)
-#else
-  c.sw x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=116
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x7db92205
@@ -1252,18 +739,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x74:
   c.sw x8, 116(x12) # perform store
   addi x12, x12, 116 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x13 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x13, Zca_c_sw_cg_cp_imm_mul_b0x74, Zca_c_sw_cg_cp_imm_mul_b0x74_str)
-#else
-  c.sw x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=120
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x6d6759cc
@@ -1273,18 +751,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x78:
   c.sw x13, 120(x14) # perform store
   addi x14, x14, 120 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x78, Zca_c_sw_cg_cp_imm_mul_b0x78_str)
-#else
-  c.sw x13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=124
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xadae6b9f
@@ -1294,18 +763,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x7c:
   c.sw x12, 124(x8) # perform store
   addi x8, x8, 124 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zca_c_sw_cg_cp_imm_mul_b0x7c, Zca_c_sw_cg_cp_imm_mul_b0x7c_str)
-#else
-  c.sw x12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x8 # restore signature pointer to default register for teardown
 

--- a/tests/rv32i/Zca/Zca-c.swsp-00.S
+++ b/tests/rv32i/Zca/Zca-c.swsp-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 226
+#define SIGUPD_COUNT 118
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -39,57 +39,27 @@ RVTEST_BEGIN
   addi sp, x18, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b0:
   c.swsp x0, 32(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x19, 0(x18) # load stored value for checking
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_b0, Zca_c_swsp_cg_cp_rs2_b0_str)
-#else
-  addi sp, sp, 32 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0x591f45ae
   addi sp, x18, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b1:
   c.swsp x1, 16(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x18) # load stored value for checking
   # Check if x26 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x26, Zca_c_swsp_cg_cp_rs2_b1, Zca_c_swsp_cg_cp_rs2_b1_str)
-#else
-  addi sp, sp, 16 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x1, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0x9d8de685
   addi sp, x18, -168  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b2:
   c.swsp x2, 168(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x18) # load stored value for checking
   # Check if x7 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x7, Zca_c_swsp_cg_cp_rs2_b2, Zca_c_swsp_cg_cp_rs2_b2_str)
-#else
-  addi sp, sp, 168 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x2, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x12, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x3)
@@ -97,19 +67,9 @@ Zca_c_swsp_cg_cp_rs2_b2:
   addi sp, x18, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b3:
   c.swsp x3, 16(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x28, 0(x18) # load stored value for checking
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_rs2_b3, Zca_c_swsp_cg_cp_rs2_b3_str)
-#else
-  addi sp, sp, 16 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x13, x4 # switch temp register to avoid conflict with test
   mv x14, x5 # switch link pointer register to avoid conflict with test
@@ -118,152 +78,72 @@ Zca_c_swsp_cg_cp_rs2_b3:
   addi sp, x18, -132  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b4:
   c.swsp x4, 132(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x29, 0(x18) # load stored value for checking
   # Check if x29 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x29, Zca_c_swsp_cg_cp_rs2_b4, Zca_c_swsp_cg_cp_rs2_b4_str)
-#else
-  addi sp, sp, 132 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x4, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x12, x5) # load rs2: x5 = 0x87601cbc
   addi sp, x18, -120  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b5:
   c.swsp x5, 120(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x27, 0(x18) # load stored value for checking
   # Check if x27 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x27, Zca_c_swsp_cg_cp_rs2_b5, Zca_c_swsp_cg_cp_rs2_b5_str)
-#else
-  addi sp, sp, 120 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rs2: x6 = 0xc8131b35
   addi sp, x18, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b6:
   c.swsp x6, 232(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x29, 0(x18) # load stored value for checking
   # Check if x29 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x29, Zca_c_swsp_cg_cp_rs2_b6, Zca_c_swsp_cg_cp_rs2_b6_str)
-#else
-  addi sp, sp, 232 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rs2: x7 = 0x6cbdaad0
   addi sp, x18, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b7:
   c.swsp x7, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x17, 0(x18) # load stored value for checking
   # Check if x17 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x17, Zca_c_swsp_cg_cp_rs2_b7, Zca_c_swsp_cg_cp_rs2_b7_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x7, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x12, x8) # load rs2: x8 = 0x555a5752
   addi sp, x18, -212  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b8:
   c.swsp x8, 212(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x31, 0(x18) # load stored value for checking
   # Check if x31 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x31, Zca_c_swsp_cg_cp_rs2_b8, Zca_c_swsp_cg_cp_rs2_b8_str)
-#else
-  addi sp, sp, 212 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x8, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rs2: x9 = 0x04ceeabd
   addi sp, x18, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b9:
   c.swsp x9, 200(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x17, 0(x18) # load stored value for checking
   # Check if x17 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x17, Zca_c_swsp_cg_cp_rs2_b9, Zca_c_swsp_cg_cp_rs2_b9_str)
-#else
-  addi sp, sp, 200 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rs2: x10 = 0x55e4ef36
   addi sp, x18, -252  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b10:
   c.swsp x10, 252(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x18) # load stored value for checking
   # Check if x9 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x9, Zca_c_swsp_cg_cp_rs2_b10, Zca_c_swsp_cg_cp_rs2_b10_str)
-#else
-  addi sp, sp, 252 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x12, x11) # load rs2: x11 = 0xa66bff60
   addi sp, x18, -140  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b11:
   c.swsp x11, 140(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x18) # load stored value for checking
   # Check if x23 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x23, Zca_c_swsp_cg_cp_rs2_b11, Zca_c_swsp_cg_cp_rs2_b11_str)
-#else
-  addi sp, sp, 140 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x1, x12 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x12)
@@ -271,19 +151,9 @@ Zca_c_swsp_cg_cp_rs2_b11:
   addi sp, x18, -8  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b12:
   c.swsp x12, 8(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x18) # load stored value for checking
   # Check if x5 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x5, Zca_c_swsp_cg_cp_rs2_b12, Zca_c_swsp_cg_cp_rs2_b12_str)
-#else
-  addi sp, sp, 8 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -292,95 +162,45 @@ Zca_c_swsp_cg_cp_rs2_b12:
   addi sp, x18, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b13:
   c.swsp x13, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x18) # load stored value for checking
   # Check if x7 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x7, Zca_c_swsp_cg_cp_rs2_b13, Zca_c_swsp_cg_cp_rs2_b13_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xd8c8c4d7
   addi sp, x18, -88  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b14:
   c.swsp x14, 88(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x18) # load stored value for checking
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_rs2_b14, Zca_c_swsp_cg_cp_rs2_b14_str)
-#else
-  addi sp, sp, 88 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x1a2b315a
   addi sp, x18, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b15:
   c.swsp x15, 232(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x19, 0(x18) # load stored value for checking
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_b15, Zca_c_swsp_cg_cp_rs2_b15_str)
-#else
-  addi sp, sp, 232 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0xd30b461b
   addi sp, x18, -100  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b16:
   c.swsp x16, 100(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x17, 0(x18) # load stored value for checking
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zca_c_swsp_cg_cp_rs2_b16, Zca_c_swsp_cg_cp_rs2_b16_str)
-#else
-  addi sp, sp, 100 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x16, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0xa2490b06
   addi sp, x18, -72  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b17:
   c.swsp x17, 72(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x25, 0(x18) # load stored value for checking
   # Check if x25 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x25, Zca_c_swsp_cg_cp_rs2_b17, Zca_c_swsp_cg_cp_rs2_b17_str)
-#else
-  addi sp, sp, 72 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x17, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x21, x18 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x18)
@@ -388,57 +208,27 @@ Zca_c_swsp_cg_cp_rs2_b17:
   addi sp, x21, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b18:
   c.swsp x18, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x21) # load stored value for checking
   # Check if x13 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x13, Zca_c_swsp_cg_cp_rs2_b18, Zca_c_swsp_cg_cp_rs2_b18_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x18, 0(sp) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0x7e4eba92
   addi sp, x21, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b19:
   c.swsp x19, 0(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x27, 0(x21) # load stored value for checking
   # Check if x27 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x27, Zca_c_swsp_cg_cp_rs2_b19, Zca_c_swsp_cg_cp_rs2_b19_str)
-#else
-  addi sp, sp, 0 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x19, 0(sp) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0xb9fdf264
   addi sp, x21, -80  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b20:
   c.swsp x20, 80(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x21) # load stored value for checking
   # Check if x14 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x14, Zca_c_swsp_cg_cp_rs2_b20, Zca_c_swsp_cg_cp_rs2_b20_str)
-#else
-  addi sp, sp, 80 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x20, 0(sp) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x26, x21 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x21)
@@ -446,95 +236,45 @@ Zca_c_swsp_cg_cp_rs2_b20:
   addi sp, x26, -112  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b21:
   c.swsp x21, 112(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x31, 0(x26) # load stored value for checking
   # Check if x31 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x31, Zca_c_swsp_cg_cp_rs2_b21, Zca_c_swsp_cg_cp_rs2_b21_str)
-#else
-  addi sp, sp, 112 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x21, 0(sp) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0x405e92c1
   addi sp, x26, -216  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b22:
   c.swsp x22, 216(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x26) # load stored value for checking
   # Check if x11 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x11, Zca_c_swsp_cg_cp_rs2_b22, Zca_c_swsp_cg_cp_rs2_b22_str)
-#else
-  addi sp, sp, 216 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x22, 0(sp) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x22443a39
   addi sp, x26, -132  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b23:
   c.swsp x23, 132(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x21, 0(x26) # load stored value for checking
   # Check if x21 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x21, Zca_c_swsp_cg_cp_rs2_b23, Zca_c_swsp_cg_cp_rs2_b23_str)
-#else
-  addi sp, sp, 132 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x23, 0(sp) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0x5850a4db
   addi sp, x26, -88  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b24:
   c.swsp x24, 88(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x26) # load stored value for checking
   # Check if x12 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x12, Zca_c_swsp_cg_cp_rs2_b24, Zca_c_swsp_cg_cp_rs2_b24_str)
-#else
-  addi sp, sp, 88 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x24, 0(sp) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0xc3e6b871
   addi sp, x26, -220  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b25:
   c.swsp x25, 220(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x26) # load stored value for checking
   # Check if x12 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x12, Zca_c_swsp_cg_cp_rs2_b25, Zca_c_swsp_cg_cp_rs2_b25_str)
-#else
-  addi sp, sp, 220 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x25, 0(sp) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x18, x26 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x26)
@@ -542,114 +282,54 @@ Zca_c_swsp_cg_cp_rs2_b25:
   addi sp, x18, -40  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b26:
   c.swsp x26, 40(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x18) # load stored value for checking
   # Check if x10 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x10, Zca_c_swsp_cg_cp_rs2_b26, Zca_c_swsp_cg_cp_rs2_b26_str)
-#else
-  addi sp, sp, 40 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x26, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x7e1dfdcf
   addi sp, x18, -40  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b27:
   c.swsp x27, 40(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x18) # load stored value for checking
   # Check if x10 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x10, Zca_c_swsp_cg_cp_rs2_b27, Zca_c_swsp_cg_cp_rs2_b27_str)
-#else
-  addi sp, sp, 40 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x27, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x6adc2353
   addi sp, x18, -132  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b28:
   c.swsp x28, 132(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x18) # load stored value for checking
   # Check if x22 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x22, Zca_c_swsp_cg_cp_rs2_b28, Zca_c_swsp_cg_cp_rs2_b28_str)
-#else
-  addi sp, sp, 132 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x28, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x8c68a879
   addi sp, x18, -60  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b29:
   c.swsp x29, 60(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x17, 0(x18) # load stored value for checking
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zca_c_swsp_cg_cp_rs2_b29, Zca_c_swsp_cg_cp_rs2_b29_str)
-#else
-  addi sp, sp, 60 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x29, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x74da8db4
   addi sp, x18, -128  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b30:
   c.swsp x30, 128(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x19, 0(x18) # load stored value for checking
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_b30, Zca_c_swsp_cg_cp_rs2_b30_str)
-#else
-  addi sp, sp, 128 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x30, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0xff67d63c
   addi sp, x18, -152  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b31:
   c.swsp x31, 152(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x18) # load stored value for checking
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zca_c_swsp_cg_cp_rs2_b31, Zca_c_swsp_cg_cp_rs2_b31_str)
-#else
-  addi sp, sp, 152 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x31, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -660,228 +340,108 @@ Zca_c_swsp_cg_cp_rs2_b31:
   addi sp, x18, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x0:
   c.swsp x9, 16(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x18) # load stored value for checking
   # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x6, Zca_c_swsp_cg_cp_rs2_edges_0x0, Zca_c_swsp_cg_cp_rs2_edges_0x0_str)
-#else
-  addi sp, sp, 16 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x00000001
   addi sp, x18, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x1:
   c.swsp x23, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x19, 0(x18) # load stored value for checking
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_edges_0x1, Zca_c_swsp_cg_cp_rs2_edges_0x1_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x23, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x00000002
   addi sp, x18, -44  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x2:
   c.swsp x11, 44(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x20, 0(x18) # load stored value for checking
   # Check if x20 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x20, Zca_c_swsp_cg_cp_rs2_edges_0x2, Zca_c_swsp_cg_cp_rs2_edges_0x2_str)
-#else
-  addi sp, sp, 44 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x80000000
   addi sp, x18, -112  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x80000000:
   c.swsp x25, 112(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x27, 0(x18) # load stored value for checking
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, Zca_c_swsp_cg_cp_rs2_edges_0x80000000, Zca_c_swsp_cg_cp_rs2_edges_0x80000000_str)
-#else
-  addi sp, sp, 112 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x25, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x80000001
   addi sp, x18, -212  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x80000001:
   c.swsp x11, 212(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x18) # load stored value for checking
   # Check if x26 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x26, Zca_c_swsp_cg_cp_rs2_edges_0x80000001, Zca_c_swsp_cg_cp_rs2_edges_0x80000001_str)
-#else
-  addi sp, sp, 212 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x7fffffff
   addi sp, x18, -28  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff:
   c.swsp x12, 28(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x18) # load stored value for checking
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff_str)
-#else
-  addi sp, sp, 28 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x7ffffffe
   addi sp, x18, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe:
   c.swsp x23, 240(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x18) # load stored value for checking
   # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x6, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe_str)
-#else
-  addi sp, sp, 240 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x23, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xffffffff
   addi sp, x18, -128  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
   c.swsp x11, 128(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x21, 0(x18) # load stored value for checking
   # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x21, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  addi sp, sp, 128 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0xfffffffe
   addi sp, x18, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
   c.swsp x20, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x28, 0(x18) # load stored value for checking
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x20, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x5bbc8872
   addi sp, x18, -196  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872:
   c.swsp x29, 196(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x18) # load stored value for checking
   # Check if x26 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x26, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872_str)
-#else
-  addi sp, sp, 196 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x29, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0xaaaaaaaa
   addi sp, x18, -172  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa:
   c.swsp x20, 172(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x18) # load stored value for checking
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa_str)
-#else
-  addi sp, sp, 172 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x20, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
   RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x55555555
   addi sp, x18, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x55555555:
   c.swsp x16, 32(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x19, 0(x18) # load stored value for checking
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_edges_0x55555555, Zca_c_swsp_cg_cp_rs2_edges_0x55555555_str)
-#else
-  addi sp, sp, 32 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x16, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_mul_4sp
@@ -892,1216 +452,576 @@ Zca_c_swsp_cg_cp_rs2_edges_0x55555555:
   addi sp, x18, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0:
   c.swsp x14, 0(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x24, 0(x18) # load stored value for checking
   # Check if x24 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0_str)
-#else
-  addi sp, sp, 0 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=4
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x212852d1
   addi sp, x18, -4  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4:
   c.swsp x21, 4(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x18) # load stored value for checking
   # Check if x12 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4_str)
-#else
-  addi sp, sp, 4 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x21, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=8
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xde9d49fb
   addi sp, x18, -8  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8:
   c.swsp x14, 8(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x27, 0(x18) # load stored value for checking
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8_str)
-#else
-  addi sp, sp, 8 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=12
   RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0xd63152f0
   addi sp, x18, -12  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc:
   c.swsp x26, 12(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x31, 0(x18) # load stored value for checking
   # Check if x31 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc_str)
-#else
-  addi sp, sp, 12 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x26, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=16
   RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0xc38312ff
   addi sp, x18, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10:
   c.swsp x16, 16(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x18) # load stored value for checking
   # Check if x14 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10_str)
-#else
-  addi sp, sp, 16 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x16, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=20
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0xbe081e73
   addi sp, x18, -20  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14:
   c.swsp x23, 20(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x30, 0(x18) # load stored value for checking
   # Check if x30 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14_str)
-#else
-  addi sp, sp, 20 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x23, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=24
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0xeaf691d2
   addi sp, x18, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18:
   c.swsp x29, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x17, 0(x18) # load stored value for checking
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x29, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=28
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x68bd767c
   addi sp, x18, -28  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c:
   c.swsp x6, 28(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x18) # load stored value for checking
   # Check if x3 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c_str)
-#else
-  addi sp, sp, 28 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=32
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0xb3a35dad
   addi sp, x18, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20:
   c.swsp x25, 32(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x18) # load stored value for checking
   # Check if x7 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20_str)
-#else
-  addi sp, sp, 32 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x25, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=36
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0xf7c9a307
   addi sp, x18, -36  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24:
   c.swsp x21, 36(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x18) # load stored value for checking
   # Check if x22 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24_str)
-#else
-  addi sp, sp, 36 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x21, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=40
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x2dc2d097
   addi sp, x18, -40  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28:
   c.swsp x11, 40(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x8, 0(x18) # load stored value for checking
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28_str)
-#else
-  addi sp, sp, 40 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=44
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x6e9d4158
   addi sp, x18, -44  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
   c.swsp x15, 44(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x28, 0(x18) # load stored value for checking
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c_str)
-#else
-  addi sp, sp, 44 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=48
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x025588f2
   addi sp, x18, -48  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
   c.swsp x20, 48(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x18) # load stored value for checking
   # Check if x22 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30_str)
-#else
-  addi sp, sp, 48 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x20, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=52
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xd6d5ceed
   addi sp, x18, -52  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
   c.swsp x12, 52(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x18) # load stored value for checking
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34_str)
-#else
-  addi sp, sp, 52 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=56
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0xbcc0102f
   addi sp, x18, -56  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
   c.swsp x9, 56(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x28, 0(x18) # load stored value for checking
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38_str)
-#else
-  addi sp, sp, 56 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=60
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0xdf3eea06
   addi sp, x18, -60  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
   c.swsp x9, 60(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x18) # load stored value for checking
   # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c_str)
-#else
-  addi sp, sp, 60 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=64
   RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x2db624b0
   addi sp, x18, -64  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
   c.swsp x26, 64(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x18) # load stored value for checking
   # Check if x13 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40_str)
-#else
-  addi sp, sp, 64 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x26, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=68
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0xccf3cd83
   addi sp, x18, -68  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
   c.swsp x21, 68(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x18) # load stored value for checking
   # Check if x3 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44_str)
-#else
-  addi sp, sp, 68 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x21, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=72
   RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0x688d5237
   addi sp, x18, -72  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
   c.swsp x17, 72(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x8, 0(x18) # load stored value for checking
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48_str)
-#else
-  addi sp, sp, 72 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x17, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=76
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x1b13aa7d
   addi sp, x18, -76  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
   c.swsp x27, 76(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x17, 0(x18) # load stored value for checking
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c_str)
-#else
-  addi sp, sp, 76 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x27, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=80
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x64c46502
   addi sp, x18, -80  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
   c.swsp x27, 80(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x31, 0(x18) # load stored value for checking
   # Check if x31 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50_str)
-#else
-  addi sp, sp, 80 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x27, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=84
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0xd0d5a125
   addi sp, x18, -84  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
   c.swsp x9, 84(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x27, 0(x18) # load stored value for checking
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54_str)
-#else
-  addi sp, sp, 84 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=88
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x2ef80023
   addi sp, x18, -88  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
   c.swsp x30, 88(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x29, 0(x18) # load stored value for checking
   # Check if x29 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58_str)
-#else
-  addi sp, sp, 88 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x30, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=92
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x007aeb44
   addi sp, x18, -92  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
   c.swsp x25, 92(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x18) # load stored value for checking
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c_str)
-#else
-  addi sp, sp, 92 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x25, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=96
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x1a9509f6
   addi sp, x18, -96  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
   c.swsp x20, 96(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x18) # load stored value for checking
   # Check if x10 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60_str)
-#else
-  addi sp, sp, 96 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x20, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=100
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xc18c3264
   addi sp, x18, -100  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
   c.swsp x3, 100(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x18) # load stored value for checking
   # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64_str)
-#else
-  addi sp, sp, 100 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=104
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0xd7d19c00
   addi sp, x18, -104  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
   c.swsp x31, 104(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x18) # load stored value for checking
   # Check if x11 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68_str)
-#else
-  addi sp, sp, 104 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x31, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=108
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0x087a85ad
   addi sp, x18, -108  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
   c.swsp x22, 108(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x18) # load stored value for checking
   # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c_str)
-#else
-  addi sp, sp, 108 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x22, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=112
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x068e9e00
   addi sp, x18, -112  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
   c.swsp x21, 112(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x8, 0(x18) # load stored value for checking
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70_str)
-#else
-  addi sp, sp, 112 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x21, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=116
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0xe87a0869
   addi sp, x18, -116  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
   c.swsp x0, 116(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x18) # load stored value for checking
   # Check if x12 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74_str)
-#else
-  addi sp, sp, 116 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=120
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x25bff6fb
   addi sp, x18, -120  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
   c.swsp x21, 120(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x18) # load stored value for checking
   # Check if x9 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78_str)
-#else
-  addi sp, sp, 120 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x21, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=124
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x7e22c6d5
   addi sp, x18, -124  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
   c.swsp x25, 124(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x19, 0(x18) # load stored value for checking
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c_str)
-#else
-  addi sp, sp, 124 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x25, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=128
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x06c2ea11
   addi sp, x18, -128  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
   c.swsp x30, 128(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x19, 0(x18) # load stored value for checking
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80_str)
-#else
-  addi sp, sp, 128 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x30, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=132
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x030293c6
   addi sp, x18, -132  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
   c.swsp x20, 132(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x18) # load stored value for checking
   # Check if x26 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84_str)
-#else
-  addi sp, sp, 132 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x20, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=136
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x12be5c00
   addi sp, x18, -136  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
   c.swsp x0, 136(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x25, 0(x18) # load stored value for checking
   # Check if x25 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x25, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88_str)
-#else
-  addi sp, sp, 136 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=140
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0xd0f0cbd2
   addi sp, x18, -140  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
   c.swsp x9, 140(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x17, 0(x18) # load stored value for checking
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c_str)
-#else
-  addi sp, sp, 140 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=144
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x2a4c1092
   addi sp, x18, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
   c.swsp x20, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x18) # load stored value for checking
   # Check if x9 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x20, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=148
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x01d0e558
   addi sp, x18, -148  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
   c.swsp x31, 148(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x28, 0(x18) # load stored value for checking
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94_str)
-#else
-  addi sp, sp, 148 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x31, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=152
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x9147f96e
   addi sp, x18, -152  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
   c.swsp x25, 152(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x27, 0(x18) # load stored value for checking
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98_str)
-#else
-  addi sp, sp, 152 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x25, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=156
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x6eefa15a
   addi sp, x18, -156  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
   c.swsp x7, 156(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x18) # load stored value for checking
   # Check if x11 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c_str)
-#else
-  addi sp, sp, 156 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x7, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=160
   RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x12412a8a
   addi sp, x18, -160  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
   c.swsp x26, 160(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x21, 0(x18) # load stored value for checking
   # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0_str)
-#else
-  addi sp, sp, 160 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x26, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=164
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x1719b70c
   addi sp, x18, -164  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
   c.swsp x15, 164(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x21, 0(x18) # load stored value for checking
   # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4_str)
-#else
-  addi sp, sp, 164 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=168
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0xaf6fdcc0
   addi sp, x18, -168  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
   c.swsp x30, 168(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x18) # load stored value for checking
   # Check if x12 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8_str)
-#else
-  addi sp, sp, 168 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x30, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=172
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x72762c57
   addi sp, x18, -172  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
   c.swsp x3, 172(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x27, 0(x18) # load stored value for checking
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac_str)
-#else
-  addi sp, sp, 172 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=176
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x81c76166
   addi sp, x18, -176  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
   c.swsp x6, 176(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x28, 0(x18) # load stored value for checking
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0_str)
-#else
-  addi sp, sp, 176 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=180
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xccacd523
   addi sp, x18, -180  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
   c.swsp x3, 180(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x18) # load stored value for checking
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4_str)
-#else
-  addi sp, sp, 180 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=184
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x9f2e744b
   addi sp, x18, -184  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
   c.swsp x10, 184(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x18) # load stored value for checking
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8_str)
-#else
-  addi sp, sp, 184 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=188
   RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x0b5a9947
   addi sp, x18, -188  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
   c.swsp x26, 188(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x19, 0(x18) # load stored value for checking
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc_str)
-#else
-  addi sp, sp, 188 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x26, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=192
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xcdaf39df
   addi sp, x18, -192  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
   c.swsp x3, 192(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x18) # load stored value for checking
   # Check if x11 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0_str)
-#else
-  addi sp, sp, 192 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=196
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0xa5fdc85b
   addi sp, x18, -196  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
   c.swsp x27, 196(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x8, 0(x18) # load stored value for checking
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4_str)
-#else
-  addi sp, sp, 196 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x27, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=200
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x0ace2b10
   addi sp, x18, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
   c.swsp x25, 200(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x31, 0(x18) # load stored value for checking
   # Check if x31 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8_str)
-#else
-  addi sp, sp, 200 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x25, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=204
   RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0xec4e4dbb
   addi sp, x18, -204  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
   c.swsp x17, 204(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x16, 0(x18) # load stored value for checking
   # Check if x16 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x16, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc_str)
-#else
-  addi sp, sp, 204 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x17, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=208
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xfe63f0d7
   addi sp, x18, -208  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
   c.swsp x10, 208(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x18) # load stored value for checking
   # Check if x22 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0_str)
-#else
-  addi sp, sp, 208 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=212
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x4d0e9cdf
   addi sp, x18, -212  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
   c.swsp x3, 212(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x30, 0(x18) # load stored value for checking
   # Check if x30 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4_str)
-#else
-  addi sp, sp, 212 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=216
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xfe3a31b4
   addi sp, x18, -216  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
   c.swsp x14, 216(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x21, 0(x18) # load stored value for checking
   # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8_str)
-#else
-  addi sp, sp, 216 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=220
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x1a38a42b
   addi sp, x18, -220  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
   c.swsp x15, 220(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x29, 0(x18) # load stored value for checking
   # Check if x29 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc_str)
-#else
-  addi sp, sp, 220 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=224
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x50912704
   addi sp, x18, -224  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
   c.swsp x8, 224(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x21, 0(x18) # load stored value for checking
   # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0_str)
-#else
-  addi sp, sp, 224 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x8, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=228
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xdb21878d
   addi sp, x18, -228  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
   c.swsp x14, 228(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x18) # load stored value for checking
   # Check if x3 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4_str)
-#else
-  addi sp, sp, 228 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=232
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0xbcc1dfe0
   addi sp, x18, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
   c.swsp x21, 232(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x18) # load stored value for checking
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8_str)
-#else
-  addi sp, sp, 232 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x21, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=236
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x6cf3621e
   addi sp, x18, -236  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
   c.swsp x8, 236(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x18) # load stored value for checking
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec_str)
-#else
-  addi sp, sp, 236 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x8, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=240
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0xdfc67ab8
   addi sp, x18, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
   c.swsp x23, 240(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x18) # load stored value for checking
   # Check if x22 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0_str)
-#else
-  addi sp, sp, 240 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x23, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=244
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x1e17df6a
   addi sp, x18, -244  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
   c.swsp x10, 244(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x18) # load stored value for checking
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4_str)
-#else
-  addi sp, sp, 244 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=248
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0xc611b086
   addi sp, x18, -248  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
   c.swsp x30, 248(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x18) # load stored value for checking
   # Check if x12 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8_str)
-#else
-  addi sp, sp, 248 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x30, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=252
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x6b889049
   addi sp, x18, -252  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc:
   c.swsp x20, 252(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x24, 0(x18) # load stored value for checking
   # Check if x24 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc_str)
-#else
-  addi sp, sp, 252 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x20, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x2, x18 # restore signature pointer to default register for teardown
 

--- a/tests/rv32i/Zca/Zca-c.swsp-00.S
+++ b/tests/rv32i/Zca/Zca-c.swsp-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 118
+#define SIGUPD_COUNT 226
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -40,6 +40,7 @@ RVTEST_BEGIN
 Zca_c_swsp_cg_cp_rs2_b0:
   c.swsp x0, 32(sp) # perform store
   LREG x19, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_b0, Zca_c_swsp_cg_cp_rs2_b0_str)
 
@@ -49,6 +50,7 @@ Zca_c_swsp_cg_cp_rs2_b0:
 Zca_c_swsp_cg_cp_rs2_b1:
   c.swsp x1, 16(sp) # perform store
   LREG x26, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x26, Zca_c_swsp_cg_cp_rs2_b1, Zca_c_swsp_cg_cp_rs2_b1_str)
 
@@ -58,6 +60,7 @@ Zca_c_swsp_cg_cp_rs2_b1:
 Zca_c_swsp_cg_cp_rs2_b2:
   c.swsp x2, 168(sp) # perform store
   LREG x7, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x7, Zca_c_swsp_cg_cp_rs2_b2, Zca_c_swsp_cg_cp_rs2_b2_str)
 
@@ -68,6 +71,7 @@ Zca_c_swsp_cg_cp_rs2_b2:
 Zca_c_swsp_cg_cp_rs2_b3:
   c.swsp x3, 16(sp) # perform store
   LREG x28, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_rs2_b3, Zca_c_swsp_cg_cp_rs2_b3_str)
 
@@ -79,6 +83,7 @@ Zca_c_swsp_cg_cp_rs2_b3:
 Zca_c_swsp_cg_cp_rs2_b4:
   c.swsp x4, 132(sp) # perform store
   LREG x29, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x29, Zca_c_swsp_cg_cp_rs2_b4, Zca_c_swsp_cg_cp_rs2_b4_str)
 
@@ -88,6 +93,7 @@ Zca_c_swsp_cg_cp_rs2_b4:
 Zca_c_swsp_cg_cp_rs2_b5:
   c.swsp x5, 120(sp) # perform store
   LREG x27, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x27, Zca_c_swsp_cg_cp_rs2_b5, Zca_c_swsp_cg_cp_rs2_b5_str)
 
@@ -97,6 +103,7 @@ Zca_c_swsp_cg_cp_rs2_b5:
 Zca_c_swsp_cg_cp_rs2_b6:
   c.swsp x6, 232(sp) # perform store
   LREG x29, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x29, Zca_c_swsp_cg_cp_rs2_b6, Zca_c_swsp_cg_cp_rs2_b6_str)
 
@@ -106,6 +113,7 @@ Zca_c_swsp_cg_cp_rs2_b6:
 Zca_c_swsp_cg_cp_rs2_b7:
   c.swsp x7, 144(sp) # perform store
   LREG x17, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x17, Zca_c_swsp_cg_cp_rs2_b7, Zca_c_swsp_cg_cp_rs2_b7_str)
 
@@ -115,6 +123,7 @@ Zca_c_swsp_cg_cp_rs2_b7:
 Zca_c_swsp_cg_cp_rs2_b8:
   c.swsp x8, 212(sp) # perform store
   LREG x31, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x31, Zca_c_swsp_cg_cp_rs2_b8, Zca_c_swsp_cg_cp_rs2_b8_str)
 
@@ -124,6 +133,7 @@ Zca_c_swsp_cg_cp_rs2_b8:
 Zca_c_swsp_cg_cp_rs2_b9:
   c.swsp x9, 200(sp) # perform store
   LREG x17, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x17, Zca_c_swsp_cg_cp_rs2_b9, Zca_c_swsp_cg_cp_rs2_b9_str)
 
@@ -133,6 +143,7 @@ Zca_c_swsp_cg_cp_rs2_b9:
 Zca_c_swsp_cg_cp_rs2_b10:
   c.swsp x10, 252(sp) # perform store
   LREG x9, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x9, Zca_c_swsp_cg_cp_rs2_b10, Zca_c_swsp_cg_cp_rs2_b10_str)
 
@@ -142,6 +153,7 @@ Zca_c_swsp_cg_cp_rs2_b10:
 Zca_c_swsp_cg_cp_rs2_b11:
   c.swsp x11, 140(sp) # perform store
   LREG x23, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x23, Zca_c_swsp_cg_cp_rs2_b11, Zca_c_swsp_cg_cp_rs2_b11_str)
 
@@ -152,6 +164,7 @@ Zca_c_swsp_cg_cp_rs2_b11:
 Zca_c_swsp_cg_cp_rs2_b12:
   c.swsp x12, 8(sp) # perform store
   LREG x5, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x5, Zca_c_swsp_cg_cp_rs2_b12, Zca_c_swsp_cg_cp_rs2_b12_str)
 
@@ -163,6 +176,7 @@ Zca_c_swsp_cg_cp_rs2_b12:
 Zca_c_swsp_cg_cp_rs2_b13:
   c.swsp x13, 24(sp) # perform store
   LREG x7, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x7, Zca_c_swsp_cg_cp_rs2_b13, Zca_c_swsp_cg_cp_rs2_b13_str)
 
@@ -172,6 +186,7 @@ Zca_c_swsp_cg_cp_rs2_b13:
 Zca_c_swsp_cg_cp_rs2_b14:
   c.swsp x14, 88(sp) # perform store
   LREG x23, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_rs2_b14, Zca_c_swsp_cg_cp_rs2_b14_str)
 
@@ -181,6 +196,7 @@ Zca_c_swsp_cg_cp_rs2_b14:
 Zca_c_swsp_cg_cp_rs2_b15:
   c.swsp x15, 232(sp) # perform store
   LREG x19, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_b15, Zca_c_swsp_cg_cp_rs2_b15_str)
 
@@ -190,6 +206,7 @@ Zca_c_swsp_cg_cp_rs2_b15:
 Zca_c_swsp_cg_cp_rs2_b16:
   c.swsp x16, 100(sp) # perform store
   LREG x17, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zca_c_swsp_cg_cp_rs2_b16, Zca_c_swsp_cg_cp_rs2_b16_str)
 
@@ -199,6 +216,7 @@ Zca_c_swsp_cg_cp_rs2_b16:
 Zca_c_swsp_cg_cp_rs2_b17:
   c.swsp x17, 72(sp) # perform store
   LREG x25, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x25, Zca_c_swsp_cg_cp_rs2_b17, Zca_c_swsp_cg_cp_rs2_b17_str)
 
@@ -209,6 +227,7 @@ Zca_c_swsp_cg_cp_rs2_b17:
 Zca_c_swsp_cg_cp_rs2_b18:
   c.swsp x18, 24(sp) # perform store
   LREG x13, 0(x21) # load stored value for checking
+  addi x21, x21, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x13, Zca_c_swsp_cg_cp_rs2_b18, Zca_c_swsp_cg_cp_rs2_b18_str)
 
@@ -218,6 +237,7 @@ Zca_c_swsp_cg_cp_rs2_b18:
 Zca_c_swsp_cg_cp_rs2_b19:
   c.swsp x19, 0(sp) # perform store
   LREG x27, 0(x21) # load stored value for checking
+  addi x21, x21, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x27, Zca_c_swsp_cg_cp_rs2_b19, Zca_c_swsp_cg_cp_rs2_b19_str)
 
@@ -227,6 +247,7 @@ Zca_c_swsp_cg_cp_rs2_b19:
 Zca_c_swsp_cg_cp_rs2_b20:
   c.swsp x20, 80(sp) # perform store
   LREG x14, 0(x21) # load stored value for checking
+  addi x21, x21, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x14, Zca_c_swsp_cg_cp_rs2_b20, Zca_c_swsp_cg_cp_rs2_b20_str)
 
@@ -237,6 +258,7 @@ Zca_c_swsp_cg_cp_rs2_b20:
 Zca_c_swsp_cg_cp_rs2_b21:
   c.swsp x21, 112(sp) # perform store
   LREG x31, 0(x26) # load stored value for checking
+  addi x26, x26, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x31, Zca_c_swsp_cg_cp_rs2_b21, Zca_c_swsp_cg_cp_rs2_b21_str)
 
@@ -246,6 +268,7 @@ Zca_c_swsp_cg_cp_rs2_b21:
 Zca_c_swsp_cg_cp_rs2_b22:
   c.swsp x22, 216(sp) # perform store
   LREG x11, 0(x26) # load stored value for checking
+  addi x26, x26, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x11, Zca_c_swsp_cg_cp_rs2_b22, Zca_c_swsp_cg_cp_rs2_b22_str)
 
@@ -255,6 +278,7 @@ Zca_c_swsp_cg_cp_rs2_b22:
 Zca_c_swsp_cg_cp_rs2_b23:
   c.swsp x23, 132(sp) # perform store
   LREG x21, 0(x26) # load stored value for checking
+  addi x26, x26, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x21, Zca_c_swsp_cg_cp_rs2_b23, Zca_c_swsp_cg_cp_rs2_b23_str)
 
@@ -264,6 +288,7 @@ Zca_c_swsp_cg_cp_rs2_b23:
 Zca_c_swsp_cg_cp_rs2_b24:
   c.swsp x24, 88(sp) # perform store
   LREG x12, 0(x26) # load stored value for checking
+  addi x26, x26, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x12, Zca_c_swsp_cg_cp_rs2_b24, Zca_c_swsp_cg_cp_rs2_b24_str)
 
@@ -273,6 +298,7 @@ Zca_c_swsp_cg_cp_rs2_b24:
 Zca_c_swsp_cg_cp_rs2_b25:
   c.swsp x25, 220(sp) # perform store
   LREG x12, 0(x26) # load stored value for checking
+  addi x26, x26, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x12, Zca_c_swsp_cg_cp_rs2_b25, Zca_c_swsp_cg_cp_rs2_b25_str)
 
@@ -283,6 +309,7 @@ Zca_c_swsp_cg_cp_rs2_b25:
 Zca_c_swsp_cg_cp_rs2_b26:
   c.swsp x26, 40(sp) # perform store
   LREG x10, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x10, Zca_c_swsp_cg_cp_rs2_b26, Zca_c_swsp_cg_cp_rs2_b26_str)
 
@@ -292,6 +319,7 @@ Zca_c_swsp_cg_cp_rs2_b26:
 Zca_c_swsp_cg_cp_rs2_b27:
   c.swsp x27, 40(sp) # perform store
   LREG x10, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x10, Zca_c_swsp_cg_cp_rs2_b27, Zca_c_swsp_cg_cp_rs2_b27_str)
 
@@ -301,6 +329,7 @@ Zca_c_swsp_cg_cp_rs2_b27:
 Zca_c_swsp_cg_cp_rs2_b28:
   c.swsp x28, 132(sp) # perform store
   LREG x22, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x22, Zca_c_swsp_cg_cp_rs2_b28, Zca_c_swsp_cg_cp_rs2_b28_str)
 
@@ -310,6 +339,7 @@ Zca_c_swsp_cg_cp_rs2_b28:
 Zca_c_swsp_cg_cp_rs2_b29:
   c.swsp x29, 60(sp) # perform store
   LREG x17, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zca_c_swsp_cg_cp_rs2_b29, Zca_c_swsp_cg_cp_rs2_b29_str)
 
@@ -319,6 +349,7 @@ Zca_c_swsp_cg_cp_rs2_b29:
 Zca_c_swsp_cg_cp_rs2_b30:
   c.swsp x30, 128(sp) # perform store
   LREG x19, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_b30, Zca_c_swsp_cg_cp_rs2_b30_str)
 
@@ -328,6 +359,7 @@ Zca_c_swsp_cg_cp_rs2_b30:
 Zca_c_swsp_cg_cp_rs2_b31:
   c.swsp x31, 152(sp) # perform store
   LREG x15, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zca_c_swsp_cg_cp_rs2_b31, Zca_c_swsp_cg_cp_rs2_b31_str)
 
@@ -341,6 +373,7 @@ Zca_c_swsp_cg_cp_rs2_b31:
 Zca_c_swsp_cg_cp_rs2_edges_0x0:
   c.swsp x9, 16(sp) # perform store
   LREG x6, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x6, Zca_c_swsp_cg_cp_rs2_edges_0x0, Zca_c_swsp_cg_cp_rs2_edges_0x0_str)
 
@@ -350,6 +383,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x0:
 Zca_c_swsp_cg_cp_rs2_edges_0x1:
   c.swsp x23, 144(sp) # perform store
   LREG x19, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_edges_0x1, Zca_c_swsp_cg_cp_rs2_edges_0x1_str)
 
@@ -359,6 +393,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x1:
 Zca_c_swsp_cg_cp_rs2_edges_0x2:
   c.swsp x11, 44(sp) # perform store
   LREG x20, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x20 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x20, Zca_c_swsp_cg_cp_rs2_edges_0x2, Zca_c_swsp_cg_cp_rs2_edges_0x2_str)
 
@@ -368,6 +403,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x2:
 Zca_c_swsp_cg_cp_rs2_edges_0x80000000:
   c.swsp x25, 112(sp) # perform store
   LREG x27, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, Zca_c_swsp_cg_cp_rs2_edges_0x80000000, Zca_c_swsp_cg_cp_rs2_edges_0x80000000_str)
 
@@ -377,6 +413,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x80000000:
 Zca_c_swsp_cg_cp_rs2_edges_0x80000001:
   c.swsp x11, 212(sp) # perform store
   LREG x26, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x26, Zca_c_swsp_cg_cp_rs2_edges_0x80000001, Zca_c_swsp_cg_cp_rs2_edges_0x80000001_str)
 
@@ -386,6 +423,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x80000001:
 Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff:
   c.swsp x12, 28(sp) # perform store
   LREG x15, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff_str)
 
@@ -395,6 +433,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff:
 Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe:
   c.swsp x23, 240(sp) # perform store
   LREG x6, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x6, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe_str)
 
@@ -404,6 +443,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe:
 Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
   c.swsp x11, 128(sp) # perform store
   LREG x21, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x21, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff_str)
 
@@ -413,6 +453,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
 Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
   c.swsp x20, 144(sp) # perform store
   LREG x28, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe_str)
 
@@ -422,6 +463,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
 Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872:
   c.swsp x29, 196(sp) # perform store
   LREG x26, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x26, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872_str)
 
@@ -431,6 +473,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872:
 Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa:
   c.swsp x20, 172(sp) # perform store
   LREG x23, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa_str)
 
@@ -440,6 +483,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa:
 Zca_c_swsp_cg_cp_rs2_edges_0x55555555:
   c.swsp x16, 32(sp) # perform store
   LREG x19, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_edges_0x55555555, Zca_c_swsp_cg_cp_rs2_edges_0x55555555_str)
 
@@ -453,6 +497,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x55555555:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0:
   c.swsp x14, 0(sp) # perform store
   LREG x24, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x24 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0_str)
 
@@ -462,6 +507,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4:
   c.swsp x21, 4(sp) # perform store
   LREG x12, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4_str)
 
@@ -471,6 +517,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8:
   c.swsp x14, 8(sp) # perform store
   LREG x27, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8_str)
 
@@ -480,6 +527,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc:
   c.swsp x26, 12(sp) # perform store
   LREG x31, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc_str)
 
@@ -489,6 +537,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10:
   c.swsp x16, 16(sp) # perform store
   LREG x14, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10_str)
 
@@ -498,6 +547,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14:
   c.swsp x23, 20(sp) # perform store
   LREG x30, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x30 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14_str)
 
@@ -507,6 +557,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18:
   c.swsp x29, 24(sp) # perform store
   LREG x17, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18_str)
 
@@ -516,6 +567,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c:
   c.swsp x6, 28(sp) # perform store
   LREG x3, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c_str)
 
@@ -525,6 +577,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20:
   c.swsp x25, 32(sp) # perform store
   LREG x7, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20_str)
 
@@ -534,6 +587,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24:
   c.swsp x21, 36(sp) # perform store
   LREG x22, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24_str)
 
@@ -543,6 +597,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28:
   c.swsp x11, 40(sp) # perform store
   LREG x8, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28_str)
 
@@ -552,6 +607,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
   c.swsp x15, 44(sp) # perform store
   LREG x28, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c_str)
 
@@ -561,6 +617,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
   c.swsp x20, 48(sp) # perform store
   LREG x22, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30_str)
 
@@ -570,6 +627,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
   c.swsp x12, 52(sp) # perform store
   LREG x23, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34_str)
 
@@ -579,6 +637,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
   c.swsp x9, 56(sp) # perform store
   LREG x28, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38_str)
 
@@ -588,6 +647,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
   c.swsp x9, 60(sp) # perform store
   LREG x6, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c_str)
 
@@ -597,6 +657,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
   c.swsp x26, 64(sp) # perform store
   LREG x13, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40_str)
 
@@ -606,6 +667,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
   c.swsp x21, 68(sp) # perform store
   LREG x3, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44_str)
 
@@ -615,6 +677,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
   c.swsp x17, 72(sp) # perform store
   LREG x8, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48_str)
 
@@ -624,6 +687,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
   c.swsp x27, 76(sp) # perform store
   LREG x17, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c_str)
 
@@ -633,6 +697,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
   c.swsp x27, 80(sp) # perform store
   LREG x31, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50_str)
 
@@ -642,6 +707,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
   c.swsp x9, 84(sp) # perform store
   LREG x27, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54_str)
 
@@ -651,6 +717,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
   c.swsp x30, 88(sp) # perform store
   LREG x29, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58_str)
 
@@ -660,6 +727,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
   c.swsp x25, 92(sp) # perform store
   LREG x23, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c_str)
 
@@ -669,6 +737,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
   c.swsp x20, 96(sp) # perform store
   LREG x10, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60_str)
 
@@ -678,6 +747,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
   c.swsp x3, 100(sp) # perform store
   LREG x6, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64_str)
 
@@ -687,6 +757,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
   c.swsp x31, 104(sp) # perform store
   LREG x11, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68_str)
 
@@ -696,6 +767,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
   c.swsp x22, 108(sp) # perform store
   LREG x6, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c_str)
 
@@ -705,6 +777,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
   c.swsp x21, 112(sp) # perform store
   LREG x8, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70_str)
 
@@ -714,6 +787,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
   c.swsp x0, 116(sp) # perform store
   LREG x12, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74_str)
 
@@ -723,6 +797,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
   c.swsp x21, 120(sp) # perform store
   LREG x9, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78_str)
 
@@ -732,6 +807,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
   c.swsp x25, 124(sp) # perform store
   LREG x19, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c_str)
 
@@ -741,6 +817,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
   c.swsp x30, 128(sp) # perform store
   LREG x19, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80_str)
 
@@ -750,6 +827,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
   c.swsp x20, 132(sp) # perform store
   LREG x26, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84_str)
 
@@ -759,6 +837,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
   c.swsp x0, 136(sp) # perform store
   LREG x25, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x25, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88_str)
 
@@ -768,6 +847,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
   c.swsp x9, 140(sp) # perform store
   LREG x17, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c_str)
 
@@ -777,6 +857,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
   c.swsp x20, 144(sp) # perform store
   LREG x9, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90_str)
 
@@ -786,6 +867,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
   c.swsp x31, 148(sp) # perform store
   LREG x28, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94_str)
 
@@ -795,6 +877,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
   c.swsp x25, 152(sp) # perform store
   LREG x27, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98_str)
 
@@ -804,6 +887,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
   c.swsp x7, 156(sp) # perform store
   LREG x11, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c_str)
 
@@ -813,6 +897,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
   c.swsp x26, 160(sp) # perform store
   LREG x21, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0_str)
 
@@ -822,6 +907,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
   c.swsp x15, 164(sp) # perform store
   LREG x21, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4_str)
 
@@ -831,6 +917,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
   c.swsp x30, 168(sp) # perform store
   LREG x12, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8_str)
 
@@ -840,6 +927,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
   c.swsp x3, 172(sp) # perform store
   LREG x27, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac_str)
 
@@ -849,6 +937,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
   c.swsp x6, 176(sp) # perform store
   LREG x28, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0_str)
 
@@ -858,6 +947,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
   c.swsp x3, 180(sp) # perform store
   LREG x23, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4_str)
 
@@ -867,6 +957,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
   c.swsp x10, 184(sp) # perform store
   LREG x15, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8_str)
 
@@ -876,6 +967,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
   c.swsp x26, 188(sp) # perform store
   LREG x19, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc_str)
 
@@ -885,6 +977,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
   c.swsp x3, 192(sp) # perform store
   LREG x11, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0_str)
 
@@ -894,6 +987,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
   c.swsp x27, 196(sp) # perform store
   LREG x8, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4_str)
 
@@ -903,6 +997,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
   c.swsp x25, 200(sp) # perform store
   LREG x31, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8_str)
 
@@ -912,6 +1007,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
   c.swsp x17, 204(sp) # perform store
   LREG x16, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x16 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x16, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc_str)
 
@@ -921,6 +1017,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
   c.swsp x10, 208(sp) # perform store
   LREG x22, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0_str)
 
@@ -930,6 +1027,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
   c.swsp x3, 212(sp) # perform store
   LREG x30, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x30 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4_str)
 
@@ -939,6 +1037,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
   c.swsp x14, 216(sp) # perform store
   LREG x21, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8_str)
 
@@ -948,6 +1047,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
   c.swsp x15, 220(sp) # perform store
   LREG x29, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc_str)
 
@@ -957,6 +1057,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
   c.swsp x8, 224(sp) # perform store
   LREG x21, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0_str)
 
@@ -966,6 +1067,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
   c.swsp x14, 228(sp) # perform store
   LREG x3, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4_str)
 
@@ -975,6 +1077,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
   c.swsp x21, 232(sp) # perform store
   LREG x23, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8_str)
 
@@ -984,6 +1087,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
   c.swsp x8, 236(sp) # perform store
   LREG x15, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec_str)
 
@@ -993,6 +1097,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
   c.swsp x23, 240(sp) # perform store
   LREG x22, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0_str)
 
@@ -1002,6 +1107,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
   c.swsp x10, 244(sp) # perform store
   LREG x15, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4_str)
 
@@ -1011,6 +1117,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
   c.swsp x30, 248(sp) # perform store
   LREG x12, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8_str)
 
@@ -1020,6 +1127,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc:
   c.swsp x20, 252(sp) # perform store
   LREG x24, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x24 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc_str)
 

--- a/tests/rv32i/Zcb/Zcb-c.sb-00.S
+++ b/tests/rv32i/Zcb/Zcb-c.sb-00.S
@@ -41,18 +41,9 @@ Zcb_c_sb_cg_cp_rs1_p_b8:
   c.sb x15, 1(x8) # perform store
   addi x8, x8, 1 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zcb_c_sb_cg_cp_rs1_p_b8, Zcb_c_sb_cg_cp_rs1_p_b8_str)
-#else
-  c.sb x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xdfe42a0e
@@ -62,18 +53,9 @@ Zcb_c_sb_cg_cp_rs1_p_b9:
   c.sb x15, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zcb_c_sb_cg_cp_rs1_p_b9, Zcb_c_sb_cg_cp_rs1_p_b9_str)
-#else
-  c.sb x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xf012096f
@@ -83,18 +65,9 @@ Zcb_c_sb_cg_cp_rs1_p_b10:
   c.sb x11, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zcb_c_sb_cg_cp_rs1_p_b10, Zcb_c_sb_cg_cp_rs1_p_b10_str)
-#else
-  c.sb x11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xac88cf00
@@ -104,18 +77,9 @@ Zcb_c_sb_cg_cp_rs1_p_b11:
   c.sb x12, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, Zcb_c_sb_cg_cp_rs1_p_b11, Zcb_c_sb_cg_cp_rs1_p_b11_str)
-#else
-  c.sb x12, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x11d95231
@@ -125,18 +89,9 @@ Zcb_c_sb_cg_cp_rs1_p_b12:
   c.sb x15, 1(x12) # perform store
   addi x12, x12, 1 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zcb_c_sb_cg_cp_rs1_p_b12, Zcb_c_sb_cg_cp_rs1_p_b12_str)
-#else
-  c.sb x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xb136bb4a
@@ -146,18 +101,9 @@ Zcb_c_sb_cg_cp_rs1_p_b13:
   c.sb x10, 2(x13) # perform store
   addi x13, x13, 2 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, Zcb_c_sb_cg_cp_rs1_p_b13, Zcb_c_sb_cg_cp_rs1_p_b13_str)
-#else
-  c.sb x10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x55491316
@@ -167,18 +113,9 @@ Zcb_c_sb_cg_cp_rs1_p_b14:
   c.sb x10, 3(x14) # perform store
   addi x14, x14, 3 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zcb_c_sb_cg_cp_rs1_p_b14, Zcb_c_sb_cg_cp_rs1_p_b14_str)
-#else
-  c.sb x10, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x2721414f
@@ -188,18 +125,9 @@ Zcb_c_sb_cg_cp_rs1_p_b15:
   c.sb x9, 0(x15) # perform store
   addi x15, x15, 0 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x8 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x8, Zcb_c_sb_cg_cp_rs1_p_b15, Zcb_c_sb_cg_cp_rs1_p_b15_str)
-#else
-  c.sb x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_p
@@ -213,18 +141,9 @@ Zcb_c_sb_cg_cp_rs2_p_b8:
   c.sb x8, 0(x12) # perform store
   addi x12, x12, 0 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zcb_c_sb_cg_cp_rs2_p_b8, Zcb_c_sb_cg_cp_rs2_p_b8_str)
-#else
-  c.sb x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x428801d9
@@ -234,18 +153,9 @@ Zcb_c_sb_cg_cp_rs2_p_b9:
   c.sb x9, 2(x14) # perform store
   addi x14, x14, 2 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zcb_c_sb_cg_cp_rs2_p_b9, Zcb_c_sb_cg_cp_rs2_p_b9_str)
-#else
-  c.sb x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x6365f1e3
@@ -255,18 +165,9 @@ Zcb_c_sb_cg_cp_rs2_p_b10:
   c.sb x10, 1(x9) # perform store
   addi x9, x9, 1 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zcb_c_sb_cg_cp_rs2_p_b10, Zcb_c_sb_cg_cp_rs2_p_b10_str)
-#else
-  c.sb x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xf8f97593
@@ -276,18 +177,9 @@ Zcb_c_sb_cg_cp_rs2_p_b11:
   c.sb x11, 0(x8) # perform store
   addi x8, x8, 0 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_p_b11, Zcb_c_sb_cg_cp_rs2_p_b11_str)
-#else
-  c.sb x11, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x5a15a429
@@ -297,18 +189,9 @@ Zcb_c_sb_cg_cp_rs2_p_b12:
   c.sb x12, 3(x9) # perform store
   addi x9, x9, 3 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_p_b12, Zcb_c_sb_cg_cp_rs2_p_b12_str)
-#else
-  c.sb x12, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xefa06588
@@ -318,18 +201,9 @@ Zcb_c_sb_cg_cp_rs2_p_b13:
   c.sb x13, 1(x10) # perform store
   addi x10, x10, 1 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, Zcb_c_sb_cg_cp_rs2_p_b13, Zcb_c_sb_cg_cp_rs2_p_b13_str)
-#else
-  c.sb x13, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xcef9066a
@@ -339,18 +213,9 @@ Zcb_c_sb_cg_cp_rs2_p_b14:
   c.sb x14, 1(x11) # perform store
   addi x11, x11, 1 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_p_b14, Zcb_c_sb_cg_cp_rs2_p_b14_str)
-#else
-  c.sb x14, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x1cdd0dd0
@@ -360,18 +225,9 @@ Zcb_c_sb_cg_cp_rs2_p_b15:
   c.sb x15, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, Zcb_c_sb_cg_cp_rs2_p_b15, Zcb_c_sb_cg_cp_rs2_p_b15_str)
-#else
-  c.sb x15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -385,18 +241,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x0:
   c.sb x12, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x9 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x9, Zcb_c_sb_cg_cp_rs2_edges_0x0, Zcb_c_sb_cg_cp_rs2_edges_0x0_str)
-#else
-  c.sb x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x00000001
@@ -406,18 +253,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x1:
   c.sb x8, 2(x11) # perform store
   addi x11, x11, 2 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, Zcb_c_sb_cg_cp_rs2_edges_0x1, Zcb_c_sb_cg_cp_rs2_edges_0x1_str)
-#else
-  c.sb x8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x00000002
@@ -427,18 +265,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x2:
   c.sb x8, 2(x15) # perform store
   addi x15, x15, 2 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x9 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x9, Zcb_c_sb_cg_cp_rs2_edges_0x2, Zcb_c_sb_cg_cp_rs2_edges_0x2_str)
-#else
-  c.sb x8, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x80000000
@@ -448,18 +277,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x80000000:
   c.sb x9, 3(x8) # perform store
   addi x8, x8, 3 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zcb_c_sb_cg_cp_rs2_edges_0x80000000, Zcb_c_sb_cg_cp_rs2_edges_0x80000000_str)
-#else
-  c.sb x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x80000001
@@ -469,18 +289,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x80000001:
   c.sb x9, 3(x15) # perform store
   addi x15, x15, 3 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_edges_0x80000001, Zcb_c_sb_cg_cp_rs2_edges_0x80000001_str)
-#else
-  c.sb x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x7fffffff
@@ -490,18 +301,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x7fffffff:
   c.sb x9, 3(x11) # perform store
   addi x11, x11, 3 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, Zcb_c_sb_cg_cp_rs2_edges_0x7fffffff, Zcb_c_sb_cg_cp_rs2_edges_0x7fffffff_str)
-#else
-  c.sb x9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x7ffffffe
@@ -511,18 +313,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x7ffffffe:
   c.sb x8, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_edges_0x7ffffffe, Zcb_c_sb_cg_cp_rs2_edges_0x7ffffffe_str)
-#else
-  c.sb x8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xffffffff
@@ -532,18 +325,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0xffffffff:
   c.sb x8, 3(x15) # perform store
   addi x15, x15, 3 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x11 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x11, Zcb_c_sb_cg_cp_rs2_edges_0xffffffff, Zcb_c_sb_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  c.sb x8, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xfffffffe
@@ -553,18 +337,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0xfffffffe:
   c.sb x14, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x11 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x11, Zcb_c_sb_cg_cp_rs2_edges_0xfffffffe, Zcb_c_sb_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  c.sb x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x5bbc8872
@@ -574,18 +349,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x5bbc8872:
   c.sb x12, 2(x9) # perform store
   addi x9, x9, 2 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zcb_c_sb_cg_cp_rs2_edges_0x5bbc8872, Zcb_c_sb_cg_cp_rs2_edges_0x5bbc8872_str)
-#else
-  c.sb x12, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xaaaaaaaa
@@ -595,18 +361,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0xaaaaaaaa:
   c.sb x11, 1(x14) # perform store
   addi x14, x14, 1 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_edges_0xaaaaaaaa, Zcb_c_sb_cg_cp_rs2_edges_0xaaaaaaaa_str)
-#else
-  c.sb x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x55555555
@@ -616,18 +373,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x55555555:
   c.sb x9, 2(x15) # perform store
   addi x15, x15, 2 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_edges_0x55555555, Zcb_c_sb_cg_cp_rs2_edges_0x55555555_str)
-#else
-  c.sb x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x15 # restore signature pointer to default register for teardown
 

--- a/tests/rv32i/Zcb/Zcb-c.sh-00.S
+++ b/tests/rv32i/Zcb/Zcb-c.sh-00.S
@@ -41,18 +41,9 @@ Zcb_c_sh_cg_cp_rs1_p_b8:
   c.sh x9, 2(x8) # perform store
   addi x8, x8, 2 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, Zcb_c_sh_cg_cp_rs1_p_b8, Zcb_c_sh_cg_cp_rs1_p_b8_str)
-#else
-  c.sh x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x891c7353
@@ -62,18 +53,9 @@ Zcb_c_sh_cg_cp_rs1_p_b9:
   c.sh x14, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zcb_c_sh_cg_cp_rs1_p_b9, Zcb_c_sh_cg_cp_rs1_p_b9_str)
-#else
-  c.sh x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x7b59b968
@@ -83,18 +65,9 @@ Zcb_c_sh_cg_cp_rs1_p_b10:
   c.sh x14, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zcb_c_sh_cg_cp_rs1_p_b10, Zcb_c_sh_cg_cp_rs1_p_b10_str)
-#else
-  c.sh x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x61a7cdcc
@@ -104,18 +77,9 @@ Zcb_c_sh_cg_cp_rs1_p_b11:
   c.sh x13, 2(x11) # perform store
   addi x11, x11, 2 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, Zcb_c_sh_cg_cp_rs1_p_b11, Zcb_c_sh_cg_cp_rs1_p_b11_str)
-#else
-  c.sh x13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xb59c3971
@@ -125,18 +89,9 @@ Zcb_c_sh_cg_cp_rs1_p_b12:
   c.sh x8, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zcb_c_sh_cg_cp_rs1_p_b12, Zcb_c_sh_cg_cp_rs1_p_b12_str)
-#else
-  c.sh x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x9719fe3b
@@ -146,18 +101,9 @@ Zcb_c_sh_cg_cp_rs1_p_b13:
   c.sh x9, 2(x13) # perform store
   addi x13, x13, 2 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, Zcb_c_sh_cg_cp_rs1_p_b13, Zcb_c_sh_cg_cp_rs1_p_b13_str)
-#else
-  c.sh x9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x0151d4a1
@@ -167,18 +113,9 @@ Zcb_c_sh_cg_cp_rs1_p_b14:
   c.sh x11, 2(x14) # perform store
   addi x14, x14, 2 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, Zcb_c_sh_cg_cp_rs1_p_b14, Zcb_c_sh_cg_cp_rs1_p_b14_str)
-#else
-  c.sh x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x47d28a74
@@ -188,18 +125,9 @@ Zcb_c_sh_cg_cp_rs1_p_b15:
   c.sh x12, 2(x15) # perform store
   addi x15, x15, 2 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, Zcb_c_sh_cg_cp_rs1_p_b15, Zcb_c_sh_cg_cp_rs1_p_b15_str)
-#else
-  c.sh x12, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_p
@@ -213,18 +141,9 @@ Zcb_c_sh_cg_cp_rs2_p_b8:
   c.sh x8, 0(x12) # perform store
   addi x12, x12, 0 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x9 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x9, Zcb_c_sh_cg_cp_rs2_p_b8, Zcb_c_sh_cg_cp_rs2_p_b8_str)
-#else
-  c.sh x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x68175dfe
@@ -234,18 +153,9 @@ Zcb_c_sh_cg_cp_rs2_p_b9:
   c.sh x9, 0(x14) # perform store
   addi x14, x14, 0 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zcb_c_sh_cg_cp_rs2_p_b9, Zcb_c_sh_cg_cp_rs2_p_b9_str)
-#else
-  c.sh x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x60552e86
@@ -255,18 +165,9 @@ Zcb_c_sh_cg_cp_rs2_p_b10:
   c.sh x10, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, Zcb_c_sh_cg_cp_rs2_p_b10, Zcb_c_sh_cg_cp_rs2_p_b10_str)
-#else
-  c.sh x10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x447c61b9
@@ -276,18 +177,9 @@ Zcb_c_sh_cg_cp_rs2_p_b11:
   c.sh x11, 2(x9) # perform store
   addi x9, x9, 2 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zcb_c_sh_cg_cp_rs2_p_b11, Zcb_c_sh_cg_cp_rs2_p_b11_str)
-#else
-  c.sh x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x2b39e3d5
@@ -297,18 +189,9 @@ Zcb_c_sh_cg_cp_rs2_p_b12:
   c.sh x12, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zcb_c_sh_cg_cp_rs2_p_b12, Zcb_c_sh_cg_cp_rs2_p_b12_str)
-#else
-  c.sh x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x8cea1e27
@@ -318,18 +201,9 @@ Zcb_c_sh_cg_cp_rs2_p_b13:
   c.sh x13, 2(x15) # perform store
   addi x15, x15, 2 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, Zcb_c_sh_cg_cp_rs2_p_b13, Zcb_c_sh_cg_cp_rs2_p_b13_str)
-#else
-  c.sh x13, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xda6c4ef4
@@ -339,18 +213,9 @@ Zcb_c_sh_cg_cp_rs2_p_b14:
   c.sh x14, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x8, Zcb_c_sh_cg_cp_rs2_p_b14, Zcb_c_sh_cg_cp_rs2_p_b14_str)
-#else
-  c.sh x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x8066342e
@@ -360,18 +225,9 @@ Zcb_c_sh_cg_cp_rs2_p_b15:
   c.sh x15, 0(x8) # perform store
   addi x8, x8, 0 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zcb_c_sh_cg_cp_rs2_p_b15, Zcb_c_sh_cg_cp_rs2_p_b15_str)
-#else
-  c.sh x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -385,18 +241,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x0:
   c.sh x9, 0(x14) # perform store
   addi x14, x14, 0 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, Zcb_c_sh_cg_cp_rs2_edges_0x0, Zcb_c_sh_cg_cp_rs2_edges_0x0_str)
-#else
-  c.sh x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x00000001
@@ -406,18 +253,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x1:
   c.sh x12, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_edges_0x1, Zcb_c_sh_cg_cp_rs2_edges_0x1_str)
-#else
-  c.sh x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x00000002
@@ -427,18 +265,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x2:
   c.sh x14, 0(x8) # perform store
   addi x8, x8, 0 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zcb_c_sh_cg_cp_rs2_edges_0x2, Zcb_c_sh_cg_cp_rs2_edges_0x2_str)
-#else
-  c.sh x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x80000000
@@ -448,18 +277,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x80000000:
   c.sh x10, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zcb_c_sh_cg_cp_rs2_edges_0x80000000, Zcb_c_sh_cg_cp_rs2_edges_0x80000000_str)
-#else
-  c.sh x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x80000001
@@ -469,18 +289,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x80000001:
   c.sh x13, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x11 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x11, Zcb_c_sh_cg_cp_rs2_edges_0x80000001, Zcb_c_sh_cg_cp_rs2_edges_0x80000001_str)
-#else
-  c.sh x13, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x7fffffff
@@ -490,18 +301,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x7fffffff:
   c.sh x14, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, Zcb_c_sh_cg_cp_rs2_edges_0x7fffffff, Zcb_c_sh_cg_cp_rs2_edges_0x7fffffff_str)
-#else
-  c.sh x14, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x7ffffffe
@@ -511,18 +313,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x7ffffffe:
   c.sh x12, 2(x9) # perform store
   addi x9, x9, 2 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zcb_c_sh_cg_cp_rs2_edges_0x7ffffffe, Zcb_c_sh_cg_cp_rs2_edges_0x7ffffffe_str)
-#else
-  c.sh x12, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xffffffff
@@ -532,18 +325,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0xffffffff:
   c.sh x12, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_edges_0xffffffff, Zcb_c_sh_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  c.sh x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xfffffffe
@@ -553,18 +337,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0xfffffffe:
   c.sh x10, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x15 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_edges_0xfffffffe, Zcb_c_sh_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  c.sh x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x5bbc8872
@@ -574,18 +349,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x5bbc8872:
   c.sh x10, 2(x13) # perform store
   addi x13, x13, 2 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zcb_c_sh_cg_cp_rs2_edges_0x5bbc8872, Zcb_c_sh_cg_cp_rs2_edges_0x5bbc8872_str)
-#else
-  c.sh x10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xaaaaaaaa
@@ -595,18 +361,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0xaaaaaaaa:
   c.sh x9, 0(x15) # perform store
   addi x15, x15, 0 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, Zcb_c_sh_cg_cp_rs2_edges_0xaaaaaaaa, Zcb_c_sh_cg_cp_rs2_edges_0xaaaaaaaa_str)
-#else
-  c.sh x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x55555555
@@ -616,18 +373,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x55555555:
   c.sh x14, 0(x8) # perform store
   addi x8, x8, 0 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zcb_c_sh_cg_cp_rs2_edges_0x55555555, Zcb_c_sh_cg_cp_rs2_edges_0x55555555_str)
-#else
-  c.sh x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x8 # restore signature pointer to default register for teardown
 

--- a/tests/rv32i/Zcd/Zcd-c.fsd-00.S
+++ b/tests/rv32i/Zcd/Zcd-c.fsd-00.S
@@ -42,18 +42,9 @@ Zcd_c_fsd_cg_cp_rs1_p_b8:
   c.fsd f10, 96(x8) # perform store
   addi x8, x8, 96 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, Zcd_c_fsd_cg_cp_rs1_p_b8, Zcd_c_fsd_cg_cp_rs1_p_b8_str)
-#else
-  c.fsd f10, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zcd_c_fsd_cg_cp_rs1_p_b8, Zcd_c_fsd_cg_cp_rs1_p_b8_str)
 
@@ -66,18 +57,9 @@ Zcd_c_fsd_cg_cp_rs1_p_b9:
   c.fsd f10, 176(x9) # perform store
   addi x9, x9, 176 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zcd_c_fsd_cg_cp_rs1_p_b9, Zcd_c_fsd_cg_cp_rs1_p_b9_str)
-#else
-  c.fsd f10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcd_c_fsd_cg_cp_rs1_p_b9, Zcd_c_fsd_cg_cp_rs1_p_b9_str)
 
@@ -90,18 +72,9 @@ Zcd_c_fsd_cg_cp_rs1_p_b10:
   c.fsd f10, 192(x10) # perform store
   addi x10, x10, 192 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zcd_c_fsd_cg_cp_rs1_p_b10, Zcd_c_fsd_cg_cp_rs1_p_b10_str)
-#else
-  c.fsd f10, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcd_c_fsd_cg_cp_rs1_p_b10, Zcd_c_fsd_cg_cp_rs1_p_b10_str)
 
@@ -114,18 +87,9 @@ Zcd_c_fsd_cg_cp_rs1_p_b11:
   c.fsd f11, 16(x11) # perform store
   addi x11, x11, 16 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, Zcd_c_fsd_cg_cp_rs1_p_b11, Zcd_c_fsd_cg_cp_rs1_p_b11_str)
-#else
-  c.fsd f11, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zcd_c_fsd_cg_cp_rs1_p_b11, Zcd_c_fsd_cg_cp_rs1_p_b11_str)
 
@@ -138,18 +102,9 @@ Zcd_c_fsd_cg_cp_rs1_p_b12:
   c.fsd f15, 96(x12) # perform store
   addi x12, x12, 96 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x9 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x9, Zcd_c_fsd_cg_cp_rs1_p_b12, Zcd_c_fsd_cg_cp_rs1_p_b12_str)
-#else
-  c.fsd f15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcd_c_fsd_cg_cp_rs1_p_b12, Zcd_c_fsd_cg_cp_rs1_p_b12_str)
 
@@ -162,18 +117,9 @@ Zcd_c_fsd_cg_cp_rs1_p_b13:
   c.fsd f13, 104(x13) # perform store
   addi x13, x13, 104 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, Zcd_c_fsd_cg_cp_rs1_p_b13, Zcd_c_fsd_cg_cp_rs1_p_b13_str)
-#else
-  c.fsd f13, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zcd_c_fsd_cg_cp_rs1_p_b13, Zcd_c_fsd_cg_cp_rs1_p_b13_str)
 
@@ -186,18 +132,9 @@ Zcd_c_fsd_cg_cp_rs1_p_b14:
   c.fsd f12, 80(x14) # perform store
   addi x14, x14, 80 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zcd_c_fsd_cg_cp_rs1_p_b14, Zcd_c_fsd_cg_cp_rs1_p_b14_str)
-#else
-  c.fsd f12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcd_c_fsd_cg_cp_rs1_p_b14, Zcd_c_fsd_cg_cp_rs1_p_b14_str)
 
@@ -210,18 +147,9 @@ Zcd_c_fsd_cg_cp_rs1_p_b15:
   c.fsd f14, 200(x15) # perform store
   addi x15, x15, 200 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, Zcd_c_fsd_cg_cp_rs1_p_b15, Zcd_c_fsd_cg_cp_rs1_p_b15_str)
-#else
-  c.fsd f14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcd_c_fsd_cg_cp_rs1_p_b15, Zcd_c_fsd_cg_cp_rs1_p_b15_str)
 
@@ -238,18 +166,9 @@ Zcd_c_fsd_cg_cp_fs2_p_b8:
   c.fsd f8, 184(x12) # perform store
   addi x12, x12, 184 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x13 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x13, Zcd_c_fsd_cg_cp_fs2_p_b8, Zcd_c_fsd_cg_cp_fs2_p_b8_str)
-#else
-  c.fsd f8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcd_c_fsd_cg_cp_fs2_p_b8, Zcd_c_fsd_cg_cp_fs2_p_b8_str)
 
@@ -262,18 +181,9 @@ Zcd_c_fsd_cg_cp_fs2_p_b9:
   c.fsd f9, 16(x10) # perform store
   addi x10, x10, 16 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zcd_c_fsd_cg_cp_fs2_p_b9, Zcd_c_fsd_cg_cp_fs2_p_b9_str)
-#else
-  c.fsd f9, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcd_c_fsd_cg_cp_fs2_p_b9, Zcd_c_fsd_cg_cp_fs2_p_b9_str)
 
@@ -286,18 +196,9 @@ Zcd_c_fsd_cg_cp_fs2_p_b10:
   c.fsd f10, 208(x11) # perform store
   addi x11, x11, 208 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, Zcd_c_fsd_cg_cp_fs2_p_b10, Zcd_c_fsd_cg_cp_fs2_p_b10_str)
-#else
-  c.fsd f10, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zcd_c_fsd_cg_cp_fs2_p_b10, Zcd_c_fsd_cg_cp_fs2_p_b10_str)
 
@@ -310,18 +211,9 @@ Zcd_c_fsd_cg_cp_fs2_p_b11:
   c.fsd f11, 136(x9) # perform store
   addi x9, x9, 136 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zcd_c_fsd_cg_cp_fs2_p_b11, Zcd_c_fsd_cg_cp_fs2_p_b11_str)
-#else
-  c.fsd f11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcd_c_fsd_cg_cp_fs2_p_b11, Zcd_c_fsd_cg_cp_fs2_p_b11_str)
 
@@ -334,18 +226,9 @@ Zcd_c_fsd_cg_cp_fs2_p_b12:
   c.fsd f12, 192(x14) # perform store
   addi x14, x14, 192 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x10 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x10, Zcd_c_fsd_cg_cp_fs2_p_b12, Zcd_c_fsd_cg_cp_fs2_p_b12_str)
-#else
-  c.fsd f12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcd_c_fsd_cg_cp_fs2_p_b12, Zcd_c_fsd_cg_cp_fs2_p_b12_str)
 
@@ -358,18 +241,9 @@ Zcd_c_fsd_cg_cp_fs2_p_b13:
   c.fsd f13, 112(x10) # perform store
   addi x10, x10, 112 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x11 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x11, Zcd_c_fsd_cg_cp_fs2_p_b13, Zcd_c_fsd_cg_cp_fs2_p_b13_str)
-#else
-  c.fsd f13, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcd_c_fsd_cg_cp_fs2_p_b13, Zcd_c_fsd_cg_cp_fs2_p_b13_str)
 
@@ -382,18 +256,9 @@ Zcd_c_fsd_cg_cp_fs2_p_b14:
   c.fsd f14, 120(x12) # perform store
   addi x12, x12, 120 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x13 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x13, Zcd_c_fsd_cg_cp_fs2_p_b14, Zcd_c_fsd_cg_cp_fs2_p_b14_str)
-#else
-  c.fsd f14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcd_c_fsd_cg_cp_fs2_p_b14, Zcd_c_fsd_cg_cp_fs2_p_b14_str)
 
@@ -406,18 +271,9 @@ Zcd_c_fsd_cg_cp_fs2_p_b15:
   c.fsd f15, 24(x10) # perform store
   addi x10, x10, 24 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zcd_c_fsd_cg_cp_fs2_p_b15, Zcd_c_fsd_cg_cp_fs2_p_b15_str)
-#else
-  c.fsd f15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcd_c_fsd_cg_cp_fs2_p_b15, Zcd_c_fsd_cg_cp_fs2_p_b15_str)
 
@@ -434,18 +290,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x0:
   c.fsd f13, 0(x14) # perform store
   addi x14, x14, 0 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x15 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x15, Zcd_c_fsd_cg_cp_imm_mul_8_b0x0, Zcd_c_fsd_cg_cp_imm_mul_8_b0x0_str)
-#else
-  c.fsd f13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x0, Zcd_c_fsd_cg_cp_imm_mul_8_b0x0_str)
 
@@ -458,18 +305,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x8:
   c.fsd f9, 8(x10) # perform store
   addi x10, x10, 8 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x8, Zcd_c_fsd_cg_cp_imm_mul_8_b0x8, Zcd_c_fsd_cg_cp_imm_mul_8_b0x8_str)
-#else
-  c.fsd f9, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x8, Zcd_c_fsd_cg_cp_imm_mul_8_b0x8_str)
 
@@ -482,18 +320,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x10:
   c.fsd f8, 16(x15) # perform store
   addi x15, x15, 16 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x9 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x9, Zcd_c_fsd_cg_cp_imm_mul_8_b0x10, Zcd_c_fsd_cg_cp_imm_mul_8_b0x10_str)
-#else
-  c.fsd f8, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x10, Zcd_c_fsd_cg_cp_imm_mul_8_b0x10_str)
 
@@ -506,18 +335,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x18:
   c.fsd f14, 24(x8) # perform store
   addi x8, x8, 24 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zcd_c_fsd_cg_cp_imm_mul_8_b0x18, Zcd_c_fsd_cg_cp_imm_mul_8_b0x18_str)
-#else
-  c.fsd f14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x18, Zcd_c_fsd_cg_cp_imm_mul_8_b0x18_str)
 
@@ -530,18 +350,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x20:
   c.fsd f9, 32(x12) # perform store
   addi x12, x12, 32 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zcd_c_fsd_cg_cp_imm_mul_8_b0x20, Zcd_c_fsd_cg_cp_imm_mul_8_b0x20_str)
-#else
-  c.fsd f9, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x20, Zcd_c_fsd_cg_cp_imm_mul_8_b0x20_str)
 
@@ -554,18 +365,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x28:
   c.fsd f11, 40(x10) # perform store
   addi x10, x10, 40 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zcd_c_fsd_cg_cp_imm_mul_8_b0x28, Zcd_c_fsd_cg_cp_imm_mul_8_b0x28_str)
-#else
-  c.fsd f11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x28, Zcd_c_fsd_cg_cp_imm_mul_8_b0x28_str)
 
@@ -578,18 +380,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x30:
   c.fsd f11, 48(x15) # perform store
   addi x15, x15, 48 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, Zcd_c_fsd_cg_cp_imm_mul_8_b0x30, Zcd_c_fsd_cg_cp_imm_mul_8_b0x30_str)
-#else
-  c.fsd f11, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x30, Zcd_c_fsd_cg_cp_imm_mul_8_b0x30_str)
 
@@ -602,18 +395,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x38:
   c.fsd f12, 56(x12) # perform store
   addi x12, x12, 56 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x10 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x10, Zcd_c_fsd_cg_cp_imm_mul_8_b0x38, Zcd_c_fsd_cg_cp_imm_mul_8_b0x38_str)
-#else
-  c.fsd f12, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x38, Zcd_c_fsd_cg_cp_imm_mul_8_b0x38_str)
 
@@ -626,18 +410,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x40:
   c.fsd f12, 64(x8) # perform store
   addi x8, x8, 64 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, Zcd_c_fsd_cg_cp_imm_mul_8_b0x40, Zcd_c_fsd_cg_cp_imm_mul_8_b0x40_str)
-#else
-  c.fsd f12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x40, Zcd_c_fsd_cg_cp_imm_mul_8_b0x40_str)
 
@@ -650,18 +425,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x48:
   c.fsd f12, 72(x9) # perform store
   addi x9, x9, 72 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zcd_c_fsd_cg_cp_imm_mul_8_b0x48, Zcd_c_fsd_cg_cp_imm_mul_8_b0x48_str)
-#else
-  c.fsd f12, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x48, Zcd_c_fsd_cg_cp_imm_mul_8_b0x48_str)
 
@@ -674,18 +440,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x50:
   c.fsd f13, 80(x11) # perform store
   addi x11, x11, 80 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zcd_c_fsd_cg_cp_imm_mul_8_b0x50, Zcd_c_fsd_cg_cp_imm_mul_8_b0x50_str)
-#else
-  c.fsd f13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x50, Zcd_c_fsd_cg_cp_imm_mul_8_b0x50_str)
 
@@ -698,18 +455,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x58:
   c.fsd f11, 88(x15) # perform store
   addi x15, x15, 88 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zcd_c_fsd_cg_cp_imm_mul_8_b0x58, Zcd_c_fsd_cg_cp_imm_mul_8_b0x58_str)
-#else
-  c.fsd f11, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x58, Zcd_c_fsd_cg_cp_imm_mul_8_b0x58_str)
 
@@ -722,18 +470,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x60:
   c.fsd f12, 96(x13) # perform store
   addi x13, x13, 96 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, Zcd_c_fsd_cg_cp_imm_mul_8_b0x60, Zcd_c_fsd_cg_cp_imm_mul_8_b0x60_str)
-#else
-  c.fsd f12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x60, Zcd_c_fsd_cg_cp_imm_mul_8_b0x60_str)
 
@@ -746,18 +485,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x68:
   c.fsd f14, 104(x9) # perform store
   addi x9, x9, 104 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zcd_c_fsd_cg_cp_imm_mul_8_b0x68, Zcd_c_fsd_cg_cp_imm_mul_8_b0x68_str)
-#else
-  c.fsd f14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x68, Zcd_c_fsd_cg_cp_imm_mul_8_b0x68_str)
 
@@ -770,18 +500,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x70:
   c.fsd f12, 112(x15) # perform store
   addi x15, x15, 112 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zcd_c_fsd_cg_cp_imm_mul_8_b0x70, Zcd_c_fsd_cg_cp_imm_mul_8_b0x70_str)
-#else
-  c.fsd f12, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x70, Zcd_c_fsd_cg_cp_imm_mul_8_b0x70_str)
 
@@ -794,18 +515,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x78:
   c.fsd f11, 120(x14) # perform store
   addi x14, x14, 120 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zcd_c_fsd_cg_cp_imm_mul_8_b0x78, Zcd_c_fsd_cg_cp_imm_mul_8_b0x78_str)
-#else
-  c.fsd f11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x78, Zcd_c_fsd_cg_cp_imm_mul_8_b0x78_str)
 
@@ -818,18 +530,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x80:
   c.fsd f10, 128(x12) # perform store
   addi x12, x12, 128 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x15 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x15, Zcd_c_fsd_cg_cp_imm_mul_8_b0x80, Zcd_c_fsd_cg_cp_imm_mul_8_b0x80_str)
-#else
-  c.fsd f10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x80, Zcd_c_fsd_cg_cp_imm_mul_8_b0x80_str)
 
@@ -842,18 +545,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x88:
   c.fsd f8, 136(x9) # perform store
   addi x9, x9, 136 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zcd_c_fsd_cg_cp_imm_mul_8_b0x88, Zcd_c_fsd_cg_cp_imm_mul_8_b0x88_str)
-#else
-  c.fsd f8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x88, Zcd_c_fsd_cg_cp_imm_mul_8_b0x88_str)
 
@@ -866,18 +560,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x90:
   c.fsd f15, 144(x14) # perform store
   addi x14, x14, 144 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x10 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x10, Zcd_c_fsd_cg_cp_imm_mul_8_b0x90, Zcd_c_fsd_cg_cp_imm_mul_8_b0x90_str)
-#else
-  c.fsd f15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x90, Zcd_c_fsd_cg_cp_imm_mul_8_b0x90_str)
 
@@ -890,18 +575,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x98:
   c.fsd f11, 152(x13) # perform store
   addi x13, x13, 152 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x10 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x10, Zcd_c_fsd_cg_cp_imm_mul_8_b0x98, Zcd_c_fsd_cg_cp_imm_mul_8_b0x98_str)
-#else
-  c.fsd f11, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x98, Zcd_c_fsd_cg_cp_imm_mul_8_b0x98_str)
 
@@ -914,18 +590,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xa0:
   c.fsd f11, 160(x14) # perform store
   addi x14, x14, 160 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xa0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xa0_str)
-#else
-  c.fsd f11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xa0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xa0_str)
 
@@ -938,18 +605,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xa8:
   c.fsd f13, 168(x10) # perform store
   addi x10, x10, 168 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, Zcd_c_fsd_cg_cp_imm_mul_8_b0xa8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xa8_str)
-#else
-  c.fsd f13, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xa8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xa8_str)
 
@@ -962,18 +620,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xb0:
   c.fsd f9, 176(x12) # perform store
   addi x12, x12, 176 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x13 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x13, Zcd_c_fsd_cg_cp_imm_mul_8_b0xb0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xb0_str)
-#else
-  c.fsd f9, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xb0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xb0_str)
 
@@ -986,18 +635,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xb8:
   c.fsd f10, 184(x9) # perform store
   addi x9, x9, 184 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zcd_c_fsd_cg_cp_imm_mul_8_b0xb8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xb8_str)
-#else
-  c.fsd f10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xb8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xb8_str)
 
@@ -1010,18 +650,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xc0:
   c.fsd f13, 192(x11) # perform store
   addi x11, x11, 192 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, Zcd_c_fsd_cg_cp_imm_mul_8_b0xc0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xc0_str)
-#else
-  c.fsd f13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xc0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xc0_str)
 
@@ -1034,18 +665,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xc8:
   c.fsd f11, 200(x14) # perform store
   addi x14, x14, 200 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zcd_c_fsd_cg_cp_imm_mul_8_b0xc8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xc8_str)
-#else
-  c.fsd f11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xc8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xc8_str)
 
@@ -1058,18 +680,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xd0:
   c.fsd f15, 208(x15) # perform store
   addi x15, x15, 208 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x11 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x11, Zcd_c_fsd_cg_cp_imm_mul_8_b0xd0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xd0_str)
-#else
-  c.fsd f15, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xd0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xd0_str)
 
@@ -1082,18 +695,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xd8:
   c.fsd f9, 216(x13) # perform store
   addi x13, x13, 216 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, Zcd_c_fsd_cg_cp_imm_mul_8_b0xd8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xd8_str)
-#else
-  c.fsd f9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xd8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xd8_str)
 
@@ -1106,18 +710,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xe0:
   c.fsd f8, 224(x9) # perform store
   addi x9, x9, 224 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zcd_c_fsd_cg_cp_imm_mul_8_b0xe0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xe0_str)
-#else
-  c.fsd f8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xe0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xe0_str)
 
@@ -1130,18 +725,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xe8:
   c.fsd f13, 232(x13) # perform store
   addi x13, x13, 232 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x10 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x10, Zcd_c_fsd_cg_cp_imm_mul_8_b0xe8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xe8_str)
-#else
-  c.fsd f13, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xe8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xe8_str)
 
@@ -1154,18 +740,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xf0:
   c.fsd f15, 240(x9) # perform store
   addi x9, x9, 240 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xf0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xf0_str)
-#else
-  c.fsd f15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xf0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xf0_str)
 
@@ -1178,18 +755,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xf8:
   c.fsd f13, 248(x11) # perform store
   addi x11, x11, 248 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zcd_c_fsd_cg_cp_imm_mul_8_b0xf8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xf8_str)
-#else
-  c.fsd f13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xf8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xf8_str)
 

--- a/tests/rv32i/Zcf/Zcf-c.fsw-00.S
+++ b/tests/rv32i/Zcf/Zcf-c.fsw-00.S
@@ -42,18 +42,9 @@ Zcf_c_fsw_cg_cp_rs1_p_b8:
   c.fsw f8, 108(x8) # perform store
   addi x8, x8, 108 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zcf_c_fsw_cg_cp_rs1_p_b8, Zcf_c_fsw_cg_cp_rs1_p_b8_str)
-#else
-  c.fsw f8, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zcf_c_fsw_cg_cp_rs1_p_b8, Zcf_c_fsw_cg_cp_rs1_p_b8_str)
 
@@ -66,18 +57,9 @@ Zcf_c_fsw_cg_cp_rs1_p_b9:
   c.fsw f10, 4(x9) # perform store
   addi x9, x9, 4 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zcf_c_fsw_cg_cp_rs1_p_b9, Zcf_c_fsw_cg_cp_rs1_p_b9_str)
-#else
-  c.fsw f10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcf_c_fsw_cg_cp_rs1_p_b9, Zcf_c_fsw_cg_cp_rs1_p_b9_str)
 
@@ -90,18 +72,9 @@ Zcf_c_fsw_cg_cp_rs1_p_b10:
   c.fsw f15, 24(x10) # perform store
   addi x10, x10, 24 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zcf_c_fsw_cg_cp_rs1_p_b10, Zcf_c_fsw_cg_cp_rs1_p_b10_str)
-#else
-  c.fsw f15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcf_c_fsw_cg_cp_rs1_p_b10, Zcf_c_fsw_cg_cp_rs1_p_b10_str)
 
@@ -114,18 +87,9 @@ Zcf_c_fsw_cg_cp_rs1_p_b11:
   c.fsw f9, 68(x11) # perform store
   addi x11, x11, 68 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, Zcf_c_fsw_cg_cp_rs1_p_b11, Zcf_c_fsw_cg_cp_rs1_p_b11_str)
-#else
-  c.fsw f9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zcf_c_fsw_cg_cp_rs1_p_b11, Zcf_c_fsw_cg_cp_rs1_p_b11_str)
 
@@ -138,18 +102,9 @@ Zcf_c_fsw_cg_cp_rs1_p_b12:
   c.fsw f8, 64(x12) # perform store
   addi x12, x12, 64 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x9 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x9, Zcf_c_fsw_cg_cp_rs1_p_b12, Zcf_c_fsw_cg_cp_rs1_p_b12_str)
-#else
-  c.fsw f8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcf_c_fsw_cg_cp_rs1_p_b12, Zcf_c_fsw_cg_cp_rs1_p_b12_str)
 
@@ -162,18 +117,9 @@ Zcf_c_fsw_cg_cp_rs1_p_b13:
   c.fsw f15, 76(x13) # perform store
   addi x13, x13, 76 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zcf_c_fsw_cg_cp_rs1_p_b13, Zcf_c_fsw_cg_cp_rs1_p_b13_str)
-#else
-  c.fsw f15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zcf_c_fsw_cg_cp_rs1_p_b13, Zcf_c_fsw_cg_cp_rs1_p_b13_str)
 
@@ -186,18 +132,9 @@ Zcf_c_fsw_cg_cp_rs1_p_b14:
   c.fsw f8, 124(x14) # perform store
   addi x14, x14, 124 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, Zcf_c_fsw_cg_cp_rs1_p_b14, Zcf_c_fsw_cg_cp_rs1_p_b14_str)
-#else
-  c.fsw f8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcf_c_fsw_cg_cp_rs1_p_b14, Zcf_c_fsw_cg_cp_rs1_p_b14_str)
 
@@ -210,18 +147,9 @@ Zcf_c_fsw_cg_cp_rs1_p_b15:
   c.fsw f14, 44(x15) # perform store
   addi x15, x15, 44 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, Zcf_c_fsw_cg_cp_rs1_p_b15, Zcf_c_fsw_cg_cp_rs1_p_b15_str)
-#else
-  c.fsw f14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcf_c_fsw_cg_cp_rs1_p_b15, Zcf_c_fsw_cg_cp_rs1_p_b15_str)
 
@@ -238,18 +166,9 @@ Zcf_c_fsw_cg_cp_fs2_p_b8:
   c.fsw f8, 88(x9) # perform store
   addi x9, x9, 88 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zcf_c_fsw_cg_cp_fs2_p_b8, Zcf_c_fsw_cg_cp_fs2_p_b8_str)
-#else
-  c.fsw f8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcf_c_fsw_cg_cp_fs2_p_b8, Zcf_c_fsw_cg_cp_fs2_p_b8_str)
 
@@ -262,18 +181,9 @@ Zcf_c_fsw_cg_cp_fs2_p_b9:
   c.fsw f9, 80(x15) # perform store
   addi x15, x15, 80 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x13, Zcf_c_fsw_cg_cp_fs2_p_b9, Zcf_c_fsw_cg_cp_fs2_p_b9_str)
-#else
-  c.fsw f9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcf_c_fsw_cg_cp_fs2_p_b9, Zcf_c_fsw_cg_cp_fs2_p_b9_str)
 
@@ -286,18 +196,9 @@ Zcf_c_fsw_cg_cp_fs2_p_b10:
   c.fsw f10, 16(x11) # perform store
   addi x11, x11, 16 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, Zcf_c_fsw_cg_cp_fs2_p_b10, Zcf_c_fsw_cg_cp_fs2_p_b10_str)
-#else
-  c.fsw f10, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zcf_c_fsw_cg_cp_fs2_p_b10, Zcf_c_fsw_cg_cp_fs2_p_b10_str)
 
@@ -310,18 +211,9 @@ Zcf_c_fsw_cg_cp_fs2_p_b11:
   c.fsw f11, 120(x14) # perform store
   addi x14, x14, 120 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zcf_c_fsw_cg_cp_fs2_p_b11, Zcf_c_fsw_cg_cp_fs2_p_b11_str)
-#else
-  c.fsw f11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcf_c_fsw_cg_cp_fs2_p_b11, Zcf_c_fsw_cg_cp_fs2_p_b11_str)
 
@@ -334,18 +226,9 @@ Zcf_c_fsw_cg_cp_fs2_p_b12:
   c.fsw f12, 72(x10) # perform store
   addi x10, x10, 72 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x8, Zcf_c_fsw_cg_cp_fs2_p_b12, Zcf_c_fsw_cg_cp_fs2_p_b12_str)
-#else
-  c.fsw f12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcf_c_fsw_cg_cp_fs2_p_b12, Zcf_c_fsw_cg_cp_fs2_p_b12_str)
 
@@ -358,18 +241,9 @@ Zcf_c_fsw_cg_cp_fs2_p_b13:
   c.fsw f13, 44(x8) # perform store
   addi x8, x8, 44 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zcf_c_fsw_cg_cp_fs2_p_b13, Zcf_c_fsw_cg_cp_fs2_p_b13_str)
-#else
-  c.fsw f13, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zcf_c_fsw_cg_cp_fs2_p_b13, Zcf_c_fsw_cg_cp_fs2_p_b13_str)
 
@@ -382,18 +256,9 @@ Zcf_c_fsw_cg_cp_fs2_p_b14:
   c.fsw f14, 52(x14) # perform store
   addi x14, x14, 52 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, Zcf_c_fsw_cg_cp_fs2_p_b14, Zcf_c_fsw_cg_cp_fs2_p_b14_str)
-#else
-  c.fsw f14, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcf_c_fsw_cg_cp_fs2_p_b14, Zcf_c_fsw_cg_cp_fs2_p_b14_str)
 
@@ -406,18 +271,9 @@ Zcf_c_fsw_cg_cp_fs2_p_b15:
   c.fsw f15, 68(x13) # perform store
   addi x13, x13, 68 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, Zcf_c_fsw_cg_cp_fs2_p_b15, Zcf_c_fsw_cg_cp_fs2_p_b15_str)
-#else
-  c.fsw f15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zcf_c_fsw_cg_cp_fs2_p_b15, Zcf_c_fsw_cg_cp_fs2_p_b15_str)
 
@@ -434,18 +290,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x0:
   c.fsw f14, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zcf_c_fsw_cg_cp_imm_mul_b0x0, Zcf_c_fsw_cg_cp_imm_mul_b0x0_str)
-#else
-  c.fsw f14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x0, Zcf_c_fsw_cg_cp_imm_mul_b0x0_str)
 
@@ -458,18 +305,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x4:
   c.fsw f15, 4(x12) # perform store
   addi x12, x12, 4 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zcf_c_fsw_cg_cp_imm_mul_b0x4, Zcf_c_fsw_cg_cp_imm_mul_b0x4_str)
-#else
-  c.fsw f15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x4, Zcf_c_fsw_cg_cp_imm_mul_b0x4_str)
 
@@ -482,18 +320,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x8:
   c.fsw f9, 8(x15) # perform store
   addi x15, x15, 8 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zcf_c_fsw_cg_cp_imm_mul_b0x8, Zcf_c_fsw_cg_cp_imm_mul_b0x8_str)
-#else
-  c.fsw f9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x8, Zcf_c_fsw_cg_cp_imm_mul_b0x8_str)
 
@@ -506,18 +335,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0xc:
   c.fsw f11, 12(x10) # perform store
   addi x10, x10, 12 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zcf_c_fsw_cg_cp_imm_mul_b0xc, Zcf_c_fsw_cg_cp_imm_mul_b0xc_str)
-#else
-  c.fsw f11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0xc, Zcf_c_fsw_cg_cp_imm_mul_b0xc_str)
 
@@ -530,18 +350,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x10:
   c.fsw f8, 16(x15) # perform store
   addi x15, x15, 16 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x13, Zcf_c_fsw_cg_cp_imm_mul_b0x10, Zcf_c_fsw_cg_cp_imm_mul_b0x10_str)
-#else
-  c.fsw f8, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x10, Zcf_c_fsw_cg_cp_imm_mul_b0x10_str)
 
@@ -554,18 +365,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x14:
   c.fsw f15, 20(x9) # perform store
   addi x9, x9, 20 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zcf_c_fsw_cg_cp_imm_mul_b0x14, Zcf_c_fsw_cg_cp_imm_mul_b0x14_str)
-#else
-  c.fsw f15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x14, Zcf_c_fsw_cg_cp_imm_mul_b0x14_str)
 
@@ -578,18 +380,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x18:
   c.fsw f12, 24(x12) # perform store
   addi x12, x12, 24 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zcf_c_fsw_cg_cp_imm_mul_b0x18, Zcf_c_fsw_cg_cp_imm_mul_b0x18_str)
-#else
-  c.fsw f12, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x18, Zcf_c_fsw_cg_cp_imm_mul_b0x18_str)
 
@@ -602,18 +395,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x1c:
   c.fsw f15, 28(x10) # perform store
   addi x10, x10, 28 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zcf_c_fsw_cg_cp_imm_mul_b0x1c, Zcf_c_fsw_cg_cp_imm_mul_b0x1c_str)
-#else
-  c.fsw f15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x1c, Zcf_c_fsw_cg_cp_imm_mul_b0x1c_str)
 
@@ -626,18 +410,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x20:
   c.fsw f10, 32(x13) # perform store
   addi x13, x13, 32 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zcf_c_fsw_cg_cp_imm_mul_b0x20, Zcf_c_fsw_cg_cp_imm_mul_b0x20_str)
-#else
-  c.fsw f10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x20, Zcf_c_fsw_cg_cp_imm_mul_b0x20_str)
 
@@ -650,18 +425,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x24:
   c.fsw f11, 36(x8) # perform store
   addi x8, x8, 36 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zcf_c_fsw_cg_cp_imm_mul_b0x24, Zcf_c_fsw_cg_cp_imm_mul_b0x24_str)
-#else
-  c.fsw f11, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x24, Zcf_c_fsw_cg_cp_imm_mul_b0x24_str)
 
@@ -674,18 +440,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x28:
   c.fsw f15, 40(x10) # perform store
   addi x10, x10, 40 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zcf_c_fsw_cg_cp_imm_mul_b0x28, Zcf_c_fsw_cg_cp_imm_mul_b0x28_str)
-#else
-  c.fsw f15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x28, Zcf_c_fsw_cg_cp_imm_mul_b0x28_str)
 
@@ -698,18 +455,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x2c:
   c.fsw f14, 44(x12) # perform store
   addi x12, x12, 44 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zcf_c_fsw_cg_cp_imm_mul_b0x2c, Zcf_c_fsw_cg_cp_imm_mul_b0x2c_str)
-#else
-  c.fsw f14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x2c, Zcf_c_fsw_cg_cp_imm_mul_b0x2c_str)
 
@@ -722,18 +470,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x30:
   c.fsw f10, 48(x13) # perform store
   addi x13, x13, 48 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zcf_c_fsw_cg_cp_imm_mul_b0x30, Zcf_c_fsw_cg_cp_imm_mul_b0x30_str)
-#else
-  c.fsw f10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x30, Zcf_c_fsw_cg_cp_imm_mul_b0x30_str)
 
@@ -746,18 +485,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x34:
   c.fsw f12, 52(x9) # perform store
   addi x9, x9, 52 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zcf_c_fsw_cg_cp_imm_mul_b0x34, Zcf_c_fsw_cg_cp_imm_mul_b0x34_str)
-#else
-  c.fsw f12, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x34, Zcf_c_fsw_cg_cp_imm_mul_b0x34_str)
 
@@ -770,18 +500,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x38:
   c.fsw f10, 56(x11) # perform store
   addi x11, x11, 56 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, Zcf_c_fsw_cg_cp_imm_mul_b0x38, Zcf_c_fsw_cg_cp_imm_mul_b0x38_str)
-#else
-  c.fsw f10, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x38, Zcf_c_fsw_cg_cp_imm_mul_b0x38_str)
 
@@ -794,18 +515,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x3c:
   c.fsw f8, 60(x10) # perform store
   addi x10, x10, 60 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zcf_c_fsw_cg_cp_imm_mul_b0x3c, Zcf_c_fsw_cg_cp_imm_mul_b0x3c_str)
-#else
-  c.fsw f8, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x3c, Zcf_c_fsw_cg_cp_imm_mul_b0x3c_str)
 
@@ -818,18 +530,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x40:
   c.fsw f15, 64(x13) # perform store
   addi x13, x13, 64 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, Zcf_c_fsw_cg_cp_imm_mul_b0x40, Zcf_c_fsw_cg_cp_imm_mul_b0x40_str)
-#else
-  c.fsw f15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x40, Zcf_c_fsw_cg_cp_imm_mul_b0x40_str)
 
@@ -842,18 +545,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x44:
   c.fsw f12, 68(x12) # perform store
   addi x12, x12, 68 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zcf_c_fsw_cg_cp_imm_mul_b0x44, Zcf_c_fsw_cg_cp_imm_mul_b0x44_str)
-#else
-  c.fsw f12, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x44, Zcf_c_fsw_cg_cp_imm_mul_b0x44_str)
 
@@ -866,18 +560,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x48:
   c.fsw f11, 72(x11) # perform store
   addi x11, x11, 72 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zcf_c_fsw_cg_cp_imm_mul_b0x48, Zcf_c_fsw_cg_cp_imm_mul_b0x48_str)
-#else
-  c.fsw f11, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x48, Zcf_c_fsw_cg_cp_imm_mul_b0x48_str)
 
@@ -890,18 +575,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x4c:
   c.fsw f15, 76(x13) # perform store
   addi x13, x13, 76 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x10 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x10, Zcf_c_fsw_cg_cp_imm_mul_b0x4c, Zcf_c_fsw_cg_cp_imm_mul_b0x4c_str)
-#else
-  c.fsw f15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x4c, Zcf_c_fsw_cg_cp_imm_mul_b0x4c_str)
 
@@ -914,18 +590,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x50:
   c.fsw f12, 80(x8) # perform store
   addi x8, x8, 80 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zcf_c_fsw_cg_cp_imm_mul_b0x50, Zcf_c_fsw_cg_cp_imm_mul_b0x50_str)
-#else
-  c.fsw f12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x50, Zcf_c_fsw_cg_cp_imm_mul_b0x50_str)
 
@@ -938,18 +605,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x54:
   c.fsw f15, 84(x11) # perform store
   addi x11, x11, 84 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zcf_c_fsw_cg_cp_imm_mul_b0x54, Zcf_c_fsw_cg_cp_imm_mul_b0x54_str)
-#else
-  c.fsw f15, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x54, Zcf_c_fsw_cg_cp_imm_mul_b0x54_str)
 
@@ -962,18 +620,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x58:
   c.fsw f9, 88(x10) # perform store
   addi x10, x10, 88 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zcf_c_fsw_cg_cp_imm_mul_b0x58, Zcf_c_fsw_cg_cp_imm_mul_b0x58_str)
-#else
-  c.fsw f9, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x58, Zcf_c_fsw_cg_cp_imm_mul_b0x58_str)
 
@@ -986,18 +635,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x5c:
   c.fsw f15, 92(x12) # perform store
   addi x12, x12, 92 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zcf_c_fsw_cg_cp_imm_mul_b0x5c, Zcf_c_fsw_cg_cp_imm_mul_b0x5c_str)
-#else
-  c.fsw f15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x5c, Zcf_c_fsw_cg_cp_imm_mul_b0x5c_str)
 
@@ -1010,18 +650,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x60:
   c.fsw f10, 96(x14) # perform store
   addi x14, x14, 96 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zcf_c_fsw_cg_cp_imm_mul_b0x60, Zcf_c_fsw_cg_cp_imm_mul_b0x60_str)
-#else
-  c.fsw f10, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x60, Zcf_c_fsw_cg_cp_imm_mul_b0x60_str)
 
@@ -1034,18 +665,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x64:
   c.fsw f8, 100(x8) # perform store
   addi x8, x8, 100 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, Zcf_c_fsw_cg_cp_imm_mul_b0x64, Zcf_c_fsw_cg_cp_imm_mul_b0x64_str)
-#else
-  c.fsw f8, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x64, Zcf_c_fsw_cg_cp_imm_mul_b0x64_str)
 
@@ -1058,18 +680,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x68:
   c.fsw f12, 104(x15) # perform store
   addi x15, x15, 104 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, Zcf_c_fsw_cg_cp_imm_mul_b0x68, Zcf_c_fsw_cg_cp_imm_mul_b0x68_str)
-#else
-  c.fsw f12, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x68, Zcf_c_fsw_cg_cp_imm_mul_b0x68_str)
 
@@ -1082,18 +695,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x6c:
   c.fsw f12, 108(x14) # perform store
   addi x14, x14, 108 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zcf_c_fsw_cg_cp_imm_mul_b0x6c, Zcf_c_fsw_cg_cp_imm_mul_b0x6c_str)
-#else
-  c.fsw f12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x6c, Zcf_c_fsw_cg_cp_imm_mul_b0x6c_str)
 
@@ -1106,18 +710,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x70:
   c.fsw f12, 112(x12) # perform store
   addi x12, x12, 112 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x13 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x13, Zcf_c_fsw_cg_cp_imm_mul_b0x70, Zcf_c_fsw_cg_cp_imm_mul_b0x70_str)
-#else
-  c.fsw f12, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x70, Zcf_c_fsw_cg_cp_imm_mul_b0x70_str)
 
@@ -1130,18 +725,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x74:
   c.fsw f9, 116(x10) # perform store
   addi x10, x10, 116 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x11 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x11, Zcf_c_fsw_cg_cp_imm_mul_b0x74, Zcf_c_fsw_cg_cp_imm_mul_b0x74_str)
-#else
-  c.fsw f9, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x74, Zcf_c_fsw_cg_cp_imm_mul_b0x74_str)
 
@@ -1154,18 +740,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x78:
   c.fsw f9, 120(x14) # perform store
   addi x14, x14, 120 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zcf_c_fsw_cg_cp_imm_mul_b0x78, Zcf_c_fsw_cg_cp_imm_mul_b0x78_str)
-#else
-  c.fsw f9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x78, Zcf_c_fsw_cg_cp_imm_mul_b0x78_str)
 
@@ -1178,18 +755,9 @@ Zcf_c_fsw_cg_cp_imm_mul_b0x7c:
   c.fsw f8, 124(x9) # perform store
   addi x9, x9, 124 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zcf_c_fsw_cg_cp_imm_mul_b0x7c, Zcf_c_fsw_cg_cp_imm_mul_b0x7c_str)
-#else
-  c.fsw f8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcf_c_fsw_cg_cp_imm_mul_b0x7c, Zcf_c_fsw_cg_cp_imm_mul_b0x7c_str)
 

--- a/tests/rv32i/Zfbfmin/Zfbfmin-fsh-00.S
+++ b/tests/rv32i/Zfbfmin/Zfbfmin-fsh-00.S
@@ -42,18 +42,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b1:
   fsh f17, -1914(x1) # perform store
   addi x1, x1, -1914 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x26 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x26, Zfbfmin_fsh_cg_cp_rs1_nx0_b1, Zfbfmin_fsh_cg_cp_rs1_nx0_b1_str)
-#else
-  fsh f17, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b1, Zfbfmin_fsh_cg_cp_rs1_nx0_b1_str)
 
@@ -66,18 +57,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b2:
   fsh f25, -1176(x2) # perform store
   addi x2, x2, -1176 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x17 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x17, Zfbfmin_fsh_cg_cp_rs1_nx0_b2, Zfbfmin_fsh_cg_cp_rs1_nx0_b2_str)
-#else
-  fsh f25, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b2, Zfbfmin_fsh_cg_cp_rs1_nx0_b2_str)
 
@@ -91,18 +73,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b3:
   fsh f29, -1263(x3) # perform store
   addi x3, x3, -1263 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x23 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x23, Zfbfmin_fsh_cg_cp_rs1_nx0_b3, Zfbfmin_fsh_cg_cp_rs1_nx0_b3_str)
-#else
-  fsh f29, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b3, Zfbfmin_fsh_cg_cp_rs1_nx0_b3_str)
 
@@ -117,18 +90,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b4:
   fsh f27, 1644(x4) # perform store
   addi x4, x4, 1644 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x10 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x10, Zfbfmin_fsh_cg_cp_rs1_nx0_b4, Zfbfmin_fsh_cg_cp_rs1_nx0_b4_str)
-#else
-  fsh f27, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x4, x8, x7, Zfbfmin_fsh_cg_cp_rs1_nx0_b4, Zfbfmin_fsh_cg_cp_rs1_nx0_b4_str)
 
@@ -141,18 +105,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b5:
   fsh f3, -167(x5) # perform store
   addi x5, x5, -167 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x31 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x31, Zfbfmin_fsh_cg_cp_rs1_nx0_b5, Zfbfmin_fsh_cg_cp_rs1_nx0_b5_str)
-#else
-  fsh f3, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x5, x8, x7, Zfbfmin_fsh_cg_cp_rs1_nx0_b5, Zfbfmin_fsh_cg_cp_rs1_nx0_b5_str)
 
@@ -165,18 +120,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b6:
   fsh f14, -352(x6) # perform store
   addi x6, x6, -352 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zfbfmin_fsh_cg_cp_rs1_nx0_b6, Zfbfmin_fsh_cg_cp_rs1_nx0_b6_str)
-#else
-  fsh f14, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x8, x7, Zfbfmin_fsh_cg_cp_rs1_nx0_b6, Zfbfmin_fsh_cg_cp_rs1_nx0_b6_str)
 
@@ -191,18 +137,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b7:
   fsh f28, -494(x7) # perform store
   addi x7, x7, -494 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x12 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x12, Zfbfmin_fsh_cg_cp_rs1_nx0_b7, Zfbfmin_fsh_cg_cp_rs1_nx0_b7_str)
-#else
-  fsh f28, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b7, Zfbfmin_fsh_cg_cp_rs1_nx0_b7_str)
 
@@ -215,18 +152,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b8:
   fsh f26, 391(x8) # perform store
   addi x8, x8, 391 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, Zfbfmin_fsh_cg_cp_rs1_nx0_b8, Zfbfmin_fsh_cg_cp_rs1_nx0_b8_str)
-#else
-  fsh f26, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b8, Zfbfmin_fsh_cg_cp_rs1_nx0_b8_str)
 
@@ -239,18 +167,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b9:
   fsh f10, -1761(x9) # perform store
   addi x9, x9, -1761 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zfbfmin_fsh_cg_cp_rs1_nx0_b9, Zfbfmin_fsh_cg_cp_rs1_nx0_b9_str)
-#else
-  fsh f10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b9, Zfbfmin_fsh_cg_cp_rs1_nx0_b9_str)
 
@@ -263,18 +182,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b10:
   fsh f6, -1585(x10) # perform store
   addi x10, x10, -1585 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x16 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x16, Zfbfmin_fsh_cg_cp_rs1_nx0_b10, Zfbfmin_fsh_cg_cp_rs1_nx0_b10_str)
-#else
-  fsh f6, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b10, Zfbfmin_fsh_cg_cp_rs1_nx0_b10_str)
 
@@ -287,18 +197,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b11:
   fsh f30, -1102(x11) # perform store
   addi x11, x11, -1102 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, Zfbfmin_fsh_cg_cp_rs1_nx0_b11, Zfbfmin_fsh_cg_cp_rs1_nx0_b11_str)
-#else
-  fsh f30, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b11, Zfbfmin_fsh_cg_cp_rs1_nx0_b11_str)
 
@@ -311,18 +212,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b12:
   fsh f18, -658(x12) # perform store
   addi x12, x12, -658 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x1 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x1, Zfbfmin_fsh_cg_cp_rs1_nx0_b12, Zfbfmin_fsh_cg_cp_rs1_nx0_b12_str)
-#else
-  fsh f18, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b12, Zfbfmin_fsh_cg_cp_rs1_nx0_b12_str)
 
@@ -335,18 +227,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b13:
   fsh f18, 727(x13) # perform store
   addi x13, x13, 727 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x1 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x1, Zfbfmin_fsh_cg_cp_rs1_nx0_b13, Zfbfmin_fsh_cg_cp_rs1_nx0_b13_str)
-#else
-  fsh f18, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b13, Zfbfmin_fsh_cg_cp_rs1_nx0_b13_str)
 
@@ -359,18 +242,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b14:
   fsh f19, -840(x14) # perform store
   addi x14, x14, -840 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zfbfmin_fsh_cg_cp_rs1_nx0_b14, Zfbfmin_fsh_cg_cp_rs1_nx0_b14_str)
-#else
-  fsh f19, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b14, Zfbfmin_fsh_cg_cp_rs1_nx0_b14_str)
 
@@ -383,18 +257,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b15:
   fsh f5, -1623(x15) # perform store
   addi x15, x15, -1623 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x7 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x7, Zfbfmin_fsh_cg_cp_rs1_nx0_b15, Zfbfmin_fsh_cg_cp_rs1_nx0_b15_str)
-#else
-  fsh f5, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b15, Zfbfmin_fsh_cg_cp_rs1_nx0_b15_str)
 
@@ -407,18 +272,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b16:
   fsh f13, 246(x16) # perform store
   addi x16, x16, 246 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x31 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x31, Zfbfmin_fsh_cg_cp_rs1_nx0_b16, Zfbfmin_fsh_cg_cp_rs1_nx0_b16_str)
-#else
-  fsh f13, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b16, Zfbfmin_fsh_cg_cp_rs1_nx0_b16_str)
 
@@ -431,18 +287,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b17:
   fsh f23, 1189(x17) # perform store
   addi x17, x17, 1189 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x6 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x6, Zfbfmin_fsh_cg_cp_rs1_nx0_b17, Zfbfmin_fsh_cg_cp_rs1_nx0_b17_str)
-#else
-  fsh f23, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b17, Zfbfmin_fsh_cg_cp_rs1_nx0_b17_str)
 
@@ -456,18 +303,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b18:
   fsh f18, 58(x18) # perform store
   addi x18, x18, 58 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zfbfmin_fsh_cg_cp_rs1_nx0_b18, Zfbfmin_fsh_cg_cp_rs1_nx0_b18_str)
-#else
-  fsh f18, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b18, Zfbfmin_fsh_cg_cp_rs1_nx0_b18_str)
 
@@ -480,18 +318,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b19:
   fsh f5, -1767(x19) # perform store
   addi x19, x19, -1767 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x9 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x9, Zfbfmin_fsh_cg_cp_rs1_nx0_b19, Zfbfmin_fsh_cg_cp_rs1_nx0_b19_str)
-#else
-  fsh f5, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b19, Zfbfmin_fsh_cg_cp_rs1_nx0_b19_str)
 
@@ -504,18 +333,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b20:
   fsh f25, -144(x20) # perform store
   addi x20, x20, -144 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x28 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x28, Zfbfmin_fsh_cg_cp_rs1_nx0_b20, Zfbfmin_fsh_cg_cp_rs1_nx0_b20_str)
-#else
-  fsh f25, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b20, Zfbfmin_fsh_cg_cp_rs1_nx0_b20_str)
 
@@ -528,18 +348,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b21:
   fsh f28, 725(x21) # perform store
   addi x21, x21, 725 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x17 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x17, Zfbfmin_fsh_cg_cp_rs1_nx0_b21, Zfbfmin_fsh_cg_cp_rs1_nx0_b21_str)
-#else
-  fsh f28, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b21, Zfbfmin_fsh_cg_cp_rs1_nx0_b21_str)
 
@@ -552,18 +363,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b22:
   fsh f0, -575(x22) # perform store
   addi x22, x22, -575 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x13 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x13, Zfbfmin_fsh_cg_cp_rs1_nx0_b22, Zfbfmin_fsh_cg_cp_rs1_nx0_b22_str)
-#else
-  fsh f0, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b22, Zfbfmin_fsh_cg_cp_rs1_nx0_b22_str)
 
@@ -576,18 +378,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b23:
   fsh f21, 445(x23) # perform store
   addi x23, x23, 445 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x31 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x31, Zfbfmin_fsh_cg_cp_rs1_nx0_b23, Zfbfmin_fsh_cg_cp_rs1_nx0_b23_str)
-#else
-  fsh f21, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b23, Zfbfmin_fsh_cg_cp_rs1_nx0_b23_str)
 
@@ -600,18 +393,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b24:
   fsh f14, 333(x24) # perform store
   addi x24, x24, 333 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x3 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x3, Zfbfmin_fsh_cg_cp_rs1_nx0_b24, Zfbfmin_fsh_cg_cp_rs1_nx0_b24_str)
-#else
-  fsh f14, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b24, Zfbfmin_fsh_cg_cp_rs1_nx0_b24_str)
 
@@ -624,18 +408,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b25:
   fsh f15, 355(x25) # perform store
   addi x25, x25, 355 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x9 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x9, Zfbfmin_fsh_cg_cp_rs1_nx0_b25, Zfbfmin_fsh_cg_cp_rs1_nx0_b25_str)
-#else
-  fsh f15, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b25, Zfbfmin_fsh_cg_cp_rs1_nx0_b25_str)
 
@@ -648,18 +423,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b26:
   fsh f16, 771(x26) # perform store
   addi x26, x26, 771 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x6 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x6, Zfbfmin_fsh_cg_cp_rs1_nx0_b26, Zfbfmin_fsh_cg_cp_rs1_nx0_b26_str)
-#else
-  fsh f16, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b26, Zfbfmin_fsh_cg_cp_rs1_nx0_b26_str)
 
@@ -672,18 +438,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b27:
   fsh f1, -12(x27) # perform store
   addi x27, x27, -12 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x14 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x14, Zfbfmin_fsh_cg_cp_rs1_nx0_b27, Zfbfmin_fsh_cg_cp_rs1_nx0_b27_str)
-#else
-  fsh f1, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b27, Zfbfmin_fsh_cg_cp_rs1_nx0_b27_str)
 
@@ -696,18 +453,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b28:
   fsh f19, -1219(x28) # perform store
   addi x28, x28, -1219 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x20 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x20, Zfbfmin_fsh_cg_cp_rs1_nx0_b28, Zfbfmin_fsh_cg_cp_rs1_nx0_b28_str)
-#else
-  fsh f19, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b28, Zfbfmin_fsh_cg_cp_rs1_nx0_b28_str)
 
@@ -720,18 +468,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b29:
   fsh f17, -1518(x29) # perform store
   addi x29, x29, -1518 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x9 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x9, Zfbfmin_fsh_cg_cp_rs1_nx0_b29, Zfbfmin_fsh_cg_cp_rs1_nx0_b29_str)
-#else
-  fsh f17, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b29, Zfbfmin_fsh_cg_cp_rs1_nx0_b29_str)
 
@@ -744,18 +483,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b30:
   fsh f9, -1795(x30) # perform store
   addi x30, x30, -1795 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x14 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x14, Zfbfmin_fsh_cg_cp_rs1_nx0_b30, Zfbfmin_fsh_cg_cp_rs1_nx0_b30_str)
-#else
-  fsh f9, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b30, Zfbfmin_fsh_cg_cp_rs1_nx0_b30_str)
 
@@ -768,18 +498,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b31:
   fsh f16, 803(x31) # perform store
   addi x31, x31, 803 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x14 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x14, Zfbfmin_fsh_cg_cp_rs1_nx0_b31, Zfbfmin_fsh_cg_cp_rs1_nx0_b31_str)
-#else
-  fsh f16, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b31, Zfbfmin_fsh_cg_cp_rs1_nx0_b31_str)
 
@@ -796,18 +517,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x0:
   fsh f17, 0(x21) # perform store
   addi x21, x21, 0 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x19 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x19, Zfbfmin_fsh_cg_cp_imm_edges_0x0, Zfbfmin_fsh_cg_cp_imm_edges_0x0_str)
-#else
-  fsh f17, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x0, Zfbfmin_fsh_cg_cp_imm_edges_0x0_str)
 
@@ -820,18 +532,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x1:
   fsh f6, 1(x29) # perform store
   addi x29, x29, 1 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x27 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x27, Zfbfmin_fsh_cg_cp_imm_edges_0x1, Zfbfmin_fsh_cg_cp_imm_edges_0x1_str)
-#else
-  fsh f6, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x1, Zfbfmin_fsh_cg_cp_imm_edges_0x1_str)
 
@@ -844,18 +547,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x2:
   fsh f5, 2(x2) # perform store
   addi x2, x2, 2 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zfbfmin_fsh_cg_cp_imm_edges_0x2, Zfbfmin_fsh_cg_cp_imm_edges_0x2_str)
-#else
-  fsh f5, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x2, Zfbfmin_fsh_cg_cp_imm_edges_0x2_str)
 
@@ -868,18 +562,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x3:
   fsh f6, 3(x29) # perform store
   addi x29, x29, 3 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x27 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x27, Zfbfmin_fsh_cg_cp_imm_edges_0x3, Zfbfmin_fsh_cg_cp_imm_edges_0x3_str)
-#else
-  fsh f6, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x3, Zfbfmin_fsh_cg_cp_imm_edges_0x3_str)
 
@@ -892,18 +577,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x4:
   fsh f30, 4(x3) # perform store
   addi x3, x3, 4 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x18 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x18, Zfbfmin_fsh_cg_cp_imm_edges_0x4, Zfbfmin_fsh_cg_cp_imm_edges_0x4_str)
-#else
-  fsh f30, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x4, Zfbfmin_fsh_cg_cp_imm_edges_0x4_str)
 
@@ -916,18 +592,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x8:
   fsh f19, 8(x2) # perform store
   addi x2, x2, 8 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x17 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x17, Zfbfmin_fsh_cg_cp_imm_edges_0x8, Zfbfmin_fsh_cg_cp_imm_edges_0x8_str)
-#else
-  fsh f19, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x8, Zfbfmin_fsh_cg_cp_imm_edges_0x8_str)
 
@@ -940,18 +607,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x10:
   fsh f11, 16(x24) # perform store
   addi x24, x24, 16 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x18 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x18, Zfbfmin_fsh_cg_cp_imm_edges_0x10, Zfbfmin_fsh_cg_cp_imm_edges_0x10_str)
-#else
-  fsh f11, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x10, Zfbfmin_fsh_cg_cp_imm_edges_0x10_str)
 
@@ -964,18 +622,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x20:
   fsh f25, 32(x26) # perform store
   addi x26, x26, 32 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x16 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x16, Zfbfmin_fsh_cg_cp_imm_edges_0x20, Zfbfmin_fsh_cg_cp_imm_edges_0x20_str)
-#else
-  fsh f25, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x20, Zfbfmin_fsh_cg_cp_imm_edges_0x20_str)
 
@@ -988,18 +637,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x40:
   fsh f13, 64(x31) # perform store
   addi x31, x31, 64 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x14 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x14, Zfbfmin_fsh_cg_cp_imm_edges_0x40, Zfbfmin_fsh_cg_cp_imm_edges_0x40_str)
-#else
-  fsh f13, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x40, Zfbfmin_fsh_cg_cp_imm_edges_0x40_str)
 
@@ -1012,18 +652,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x80:
   fsh f18, 128(x26) # perform store
   addi x26, x26, 128 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x9 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x9, Zfbfmin_fsh_cg_cp_imm_edges_0x80, Zfbfmin_fsh_cg_cp_imm_edges_0x80_str)
-#else
-  fsh f18, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x80, Zfbfmin_fsh_cg_cp_imm_edges_0x80_str)
 
@@ -1036,18 +667,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x100:
   fsh f27, 256(x31) # perform store
   addi x31, x31, 256 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x11 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x11, Zfbfmin_fsh_cg_cp_imm_edges_0x100, Zfbfmin_fsh_cg_cp_imm_edges_0x100_str)
-#else
-  fsh f27, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x100, Zfbfmin_fsh_cg_cp_imm_edges_0x100_str)
 
@@ -1060,18 +682,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x200:
   fsh f22, 512(x12) # perform store
   addi x12, x12, 512 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x27 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x27, Zfbfmin_fsh_cg_cp_imm_edges_0x200, Zfbfmin_fsh_cg_cp_imm_edges_0x200_str)
-#else
-  fsh f22, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x200, Zfbfmin_fsh_cg_cp_imm_edges_0x200_str)
 
@@ -1084,18 +697,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x3ff:
   fsh f31, 1023(x22) # perform store
   addi x22, x22, 1023 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x23 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x23, Zfbfmin_fsh_cg_cp_imm_edges_0x3ff, Zfbfmin_fsh_cg_cp_imm_edges_0x3ff_str)
-#else
-  fsh f31, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x3ff, Zfbfmin_fsh_cg_cp_imm_edges_0x3ff_str)
 
@@ -1108,18 +712,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x400:
   fsh f14, 1024(x12) # perform store
   addi x12, x12, 1024 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x6 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x6, Zfbfmin_fsh_cg_cp_imm_edges_0x400, Zfbfmin_fsh_cg_cp_imm_edges_0x400_str)
-#else
-  fsh f14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x400, Zfbfmin_fsh_cg_cp_imm_edges_0x400_str)
 
@@ -1132,18 +727,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x703:
   fsh f13, 1795(x21) # perform store
   addi x21, x21, 1795 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x16 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x16, Zfbfmin_fsh_cg_cp_imm_edges_0x703, Zfbfmin_fsh_cg_cp_imm_edges_0x703_str)
-#else
-  fsh f13, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x703, Zfbfmin_fsh_cg_cp_imm_edges_0x703_str)
 
@@ -1156,18 +742,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x7ff:
   fsh f26, 2047(x8) # perform store
   addi x8, x8, 2047 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x18 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x18, Zfbfmin_fsh_cg_cp_imm_edges_0x7ff, Zfbfmin_fsh_cg_cp_imm_edges_0x7ff_str)
-#else
-  fsh f26, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x7ff, Zfbfmin_fsh_cg_cp_imm_edges_0x7ff_str)
 
@@ -1181,18 +758,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_m0x800:
   fsh f10, -2048(x16) # perform store
   addi x16, x16, -2048 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x22 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x22, Zfbfmin_fsh_cg_cp_imm_edges_m0x800, Zfbfmin_fsh_cg_cp_imm_edges_m0x800_str)
-#else
-  fsh f10, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_m0x800, Zfbfmin_fsh_cg_cp_imm_edges_m0x800_str)
 
@@ -1205,18 +773,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_m0x7ff:
   fsh f30, -2047(x28) # perform store
   addi x28, x28, -2047 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x23 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x23, Zfbfmin_fsh_cg_cp_imm_edges_m0x7ff, Zfbfmin_fsh_cg_cp_imm_edges_m0x7ff_str)
-#else
-  fsh f30, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_m0x7ff, Zfbfmin_fsh_cg_cp_imm_edges_m0x7ff_str)
 
@@ -1229,18 +788,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_m0x2:
   fsh f19, -2(x7) # perform store
   addi x7, x7, -2 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x6 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x6, Zfbfmin_fsh_cg_cp_imm_edges_m0x2, Zfbfmin_fsh_cg_cp_imm_edges_m0x2_str)
-#else
-  fsh f19, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_m0x2, Zfbfmin_fsh_cg_cp_imm_edges_m0x2_str)
 
@@ -1253,18 +803,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_m0x1:
   fsh f2, -1(x23) # perform store
   addi x23, x23, -1 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x27 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x27, Zfbfmin_fsh_cg_cp_imm_edges_m0x1, Zfbfmin_fsh_cg_cp_imm_edges_m0x1_str)
-#else
-  fsh f2, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_m0x1, Zfbfmin_fsh_cg_cp_imm_edges_m0x1_str)
 
@@ -1281,18 +822,9 @@ Zfbfmin_fsh_cg_cp_fs2_b0:
   fsh f0, 422(x17) # perform store
   addi x17, x17, 422 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x12 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x12, Zfbfmin_fsh_cg_cp_fs2_b0, Zfbfmin_fsh_cg_cp_fs2_b0_str)
-#else
-  fsh f0, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b0, Zfbfmin_fsh_cg_cp_fs2_b0_str)
 
@@ -1305,18 +837,9 @@ Zfbfmin_fsh_cg_cp_fs2_b1:
   fsh f1, 1493(x10) # perform store
   addi x10, x10, 1493 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x31 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x31, Zfbfmin_fsh_cg_cp_fs2_b1, Zfbfmin_fsh_cg_cp_fs2_b1_str)
-#else
-  fsh f1, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b1, Zfbfmin_fsh_cg_cp_fs2_b1_str)
 
@@ -1329,18 +852,9 @@ Zfbfmin_fsh_cg_cp_fs2_b2:
   fsh f2, 2040(x25) # perform store
   addi x25, x25, 2040 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x21 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x21, Zfbfmin_fsh_cg_cp_fs2_b2, Zfbfmin_fsh_cg_cp_fs2_b2_str)
-#else
-  fsh f2, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b2, Zfbfmin_fsh_cg_cp_fs2_b2_str)
 
@@ -1353,18 +867,9 @@ Zfbfmin_fsh_cg_cp_fs2_b3:
   fsh f3, 397(x17) # perform store
   addi x17, x17, 397 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x26 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x26, Zfbfmin_fsh_cg_cp_fs2_b3, Zfbfmin_fsh_cg_cp_fs2_b3_str)
-#else
-  fsh f3, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b3, Zfbfmin_fsh_cg_cp_fs2_b3_str)
 
@@ -1377,18 +882,9 @@ Zfbfmin_fsh_cg_cp_fs2_b4:
   fsh f4, 1550(x14) # perform store
   addi x14, x14, 1550 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, Zfbfmin_fsh_cg_cp_fs2_b4, Zfbfmin_fsh_cg_cp_fs2_b4_str)
-#else
-  fsh f4, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b4, Zfbfmin_fsh_cg_cp_fs2_b4_str)
 
@@ -1401,18 +897,9 @@ Zfbfmin_fsh_cg_cp_fs2_b5:
   fsh f5, 576(x20) # perform store
   addi x20, x20, 576 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x26 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x26, Zfbfmin_fsh_cg_cp_fs2_b5, Zfbfmin_fsh_cg_cp_fs2_b5_str)
-#else
-  fsh f5, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b5, Zfbfmin_fsh_cg_cp_fs2_b5_str)
 
@@ -1425,18 +912,9 @@ Zfbfmin_fsh_cg_cp_fs2_b6:
   fsh f6, -427(x19) # perform store
   addi x19, x19, -427 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x26 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x26, Zfbfmin_fsh_cg_cp_fs2_b6, Zfbfmin_fsh_cg_cp_fs2_b6_str)
-#else
-  fsh f6, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b6, Zfbfmin_fsh_cg_cp_fs2_b6_str)
 
@@ -1449,18 +927,9 @@ Zfbfmin_fsh_cg_cp_fs2_b7:
   fsh f7, -1960(x13) # perform store
   addi x13, x13, -1960 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x17 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x17, Zfbfmin_fsh_cg_cp_fs2_b7, Zfbfmin_fsh_cg_cp_fs2_b7_str)
-#else
-  fsh f7, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b7, Zfbfmin_fsh_cg_cp_fs2_b7_str)
 
@@ -1473,18 +942,9 @@ Zfbfmin_fsh_cg_cp_fs2_b8:
   fsh f8, -1731(x11) # perform store
   addi x11, x11, -1731 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zfbfmin_fsh_cg_cp_fs2_b8, Zfbfmin_fsh_cg_cp_fs2_b8_str)
-#else
-  fsh f8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b8, Zfbfmin_fsh_cg_cp_fs2_b8_str)
 
@@ -1497,18 +957,9 @@ Zfbfmin_fsh_cg_cp_fs2_b9:
   fsh f9, -347(x30) # perform store
   addi x30, x30, -347 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x29 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x29, Zfbfmin_fsh_cg_cp_fs2_b9, Zfbfmin_fsh_cg_cp_fs2_b9_str)
-#else
-  fsh f9, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b9, Zfbfmin_fsh_cg_cp_fs2_b9_str)
 
@@ -1521,18 +972,9 @@ Zfbfmin_fsh_cg_cp_fs2_b10:
   fsh f10, -1112(x20) # perform store
   addi x20, x20, -1112 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x17 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x17, Zfbfmin_fsh_cg_cp_fs2_b10, Zfbfmin_fsh_cg_cp_fs2_b10_str)
-#else
-  fsh f10, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b10, Zfbfmin_fsh_cg_cp_fs2_b10_str)
 
@@ -1545,18 +987,9 @@ Zfbfmin_fsh_cg_cp_fs2_b11:
   fsh f11, 163(x14) # perform store
   addi x14, x14, 163 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zfbfmin_fsh_cg_cp_fs2_b11, Zfbfmin_fsh_cg_cp_fs2_b11_str)
-#else
-  fsh f11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b11, Zfbfmin_fsh_cg_cp_fs2_b11_str)
 
@@ -1569,18 +1002,9 @@ Zfbfmin_fsh_cg_cp_fs2_b12:
   fsh f12, -838(x29) # perform store
   addi x29, x29, -838 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x17 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x17, Zfbfmin_fsh_cg_cp_fs2_b12, Zfbfmin_fsh_cg_cp_fs2_b12_str)
-#else
-  fsh f12, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b12, Zfbfmin_fsh_cg_cp_fs2_b12_str)
 
@@ -1593,18 +1017,9 @@ Zfbfmin_fsh_cg_cp_fs2_b13:
   fsh f13, -651(x22) # perform store
   addi x22, x22, -651 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x12 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x12, Zfbfmin_fsh_cg_cp_fs2_b13, Zfbfmin_fsh_cg_cp_fs2_b13_str)
-#else
-  fsh f13, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b13, Zfbfmin_fsh_cg_cp_fs2_b13_str)
 
@@ -1617,18 +1032,9 @@ Zfbfmin_fsh_cg_cp_fs2_b14:
   fsh f14, 156(x29) # perform store
   addi x29, x29, 156 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x26 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x26, Zfbfmin_fsh_cg_cp_fs2_b14, Zfbfmin_fsh_cg_cp_fs2_b14_str)
-#else
-  fsh f14, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b14, Zfbfmin_fsh_cg_cp_fs2_b14_str)
 
@@ -1641,18 +1047,9 @@ Zfbfmin_fsh_cg_cp_fs2_b15:
   fsh f15, 1700(x25) # perform store
   addi x25, x25, 1700 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x3 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x3, Zfbfmin_fsh_cg_cp_fs2_b15, Zfbfmin_fsh_cg_cp_fs2_b15_str)
-#else
-  fsh f15, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b15, Zfbfmin_fsh_cg_cp_fs2_b15_str)
 
@@ -1665,18 +1062,9 @@ Zfbfmin_fsh_cg_cp_fs2_b16:
   fsh f16, -678(x8) # perform store
   addi x8, x8, -678 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x31 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x31, Zfbfmin_fsh_cg_cp_fs2_b16, Zfbfmin_fsh_cg_cp_fs2_b16_str)
-#else
-  fsh f16, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b16, Zfbfmin_fsh_cg_cp_fs2_b16_str)
 
@@ -1689,18 +1077,9 @@ Zfbfmin_fsh_cg_cp_fs2_b17:
   fsh f17, 1576(x12) # perform store
   addi x12, x12, 1576 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x28 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x28, Zfbfmin_fsh_cg_cp_fs2_b17, Zfbfmin_fsh_cg_cp_fs2_b17_str)
-#else
-  fsh f17, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b17, Zfbfmin_fsh_cg_cp_fs2_b17_str)
 
@@ -1713,18 +1092,9 @@ Zfbfmin_fsh_cg_cp_fs2_b18:
   fsh f18, 985(x9) # perform store
   addi x9, x9, 985 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zfbfmin_fsh_cg_cp_fs2_b18, Zfbfmin_fsh_cg_cp_fs2_b18_str)
-#else
-  fsh f18, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b18, Zfbfmin_fsh_cg_cp_fs2_b18_str)
 
@@ -1737,18 +1107,9 @@ Zfbfmin_fsh_cg_cp_fs2_b19:
   fsh f19, -608(x24) # perform store
   addi x24, x24, -608 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x30 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x30, Zfbfmin_fsh_cg_cp_fs2_b19, Zfbfmin_fsh_cg_cp_fs2_b19_str)
-#else
-  fsh f19, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b19, Zfbfmin_fsh_cg_cp_fs2_b19_str)
 
@@ -1761,18 +1122,9 @@ Zfbfmin_fsh_cg_cp_fs2_b20:
   fsh f20, 2035(x20) # perform store
   addi x20, x20, 2035 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x14 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x14, Zfbfmin_fsh_cg_cp_fs2_b20, Zfbfmin_fsh_cg_cp_fs2_b20_str)
-#else
-  fsh f20, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b20, Zfbfmin_fsh_cg_cp_fs2_b20_str)
 
@@ -1785,18 +1137,9 @@ Zfbfmin_fsh_cg_cp_fs2_b21:
   fsh f21, 991(x30) # perform store
   addi x30, x30, 991 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x10 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x10, Zfbfmin_fsh_cg_cp_fs2_b21, Zfbfmin_fsh_cg_cp_fs2_b21_str)
-#else
-  fsh f21, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b21, Zfbfmin_fsh_cg_cp_fs2_b21_str)
 
@@ -1809,18 +1152,9 @@ Zfbfmin_fsh_cg_cp_fs2_b22:
   fsh f22, -77(x29) # perform store
   addi x29, x29, -77 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x16 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x16, Zfbfmin_fsh_cg_cp_fs2_b22, Zfbfmin_fsh_cg_cp_fs2_b22_str)
-#else
-  fsh f22, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b22, Zfbfmin_fsh_cg_cp_fs2_b22_str)
 
@@ -1833,18 +1167,9 @@ Zfbfmin_fsh_cg_cp_fs2_b23:
   fsh f23, 1302(x6) # perform store
   addi x6, x6, 1302 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x9 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x9, Zfbfmin_fsh_cg_cp_fs2_b23, Zfbfmin_fsh_cg_cp_fs2_b23_str)
-#else
-  fsh f23, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b23, Zfbfmin_fsh_cg_cp_fs2_b23_str)
 
@@ -1857,18 +1182,9 @@ Zfbfmin_fsh_cg_cp_fs2_b24:
   fsh f24, -1825(x21) # perform store
   addi x21, x21, -1825 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x26 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x26, Zfbfmin_fsh_cg_cp_fs2_b24, Zfbfmin_fsh_cg_cp_fs2_b24_str)
-#else
-  fsh f24, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b24, Zfbfmin_fsh_cg_cp_fs2_b24_str)
 
@@ -1881,18 +1197,9 @@ Zfbfmin_fsh_cg_cp_fs2_b25:
   fsh f25, 257(x2) # perform store
   addi x2, x2, 257 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x7 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x7, Zfbfmin_fsh_cg_cp_fs2_b25, Zfbfmin_fsh_cg_cp_fs2_b25_str)
-#else
-  fsh f25, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b25, Zfbfmin_fsh_cg_cp_fs2_b25_str)
 
@@ -1905,18 +1212,9 @@ Zfbfmin_fsh_cg_cp_fs2_b26:
   fsh f26, -1411(x6) # perform store
   addi x6, x6, -1411 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x23 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x23, Zfbfmin_fsh_cg_cp_fs2_b26, Zfbfmin_fsh_cg_cp_fs2_b26_str)
-#else
-  fsh f26, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b26, Zfbfmin_fsh_cg_cp_fs2_b26_str)
 
@@ -1929,18 +1227,9 @@ Zfbfmin_fsh_cg_cp_fs2_b27:
   fsh f27, -950(x9) # perform store
   addi x9, x9, -950 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x22 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x22, Zfbfmin_fsh_cg_cp_fs2_b27, Zfbfmin_fsh_cg_cp_fs2_b27_str)
-#else
-  fsh f27, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b27, Zfbfmin_fsh_cg_cp_fs2_b27_str)
 
@@ -1953,18 +1242,9 @@ Zfbfmin_fsh_cg_cp_fs2_b28:
   fsh f28, 593(x23) # perform store
   addi x23, x23, 593 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x19 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x19, Zfbfmin_fsh_cg_cp_fs2_b28, Zfbfmin_fsh_cg_cp_fs2_b28_str)
-#else
-  fsh f28, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b28, Zfbfmin_fsh_cg_cp_fs2_b28_str)
 
@@ -1977,18 +1257,9 @@ Zfbfmin_fsh_cg_cp_fs2_b29:
   fsh f29, -799(x6) # perform store
   addi x6, x6, -799 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x1 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x1, Zfbfmin_fsh_cg_cp_fs2_b29, Zfbfmin_fsh_cg_cp_fs2_b29_str)
-#else
-  fsh f29, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b29, Zfbfmin_fsh_cg_cp_fs2_b29_str)
 
@@ -2001,18 +1272,9 @@ Zfbfmin_fsh_cg_cp_fs2_b30:
   fsh f30, 269(x25) # perform store
   addi x25, x25, 269 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x28 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x28, Zfbfmin_fsh_cg_cp_fs2_b30, Zfbfmin_fsh_cg_cp_fs2_b30_str)
-#else
-  fsh f30, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b30, Zfbfmin_fsh_cg_cp_fs2_b30_str)
 
@@ -2025,18 +1287,9 @@ Zfbfmin_fsh_cg_cp_fs2_b31:
   fsh f31, 1958(x8) # perform store
   addi x8, x8, 1958 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x30 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x30, Zfbfmin_fsh_cg_cp_fs2_b31, Zfbfmin_fsh_cg_cp_fs2_b31_str)
-#else
-  fsh f31, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b31, Zfbfmin_fsh_cg_cp_fs2_b31_str)
 
@@ -2053,18 +1306,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x0:
   fsh f15, 334(x18) # perform store
   addi x18, x18, 334 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x21, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x0, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x0_str)
-#else
-  fsh f15, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x0, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x0_str)
 
@@ -2077,18 +1321,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8000:
   fsh f27, 847(x7) # perform store
   addi x7, x7, 847 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x22 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x22, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8000, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8000_str)
-#else
-  fsh f27, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8000, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8000_str)
 
@@ -2101,18 +1336,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3c00:
   fsh f31, -380(x11) # perform store
   addi x11, x11, -380 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3c00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3c00_str)
-#else
-  fsh f31, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3c00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3c00_str)
 
@@ -2125,18 +1351,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbc00:
   fsh f23, -947(x29) # perform store
   addi x29, x29, -947 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x22 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x22, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbc00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbc00_str)
-#else
-  fsh f23, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbc00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbc00_str)
 
@@ -2149,18 +1366,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3e00:
   fsh f31, 1592(x23) # perform store
   addi x23, x23, 1592 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x28 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x28, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3e00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3e00_str)
-#else
-  fsh f31, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3e00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3e00_str)
 
@@ -2173,18 +1381,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbe00:
   fsh f16, -599(x16) # perform store
   addi x16, x16, -599 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x24 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x24, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbe00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbe00_str)
-#else
-  fsh f16, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbe00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbe00_str)
 
@@ -2197,18 +1396,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x4000:
   fsh f6, 1325(x22) # perform store
   addi x22, x22, 1325 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x14 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x14, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x4000, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x4000_str)
-#else
-  fsh f6, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x4000, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x4000_str)
 
@@ -2221,18 +1411,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc000:
   fsh f13, 756(x24) # perform store
   addi x24, x24, 756 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x6 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x6, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc000, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc000_str)
-#else
-  fsh f13, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc000, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc000_str)
 
@@ -2245,18 +1426,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x400:
   fsh f17, -1411(x18) # perform store
   addi x18, x18, -1411 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x30 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x30, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x400, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x400_str)
-#else
-  fsh f17, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x400, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x400_str)
 
@@ -2269,18 +1441,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8400:
   fsh f12, 202(x14) # perform store
   addi x14, x14, 202 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8400, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8400_str)
-#else
-  fsh f12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8400, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8400_str)
 
@@ -2293,18 +1456,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7bff:
   fsh f20, 1405(x25) # perform store
   addi x25, x25, 1405 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x3 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x3, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7bff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7bff_str)
-#else
-  fsh f20, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7bff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7bff_str)
 
@@ -2317,18 +1471,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfbff:
   fsh f13, -329(x14) # perform store
   addi x14, x14, -329 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x1 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x1, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfbff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfbff_str)
-#else
-  fsh f13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfbff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfbff_str)
 
@@ -2341,18 +1486,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3ff:
   fsh f24, 1521(x6) # perform store
   addi x6, x6, 1521 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x22 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x22, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3ff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3ff_str)
-#else
-  fsh f24, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3ff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3ff_str)
 
@@ -2365,18 +1501,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x83ff:
   fsh f14, -911(x22) # perform store
   addi x22, x22, -911 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x12 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x12, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x83ff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x83ff_str)
-#else
-  fsh f14, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x83ff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x83ff_str)
 
@@ -2389,18 +1516,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x200:
   fsh f15, -380(x11) # perform store
   addi x11, x11, -380 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x1 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x1, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x200, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x200_str)
-#else
-  fsh f15, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x200, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x200_str)
 
@@ -2413,18 +1531,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8200:
   fsh f17, 1530(x9) # perform store
   addi x9, x9, 1530 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x23 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x23, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8200, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8200_str)
-#else
-  fsh f17, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8200, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8200_str)
 
@@ -2437,18 +1546,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x1:
   fsh f28, 1545(x3) # perform store
   addi x3, x3, 1545 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x24 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x24, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x1, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x1_str)
-#else
-  fsh f28, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x1, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x1_str)
 
@@ -2461,18 +1561,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8001:
   fsh f25, -1102(x22) # perform store
   addi x22, x22, -1102 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x8 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x8, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8001, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8001_str)
-#else
-  fsh f25, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8001, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8001_str)
 
@@ -2485,18 +1576,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c00:
   fsh f1, 364(x30) # perform store
   addi x30, x30, 364 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x27 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x27, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c00_str)
-#else
-  fsh f1, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c00_str)
 
@@ -2509,18 +1591,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc00:
   fsh f20, 1641(x29) # perform store
   addi x29, x29, 1641 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x8 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x8, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc00_str)
-#else
-  fsh f20, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc00_str)
 
@@ -2533,18 +1606,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7e00:
   fsh f14, 466(x30) # perform store
   addi x30, x30, 466 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x18 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x18, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7e00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7e00_str)
-#else
-  fsh f14, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7e00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7e00_str)
 
@@ -2557,18 +1621,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7fff:
   fsh f11, 517(x27) # perform store
   addi x27, x27, 517 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x23 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x23, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7fff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7fff_str)
-#else
-  fsh f11, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7fff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7fff_str)
 
@@ -2581,18 +1636,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfe00:
   fsh f19, 878(x6) # perform store
   addi x6, x6, 878 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x8 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x8, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfe00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfe00_str)
-#else
-  fsh f19, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfe00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfe00_str)
 
@@ -2605,18 +1651,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c01:
   fsh f25, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c01, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c01_str)
-#else
-  fsh f25, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c01, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c01_str)
 
@@ -2629,18 +1666,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7dff:
   fsh f9, -1280(x24) # perform store
   addi x24, x24, -1280 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x10 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x10, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7dff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7dff_str)
-#else
-  fsh f9, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7dff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7dff_str)
 
@@ -2653,18 +1681,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc01:
   fsh f1, -1915(x29) # perform store
   addi x29, x29, -1915 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x17 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x17, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc01, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc01_str)
-#else
-  fsh f1, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc01, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc01_str)
 
@@ -2677,18 +1696,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x58b4:
   fsh f7, 1090(x31) # perform store
   addi x31, x31, 1090 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x12 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x12, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x58b4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x58b4_str)
-#else
-  fsh f7, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x58b4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x58b4_str)
 
@@ -2701,18 +1711,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc93a:
   fsh f22, 448(x29) # perform store
   addi x29, x29, 448 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x10 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x10, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc93a, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc93a_str)
-#else
-  fsh f22, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc93a, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc93a_str)
 
@@ -2729,18 +1730,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x0:
   fsh f23, 1329(x10) # perform store
   addi x10, x10, 1329 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x0, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x0_str)
-#else
-  fsh f23, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x0, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x0_str)
 
@@ -2753,18 +1745,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000:
   fsh f8, 1467(x8) # perform store
   addi x8, x8, 1467 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x26 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x26, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000_str)
-#else
-  fsh f8, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000_str)
 
@@ -2777,18 +1760,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00:
   fsh f23, -483(x17) # perform store
   addi x17, x17, -483 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x11 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x11, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00_str)
-#else
-  fsh f23, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00_str)
 
@@ -2801,18 +1775,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00:
   fsh f21, 179(x18) # perform store
   addi x18, x18, 179 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x24 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x24, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00_str)
-#else
-  fsh f21, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00_str)
 
@@ -2825,18 +1790,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400:
   fsh f16, 344(x22) # perform store
   addi x22, x22, 344 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x16 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x16, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400_str)
-#else
-  fsh f16, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400_str)
 
@@ -2849,18 +1805,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400:
   fsh f26, 164(x16) # perform store
   addi x16, x16, 164 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x11 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x11, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400_str)
-#else
-  fsh f26, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400_str)
 
@@ -2873,18 +1820,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff:
   fsh f24, 1839(x9) # perform store
   addi x9, x9, 1839 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x21 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x21, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff_str)
-#else
-  fsh f24, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff_str)
 
@@ -2897,18 +1835,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff:
   fsh f12, 928(x14) # perform store
   addi x14, x14, 928 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x18 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x18, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff_str)
-#else
-  fsh f12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff_str)
 
@@ -2921,18 +1850,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00:
   fsh f15, 1600(x12) # perform store
   addi x12, x12, 1600 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x1 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x1, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00_str)
-#else
-  fsh f15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00_str)
 
@@ -2945,18 +1865,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00:
   fsh f9, -1060(x27) # perform store
   addi x27, x27, -1060 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x30 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x30, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00_str)
-#else
-  fsh f9, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00_str)
 
@@ -2969,18 +1880,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00:
   fsh f30, 1899(x20) # perform store
   addi x20, x20, 1899 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x7 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x7, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00_str)
-#else
-  fsh f30, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00_str)
 
@@ -2993,18 +1895,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff:
   fsh f25, -1762(x30) # perform store
   addi x30, x30, -1762 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x24 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x24, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff_str)
-#else
-  fsh f25, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff_str)
 
@@ -3017,18 +1910,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01:
   fsh f27, -509(x13) # perform store
   addi x13, x13, -509 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x28 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x28, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01_str)
-#else
-  fsh f27, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01_str)
 
@@ -3041,18 +1925,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff:
   fsh f25, 31(x17) # perform store
   addi x17, x17, 31 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x19 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x19, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff_str)
-#else
-  fsh f25, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff_str)
 

--- a/tests/rv32i/Zfh/Zfh-fsh-00.S
+++ b/tests/rv32i/Zfh/Zfh-fsh-00.S
@@ -42,18 +42,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b1:
   fsh f17, -1914(x1) # perform store
   addi x1, x1, -1914 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x26 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x26, Zfh_fsh_cg_cp_rs1_nx0_b1, Zfh_fsh_cg_cp_rs1_nx0_b1_str)
-#else
-  fsh f17, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b1, Zfh_fsh_cg_cp_rs1_nx0_b1_str)
 
@@ -66,18 +57,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b2:
   fsh f25, -1176(x2) # perform store
   addi x2, x2, -1176 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x17 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x17, Zfh_fsh_cg_cp_rs1_nx0_b2, Zfh_fsh_cg_cp_rs1_nx0_b2_str)
-#else
-  fsh f25, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b2, Zfh_fsh_cg_cp_rs1_nx0_b2_str)
 
@@ -91,18 +73,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b3:
   fsh f29, -1263(x3) # perform store
   addi x3, x3, -1263 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x23 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x23, Zfh_fsh_cg_cp_rs1_nx0_b3, Zfh_fsh_cg_cp_rs1_nx0_b3_str)
-#else
-  fsh f29, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b3, Zfh_fsh_cg_cp_rs1_nx0_b3_str)
 
@@ -117,18 +90,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b4:
   fsh f27, 1644(x4) # perform store
   addi x4, x4, 1644 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x10 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x10, Zfh_fsh_cg_cp_rs1_nx0_b4, Zfh_fsh_cg_cp_rs1_nx0_b4_str)
-#else
-  fsh f27, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x4, x8, x7, Zfh_fsh_cg_cp_rs1_nx0_b4, Zfh_fsh_cg_cp_rs1_nx0_b4_str)
 
@@ -141,18 +105,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b5:
   fsh f3, -167(x5) # perform store
   addi x5, x5, -167 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x31 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x31, Zfh_fsh_cg_cp_rs1_nx0_b5, Zfh_fsh_cg_cp_rs1_nx0_b5_str)
-#else
-  fsh f3, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x5, x8, x7, Zfh_fsh_cg_cp_rs1_nx0_b5, Zfh_fsh_cg_cp_rs1_nx0_b5_str)
 
@@ -165,18 +120,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b6:
   fsh f14, -352(x6) # perform store
   addi x6, x6, -352 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zfh_fsh_cg_cp_rs1_nx0_b6, Zfh_fsh_cg_cp_rs1_nx0_b6_str)
-#else
-  fsh f14, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x8, x7, Zfh_fsh_cg_cp_rs1_nx0_b6, Zfh_fsh_cg_cp_rs1_nx0_b6_str)
 
@@ -191,18 +137,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b7:
   fsh f28, -494(x7) # perform store
   addi x7, x7, -494 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x12 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x12, Zfh_fsh_cg_cp_rs1_nx0_b7, Zfh_fsh_cg_cp_rs1_nx0_b7_str)
-#else
-  fsh f28, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b7, Zfh_fsh_cg_cp_rs1_nx0_b7_str)
 
@@ -215,18 +152,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b8:
   fsh f26, 391(x8) # perform store
   addi x8, x8, 391 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, Zfh_fsh_cg_cp_rs1_nx0_b8, Zfh_fsh_cg_cp_rs1_nx0_b8_str)
-#else
-  fsh f26, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b8, Zfh_fsh_cg_cp_rs1_nx0_b8_str)
 
@@ -239,18 +167,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b9:
   fsh f10, -1761(x9) # perform store
   addi x9, x9, -1761 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zfh_fsh_cg_cp_rs1_nx0_b9, Zfh_fsh_cg_cp_rs1_nx0_b9_str)
-#else
-  fsh f10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b9, Zfh_fsh_cg_cp_rs1_nx0_b9_str)
 
@@ -263,18 +182,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b10:
   fsh f6, -1585(x10) # perform store
   addi x10, x10, -1585 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x16 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x16, Zfh_fsh_cg_cp_rs1_nx0_b10, Zfh_fsh_cg_cp_rs1_nx0_b10_str)
-#else
-  fsh f6, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b10, Zfh_fsh_cg_cp_rs1_nx0_b10_str)
 
@@ -287,18 +197,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b11:
   fsh f30, -1102(x11) # perform store
   addi x11, x11, -1102 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, Zfh_fsh_cg_cp_rs1_nx0_b11, Zfh_fsh_cg_cp_rs1_nx0_b11_str)
-#else
-  fsh f30, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b11, Zfh_fsh_cg_cp_rs1_nx0_b11_str)
 
@@ -311,18 +212,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b12:
   fsh f18, -658(x12) # perform store
   addi x12, x12, -658 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x1 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x1, Zfh_fsh_cg_cp_rs1_nx0_b12, Zfh_fsh_cg_cp_rs1_nx0_b12_str)
-#else
-  fsh f18, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b12, Zfh_fsh_cg_cp_rs1_nx0_b12_str)
 
@@ -335,18 +227,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b13:
   fsh f18, 727(x13) # perform store
   addi x13, x13, 727 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x1 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x1, Zfh_fsh_cg_cp_rs1_nx0_b13, Zfh_fsh_cg_cp_rs1_nx0_b13_str)
-#else
-  fsh f18, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b13, Zfh_fsh_cg_cp_rs1_nx0_b13_str)
 
@@ -359,18 +242,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b14:
   fsh f19, -840(x14) # perform store
   addi x14, x14, -840 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zfh_fsh_cg_cp_rs1_nx0_b14, Zfh_fsh_cg_cp_rs1_nx0_b14_str)
-#else
-  fsh f19, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b14, Zfh_fsh_cg_cp_rs1_nx0_b14_str)
 
@@ -383,18 +257,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b15:
   fsh f5, -1623(x15) # perform store
   addi x15, x15, -1623 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x7 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x7, Zfh_fsh_cg_cp_rs1_nx0_b15, Zfh_fsh_cg_cp_rs1_nx0_b15_str)
-#else
-  fsh f5, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b15, Zfh_fsh_cg_cp_rs1_nx0_b15_str)
 
@@ -407,18 +272,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b16:
   fsh f13, 246(x16) # perform store
   addi x16, x16, 246 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x31 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x31, Zfh_fsh_cg_cp_rs1_nx0_b16, Zfh_fsh_cg_cp_rs1_nx0_b16_str)
-#else
-  fsh f13, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b16, Zfh_fsh_cg_cp_rs1_nx0_b16_str)
 
@@ -431,18 +287,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b17:
   fsh f23, 1189(x17) # perform store
   addi x17, x17, 1189 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x6 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x6, Zfh_fsh_cg_cp_rs1_nx0_b17, Zfh_fsh_cg_cp_rs1_nx0_b17_str)
-#else
-  fsh f23, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b17, Zfh_fsh_cg_cp_rs1_nx0_b17_str)
 
@@ -456,18 +303,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b18:
   fsh f18, 58(x18) # perform store
   addi x18, x18, 58 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zfh_fsh_cg_cp_rs1_nx0_b18, Zfh_fsh_cg_cp_rs1_nx0_b18_str)
-#else
-  fsh f18, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b18, Zfh_fsh_cg_cp_rs1_nx0_b18_str)
 
@@ -480,18 +318,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b19:
   fsh f5, -1767(x19) # perform store
   addi x19, x19, -1767 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x9 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x9, Zfh_fsh_cg_cp_rs1_nx0_b19, Zfh_fsh_cg_cp_rs1_nx0_b19_str)
-#else
-  fsh f5, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b19, Zfh_fsh_cg_cp_rs1_nx0_b19_str)
 
@@ -504,18 +333,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b20:
   fsh f25, -144(x20) # perform store
   addi x20, x20, -144 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x28 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x28, Zfh_fsh_cg_cp_rs1_nx0_b20, Zfh_fsh_cg_cp_rs1_nx0_b20_str)
-#else
-  fsh f25, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b20, Zfh_fsh_cg_cp_rs1_nx0_b20_str)
 
@@ -528,18 +348,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b21:
   fsh f28, 725(x21) # perform store
   addi x21, x21, 725 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x17 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x17, Zfh_fsh_cg_cp_rs1_nx0_b21, Zfh_fsh_cg_cp_rs1_nx0_b21_str)
-#else
-  fsh f28, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b21, Zfh_fsh_cg_cp_rs1_nx0_b21_str)
 
@@ -552,18 +363,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b22:
   fsh f0, -575(x22) # perform store
   addi x22, x22, -575 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x13 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x13, Zfh_fsh_cg_cp_rs1_nx0_b22, Zfh_fsh_cg_cp_rs1_nx0_b22_str)
-#else
-  fsh f0, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b22, Zfh_fsh_cg_cp_rs1_nx0_b22_str)
 
@@ -576,18 +378,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b23:
   fsh f21, 445(x23) # perform store
   addi x23, x23, 445 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x31 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x31, Zfh_fsh_cg_cp_rs1_nx0_b23, Zfh_fsh_cg_cp_rs1_nx0_b23_str)
-#else
-  fsh f21, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b23, Zfh_fsh_cg_cp_rs1_nx0_b23_str)
 
@@ -600,18 +393,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b24:
   fsh f14, 333(x24) # perform store
   addi x24, x24, 333 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x3 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x3, Zfh_fsh_cg_cp_rs1_nx0_b24, Zfh_fsh_cg_cp_rs1_nx0_b24_str)
-#else
-  fsh f14, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b24, Zfh_fsh_cg_cp_rs1_nx0_b24_str)
 
@@ -624,18 +408,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b25:
   fsh f15, 355(x25) # perform store
   addi x25, x25, 355 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x9 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x9, Zfh_fsh_cg_cp_rs1_nx0_b25, Zfh_fsh_cg_cp_rs1_nx0_b25_str)
-#else
-  fsh f15, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b25, Zfh_fsh_cg_cp_rs1_nx0_b25_str)
 
@@ -648,18 +423,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b26:
   fsh f16, 771(x26) # perform store
   addi x26, x26, 771 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x6 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x6, Zfh_fsh_cg_cp_rs1_nx0_b26, Zfh_fsh_cg_cp_rs1_nx0_b26_str)
-#else
-  fsh f16, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b26, Zfh_fsh_cg_cp_rs1_nx0_b26_str)
 
@@ -672,18 +438,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b27:
   fsh f1, -12(x27) # perform store
   addi x27, x27, -12 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x14 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x14, Zfh_fsh_cg_cp_rs1_nx0_b27, Zfh_fsh_cg_cp_rs1_nx0_b27_str)
-#else
-  fsh f1, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b27, Zfh_fsh_cg_cp_rs1_nx0_b27_str)
 
@@ -696,18 +453,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b28:
   fsh f19, -1219(x28) # perform store
   addi x28, x28, -1219 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x20 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x20, Zfh_fsh_cg_cp_rs1_nx0_b28, Zfh_fsh_cg_cp_rs1_nx0_b28_str)
-#else
-  fsh f19, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b28, Zfh_fsh_cg_cp_rs1_nx0_b28_str)
 
@@ -720,18 +468,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b29:
   fsh f17, -1518(x29) # perform store
   addi x29, x29, -1518 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x9 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x9, Zfh_fsh_cg_cp_rs1_nx0_b29, Zfh_fsh_cg_cp_rs1_nx0_b29_str)
-#else
-  fsh f17, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b29, Zfh_fsh_cg_cp_rs1_nx0_b29_str)
 
@@ -744,18 +483,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b30:
   fsh f9, -1795(x30) # perform store
   addi x30, x30, -1795 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x14 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x14, Zfh_fsh_cg_cp_rs1_nx0_b30, Zfh_fsh_cg_cp_rs1_nx0_b30_str)
-#else
-  fsh f9, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b30, Zfh_fsh_cg_cp_rs1_nx0_b30_str)
 
@@ -768,18 +498,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b31:
   fsh f16, 803(x31) # perform store
   addi x31, x31, 803 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x14 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x14, Zfh_fsh_cg_cp_rs1_nx0_b31, Zfh_fsh_cg_cp_rs1_nx0_b31_str)
-#else
-  fsh f16, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b31, Zfh_fsh_cg_cp_rs1_nx0_b31_str)
 
@@ -796,18 +517,9 @@ Zfh_fsh_cg_cp_imm_edges_0x0:
   fsh f17, 0(x21) # perform store
   addi x21, x21, 0 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x19 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x19, Zfh_fsh_cg_cp_imm_edges_0x0, Zfh_fsh_cg_cp_imm_edges_0x0_str)
-#else
-  fsh f17, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x0, Zfh_fsh_cg_cp_imm_edges_0x0_str)
 
@@ -820,18 +532,9 @@ Zfh_fsh_cg_cp_imm_edges_0x1:
   fsh f6, 1(x29) # perform store
   addi x29, x29, 1 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x27 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x27, Zfh_fsh_cg_cp_imm_edges_0x1, Zfh_fsh_cg_cp_imm_edges_0x1_str)
-#else
-  fsh f6, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x1, Zfh_fsh_cg_cp_imm_edges_0x1_str)
 
@@ -844,18 +547,9 @@ Zfh_fsh_cg_cp_imm_edges_0x2:
   fsh f5, 2(x2) # perform store
   addi x2, x2, 2 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zfh_fsh_cg_cp_imm_edges_0x2, Zfh_fsh_cg_cp_imm_edges_0x2_str)
-#else
-  fsh f5, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x2, Zfh_fsh_cg_cp_imm_edges_0x2_str)
 
@@ -868,18 +562,9 @@ Zfh_fsh_cg_cp_imm_edges_0x3:
   fsh f6, 3(x29) # perform store
   addi x29, x29, 3 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x27 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x27, Zfh_fsh_cg_cp_imm_edges_0x3, Zfh_fsh_cg_cp_imm_edges_0x3_str)
-#else
-  fsh f6, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x3, Zfh_fsh_cg_cp_imm_edges_0x3_str)
 
@@ -892,18 +577,9 @@ Zfh_fsh_cg_cp_imm_edges_0x4:
   fsh f30, 4(x3) # perform store
   addi x3, x3, 4 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x18 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x18, Zfh_fsh_cg_cp_imm_edges_0x4, Zfh_fsh_cg_cp_imm_edges_0x4_str)
-#else
-  fsh f30, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x4, Zfh_fsh_cg_cp_imm_edges_0x4_str)
 
@@ -916,18 +592,9 @@ Zfh_fsh_cg_cp_imm_edges_0x8:
   fsh f19, 8(x2) # perform store
   addi x2, x2, 8 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x17 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x17, Zfh_fsh_cg_cp_imm_edges_0x8, Zfh_fsh_cg_cp_imm_edges_0x8_str)
-#else
-  fsh f19, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x8, Zfh_fsh_cg_cp_imm_edges_0x8_str)
 
@@ -940,18 +607,9 @@ Zfh_fsh_cg_cp_imm_edges_0x10:
   fsh f11, 16(x24) # perform store
   addi x24, x24, 16 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x18 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x18, Zfh_fsh_cg_cp_imm_edges_0x10, Zfh_fsh_cg_cp_imm_edges_0x10_str)
-#else
-  fsh f11, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x10, Zfh_fsh_cg_cp_imm_edges_0x10_str)
 
@@ -964,18 +622,9 @@ Zfh_fsh_cg_cp_imm_edges_0x20:
   fsh f25, 32(x26) # perform store
   addi x26, x26, 32 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x16 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x16, Zfh_fsh_cg_cp_imm_edges_0x20, Zfh_fsh_cg_cp_imm_edges_0x20_str)
-#else
-  fsh f25, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x20, Zfh_fsh_cg_cp_imm_edges_0x20_str)
 
@@ -988,18 +637,9 @@ Zfh_fsh_cg_cp_imm_edges_0x40:
   fsh f13, 64(x31) # perform store
   addi x31, x31, 64 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x14 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x14, Zfh_fsh_cg_cp_imm_edges_0x40, Zfh_fsh_cg_cp_imm_edges_0x40_str)
-#else
-  fsh f13, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x40, Zfh_fsh_cg_cp_imm_edges_0x40_str)
 
@@ -1012,18 +652,9 @@ Zfh_fsh_cg_cp_imm_edges_0x80:
   fsh f18, 128(x26) # perform store
   addi x26, x26, 128 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x9 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x9, Zfh_fsh_cg_cp_imm_edges_0x80, Zfh_fsh_cg_cp_imm_edges_0x80_str)
-#else
-  fsh f18, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x80, Zfh_fsh_cg_cp_imm_edges_0x80_str)
 
@@ -1036,18 +667,9 @@ Zfh_fsh_cg_cp_imm_edges_0x100:
   fsh f27, 256(x31) # perform store
   addi x31, x31, 256 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x11 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x11, Zfh_fsh_cg_cp_imm_edges_0x100, Zfh_fsh_cg_cp_imm_edges_0x100_str)
-#else
-  fsh f27, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x100, Zfh_fsh_cg_cp_imm_edges_0x100_str)
 
@@ -1060,18 +682,9 @@ Zfh_fsh_cg_cp_imm_edges_0x200:
   fsh f22, 512(x12) # perform store
   addi x12, x12, 512 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x27 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x27, Zfh_fsh_cg_cp_imm_edges_0x200, Zfh_fsh_cg_cp_imm_edges_0x200_str)
-#else
-  fsh f22, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x200, Zfh_fsh_cg_cp_imm_edges_0x200_str)
 
@@ -1084,18 +697,9 @@ Zfh_fsh_cg_cp_imm_edges_0x3ff:
   fsh f31, 1023(x22) # perform store
   addi x22, x22, 1023 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x23 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x23, Zfh_fsh_cg_cp_imm_edges_0x3ff, Zfh_fsh_cg_cp_imm_edges_0x3ff_str)
-#else
-  fsh f31, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x3ff, Zfh_fsh_cg_cp_imm_edges_0x3ff_str)
 
@@ -1108,18 +712,9 @@ Zfh_fsh_cg_cp_imm_edges_0x400:
   fsh f14, 1024(x12) # perform store
   addi x12, x12, 1024 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x6 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x6, Zfh_fsh_cg_cp_imm_edges_0x400, Zfh_fsh_cg_cp_imm_edges_0x400_str)
-#else
-  fsh f14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x400, Zfh_fsh_cg_cp_imm_edges_0x400_str)
 
@@ -1132,18 +727,9 @@ Zfh_fsh_cg_cp_imm_edges_0x703:
   fsh f13, 1795(x21) # perform store
   addi x21, x21, 1795 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x16 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x16, Zfh_fsh_cg_cp_imm_edges_0x703, Zfh_fsh_cg_cp_imm_edges_0x703_str)
-#else
-  fsh f13, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x703, Zfh_fsh_cg_cp_imm_edges_0x703_str)
 
@@ -1156,18 +742,9 @@ Zfh_fsh_cg_cp_imm_edges_0x7ff:
   fsh f26, 2047(x8) # perform store
   addi x8, x8, 2047 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x18 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x18, Zfh_fsh_cg_cp_imm_edges_0x7ff, Zfh_fsh_cg_cp_imm_edges_0x7ff_str)
-#else
-  fsh f26, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x7ff, Zfh_fsh_cg_cp_imm_edges_0x7ff_str)
 
@@ -1181,18 +758,9 @@ Zfh_fsh_cg_cp_imm_edges_m0x800:
   fsh f10, -2048(x16) # perform store
   addi x16, x16, -2048 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x22 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x22, Zfh_fsh_cg_cp_imm_edges_m0x800, Zfh_fsh_cg_cp_imm_edges_m0x800_str)
-#else
-  fsh f10, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfh_fsh_cg_cp_imm_edges_m0x800, Zfh_fsh_cg_cp_imm_edges_m0x800_str)
 
@@ -1205,18 +773,9 @@ Zfh_fsh_cg_cp_imm_edges_m0x7ff:
   fsh f30, -2047(x28) # perform store
   addi x28, x28, -2047 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x23 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x23, Zfh_fsh_cg_cp_imm_edges_m0x7ff, Zfh_fsh_cg_cp_imm_edges_m0x7ff_str)
-#else
-  fsh f30, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, Zfh_fsh_cg_cp_imm_edges_m0x7ff, Zfh_fsh_cg_cp_imm_edges_m0x7ff_str)
 
@@ -1229,18 +788,9 @@ Zfh_fsh_cg_cp_imm_edges_m0x2:
   fsh f19, -2(x7) # perform store
   addi x7, x7, -2 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x6 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x6, Zfh_fsh_cg_cp_imm_edges_m0x2, Zfh_fsh_cg_cp_imm_edges_m0x2_str)
-#else
-  fsh f19, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, Zfh_fsh_cg_cp_imm_edges_m0x2, Zfh_fsh_cg_cp_imm_edges_m0x2_str)
 
@@ -1253,18 +803,9 @@ Zfh_fsh_cg_cp_imm_edges_m0x1:
   fsh f2, -1(x23) # perform store
   addi x23, x23, -1 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x27 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x27, Zfh_fsh_cg_cp_imm_edges_m0x1, Zfh_fsh_cg_cp_imm_edges_m0x1_str)
-#else
-  fsh f2, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfh_fsh_cg_cp_imm_edges_m0x1, Zfh_fsh_cg_cp_imm_edges_m0x1_str)
 
@@ -1281,18 +822,9 @@ Zfh_fsh_cg_cp_fs2_b0:
   fsh f0, 422(x17) # perform store
   addi x17, x17, 422 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x12 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x12, Zfh_fsh_cg_cp_fs2_b0, Zfh_fsh_cg_cp_fs2_b0_str)
-#else
-  fsh f0, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfh_fsh_cg_cp_fs2_b0, Zfh_fsh_cg_cp_fs2_b0_str)
 
@@ -1305,18 +837,9 @@ Zfh_fsh_cg_cp_fs2_b1:
   fsh f1, 1493(x10) # perform store
   addi x10, x10, 1493 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x31 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x31, Zfh_fsh_cg_cp_fs2_b1, Zfh_fsh_cg_cp_fs2_b1_str)
-#else
-  fsh f1, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfh_fsh_cg_cp_fs2_b1, Zfh_fsh_cg_cp_fs2_b1_str)
 
@@ -1329,18 +852,9 @@ Zfh_fsh_cg_cp_fs2_b2:
   fsh f2, 2040(x25) # perform store
   addi x25, x25, 2040 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x21 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x21, Zfh_fsh_cg_cp_fs2_b2, Zfh_fsh_cg_cp_fs2_b2_str)
-#else
-  fsh f2, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfh_fsh_cg_cp_fs2_b2, Zfh_fsh_cg_cp_fs2_b2_str)
 
@@ -1353,18 +867,9 @@ Zfh_fsh_cg_cp_fs2_b3:
   fsh f3, 397(x17) # perform store
   addi x17, x17, 397 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x26 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x26, Zfh_fsh_cg_cp_fs2_b3, Zfh_fsh_cg_cp_fs2_b3_str)
-#else
-  fsh f3, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfh_fsh_cg_cp_fs2_b3, Zfh_fsh_cg_cp_fs2_b3_str)
 
@@ -1377,18 +882,9 @@ Zfh_fsh_cg_cp_fs2_b4:
   fsh f4, 1550(x14) # perform store
   addi x14, x14, 1550 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, Zfh_fsh_cg_cp_fs2_b4, Zfh_fsh_cg_cp_fs2_b4_str)
-#else
-  fsh f4, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfh_fsh_cg_cp_fs2_b4, Zfh_fsh_cg_cp_fs2_b4_str)
 
@@ -1401,18 +897,9 @@ Zfh_fsh_cg_cp_fs2_b5:
   fsh f5, 576(x20) # perform store
   addi x20, x20, 576 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x26 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x26, Zfh_fsh_cg_cp_fs2_b5, Zfh_fsh_cg_cp_fs2_b5_str)
-#else
-  fsh f5, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfh_fsh_cg_cp_fs2_b5, Zfh_fsh_cg_cp_fs2_b5_str)
 
@@ -1425,18 +912,9 @@ Zfh_fsh_cg_cp_fs2_b6:
   fsh f6, -427(x19) # perform store
   addi x19, x19, -427 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x26 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x26, Zfh_fsh_cg_cp_fs2_b6, Zfh_fsh_cg_cp_fs2_b6_str)
-#else
-  fsh f6, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfh_fsh_cg_cp_fs2_b6, Zfh_fsh_cg_cp_fs2_b6_str)
 
@@ -1449,18 +927,9 @@ Zfh_fsh_cg_cp_fs2_b7:
   fsh f7, -1960(x13) # perform store
   addi x13, x13, -1960 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x17 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x17, Zfh_fsh_cg_cp_fs2_b7, Zfh_fsh_cg_cp_fs2_b7_str)
-#else
-  fsh f7, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfh_fsh_cg_cp_fs2_b7, Zfh_fsh_cg_cp_fs2_b7_str)
 
@@ -1473,18 +942,9 @@ Zfh_fsh_cg_cp_fs2_b8:
   fsh f8, -1731(x11) # perform store
   addi x11, x11, -1731 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zfh_fsh_cg_cp_fs2_b8, Zfh_fsh_cg_cp_fs2_b8_str)
-#else
-  fsh f8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfh_fsh_cg_cp_fs2_b8, Zfh_fsh_cg_cp_fs2_b8_str)
 
@@ -1497,18 +957,9 @@ Zfh_fsh_cg_cp_fs2_b9:
   fsh f9, -347(x30) # perform store
   addi x30, x30, -347 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x29 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x29, Zfh_fsh_cg_cp_fs2_b9, Zfh_fsh_cg_cp_fs2_b9_str)
-#else
-  fsh f9, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfh_fsh_cg_cp_fs2_b9, Zfh_fsh_cg_cp_fs2_b9_str)
 
@@ -1521,18 +972,9 @@ Zfh_fsh_cg_cp_fs2_b10:
   fsh f10, -1112(x20) # perform store
   addi x20, x20, -1112 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x17 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x17, Zfh_fsh_cg_cp_fs2_b10, Zfh_fsh_cg_cp_fs2_b10_str)
-#else
-  fsh f10, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfh_fsh_cg_cp_fs2_b10, Zfh_fsh_cg_cp_fs2_b10_str)
 
@@ -1545,18 +987,9 @@ Zfh_fsh_cg_cp_fs2_b11:
   fsh f11, 163(x14) # perform store
   addi x14, x14, 163 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zfh_fsh_cg_cp_fs2_b11, Zfh_fsh_cg_cp_fs2_b11_str)
-#else
-  fsh f11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfh_fsh_cg_cp_fs2_b11, Zfh_fsh_cg_cp_fs2_b11_str)
 
@@ -1569,18 +1002,9 @@ Zfh_fsh_cg_cp_fs2_b12:
   fsh f12, -838(x29) # perform store
   addi x29, x29, -838 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x17 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x17, Zfh_fsh_cg_cp_fs2_b12, Zfh_fsh_cg_cp_fs2_b12_str)
-#else
-  fsh f12, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfh_fsh_cg_cp_fs2_b12, Zfh_fsh_cg_cp_fs2_b12_str)
 
@@ -1593,18 +1017,9 @@ Zfh_fsh_cg_cp_fs2_b13:
   fsh f13, -651(x22) # perform store
   addi x22, x22, -651 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x12 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x12, Zfh_fsh_cg_cp_fs2_b13, Zfh_fsh_cg_cp_fs2_b13_str)
-#else
-  fsh f13, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfh_fsh_cg_cp_fs2_b13, Zfh_fsh_cg_cp_fs2_b13_str)
 
@@ -1617,18 +1032,9 @@ Zfh_fsh_cg_cp_fs2_b14:
   fsh f14, 156(x29) # perform store
   addi x29, x29, 156 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x26 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x26, Zfh_fsh_cg_cp_fs2_b14, Zfh_fsh_cg_cp_fs2_b14_str)
-#else
-  fsh f14, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfh_fsh_cg_cp_fs2_b14, Zfh_fsh_cg_cp_fs2_b14_str)
 
@@ -1641,18 +1047,9 @@ Zfh_fsh_cg_cp_fs2_b15:
   fsh f15, 1700(x25) # perform store
   addi x25, x25, 1700 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x3 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x3, Zfh_fsh_cg_cp_fs2_b15, Zfh_fsh_cg_cp_fs2_b15_str)
-#else
-  fsh f15, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfh_fsh_cg_cp_fs2_b15, Zfh_fsh_cg_cp_fs2_b15_str)
 
@@ -1665,18 +1062,9 @@ Zfh_fsh_cg_cp_fs2_b16:
   fsh f16, -678(x8) # perform store
   addi x8, x8, -678 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x31 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x31, Zfh_fsh_cg_cp_fs2_b16, Zfh_fsh_cg_cp_fs2_b16_str)
-#else
-  fsh f16, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfh_fsh_cg_cp_fs2_b16, Zfh_fsh_cg_cp_fs2_b16_str)
 
@@ -1689,18 +1077,9 @@ Zfh_fsh_cg_cp_fs2_b17:
   fsh f17, 1576(x12) # perform store
   addi x12, x12, 1576 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x28 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x28, Zfh_fsh_cg_cp_fs2_b17, Zfh_fsh_cg_cp_fs2_b17_str)
-#else
-  fsh f17, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfh_fsh_cg_cp_fs2_b17, Zfh_fsh_cg_cp_fs2_b17_str)
 
@@ -1713,18 +1092,9 @@ Zfh_fsh_cg_cp_fs2_b18:
   fsh f18, 985(x9) # perform store
   addi x9, x9, 985 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zfh_fsh_cg_cp_fs2_b18, Zfh_fsh_cg_cp_fs2_b18_str)
-#else
-  fsh f18, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfh_fsh_cg_cp_fs2_b18, Zfh_fsh_cg_cp_fs2_b18_str)
 
@@ -1737,18 +1107,9 @@ Zfh_fsh_cg_cp_fs2_b19:
   fsh f19, -608(x24) # perform store
   addi x24, x24, -608 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x30 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x30, Zfh_fsh_cg_cp_fs2_b19, Zfh_fsh_cg_cp_fs2_b19_str)
-#else
-  fsh f19, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfh_fsh_cg_cp_fs2_b19, Zfh_fsh_cg_cp_fs2_b19_str)
 
@@ -1761,18 +1122,9 @@ Zfh_fsh_cg_cp_fs2_b20:
   fsh f20, 2035(x20) # perform store
   addi x20, x20, 2035 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x14 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x14, Zfh_fsh_cg_cp_fs2_b20, Zfh_fsh_cg_cp_fs2_b20_str)
-#else
-  fsh f20, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfh_fsh_cg_cp_fs2_b20, Zfh_fsh_cg_cp_fs2_b20_str)
 
@@ -1785,18 +1137,9 @@ Zfh_fsh_cg_cp_fs2_b21:
   fsh f21, 991(x30) # perform store
   addi x30, x30, 991 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x10 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x10, Zfh_fsh_cg_cp_fs2_b21, Zfh_fsh_cg_cp_fs2_b21_str)
-#else
-  fsh f21, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfh_fsh_cg_cp_fs2_b21, Zfh_fsh_cg_cp_fs2_b21_str)
 
@@ -1809,18 +1152,9 @@ Zfh_fsh_cg_cp_fs2_b22:
   fsh f22, -77(x29) # perform store
   addi x29, x29, -77 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x16 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x16, Zfh_fsh_cg_cp_fs2_b22, Zfh_fsh_cg_cp_fs2_b22_str)
-#else
-  fsh f22, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfh_fsh_cg_cp_fs2_b22, Zfh_fsh_cg_cp_fs2_b22_str)
 
@@ -1833,18 +1167,9 @@ Zfh_fsh_cg_cp_fs2_b23:
   fsh f23, 1302(x6) # perform store
   addi x6, x6, 1302 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x9 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x9, Zfh_fsh_cg_cp_fs2_b23, Zfh_fsh_cg_cp_fs2_b23_str)
-#else
-  fsh f23, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfh_fsh_cg_cp_fs2_b23, Zfh_fsh_cg_cp_fs2_b23_str)
 
@@ -1857,18 +1182,9 @@ Zfh_fsh_cg_cp_fs2_b24:
   fsh f24, -1825(x21) # perform store
   addi x21, x21, -1825 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x26 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x26, Zfh_fsh_cg_cp_fs2_b24, Zfh_fsh_cg_cp_fs2_b24_str)
-#else
-  fsh f24, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfh_fsh_cg_cp_fs2_b24, Zfh_fsh_cg_cp_fs2_b24_str)
 
@@ -1881,18 +1197,9 @@ Zfh_fsh_cg_cp_fs2_b25:
   fsh f25, 257(x2) # perform store
   addi x2, x2, 257 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x7 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x7, Zfh_fsh_cg_cp_fs2_b25, Zfh_fsh_cg_cp_fs2_b25_str)
-#else
-  fsh f25, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfh_fsh_cg_cp_fs2_b25, Zfh_fsh_cg_cp_fs2_b25_str)
 
@@ -1905,18 +1212,9 @@ Zfh_fsh_cg_cp_fs2_b26:
   fsh f26, -1411(x6) # perform store
   addi x6, x6, -1411 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x23 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x23, Zfh_fsh_cg_cp_fs2_b26, Zfh_fsh_cg_cp_fs2_b26_str)
-#else
-  fsh f26, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfh_fsh_cg_cp_fs2_b26, Zfh_fsh_cg_cp_fs2_b26_str)
 
@@ -1929,18 +1227,9 @@ Zfh_fsh_cg_cp_fs2_b27:
   fsh f27, -950(x9) # perform store
   addi x9, x9, -950 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x22 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x22, Zfh_fsh_cg_cp_fs2_b27, Zfh_fsh_cg_cp_fs2_b27_str)
-#else
-  fsh f27, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfh_fsh_cg_cp_fs2_b27, Zfh_fsh_cg_cp_fs2_b27_str)
 
@@ -1953,18 +1242,9 @@ Zfh_fsh_cg_cp_fs2_b28:
   fsh f28, 593(x23) # perform store
   addi x23, x23, 593 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x19 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x19, Zfh_fsh_cg_cp_fs2_b28, Zfh_fsh_cg_cp_fs2_b28_str)
-#else
-  fsh f28, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfh_fsh_cg_cp_fs2_b28, Zfh_fsh_cg_cp_fs2_b28_str)
 
@@ -1977,18 +1257,9 @@ Zfh_fsh_cg_cp_fs2_b29:
   fsh f29, -799(x6) # perform store
   addi x6, x6, -799 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x1 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x1, Zfh_fsh_cg_cp_fs2_b29, Zfh_fsh_cg_cp_fs2_b29_str)
-#else
-  fsh f29, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfh_fsh_cg_cp_fs2_b29, Zfh_fsh_cg_cp_fs2_b29_str)
 
@@ -2001,18 +1272,9 @@ Zfh_fsh_cg_cp_fs2_b30:
   fsh f30, 269(x25) # perform store
   addi x25, x25, 269 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x28 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x28, Zfh_fsh_cg_cp_fs2_b30, Zfh_fsh_cg_cp_fs2_b30_str)
-#else
-  fsh f30, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfh_fsh_cg_cp_fs2_b30, Zfh_fsh_cg_cp_fs2_b30_str)
 
@@ -2025,18 +1287,9 @@ Zfh_fsh_cg_cp_fs2_b31:
   fsh f31, 1958(x8) # perform store
   addi x8, x8, 1958 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x30 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x30, Zfh_fsh_cg_cp_fs2_b31, Zfh_fsh_cg_cp_fs2_b31_str)
-#else
-  fsh f31, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfh_fsh_cg_cp_fs2_b31, Zfh_fsh_cg_cp_fs2_b31_str)
 
@@ -2053,18 +1306,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x0:
   fsh f15, 334(x18) # perform store
   addi x18, x18, 334 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x21, Zfh_fsh_cg_cp_fs2_edges_H_b0x0, Zfh_fsh_cg_cp_fs2_edges_H_b0x0_str)
-#else
-  fsh f15, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x0, Zfh_fsh_cg_cp_fs2_edges_H_b0x0_str)
 
@@ -2077,18 +1321,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x8000:
   fsh f27, 847(x7) # perform store
   addi x7, x7, 847 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x22 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x22, Zfh_fsh_cg_cp_fs2_edges_H_b0x8000, Zfh_fsh_cg_cp_fs2_edges_H_b0x8000_str)
-#else
-  fsh f27, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x8000, Zfh_fsh_cg_cp_fs2_edges_H_b0x8000_str)
 
@@ -2101,18 +1336,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x3c00:
   fsh f31, -380(x11) # perform store
   addi x11, x11, -380 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zfh_fsh_cg_cp_fs2_edges_H_b0x3c00, Zfh_fsh_cg_cp_fs2_edges_H_b0x3c00_str)
-#else
-  fsh f31, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x3c00, Zfh_fsh_cg_cp_fs2_edges_H_b0x3c00_str)
 
@@ -2125,18 +1351,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0xbc00:
   fsh f23, -947(x29) # perform store
   addi x29, x29, -947 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x22 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x22, Zfh_fsh_cg_cp_fs2_edges_H_b0xbc00, Zfh_fsh_cg_cp_fs2_edges_H_b0xbc00_str)
-#else
-  fsh f23, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0xbc00, Zfh_fsh_cg_cp_fs2_edges_H_b0xbc00_str)
 
@@ -2149,18 +1366,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x3e00:
   fsh f31, 1592(x23) # perform store
   addi x23, x23, 1592 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x28 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x28, Zfh_fsh_cg_cp_fs2_edges_H_b0x3e00, Zfh_fsh_cg_cp_fs2_edges_H_b0x3e00_str)
-#else
-  fsh f31, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x3e00, Zfh_fsh_cg_cp_fs2_edges_H_b0x3e00_str)
 
@@ -2173,18 +1381,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0xbe00:
   fsh f16, -599(x16) # perform store
   addi x16, x16, -599 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x24 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x24, Zfh_fsh_cg_cp_fs2_edges_H_b0xbe00, Zfh_fsh_cg_cp_fs2_edges_H_b0xbe00_str)
-#else
-  fsh f16, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0xbe00, Zfh_fsh_cg_cp_fs2_edges_H_b0xbe00_str)
 
@@ -2197,18 +1396,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x4000:
   fsh f6, 1325(x22) # perform store
   addi x22, x22, 1325 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x14 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x14, Zfh_fsh_cg_cp_fs2_edges_H_b0x4000, Zfh_fsh_cg_cp_fs2_edges_H_b0x4000_str)
-#else
-  fsh f6, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x4000, Zfh_fsh_cg_cp_fs2_edges_H_b0x4000_str)
 
@@ -2221,18 +1411,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0xc000:
   fsh f13, 756(x24) # perform store
   addi x24, x24, 756 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x6 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x6, Zfh_fsh_cg_cp_fs2_edges_H_b0xc000, Zfh_fsh_cg_cp_fs2_edges_H_b0xc000_str)
-#else
-  fsh f13, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0xc000, Zfh_fsh_cg_cp_fs2_edges_H_b0xc000_str)
 
@@ -2245,18 +1426,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x400:
   fsh f17, -1411(x18) # perform store
   addi x18, x18, -1411 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x30 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x30, Zfh_fsh_cg_cp_fs2_edges_H_b0x400, Zfh_fsh_cg_cp_fs2_edges_H_b0x400_str)
-#else
-  fsh f17, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x400, Zfh_fsh_cg_cp_fs2_edges_H_b0x400_str)
 
@@ -2269,18 +1441,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x8400:
   fsh f12, 202(x14) # perform store
   addi x14, x14, 202 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zfh_fsh_cg_cp_fs2_edges_H_b0x8400, Zfh_fsh_cg_cp_fs2_edges_H_b0x8400_str)
-#else
-  fsh f12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x8400, Zfh_fsh_cg_cp_fs2_edges_H_b0x8400_str)
 
@@ -2293,18 +1456,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x7bff:
   fsh f20, 1405(x25) # perform store
   addi x25, x25, 1405 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x3 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x3, Zfh_fsh_cg_cp_fs2_edges_H_b0x7bff, Zfh_fsh_cg_cp_fs2_edges_H_b0x7bff_str)
-#else
-  fsh f20, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x7bff, Zfh_fsh_cg_cp_fs2_edges_H_b0x7bff_str)
 
@@ -2317,18 +1471,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0xfbff:
   fsh f13, -329(x14) # perform store
   addi x14, x14, -329 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x1 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x1, Zfh_fsh_cg_cp_fs2_edges_H_b0xfbff, Zfh_fsh_cg_cp_fs2_edges_H_b0xfbff_str)
-#else
-  fsh f13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0xfbff, Zfh_fsh_cg_cp_fs2_edges_H_b0xfbff_str)
 
@@ -2341,18 +1486,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x3ff:
   fsh f24, 1521(x6) # perform store
   addi x6, x6, 1521 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x22 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x22, Zfh_fsh_cg_cp_fs2_edges_H_b0x3ff, Zfh_fsh_cg_cp_fs2_edges_H_b0x3ff_str)
-#else
-  fsh f24, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x3ff, Zfh_fsh_cg_cp_fs2_edges_H_b0x3ff_str)
 
@@ -2365,18 +1501,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x83ff:
   fsh f14, -911(x22) # perform store
   addi x22, x22, -911 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x12 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x12, Zfh_fsh_cg_cp_fs2_edges_H_b0x83ff, Zfh_fsh_cg_cp_fs2_edges_H_b0x83ff_str)
-#else
-  fsh f14, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x83ff, Zfh_fsh_cg_cp_fs2_edges_H_b0x83ff_str)
 
@@ -2389,18 +1516,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x200:
   fsh f15, -380(x11) # perform store
   addi x11, x11, -380 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x1 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x1, Zfh_fsh_cg_cp_fs2_edges_H_b0x200, Zfh_fsh_cg_cp_fs2_edges_H_b0x200_str)
-#else
-  fsh f15, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x200, Zfh_fsh_cg_cp_fs2_edges_H_b0x200_str)
 
@@ -2413,18 +1531,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x8200:
   fsh f17, 1530(x9) # perform store
   addi x9, x9, 1530 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x23 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x23, Zfh_fsh_cg_cp_fs2_edges_H_b0x8200, Zfh_fsh_cg_cp_fs2_edges_H_b0x8200_str)
-#else
-  fsh f17, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x8200, Zfh_fsh_cg_cp_fs2_edges_H_b0x8200_str)
 
@@ -2437,18 +1546,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x1:
   fsh f28, 1545(x3) # perform store
   addi x3, x3, 1545 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x24 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x24, Zfh_fsh_cg_cp_fs2_edges_H_b0x1, Zfh_fsh_cg_cp_fs2_edges_H_b0x1_str)
-#else
-  fsh f28, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x1, Zfh_fsh_cg_cp_fs2_edges_H_b0x1_str)
 
@@ -2461,18 +1561,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x8001:
   fsh f25, -1102(x22) # perform store
   addi x22, x22, -1102 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x8 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x8, Zfh_fsh_cg_cp_fs2_edges_H_b0x8001, Zfh_fsh_cg_cp_fs2_edges_H_b0x8001_str)
-#else
-  fsh f25, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x8001, Zfh_fsh_cg_cp_fs2_edges_H_b0x8001_str)
 
@@ -2485,18 +1576,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x7c00:
   fsh f1, 364(x30) # perform store
   addi x30, x30, 364 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x27 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x27, Zfh_fsh_cg_cp_fs2_edges_H_b0x7c00, Zfh_fsh_cg_cp_fs2_edges_H_b0x7c00_str)
-#else
-  fsh f1, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x7c00, Zfh_fsh_cg_cp_fs2_edges_H_b0x7c00_str)
 
@@ -2509,18 +1591,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0xfc00:
   fsh f20, 1641(x29) # perform store
   addi x29, x29, 1641 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x8 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x8, Zfh_fsh_cg_cp_fs2_edges_H_b0xfc00, Zfh_fsh_cg_cp_fs2_edges_H_b0xfc00_str)
-#else
-  fsh f20, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0xfc00, Zfh_fsh_cg_cp_fs2_edges_H_b0xfc00_str)
 
@@ -2533,18 +1606,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x7e00:
   fsh f14, 466(x30) # perform store
   addi x30, x30, 466 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x18 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x18, Zfh_fsh_cg_cp_fs2_edges_H_b0x7e00, Zfh_fsh_cg_cp_fs2_edges_H_b0x7e00_str)
-#else
-  fsh f14, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x7e00, Zfh_fsh_cg_cp_fs2_edges_H_b0x7e00_str)
 
@@ -2557,18 +1621,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x7fff:
   fsh f11, 517(x27) # perform store
   addi x27, x27, 517 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x23 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x23, Zfh_fsh_cg_cp_fs2_edges_H_b0x7fff, Zfh_fsh_cg_cp_fs2_edges_H_b0x7fff_str)
-#else
-  fsh f11, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x7fff, Zfh_fsh_cg_cp_fs2_edges_H_b0x7fff_str)
 
@@ -2581,18 +1636,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0xfe00:
   fsh f19, 878(x6) # perform store
   addi x6, x6, 878 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x8 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x8, Zfh_fsh_cg_cp_fs2_edges_H_b0xfe00, Zfh_fsh_cg_cp_fs2_edges_H_b0xfe00_str)
-#else
-  fsh f19, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0xfe00, Zfh_fsh_cg_cp_fs2_edges_H_b0xfe00_str)
 
@@ -2605,18 +1651,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x7c01:
   fsh f25, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zfh_fsh_cg_cp_fs2_edges_H_b0x7c01, Zfh_fsh_cg_cp_fs2_edges_H_b0x7c01_str)
-#else
-  fsh f25, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x7c01, Zfh_fsh_cg_cp_fs2_edges_H_b0x7c01_str)
 
@@ -2629,18 +1666,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x7dff:
   fsh f9, -1280(x24) # perform store
   addi x24, x24, -1280 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x10 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x10, Zfh_fsh_cg_cp_fs2_edges_H_b0x7dff, Zfh_fsh_cg_cp_fs2_edges_H_b0x7dff_str)
-#else
-  fsh f9, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x7dff, Zfh_fsh_cg_cp_fs2_edges_H_b0x7dff_str)
 
@@ -2653,18 +1681,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0xfc01:
   fsh f1, -1915(x29) # perform store
   addi x29, x29, -1915 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x17 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x17, Zfh_fsh_cg_cp_fs2_edges_H_b0xfc01, Zfh_fsh_cg_cp_fs2_edges_H_b0xfc01_str)
-#else
-  fsh f1, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0xfc01, Zfh_fsh_cg_cp_fs2_edges_H_b0xfc01_str)
 
@@ -2677,18 +1696,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x58b4:
   fsh f7, 1090(x31) # perform store
   addi x31, x31, 1090 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x12 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x12, Zfh_fsh_cg_cp_fs2_edges_H_b0x58b4, Zfh_fsh_cg_cp_fs2_edges_H_b0x58b4_str)
-#else
-  fsh f7, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x58b4, Zfh_fsh_cg_cp_fs2_edges_H_b0x58b4_str)
 
@@ -2701,18 +1711,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0xc93a:
   fsh f22, 448(x29) # perform store
   addi x29, x29, 448 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x10 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x10, Zfh_fsh_cg_cp_fs2_edges_H_b0xc93a, Zfh_fsh_cg_cp_fs2_edges_H_b0xc93a_str)
-#else
-  fsh f22, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0xc93a, Zfh_fsh_cg_cp_fs2_edges_H_b0xc93a_str)
 
@@ -2729,18 +1730,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x0:
   fsh f23, 1329(x10) # perform store
   addi x10, x10, 1329 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x0, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x0_str)
-#else
-  fsh f23, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x0, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x0_str)
 
@@ -2753,18 +1745,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000:
   fsh f8, 1467(x8) # perform store
   addi x8, x8, 1467 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x26 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x26, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000_str)
-#else
-  fsh f8, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000_str)
 
@@ -2777,18 +1760,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00:
   fsh f23, -483(x17) # perform store
   addi x17, x17, -483 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x11 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x11, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00_str)
-#else
-  fsh f23, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00_str)
 
@@ -2801,18 +1775,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00:
   fsh f21, 179(x18) # perform store
   addi x18, x18, 179 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x24 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x24, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00_str)
-#else
-  fsh f21, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00_str)
 
@@ -2825,18 +1790,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400:
   fsh f16, 344(x22) # perform store
   addi x22, x22, 344 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x16 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x16, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400_str)
-#else
-  fsh f16, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400_str)
 
@@ -2849,18 +1805,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400:
   fsh f26, 164(x16) # perform store
   addi x16, x16, 164 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x11 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x11, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400_str)
-#else
-  fsh f26, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400_str)
 
@@ -2873,18 +1820,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff:
   fsh f24, 1839(x9) # perform store
   addi x9, x9, 1839 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x21 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x21, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff_str)
-#else
-  fsh f24, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff_str)
 
@@ -2897,18 +1835,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff:
   fsh f12, 928(x14) # perform store
   addi x14, x14, 928 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x18 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x18, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff_str)
-#else
-  fsh f12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff_str)
 
@@ -2921,18 +1850,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00:
   fsh f15, 1600(x12) # perform store
   addi x12, x12, 1600 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x1 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x1, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00_str)
-#else
-  fsh f15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00_str)
 
@@ -2945,18 +1865,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00:
   fsh f9, -1060(x27) # perform store
   addi x27, x27, -1060 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x30 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x30, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00_str)
-#else
-  fsh f9, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00_str)
 
@@ -2969,18 +1880,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00:
   fsh f30, 1899(x20) # perform store
   addi x20, x20, 1899 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x7 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x7, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00_str)
-#else
-  fsh f30, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00_str)
 
@@ -2993,18 +1895,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff:
   fsh f25, -1762(x30) # perform store
   addi x30, x30, -1762 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x24 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x24, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff_str)
-#else
-  fsh f25, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff_str)
 
@@ -3017,18 +1910,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01:
   fsh f27, -509(x13) # perform store
   addi x13, x13, -509 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x28 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x28, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01_str)
-#else
-  fsh f27, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01_str)
 
@@ -3041,18 +1925,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff:
   fsh f25, 31(x17) # perform store
   addi x17, x17, 31 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x19 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x19, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff_str)
-#else
-  fsh f25, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff_str)
 

--- a/tests/rv32i/ZfhD/ZfhD-fsh-00.S
+++ b/tests/rv32i/ZfhD/ZfhD-fsh-00.S
@@ -42,18 +42,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000:
   fsh f9, -969(x25) # perform store
   addi x25, x25, -969 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x13 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x13, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000_str)
-#else
-  fsh f9, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000_str)
 
@@ -66,18 +57,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000:
   fsh f23, 130(x6) # perform store
   addi x6, x6, 130 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x27 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x27, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000_str)
-#else
-  fsh f23, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000_str)
 
@@ -90,18 +72,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00:
   fsh f26, 1030(x11) # perform store
   addi x11, x11, 1030 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00_str)
-#else
-  fsh f26, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00_str)
 
@@ -114,18 +87,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00:
   fsh f29, -45(x28) # perform store
   addi x28, x28, -45 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x16 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x16, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00_str)
-#else
-  fsh f29, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00_str)
 
@@ -138,18 +102,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400:
   fsh f24, 1789(x13) # perform store
   addi x13, x13, 1789 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400_str)
-#else
-  fsh f24, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400_str)
 
@@ -162,18 +117,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400:
   fsh f25, -1550(x10) # perform store
   addi x10, x10, -1550 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x6 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x6, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400_str)
-#else
-  fsh f25, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400_str)
 
@@ -186,18 +132,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff:
   fsh f25, 372(x29) # perform store
   addi x29, x29, 372 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x17 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x17, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff_str)
-#else
-  fsh f25, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff_str)
 
@@ -210,18 +147,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff:
   fsh f6, 931(x10) # perform store
   addi x10, x10, 931 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x19 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x19, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff_str)
-#else
-  fsh f6, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff_str)
 
@@ -234,18 +162,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00:
   fsh f14, -2015(x28) # perform store
   addi x28, x28, -2015 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x15 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x15, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00_str)
-#else
-  fsh f14, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00_str)
 
@@ -258,18 +177,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00:
   fsh f12, 1351(x25) # perform store
   addi x25, x25, 1351 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x27 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x27, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00_str)
-#else
-  fsh f12, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00_str)
 
@@ -282,18 +192,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00:
   fsh f30, 2033(x17) # perform store
   addi x17, x17, 2033 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x12 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x12, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00_str)
-#else
-  fsh f30, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00_str)
 
@@ -306,18 +207,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff:
   fsh f16, 779(x15) # perform store
   addi x15, x15, 779 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x7 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x7, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff_str)
-#else
-  fsh f16, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff_str)
 
@@ -330,18 +222,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01:
   fsh f25, 332(x2) # perform store
   addi x2, x2, 332 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x25 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x25, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01_str)
-#else
-  fsh f25, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01_str)
 
@@ -354,18 +237,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff:
   fsh f20, -958(x31) # perform store
   addi x31, x31, -958 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x12 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x12, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff_str)
-#else
-  fsh f20, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff_str)
 

--- a/tests/rv32i/Zfhmin/Zfhmin-fsh-00.S
+++ b/tests/rv32i/Zfhmin/Zfhmin-fsh-00.S
@@ -42,18 +42,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b1:
   fsh f17, -1914(x1) # perform store
   addi x1, x1, -1914 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x26 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x26, Zfhmin_fsh_cg_cp_rs1_nx0_b1, Zfhmin_fsh_cg_cp_rs1_nx0_b1_str)
-#else
-  fsh f17, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b1, Zfhmin_fsh_cg_cp_rs1_nx0_b1_str)
 
@@ -66,18 +57,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b2:
   fsh f25, -1176(x2) # perform store
   addi x2, x2, -1176 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x17 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x17, Zfhmin_fsh_cg_cp_rs1_nx0_b2, Zfhmin_fsh_cg_cp_rs1_nx0_b2_str)
-#else
-  fsh f25, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b2, Zfhmin_fsh_cg_cp_rs1_nx0_b2_str)
 
@@ -91,18 +73,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b3:
   fsh f29, -1263(x3) # perform store
   addi x3, x3, -1263 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x23 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x23, Zfhmin_fsh_cg_cp_rs1_nx0_b3, Zfhmin_fsh_cg_cp_rs1_nx0_b3_str)
-#else
-  fsh f29, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b3, Zfhmin_fsh_cg_cp_rs1_nx0_b3_str)
 
@@ -117,18 +90,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b4:
   fsh f27, 1644(x4) # perform store
   addi x4, x4, 1644 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x10 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x10, Zfhmin_fsh_cg_cp_rs1_nx0_b4, Zfhmin_fsh_cg_cp_rs1_nx0_b4_str)
-#else
-  fsh f27, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x4, x8, x7, Zfhmin_fsh_cg_cp_rs1_nx0_b4, Zfhmin_fsh_cg_cp_rs1_nx0_b4_str)
 
@@ -141,18 +105,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b5:
   fsh f3, -167(x5) # perform store
   addi x5, x5, -167 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x31 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x31, Zfhmin_fsh_cg_cp_rs1_nx0_b5, Zfhmin_fsh_cg_cp_rs1_nx0_b5_str)
-#else
-  fsh f3, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x5, x8, x7, Zfhmin_fsh_cg_cp_rs1_nx0_b5, Zfhmin_fsh_cg_cp_rs1_nx0_b5_str)
 
@@ -165,18 +120,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b6:
   fsh f14, -352(x6) # perform store
   addi x6, x6, -352 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zfhmin_fsh_cg_cp_rs1_nx0_b6, Zfhmin_fsh_cg_cp_rs1_nx0_b6_str)
-#else
-  fsh f14, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x8, x7, Zfhmin_fsh_cg_cp_rs1_nx0_b6, Zfhmin_fsh_cg_cp_rs1_nx0_b6_str)
 
@@ -191,18 +137,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b7:
   fsh f28, -494(x7) # perform store
   addi x7, x7, -494 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x12 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x12, Zfhmin_fsh_cg_cp_rs1_nx0_b7, Zfhmin_fsh_cg_cp_rs1_nx0_b7_str)
-#else
-  fsh f28, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b7, Zfhmin_fsh_cg_cp_rs1_nx0_b7_str)
 
@@ -215,18 +152,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b8:
   fsh f26, 391(x8) # perform store
   addi x8, x8, 391 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, Zfhmin_fsh_cg_cp_rs1_nx0_b8, Zfhmin_fsh_cg_cp_rs1_nx0_b8_str)
-#else
-  fsh f26, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b8, Zfhmin_fsh_cg_cp_rs1_nx0_b8_str)
 
@@ -239,18 +167,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b9:
   fsh f10, -1761(x9) # perform store
   addi x9, x9, -1761 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zfhmin_fsh_cg_cp_rs1_nx0_b9, Zfhmin_fsh_cg_cp_rs1_nx0_b9_str)
-#else
-  fsh f10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b9, Zfhmin_fsh_cg_cp_rs1_nx0_b9_str)
 
@@ -263,18 +182,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b10:
   fsh f6, -1585(x10) # perform store
   addi x10, x10, -1585 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x16 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x16, Zfhmin_fsh_cg_cp_rs1_nx0_b10, Zfhmin_fsh_cg_cp_rs1_nx0_b10_str)
-#else
-  fsh f6, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b10, Zfhmin_fsh_cg_cp_rs1_nx0_b10_str)
 
@@ -287,18 +197,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b11:
   fsh f30, -1102(x11) # perform store
   addi x11, x11, -1102 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, Zfhmin_fsh_cg_cp_rs1_nx0_b11, Zfhmin_fsh_cg_cp_rs1_nx0_b11_str)
-#else
-  fsh f30, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b11, Zfhmin_fsh_cg_cp_rs1_nx0_b11_str)
 
@@ -311,18 +212,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b12:
   fsh f18, -658(x12) # perform store
   addi x12, x12, -658 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x1 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x1, Zfhmin_fsh_cg_cp_rs1_nx0_b12, Zfhmin_fsh_cg_cp_rs1_nx0_b12_str)
-#else
-  fsh f18, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b12, Zfhmin_fsh_cg_cp_rs1_nx0_b12_str)
 
@@ -335,18 +227,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b13:
   fsh f18, 727(x13) # perform store
   addi x13, x13, 727 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x1 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x1, Zfhmin_fsh_cg_cp_rs1_nx0_b13, Zfhmin_fsh_cg_cp_rs1_nx0_b13_str)
-#else
-  fsh f18, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b13, Zfhmin_fsh_cg_cp_rs1_nx0_b13_str)
 
@@ -359,18 +242,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b14:
   fsh f19, -840(x14) # perform store
   addi x14, x14, -840 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zfhmin_fsh_cg_cp_rs1_nx0_b14, Zfhmin_fsh_cg_cp_rs1_nx0_b14_str)
-#else
-  fsh f19, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b14, Zfhmin_fsh_cg_cp_rs1_nx0_b14_str)
 
@@ -383,18 +257,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b15:
   fsh f5, -1623(x15) # perform store
   addi x15, x15, -1623 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x7 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x7, Zfhmin_fsh_cg_cp_rs1_nx0_b15, Zfhmin_fsh_cg_cp_rs1_nx0_b15_str)
-#else
-  fsh f5, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b15, Zfhmin_fsh_cg_cp_rs1_nx0_b15_str)
 
@@ -407,18 +272,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b16:
   fsh f13, 246(x16) # perform store
   addi x16, x16, 246 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x31 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x31, Zfhmin_fsh_cg_cp_rs1_nx0_b16, Zfhmin_fsh_cg_cp_rs1_nx0_b16_str)
-#else
-  fsh f13, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b16, Zfhmin_fsh_cg_cp_rs1_nx0_b16_str)
 
@@ -431,18 +287,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b17:
   fsh f23, 1189(x17) # perform store
   addi x17, x17, 1189 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x6 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x6, Zfhmin_fsh_cg_cp_rs1_nx0_b17, Zfhmin_fsh_cg_cp_rs1_nx0_b17_str)
-#else
-  fsh f23, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b17, Zfhmin_fsh_cg_cp_rs1_nx0_b17_str)
 
@@ -456,18 +303,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b18:
   fsh f18, 58(x18) # perform store
   addi x18, x18, 58 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zfhmin_fsh_cg_cp_rs1_nx0_b18, Zfhmin_fsh_cg_cp_rs1_nx0_b18_str)
-#else
-  fsh f18, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b18, Zfhmin_fsh_cg_cp_rs1_nx0_b18_str)
 
@@ -480,18 +318,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b19:
   fsh f5, -1767(x19) # perform store
   addi x19, x19, -1767 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x9 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x9, Zfhmin_fsh_cg_cp_rs1_nx0_b19, Zfhmin_fsh_cg_cp_rs1_nx0_b19_str)
-#else
-  fsh f5, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b19, Zfhmin_fsh_cg_cp_rs1_nx0_b19_str)
 
@@ -504,18 +333,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b20:
   fsh f25, -144(x20) # perform store
   addi x20, x20, -144 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x28 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x28, Zfhmin_fsh_cg_cp_rs1_nx0_b20, Zfhmin_fsh_cg_cp_rs1_nx0_b20_str)
-#else
-  fsh f25, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b20, Zfhmin_fsh_cg_cp_rs1_nx0_b20_str)
 
@@ -528,18 +348,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b21:
   fsh f28, 725(x21) # perform store
   addi x21, x21, 725 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x17 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x17, Zfhmin_fsh_cg_cp_rs1_nx0_b21, Zfhmin_fsh_cg_cp_rs1_nx0_b21_str)
-#else
-  fsh f28, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b21, Zfhmin_fsh_cg_cp_rs1_nx0_b21_str)
 
@@ -552,18 +363,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b22:
   fsh f0, -575(x22) # perform store
   addi x22, x22, -575 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x13 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x13, Zfhmin_fsh_cg_cp_rs1_nx0_b22, Zfhmin_fsh_cg_cp_rs1_nx0_b22_str)
-#else
-  fsh f0, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b22, Zfhmin_fsh_cg_cp_rs1_nx0_b22_str)
 
@@ -576,18 +378,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b23:
   fsh f21, 445(x23) # perform store
   addi x23, x23, 445 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x31 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x31, Zfhmin_fsh_cg_cp_rs1_nx0_b23, Zfhmin_fsh_cg_cp_rs1_nx0_b23_str)
-#else
-  fsh f21, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b23, Zfhmin_fsh_cg_cp_rs1_nx0_b23_str)
 
@@ -600,18 +393,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b24:
   fsh f14, 333(x24) # perform store
   addi x24, x24, 333 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x3 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x3, Zfhmin_fsh_cg_cp_rs1_nx0_b24, Zfhmin_fsh_cg_cp_rs1_nx0_b24_str)
-#else
-  fsh f14, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b24, Zfhmin_fsh_cg_cp_rs1_nx0_b24_str)
 
@@ -624,18 +408,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b25:
   fsh f15, 355(x25) # perform store
   addi x25, x25, 355 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x9 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x9, Zfhmin_fsh_cg_cp_rs1_nx0_b25, Zfhmin_fsh_cg_cp_rs1_nx0_b25_str)
-#else
-  fsh f15, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b25, Zfhmin_fsh_cg_cp_rs1_nx0_b25_str)
 
@@ -648,18 +423,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b26:
   fsh f16, 771(x26) # perform store
   addi x26, x26, 771 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x6 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x6, Zfhmin_fsh_cg_cp_rs1_nx0_b26, Zfhmin_fsh_cg_cp_rs1_nx0_b26_str)
-#else
-  fsh f16, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b26, Zfhmin_fsh_cg_cp_rs1_nx0_b26_str)
 
@@ -672,18 +438,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b27:
   fsh f1, -12(x27) # perform store
   addi x27, x27, -12 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x14 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x14, Zfhmin_fsh_cg_cp_rs1_nx0_b27, Zfhmin_fsh_cg_cp_rs1_nx0_b27_str)
-#else
-  fsh f1, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b27, Zfhmin_fsh_cg_cp_rs1_nx0_b27_str)
 
@@ -696,18 +453,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b28:
   fsh f19, -1219(x28) # perform store
   addi x28, x28, -1219 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x20 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x20, Zfhmin_fsh_cg_cp_rs1_nx0_b28, Zfhmin_fsh_cg_cp_rs1_nx0_b28_str)
-#else
-  fsh f19, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b28, Zfhmin_fsh_cg_cp_rs1_nx0_b28_str)
 
@@ -720,18 +468,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b29:
   fsh f17, -1518(x29) # perform store
   addi x29, x29, -1518 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x9 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x9, Zfhmin_fsh_cg_cp_rs1_nx0_b29, Zfhmin_fsh_cg_cp_rs1_nx0_b29_str)
-#else
-  fsh f17, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b29, Zfhmin_fsh_cg_cp_rs1_nx0_b29_str)
 
@@ -744,18 +483,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b30:
   fsh f9, -1795(x30) # perform store
   addi x30, x30, -1795 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x14 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x14, Zfhmin_fsh_cg_cp_rs1_nx0_b30, Zfhmin_fsh_cg_cp_rs1_nx0_b30_str)
-#else
-  fsh f9, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b30, Zfhmin_fsh_cg_cp_rs1_nx0_b30_str)
 
@@ -768,18 +498,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b31:
   fsh f16, 803(x31) # perform store
   addi x31, x31, 803 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x14 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x14, Zfhmin_fsh_cg_cp_rs1_nx0_b31, Zfhmin_fsh_cg_cp_rs1_nx0_b31_str)
-#else
-  fsh f16, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b31, Zfhmin_fsh_cg_cp_rs1_nx0_b31_str)
 
@@ -796,18 +517,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x0:
   fsh f17, 0(x21) # perform store
   addi x21, x21, 0 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x19 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x19, Zfhmin_fsh_cg_cp_imm_edges_0x0, Zfhmin_fsh_cg_cp_imm_edges_0x0_str)
-#else
-  fsh f17, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x0, Zfhmin_fsh_cg_cp_imm_edges_0x0_str)
 
@@ -820,18 +532,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x1:
   fsh f6, 1(x29) # perform store
   addi x29, x29, 1 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x27 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x27, Zfhmin_fsh_cg_cp_imm_edges_0x1, Zfhmin_fsh_cg_cp_imm_edges_0x1_str)
-#else
-  fsh f6, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x1, Zfhmin_fsh_cg_cp_imm_edges_0x1_str)
 
@@ -844,18 +547,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x2:
   fsh f5, 2(x2) # perform store
   addi x2, x2, 2 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zfhmin_fsh_cg_cp_imm_edges_0x2, Zfhmin_fsh_cg_cp_imm_edges_0x2_str)
-#else
-  fsh f5, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x2, Zfhmin_fsh_cg_cp_imm_edges_0x2_str)
 
@@ -868,18 +562,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x3:
   fsh f6, 3(x29) # perform store
   addi x29, x29, 3 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x27 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x27, Zfhmin_fsh_cg_cp_imm_edges_0x3, Zfhmin_fsh_cg_cp_imm_edges_0x3_str)
-#else
-  fsh f6, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x3, Zfhmin_fsh_cg_cp_imm_edges_0x3_str)
 
@@ -892,18 +577,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x4:
   fsh f30, 4(x3) # perform store
   addi x3, x3, 4 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x18 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x18, Zfhmin_fsh_cg_cp_imm_edges_0x4, Zfhmin_fsh_cg_cp_imm_edges_0x4_str)
-#else
-  fsh f30, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x4, Zfhmin_fsh_cg_cp_imm_edges_0x4_str)
 
@@ -916,18 +592,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x8:
   fsh f19, 8(x2) # perform store
   addi x2, x2, 8 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x17 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x17, Zfhmin_fsh_cg_cp_imm_edges_0x8, Zfhmin_fsh_cg_cp_imm_edges_0x8_str)
-#else
-  fsh f19, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x8, Zfhmin_fsh_cg_cp_imm_edges_0x8_str)
 
@@ -940,18 +607,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x10:
   fsh f11, 16(x24) # perform store
   addi x24, x24, 16 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x18 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x18, Zfhmin_fsh_cg_cp_imm_edges_0x10, Zfhmin_fsh_cg_cp_imm_edges_0x10_str)
-#else
-  fsh f11, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x10, Zfhmin_fsh_cg_cp_imm_edges_0x10_str)
 
@@ -964,18 +622,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x20:
   fsh f25, 32(x26) # perform store
   addi x26, x26, 32 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x16 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x16, Zfhmin_fsh_cg_cp_imm_edges_0x20, Zfhmin_fsh_cg_cp_imm_edges_0x20_str)
-#else
-  fsh f25, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x20, Zfhmin_fsh_cg_cp_imm_edges_0x20_str)
 
@@ -988,18 +637,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x40:
   fsh f13, 64(x31) # perform store
   addi x31, x31, 64 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x14 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x14, Zfhmin_fsh_cg_cp_imm_edges_0x40, Zfhmin_fsh_cg_cp_imm_edges_0x40_str)
-#else
-  fsh f13, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x40, Zfhmin_fsh_cg_cp_imm_edges_0x40_str)
 
@@ -1012,18 +652,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x80:
   fsh f18, 128(x26) # perform store
   addi x26, x26, 128 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x9 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x9, Zfhmin_fsh_cg_cp_imm_edges_0x80, Zfhmin_fsh_cg_cp_imm_edges_0x80_str)
-#else
-  fsh f18, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x80, Zfhmin_fsh_cg_cp_imm_edges_0x80_str)
 
@@ -1036,18 +667,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x100:
   fsh f27, 256(x31) # perform store
   addi x31, x31, 256 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x11 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x11, Zfhmin_fsh_cg_cp_imm_edges_0x100, Zfhmin_fsh_cg_cp_imm_edges_0x100_str)
-#else
-  fsh f27, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x100, Zfhmin_fsh_cg_cp_imm_edges_0x100_str)
 
@@ -1060,18 +682,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x200:
   fsh f22, 512(x12) # perform store
   addi x12, x12, 512 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x27 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x27, Zfhmin_fsh_cg_cp_imm_edges_0x200, Zfhmin_fsh_cg_cp_imm_edges_0x200_str)
-#else
-  fsh f22, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x200, Zfhmin_fsh_cg_cp_imm_edges_0x200_str)
 
@@ -1084,18 +697,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x3ff:
   fsh f31, 1023(x22) # perform store
   addi x22, x22, 1023 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x23 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x23, Zfhmin_fsh_cg_cp_imm_edges_0x3ff, Zfhmin_fsh_cg_cp_imm_edges_0x3ff_str)
-#else
-  fsh f31, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x3ff, Zfhmin_fsh_cg_cp_imm_edges_0x3ff_str)
 
@@ -1108,18 +712,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x400:
   fsh f14, 1024(x12) # perform store
   addi x12, x12, 1024 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x6 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x6, Zfhmin_fsh_cg_cp_imm_edges_0x400, Zfhmin_fsh_cg_cp_imm_edges_0x400_str)
-#else
-  fsh f14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x400, Zfhmin_fsh_cg_cp_imm_edges_0x400_str)
 
@@ -1132,18 +727,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x703:
   fsh f13, 1795(x21) # perform store
   addi x21, x21, 1795 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x16 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x16, Zfhmin_fsh_cg_cp_imm_edges_0x703, Zfhmin_fsh_cg_cp_imm_edges_0x703_str)
-#else
-  fsh f13, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x703, Zfhmin_fsh_cg_cp_imm_edges_0x703_str)
 
@@ -1156,18 +742,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x7ff:
   fsh f26, 2047(x8) # perform store
   addi x8, x8, 2047 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x18 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x18, Zfhmin_fsh_cg_cp_imm_edges_0x7ff, Zfhmin_fsh_cg_cp_imm_edges_0x7ff_str)
-#else
-  fsh f26, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x7ff, Zfhmin_fsh_cg_cp_imm_edges_0x7ff_str)
 
@@ -1181,18 +758,9 @@ Zfhmin_fsh_cg_cp_imm_edges_m0x800:
   fsh f10, -2048(x16) # perform store
   addi x16, x16, -2048 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x22 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x22, Zfhmin_fsh_cg_cp_imm_edges_m0x800, Zfhmin_fsh_cg_cp_imm_edges_m0x800_str)
-#else
-  fsh f10, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_m0x800, Zfhmin_fsh_cg_cp_imm_edges_m0x800_str)
 
@@ -1205,18 +773,9 @@ Zfhmin_fsh_cg_cp_imm_edges_m0x7ff:
   fsh f30, -2047(x28) # perform store
   addi x28, x28, -2047 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x23 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x23, Zfhmin_fsh_cg_cp_imm_edges_m0x7ff, Zfhmin_fsh_cg_cp_imm_edges_m0x7ff_str)
-#else
-  fsh f30, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_m0x7ff, Zfhmin_fsh_cg_cp_imm_edges_m0x7ff_str)
 
@@ -1229,18 +788,9 @@ Zfhmin_fsh_cg_cp_imm_edges_m0x2:
   fsh f19, -2(x7) # perform store
   addi x7, x7, -2 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x6 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x6, Zfhmin_fsh_cg_cp_imm_edges_m0x2, Zfhmin_fsh_cg_cp_imm_edges_m0x2_str)
-#else
-  fsh f19, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_m0x2, Zfhmin_fsh_cg_cp_imm_edges_m0x2_str)
 
@@ -1253,18 +803,9 @@ Zfhmin_fsh_cg_cp_imm_edges_m0x1:
   fsh f2, -1(x23) # perform store
   addi x23, x23, -1 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x27 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x27, Zfhmin_fsh_cg_cp_imm_edges_m0x1, Zfhmin_fsh_cg_cp_imm_edges_m0x1_str)
-#else
-  fsh f2, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_m0x1, Zfhmin_fsh_cg_cp_imm_edges_m0x1_str)
 
@@ -1281,18 +822,9 @@ Zfhmin_fsh_cg_cp_fs2_b0:
   fsh f0, 422(x17) # perform store
   addi x17, x17, 422 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x12 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x12, Zfhmin_fsh_cg_cp_fs2_b0, Zfhmin_fsh_cg_cp_fs2_b0_str)
-#else
-  fsh f0, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfhmin_fsh_cg_cp_fs2_b0, Zfhmin_fsh_cg_cp_fs2_b0_str)
 
@@ -1305,18 +837,9 @@ Zfhmin_fsh_cg_cp_fs2_b1:
   fsh f1, 1493(x10) # perform store
   addi x10, x10, 1493 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x31 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x31, Zfhmin_fsh_cg_cp_fs2_b1, Zfhmin_fsh_cg_cp_fs2_b1_str)
-#else
-  fsh f1, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfhmin_fsh_cg_cp_fs2_b1, Zfhmin_fsh_cg_cp_fs2_b1_str)
 
@@ -1329,18 +852,9 @@ Zfhmin_fsh_cg_cp_fs2_b2:
   fsh f2, 2040(x25) # perform store
   addi x25, x25, 2040 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x21 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x21, Zfhmin_fsh_cg_cp_fs2_b2, Zfhmin_fsh_cg_cp_fs2_b2_str)
-#else
-  fsh f2, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfhmin_fsh_cg_cp_fs2_b2, Zfhmin_fsh_cg_cp_fs2_b2_str)
 
@@ -1353,18 +867,9 @@ Zfhmin_fsh_cg_cp_fs2_b3:
   fsh f3, 397(x17) # perform store
   addi x17, x17, 397 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x26 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x26, Zfhmin_fsh_cg_cp_fs2_b3, Zfhmin_fsh_cg_cp_fs2_b3_str)
-#else
-  fsh f3, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfhmin_fsh_cg_cp_fs2_b3, Zfhmin_fsh_cg_cp_fs2_b3_str)
 
@@ -1377,18 +882,9 @@ Zfhmin_fsh_cg_cp_fs2_b4:
   fsh f4, 1550(x14) # perform store
   addi x14, x14, 1550 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, Zfhmin_fsh_cg_cp_fs2_b4, Zfhmin_fsh_cg_cp_fs2_b4_str)
-#else
-  fsh f4, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfhmin_fsh_cg_cp_fs2_b4, Zfhmin_fsh_cg_cp_fs2_b4_str)
 
@@ -1401,18 +897,9 @@ Zfhmin_fsh_cg_cp_fs2_b5:
   fsh f5, 576(x20) # perform store
   addi x20, x20, 576 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x26 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x26, Zfhmin_fsh_cg_cp_fs2_b5, Zfhmin_fsh_cg_cp_fs2_b5_str)
-#else
-  fsh f5, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfhmin_fsh_cg_cp_fs2_b5, Zfhmin_fsh_cg_cp_fs2_b5_str)
 
@@ -1425,18 +912,9 @@ Zfhmin_fsh_cg_cp_fs2_b6:
   fsh f6, -427(x19) # perform store
   addi x19, x19, -427 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x26 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x26, Zfhmin_fsh_cg_cp_fs2_b6, Zfhmin_fsh_cg_cp_fs2_b6_str)
-#else
-  fsh f6, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfhmin_fsh_cg_cp_fs2_b6, Zfhmin_fsh_cg_cp_fs2_b6_str)
 
@@ -1449,18 +927,9 @@ Zfhmin_fsh_cg_cp_fs2_b7:
   fsh f7, -1960(x13) # perform store
   addi x13, x13, -1960 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x17 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x17, Zfhmin_fsh_cg_cp_fs2_b7, Zfhmin_fsh_cg_cp_fs2_b7_str)
-#else
-  fsh f7, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfhmin_fsh_cg_cp_fs2_b7, Zfhmin_fsh_cg_cp_fs2_b7_str)
 
@@ -1473,18 +942,9 @@ Zfhmin_fsh_cg_cp_fs2_b8:
   fsh f8, -1731(x11) # perform store
   addi x11, x11, -1731 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zfhmin_fsh_cg_cp_fs2_b8, Zfhmin_fsh_cg_cp_fs2_b8_str)
-#else
-  fsh f8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfhmin_fsh_cg_cp_fs2_b8, Zfhmin_fsh_cg_cp_fs2_b8_str)
 
@@ -1497,18 +957,9 @@ Zfhmin_fsh_cg_cp_fs2_b9:
   fsh f9, -347(x30) # perform store
   addi x30, x30, -347 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x29 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x29, Zfhmin_fsh_cg_cp_fs2_b9, Zfhmin_fsh_cg_cp_fs2_b9_str)
-#else
-  fsh f9, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfhmin_fsh_cg_cp_fs2_b9, Zfhmin_fsh_cg_cp_fs2_b9_str)
 
@@ -1521,18 +972,9 @@ Zfhmin_fsh_cg_cp_fs2_b10:
   fsh f10, -1112(x20) # perform store
   addi x20, x20, -1112 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x17 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x17, Zfhmin_fsh_cg_cp_fs2_b10, Zfhmin_fsh_cg_cp_fs2_b10_str)
-#else
-  fsh f10, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfhmin_fsh_cg_cp_fs2_b10, Zfhmin_fsh_cg_cp_fs2_b10_str)
 
@@ -1545,18 +987,9 @@ Zfhmin_fsh_cg_cp_fs2_b11:
   fsh f11, 163(x14) # perform store
   addi x14, x14, 163 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zfhmin_fsh_cg_cp_fs2_b11, Zfhmin_fsh_cg_cp_fs2_b11_str)
-#else
-  fsh f11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfhmin_fsh_cg_cp_fs2_b11, Zfhmin_fsh_cg_cp_fs2_b11_str)
 
@@ -1569,18 +1002,9 @@ Zfhmin_fsh_cg_cp_fs2_b12:
   fsh f12, -838(x29) # perform store
   addi x29, x29, -838 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x17 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x17, Zfhmin_fsh_cg_cp_fs2_b12, Zfhmin_fsh_cg_cp_fs2_b12_str)
-#else
-  fsh f12, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfhmin_fsh_cg_cp_fs2_b12, Zfhmin_fsh_cg_cp_fs2_b12_str)
 
@@ -1593,18 +1017,9 @@ Zfhmin_fsh_cg_cp_fs2_b13:
   fsh f13, -651(x22) # perform store
   addi x22, x22, -651 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x12 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x12, Zfhmin_fsh_cg_cp_fs2_b13, Zfhmin_fsh_cg_cp_fs2_b13_str)
-#else
-  fsh f13, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfhmin_fsh_cg_cp_fs2_b13, Zfhmin_fsh_cg_cp_fs2_b13_str)
 
@@ -1617,18 +1032,9 @@ Zfhmin_fsh_cg_cp_fs2_b14:
   fsh f14, 156(x29) # perform store
   addi x29, x29, 156 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x26 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x26, Zfhmin_fsh_cg_cp_fs2_b14, Zfhmin_fsh_cg_cp_fs2_b14_str)
-#else
-  fsh f14, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfhmin_fsh_cg_cp_fs2_b14, Zfhmin_fsh_cg_cp_fs2_b14_str)
 
@@ -1641,18 +1047,9 @@ Zfhmin_fsh_cg_cp_fs2_b15:
   fsh f15, 1700(x25) # perform store
   addi x25, x25, 1700 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x3 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x3, Zfhmin_fsh_cg_cp_fs2_b15, Zfhmin_fsh_cg_cp_fs2_b15_str)
-#else
-  fsh f15, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfhmin_fsh_cg_cp_fs2_b15, Zfhmin_fsh_cg_cp_fs2_b15_str)
 
@@ -1665,18 +1062,9 @@ Zfhmin_fsh_cg_cp_fs2_b16:
   fsh f16, -678(x8) # perform store
   addi x8, x8, -678 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x31 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x31, Zfhmin_fsh_cg_cp_fs2_b16, Zfhmin_fsh_cg_cp_fs2_b16_str)
-#else
-  fsh f16, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfhmin_fsh_cg_cp_fs2_b16, Zfhmin_fsh_cg_cp_fs2_b16_str)
 
@@ -1689,18 +1077,9 @@ Zfhmin_fsh_cg_cp_fs2_b17:
   fsh f17, 1576(x12) # perform store
   addi x12, x12, 1576 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x28 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x28, Zfhmin_fsh_cg_cp_fs2_b17, Zfhmin_fsh_cg_cp_fs2_b17_str)
-#else
-  fsh f17, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfhmin_fsh_cg_cp_fs2_b17, Zfhmin_fsh_cg_cp_fs2_b17_str)
 
@@ -1713,18 +1092,9 @@ Zfhmin_fsh_cg_cp_fs2_b18:
   fsh f18, 985(x9) # perform store
   addi x9, x9, 985 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zfhmin_fsh_cg_cp_fs2_b18, Zfhmin_fsh_cg_cp_fs2_b18_str)
-#else
-  fsh f18, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfhmin_fsh_cg_cp_fs2_b18, Zfhmin_fsh_cg_cp_fs2_b18_str)
 
@@ -1737,18 +1107,9 @@ Zfhmin_fsh_cg_cp_fs2_b19:
   fsh f19, -608(x24) # perform store
   addi x24, x24, -608 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x30 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x30, Zfhmin_fsh_cg_cp_fs2_b19, Zfhmin_fsh_cg_cp_fs2_b19_str)
-#else
-  fsh f19, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfhmin_fsh_cg_cp_fs2_b19, Zfhmin_fsh_cg_cp_fs2_b19_str)
 
@@ -1761,18 +1122,9 @@ Zfhmin_fsh_cg_cp_fs2_b20:
   fsh f20, 2035(x20) # perform store
   addi x20, x20, 2035 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x14 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x14, Zfhmin_fsh_cg_cp_fs2_b20, Zfhmin_fsh_cg_cp_fs2_b20_str)
-#else
-  fsh f20, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfhmin_fsh_cg_cp_fs2_b20, Zfhmin_fsh_cg_cp_fs2_b20_str)
 
@@ -1785,18 +1137,9 @@ Zfhmin_fsh_cg_cp_fs2_b21:
   fsh f21, 991(x30) # perform store
   addi x30, x30, 991 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x10 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x10, Zfhmin_fsh_cg_cp_fs2_b21, Zfhmin_fsh_cg_cp_fs2_b21_str)
-#else
-  fsh f21, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfhmin_fsh_cg_cp_fs2_b21, Zfhmin_fsh_cg_cp_fs2_b21_str)
 
@@ -1809,18 +1152,9 @@ Zfhmin_fsh_cg_cp_fs2_b22:
   fsh f22, -77(x29) # perform store
   addi x29, x29, -77 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x16 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x16, Zfhmin_fsh_cg_cp_fs2_b22, Zfhmin_fsh_cg_cp_fs2_b22_str)
-#else
-  fsh f22, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfhmin_fsh_cg_cp_fs2_b22, Zfhmin_fsh_cg_cp_fs2_b22_str)
 
@@ -1833,18 +1167,9 @@ Zfhmin_fsh_cg_cp_fs2_b23:
   fsh f23, 1302(x6) # perform store
   addi x6, x6, 1302 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x9 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x9, Zfhmin_fsh_cg_cp_fs2_b23, Zfhmin_fsh_cg_cp_fs2_b23_str)
-#else
-  fsh f23, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfhmin_fsh_cg_cp_fs2_b23, Zfhmin_fsh_cg_cp_fs2_b23_str)
 
@@ -1857,18 +1182,9 @@ Zfhmin_fsh_cg_cp_fs2_b24:
   fsh f24, -1825(x21) # perform store
   addi x21, x21, -1825 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x26 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x26, Zfhmin_fsh_cg_cp_fs2_b24, Zfhmin_fsh_cg_cp_fs2_b24_str)
-#else
-  fsh f24, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfhmin_fsh_cg_cp_fs2_b24, Zfhmin_fsh_cg_cp_fs2_b24_str)
 
@@ -1881,18 +1197,9 @@ Zfhmin_fsh_cg_cp_fs2_b25:
   fsh f25, 257(x2) # perform store
   addi x2, x2, 257 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x7 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x7, Zfhmin_fsh_cg_cp_fs2_b25, Zfhmin_fsh_cg_cp_fs2_b25_str)
-#else
-  fsh f25, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfhmin_fsh_cg_cp_fs2_b25, Zfhmin_fsh_cg_cp_fs2_b25_str)
 
@@ -1905,18 +1212,9 @@ Zfhmin_fsh_cg_cp_fs2_b26:
   fsh f26, -1411(x6) # perform store
   addi x6, x6, -1411 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x23 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x23, Zfhmin_fsh_cg_cp_fs2_b26, Zfhmin_fsh_cg_cp_fs2_b26_str)
-#else
-  fsh f26, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfhmin_fsh_cg_cp_fs2_b26, Zfhmin_fsh_cg_cp_fs2_b26_str)
 
@@ -1929,18 +1227,9 @@ Zfhmin_fsh_cg_cp_fs2_b27:
   fsh f27, -950(x9) # perform store
   addi x9, x9, -950 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x22 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x22, Zfhmin_fsh_cg_cp_fs2_b27, Zfhmin_fsh_cg_cp_fs2_b27_str)
-#else
-  fsh f27, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfhmin_fsh_cg_cp_fs2_b27, Zfhmin_fsh_cg_cp_fs2_b27_str)
 
@@ -1953,18 +1242,9 @@ Zfhmin_fsh_cg_cp_fs2_b28:
   fsh f28, 593(x23) # perform store
   addi x23, x23, 593 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x19 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x19, Zfhmin_fsh_cg_cp_fs2_b28, Zfhmin_fsh_cg_cp_fs2_b28_str)
-#else
-  fsh f28, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfhmin_fsh_cg_cp_fs2_b28, Zfhmin_fsh_cg_cp_fs2_b28_str)
 
@@ -1977,18 +1257,9 @@ Zfhmin_fsh_cg_cp_fs2_b29:
   fsh f29, -799(x6) # perform store
   addi x6, x6, -799 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x1 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x1, Zfhmin_fsh_cg_cp_fs2_b29, Zfhmin_fsh_cg_cp_fs2_b29_str)
-#else
-  fsh f29, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfhmin_fsh_cg_cp_fs2_b29, Zfhmin_fsh_cg_cp_fs2_b29_str)
 
@@ -2001,18 +1272,9 @@ Zfhmin_fsh_cg_cp_fs2_b30:
   fsh f30, 269(x25) # perform store
   addi x25, x25, 269 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x28 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x28, Zfhmin_fsh_cg_cp_fs2_b30, Zfhmin_fsh_cg_cp_fs2_b30_str)
-#else
-  fsh f30, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfhmin_fsh_cg_cp_fs2_b30, Zfhmin_fsh_cg_cp_fs2_b30_str)
 
@@ -2025,18 +1287,9 @@ Zfhmin_fsh_cg_cp_fs2_b31:
   fsh f31, 1958(x8) # perform store
   addi x8, x8, 1958 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x30 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x30, Zfhmin_fsh_cg_cp_fs2_b31, Zfhmin_fsh_cg_cp_fs2_b31_str)
-#else
-  fsh f31, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfhmin_fsh_cg_cp_fs2_b31, Zfhmin_fsh_cg_cp_fs2_b31_str)
 
@@ -2053,18 +1306,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x0:
   fsh f15, 334(x18) # perform store
   addi x18, x18, 334 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x21, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x0, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x0_str)
-#else
-  fsh f15, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x0, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x0_str)
 
@@ -2077,18 +1321,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8000:
   fsh f27, 847(x7) # perform store
   addi x7, x7, 847 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x22 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x22, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8000, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8000_str)
-#else
-  fsh f27, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8000, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8000_str)
 
@@ -2101,18 +1336,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3c00:
   fsh f31, -380(x11) # perform store
   addi x11, x11, -380 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3c00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3c00_str)
-#else
-  fsh f31, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3c00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3c00_str)
 
@@ -2125,18 +1351,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbc00:
   fsh f23, -947(x29) # perform store
   addi x29, x29, -947 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x22 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x22, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbc00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbc00_str)
-#else
-  fsh f23, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbc00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbc00_str)
 
@@ -2149,18 +1366,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3e00:
   fsh f31, 1592(x23) # perform store
   addi x23, x23, 1592 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x28 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x28, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3e00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3e00_str)
-#else
-  fsh f31, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3e00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3e00_str)
 
@@ -2173,18 +1381,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbe00:
   fsh f16, -599(x16) # perform store
   addi x16, x16, -599 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x24 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x24, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbe00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbe00_str)
-#else
-  fsh f16, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbe00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbe00_str)
 
@@ -2197,18 +1396,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x4000:
   fsh f6, 1325(x22) # perform store
   addi x22, x22, 1325 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x14 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x14, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x4000, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x4000_str)
-#else
-  fsh f6, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x4000, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x4000_str)
 
@@ -2221,18 +1411,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc000:
   fsh f13, 756(x24) # perform store
   addi x24, x24, 756 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x6 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x6, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc000, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc000_str)
-#else
-  fsh f13, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc000, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc000_str)
 
@@ -2245,18 +1426,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x400:
   fsh f17, -1411(x18) # perform store
   addi x18, x18, -1411 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x30 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x30, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x400, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x400_str)
-#else
-  fsh f17, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x400, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x400_str)
 
@@ -2269,18 +1441,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8400:
   fsh f12, 202(x14) # perform store
   addi x14, x14, 202 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8400, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8400_str)
-#else
-  fsh f12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8400, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8400_str)
 
@@ -2293,18 +1456,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7bff:
   fsh f20, 1405(x25) # perform store
   addi x25, x25, 1405 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x3 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x3, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7bff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7bff_str)
-#else
-  fsh f20, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7bff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7bff_str)
 
@@ -2317,18 +1471,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfbff:
   fsh f13, -329(x14) # perform store
   addi x14, x14, -329 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x1 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x1, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfbff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfbff_str)
-#else
-  fsh f13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfbff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfbff_str)
 
@@ -2341,18 +1486,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3ff:
   fsh f24, 1521(x6) # perform store
   addi x6, x6, 1521 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x22 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x22, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3ff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3ff_str)
-#else
-  fsh f24, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3ff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3ff_str)
 
@@ -2365,18 +1501,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x83ff:
   fsh f14, -911(x22) # perform store
   addi x22, x22, -911 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x12 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x12, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x83ff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x83ff_str)
-#else
-  fsh f14, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x83ff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x83ff_str)
 
@@ -2389,18 +1516,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x200:
   fsh f15, -380(x11) # perform store
   addi x11, x11, -380 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x1 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x1, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x200, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x200_str)
-#else
-  fsh f15, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x200, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x200_str)
 
@@ -2413,18 +1531,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8200:
   fsh f17, 1530(x9) # perform store
   addi x9, x9, 1530 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x23 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x23, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8200, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8200_str)
-#else
-  fsh f17, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8200, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8200_str)
 
@@ -2437,18 +1546,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x1:
   fsh f28, 1545(x3) # perform store
   addi x3, x3, 1545 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x24 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x24, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x1, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x1_str)
-#else
-  fsh f28, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x1, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x1_str)
 
@@ -2461,18 +1561,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8001:
   fsh f25, -1102(x22) # perform store
   addi x22, x22, -1102 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x8 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x8, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8001, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8001_str)
-#else
-  fsh f25, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8001, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8001_str)
 
@@ -2485,18 +1576,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c00:
   fsh f1, 364(x30) # perform store
   addi x30, x30, 364 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x27 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x27, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c00_str)
-#else
-  fsh f1, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c00_str)
 
@@ -2509,18 +1591,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc00:
   fsh f20, 1641(x29) # perform store
   addi x29, x29, 1641 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x8 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x8, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc00_str)
-#else
-  fsh f20, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc00_str)
 
@@ -2533,18 +1606,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7e00:
   fsh f14, 466(x30) # perform store
   addi x30, x30, 466 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x18 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x18, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7e00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7e00_str)
-#else
-  fsh f14, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7e00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7e00_str)
 
@@ -2557,18 +1621,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7fff:
   fsh f11, 517(x27) # perform store
   addi x27, x27, 517 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x23 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x23, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7fff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7fff_str)
-#else
-  fsh f11, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7fff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7fff_str)
 
@@ -2581,18 +1636,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfe00:
   fsh f19, 878(x6) # perform store
   addi x6, x6, 878 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x8 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x8, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfe00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfe00_str)
-#else
-  fsh f19, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfe00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfe00_str)
 
@@ -2605,18 +1651,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c01:
   fsh f25, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c01, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c01_str)
-#else
-  fsh f25, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c01, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c01_str)
 
@@ -2629,18 +1666,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7dff:
   fsh f9, -1280(x24) # perform store
   addi x24, x24, -1280 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x10 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x10, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7dff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7dff_str)
-#else
-  fsh f9, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7dff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7dff_str)
 
@@ -2653,18 +1681,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc01:
   fsh f1, -1915(x29) # perform store
   addi x29, x29, -1915 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x17 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x17, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc01, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc01_str)
-#else
-  fsh f1, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc01, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc01_str)
 
@@ -2677,18 +1696,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x58b4:
   fsh f7, 1090(x31) # perform store
   addi x31, x31, 1090 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x12 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x12, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x58b4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x58b4_str)
-#else
-  fsh f7, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x58b4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x58b4_str)
 
@@ -2701,18 +1711,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc93a:
   fsh f22, 448(x29) # perform store
   addi x29, x29, 448 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x10 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x10, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc93a, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc93a_str)
-#else
-  fsh f22, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc93a, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc93a_str)
 
@@ -2729,18 +1730,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x0:
   fsh f23, 1329(x10) # perform store
   addi x10, x10, 1329 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x0, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x0_str)
-#else
-  fsh f23, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x0, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x0_str)
 
@@ -2753,18 +1745,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000:
   fsh f8, 1467(x8) # perform store
   addi x8, x8, 1467 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x26 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x26, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000_str)
-#else
-  fsh f8, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000_str)
 
@@ -2777,18 +1760,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00:
   fsh f23, -483(x17) # perform store
   addi x17, x17, -483 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x11 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x11, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00_str)
-#else
-  fsh f23, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00_str)
 
@@ -2801,18 +1775,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00:
   fsh f21, 179(x18) # perform store
   addi x18, x18, 179 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x24 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x24, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00_str)
-#else
-  fsh f21, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00_str)
 
@@ -2825,18 +1790,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400:
   fsh f16, 344(x22) # perform store
   addi x22, x22, 344 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x16 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x16, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400_str)
-#else
-  fsh f16, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400_str)
 
@@ -2849,18 +1805,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400:
   fsh f26, 164(x16) # perform store
   addi x16, x16, 164 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x11 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x11, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400_str)
-#else
-  fsh f26, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400_str)
 
@@ -2873,18 +1820,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff:
   fsh f24, 1839(x9) # perform store
   addi x9, x9, 1839 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x21 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x21, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff_str)
-#else
-  fsh f24, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff_str)
 
@@ -2897,18 +1835,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff:
   fsh f12, 928(x14) # perform store
   addi x14, x14, 928 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x18 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x18, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff_str)
-#else
-  fsh f12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff_str)
 
@@ -2921,18 +1850,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00:
   fsh f15, 1600(x12) # perform store
   addi x12, x12, 1600 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x1 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x1, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00_str)
-#else
-  fsh f15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00_str)
 
@@ -2945,18 +1865,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00:
   fsh f9, -1060(x27) # perform store
   addi x27, x27, -1060 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x30 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x30, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00_str)
-#else
-  fsh f9, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00_str)
 
@@ -2969,18 +1880,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00:
   fsh f30, 1899(x20) # perform store
   addi x20, x20, 1899 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x7 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x7, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00_str)
-#else
-  fsh f30, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00_str)
 
@@ -2993,18 +1895,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff:
   fsh f25, -1762(x30) # perform store
   addi x30, x30, -1762 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x24 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x24, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff_str)
-#else
-  fsh f25, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff_str)
 
@@ -3017,18 +1910,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01:
   fsh f27, -509(x13) # perform store
   addi x13, x13, -509 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x28 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x28, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01_str)
-#else
-  fsh f27, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01_str)
 
@@ -3041,18 +1925,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff:
   fsh f25, 31(x17) # perform store
   addi x17, x17, 31 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x19 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x19, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff_str)
-#else
-  fsh f25, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff_str)
 

--- a/tests/rv32i/ZfhminD/ZfhminD-fsh-00.S
+++ b/tests/rv32i/ZfhminD/ZfhminD-fsh-00.S
@@ -42,18 +42,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000:
   fsh f9, -969(x25) # perform store
   addi x25, x25, -969 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x13 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x13, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000_str)
-#else
-  fsh f9, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000_str)
 
@@ -66,18 +57,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000:
   fsh f23, 130(x6) # perform store
   addi x6, x6, 130 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x27 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x27, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000_str)
-#else
-  fsh f23, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000_str)
 
@@ -90,18 +72,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00:
   fsh f26, 1030(x11) # perform store
   addi x11, x11, 1030 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00_str)
-#else
-  fsh f26, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00_str)
 
@@ -114,18 +87,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00:
   fsh f29, -45(x28) # perform store
   addi x28, x28, -45 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x16 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x16, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00_str)
-#else
-  fsh f29, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00_str)
 
@@ -138,18 +102,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400:
   fsh f24, 1789(x13) # perform store
   addi x13, x13, 1789 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400_str)
-#else
-  fsh f24, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400_str)
 
@@ -162,18 +117,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400:
   fsh f25, -1550(x10) # perform store
   addi x10, x10, -1550 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x6 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x6, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400_str)
-#else
-  fsh f25, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400_str)
 
@@ -186,18 +132,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff:
   fsh f25, 372(x29) # perform store
   addi x29, x29, 372 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x17 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x17, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff_str)
-#else
-  fsh f25, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff_str)
 
@@ -210,18 +147,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff:
   fsh f6, 931(x10) # perform store
   addi x10, x10, 931 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x19 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x19, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff_str)
-#else
-  fsh f6, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff_str)
 
@@ -234,18 +162,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00:
   fsh f14, -2015(x28) # perform store
   addi x28, x28, -2015 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x15 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x15, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00_str)
-#else
-  fsh f14, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00_str)
 
@@ -258,18 +177,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00:
   fsh f12, 1351(x25) # perform store
   addi x25, x25, 1351 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x27 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x27, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00_str)
-#else
-  fsh f12, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00_str)
 
@@ -282,18 +192,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00:
   fsh f30, 2033(x17) # perform store
   addi x17, x17, 2033 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x12 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x12, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00_str)
-#else
-  fsh f30, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00_str)
 
@@ -306,18 +207,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff:
   fsh f16, 779(x15) # perform store
   addi x15, x15, 779 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x7 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x7, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff_str)
-#else
-  fsh f16, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff_str)
 
@@ -330,18 +222,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01:
   fsh f25, 332(x2) # perform store
   addi x2, x2, 332 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x25 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x25, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01_str)
-#else
-  fsh f25, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01_str)
 
@@ -354,18 +237,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff:
   fsh f20, -958(x31) # perform store
   addi x31, x31, -958 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x12 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x12, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff_str)
-#else
-  fsh f20, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff_str)
 

--- a/tests/rv64e/E/E-sb-00.S
+++ b/tests/rv64e/E/E-sb-00.S
@@ -41,18 +41,9 @@ E_sb_cg_cp_rs1_nx0_b1:
   sb x7, 1526(x1) # perform store
   addi x1, x1, 1526 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x14 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x14, E_sb_cg_cp_rs1_nx0_b1, E_sb_cg_cp_rs1_nx0_b1_str)
-#else
-  sb x7, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x1eb3dee908eb4d46
@@ -62,18 +53,9 @@ E_sb_cg_cp_rs1_nx0_b2:
   sb x14, 729(x2) # perform store
   addi x2, x2, 729 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x9 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x9, E_sb_cg_cp_rs1_nx0_b2, E_sb_cg_cp_rs1_nx0_b2_str)
-#else
-  sb x14, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x1, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
@@ -84,18 +66,9 @@ E_sb_cg_cp_rs1_nx0_b3:
   sb x15, 1906(x3) # perform store
   addi x3, x3, 1906 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x11 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x11, E_sb_cg_cp_rs1_nx0_b3, E_sb_cg_cp_rs1_nx0_b3_str)
-#else
-  sb x15, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x4 # switch temp register to avoid conflict with test
   mv x14, x5 # switch link pointer register to avoid conflict with test
@@ -107,18 +80,9 @@ E_sb_cg_cp_rs1_nx0_b4:
   sb x5, 625(x4) # perform store
   addi x4, x4, 625 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x12 contains the expected result. x4 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x4, x14, x13, x12, E_sb_cg_cp_rs1_nx0_b4, E_sb_cg_cp_rs1_nx0_b4_str)
-#else
-  sb x5, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x2aa80d1f71d595c9
@@ -128,18 +92,9 @@ E_sb_cg_cp_rs1_nx0_b5:
   sb x9, 551(x5) # perform store
   addi x5, x5, 551 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x11 contains the expected result. x5 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x5, x14, x13, x11, E_sb_cg_cp_rs1_nx0_b5, E_sb_cg_cp_rs1_nx0_b5_str)
-#else
-  sb x9, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xb7062cbf137e8bfd
@@ -149,18 +104,9 @@ E_sb_cg_cp_rs1_nx0_b6:
   sb x15, -1839(x6) # perform store
   addi x6, x6, -1839 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x7 contains the expected result. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x6, x14, x13, x7, E_sb_cg_cp_rs1_nx0_b6, E_sb_cg_cp_rs1_nx0_b6_str)
-#else
-  sb x15, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x7)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x8fcccb07551016ed
@@ -170,18 +116,9 @@ E_sb_cg_cp_rs1_nx0_b7:
   sb x11, -1726(x7) # perform store
   addi x7, x7, -1726 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x3 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x3, E_sb_cg_cp_rs1_nx0_b7, E_sb_cg_cp_rs1_nx0_b7_str)
-#else
-  sb x11, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0xf8d3e2b0d27b9d38
@@ -191,18 +128,9 @@ E_sb_cg_cp_rs1_nx0_b8:
   sb x9, 1009(x8) # perform store
   addi x8, x8, 1009 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x4 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x4, E_sb_cg_cp_rs1_nx0_b8, E_sb_cg_cp_rs1_nx0_b8_str)
-#else
-  sb x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x1, x4) # load rs2: x4 = 0xa0a65cc143c6a0ea
@@ -212,18 +140,9 @@ E_sb_cg_cp_rs1_nx0_b9:
   sb x4, 520(x9) # perform store
   addi x9, x9, 520 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x12, E_sb_cg_cp_rs1_nx0_b9, E_sb_cg_cp_rs1_nx0_b9_str)
-#else
-  sb x4, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xb863213617fa703c
@@ -233,18 +152,9 @@ E_sb_cg_cp_rs1_nx0_b10:
   sb x12, -915(x10) # perform store
   addi x10, x10, -915 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x6 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x6, E_sb_cg_cp_rs1_nx0_b10, E_sb_cg_cp_rs1_nx0_b10_str)
-#else
-  sb x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x5335039579056ab8
@@ -254,18 +164,9 @@ E_sb_cg_cp_rs1_nx0_b11:
   sb x5, 1210(x11) # perform store
   addi x11, x11, 1210 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x9, E_sb_cg_cp_rs1_nx0_b11, E_sb_cg_cp_rs1_nx0_b11_str)
-#else
-  sb x5, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x1, x4) # load rs2: x4 = 0x41a023c03e0196ad
@@ -275,18 +176,9 @@ E_sb_cg_cp_rs1_nx0_b12:
   sb x4, 1973(x12) # perform store
   addi x12, x12, 1973 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x6 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x6, E_sb_cg_cp_rs1_nx0_b12, E_sb_cg_cp_rs1_nx0_b12_str)
-#else
-  sb x4, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -298,18 +190,9 @@ E_sb_cg_cp_rs1_nx0_b13:
   sb x15, 851(x13) # perform store
   addi x13, x13, 851 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x6 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x6, E_sb_cg_cp_rs1_nx0_b13, E_sb_cg_cp_rs1_nx0_b13_str)
-#else
-  sb x15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x16c21637f580af86
@@ -319,18 +202,9 @@ E_sb_cg_cp_rs1_nx0_b14:
   sb x8, 197(x14) # perform store
   addi x14, x14, 197 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x7 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x7, E_sb_cg_cp_rs1_nx0_b14, E_sb_cg_cp_rs1_nx0_b14_str)
-#else
-  sb x8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x9446ad834d402e91
@@ -340,18 +214,9 @@ E_sb_cg_cp_rs1_nx0_b15:
   sb x10, 1676(x15) # perform store
   addi x15, x15, 1676 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, E_sb_cg_cp_rs1_nx0_b15, E_sb_cg_cp_rs1_nx0_b15_str)
-#else
-  sb x10, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2
@@ -365,18 +230,9 @@ E_sb_cg_cp_rs2_b0:
   sb x0, -1464(x3) # perform store
   addi x3, x3, -1464 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x13 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x13, E_sb_cg_cp_rs2_b0, E_sb_cg_cp_rs2_b0_str)
-#else
-  sb x0, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x6, x1 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x1)
@@ -387,18 +243,9 @@ E_sb_cg_cp_rs2_b1:
   sb x1, 1670(x2) # perform store
   addi x2, x2, 1670 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x10 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x10, E_sb_cg_cp_rs2_b1, E_sb_cg_cp_rs2_b1_str)
-#else
-  sb x1, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x1, x2 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x2)
@@ -409,18 +256,9 @@ E_sb_cg_cp_rs2_b2:
   sb x2, 1851(x15) # perform store
   addi x15, x15, 1851 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x13, E_sb_cg_cp_rs2_b2, E_sb_cg_cp_rs2_b2_str)
-#else
-  sb x2, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x6, x3) # load rs2: x3 = 0x8b898a99dfe67374
@@ -430,18 +268,9 @@ E_sb_cg_cp_rs2_b3:
   sb x3, -1979(x13) # perform store
   addi x13, x13, -1979 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x10 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x10, E_sb_cg_cp_rs2_b3, E_sb_cg_cp_rs2_b3_str)
-#else
-  sb x3, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -453,18 +282,9 @@ E_sb_cg_cp_rs2_b4:
   sb x4, -741(x12) # perform store
   addi x12, x12, -741 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x15 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x12, x8, x7, x15, E_sb_cg_cp_rs2_b4, E_sb_cg_cp_rs2_b4_str)
-#else
-  sb x4, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x6, x5) # load rs2: x5 = 0x7fdb7dccf48b56ed
@@ -474,18 +294,9 @@ E_sb_cg_cp_rs2_b5:
   sb x5, -1178(x15) # perform store
   addi x15, x15, -1178 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x1 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x15, x8, x7, x1, E_sb_cg_cp_rs2_b5, E_sb_cg_cp_rs2_b5_str)
-#else
-  sb x5, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x1, x6 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x6)
@@ -496,18 +307,9 @@ E_sb_cg_cp_rs2_b6:
   sb x6, 645(x5) # perform store
   addi x5, x5, 645 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x4 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x4, E_sb_cg_cp_rs2_b6, E_sb_cg_cp_rs2_b6_str)
-#else
-  sb x6, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x7 # switch temp register to avoid conflict with test
   mv x14, x8 # switch link pointer register to avoid conflict with test
@@ -519,18 +321,9 @@ E_sb_cg_cp_rs2_b7:
   sb x7, 1314(x6) # perform store
   addi x6, x6, 1314 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x3 contains the expected result. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x6, x14, x13, x3, E_sb_cg_cp_rs2_b7, E_sb_cg_cp_rs2_b7_str)
-#else
-  sb x7, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xb7507451bee66570
@@ -540,18 +333,9 @@ E_sb_cg_cp_rs2_b8:
   sb x8, -1659(x2) # perform store
   addi x2, x2, -1659 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x9 contains the expected result. x2 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x2, x14, x13, x9, E_sb_cg_cp_rs2_b8, E_sb_cg_cp_rs2_b8_str)
-#else
-  sb x8, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0xe216f9467f0736ae
@@ -561,18 +345,9 @@ E_sb_cg_cp_rs2_b9:
   sb x9, -225(x4) # perform store
   addi x4, x4, -225 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x10 contains the expected result. x4 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x4, x14, x13, x10, E_sb_cg_cp_rs2_b9, E_sb_cg_cp_rs2_b9_str)
-#else
-  sb x9, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x7a1da9e7690d3d3d
@@ -582,18 +357,9 @@ E_sb_cg_cp_rs2_b10:
   sb x10, -296(x8) # perform store
   addi x8, x8, -296 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x12, E_sb_cg_cp_rs2_b10, E_sb_cg_cp_rs2_b10_str)
-#else
-  sb x10, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xf680a9fc2d516b8a
@@ -603,18 +369,9 @@ E_sb_cg_cp_rs2_b11:
   sb x11, -1123(x6) # perform store
   addi x6, x6, -1123 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x4 contains the expected result. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x6, x14, x13, x4, E_sb_cg_cp_rs2_b11, E_sb_cg_cp_rs2_b11_str)
-#else
-  sb x11, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x24919fc8cc5394f0
@@ -624,18 +381,9 @@ E_sb_cg_cp_rs2_b12:
   sb x12, 1664(x10) # perform store
   addi x10, x10, 1664 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x3 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x3, E_sb_cg_cp_rs2_b12, E_sb_cg_cp_rs2_b12_str)
-#else
-  sb x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -647,18 +395,9 @@ E_sb_cg_cp_rs2_b13:
   sb x13, 542(x7) # perform store
   addi x7, x7, 542 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x12 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x12, E_sb_cg_cp_rs2_b13, E_sb_cg_cp_rs2_b13_str)
-#else
-  sb x13, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x7fce0ad162a2523d
@@ -668,18 +407,9 @@ E_sb_cg_cp_rs2_b14:
   sb x14, -1740(x8) # perform store
   addi x8, x8, -1740 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x6 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x6, E_sb_cg_cp_rs2_b14, E_sb_cg_cp_rs2_b14_str)
-#else
-  sb x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xfda3fabe41ea1776
@@ -689,18 +419,9 @@ E_sb_cg_cp_rs2_b15:
   sb x15, -1374(x14) # perform store
   addi x14, x14, -1374 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x10 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x10, E_sb_cg_cp_rs2_b15, E_sb_cg_cp_rs2_b15_str)
-#else
-  sb x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -714,18 +435,9 @@ E_sb_cg_cp_rs2_edges_0x0:
   sb x2, -89(x13) # perform store
   addi x13, x13, -89 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, E_sb_cg_cp_rs2_edges_0x0, E_sb_cg_cp_rs2_edges_0x0_str)
-#else
-  sb x2, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x0000000000000001
@@ -735,18 +447,9 @@ E_sb_cg_cp_rs2_edges_0x1:
   sb x10, 1105(x2) # perform store
   addi x2, x2, 1105 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x15 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x15, E_sb_cg_cp_rs2_edges_0x1, E_sb_cg_cp_rs2_edges_0x1_str)
-#else
-  sb x10, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x0000000000000002
@@ -756,18 +459,9 @@ E_sb_cg_cp_rs2_edges_0x2:
   sb x3, -1022(x14) # perform store
   addi x14, x14, -1022 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, E_sb_cg_cp_rs2_edges_0x2, E_sb_cg_cp_rs2_edges_0x2_str)
-#else
-  sb x3, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x8000000000000000
@@ -777,18 +471,9 @@ E_sb_cg_cp_rs2_edges_0x8000000000000000:
   sb x3, -178(x8) # perform store
   addi x8, x8, -178 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x15 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x15, E_sb_cg_cp_rs2_edges_0x8000000000000000, E_sb_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  sb x3, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x8000000000000001
@@ -798,18 +483,9 @@ E_sb_cg_cp_rs2_edges_0x8000000000000001:
   sb x12, -1297(x10) # perform store
   addi x10, x10, -1297 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, E_sb_cg_cp_rs2_edges_0x8000000000000001, E_sb_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  sb x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x7fffffffffffffff
@@ -819,18 +495,9 @@ E_sb_cg_cp_rs2_edges_0x7fffffffffffffff:
   sb x3, 1423(x11) # perform store
   addi x11, x11, 1423 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, E_sb_cg_cp_rs2_edges_0x7fffffffffffffff, E_sb_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  sb x3, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x7ffffffffffffffe
@@ -840,18 +507,9 @@ E_sb_cg_cp_rs2_edges_0x7ffffffffffffffe:
   sb x14, 197(x13) # perform store
   addi x13, x13, 197 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, E_sb_cg_cp_rs2_edges_0x7ffffffffffffffe, E_sb_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  sb x14, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xffffffffffffffff
@@ -861,18 +519,9 @@ E_sb_cg_cp_rs2_edges_0xffffffffffffffff:
   sb x8, -1907(x10) # perform store
   addi x10, x10, -1907 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, E_sb_cg_cp_rs2_edges_0xffffffffffffffff, E_sb_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  sb x8, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xfffffffffffffffe
@@ -882,18 +531,9 @@ E_sb_cg_cp_rs2_edges_0xfffffffffffffffe:
   sb x6, -1920(x2) # perform store
   addi x2, x2, -1920 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x13 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x13, E_sb_cg_cp_rs2_edges_0xfffffffffffffffe, E_sb_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  sb x6, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x5bbc887763ae86f2
@@ -903,18 +543,9 @@ E_sb_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   sb x14, -1348(x15) # perform store
   addi x15, x15, -1348 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x11 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x11, E_sb_cg_cp_rs2_edges_0x5bbc887763ae86f2, E_sb_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  sb x14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xaaaaaaaaaaaaaaaa
@@ -924,18 +555,9 @@ E_sb_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   sb x13, 510(x3) # perform store
   addi x3, x3, 510 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x11 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x11, E_sb_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, E_sb_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  sb x13, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x5555555555555555
@@ -945,18 +567,9 @@ E_sb_cg_cp_rs2_edges_0x5555555555555555:
   sb x11, -1833(x13) # perform store
   addi x13, x13, -1833 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, E_sb_cg_cp_rs2_edges_0x5555555555555555, E_sb_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  sb x11, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x00000000ffffffff
@@ -966,18 +579,9 @@ E_sb_cg_cp_rs2_edges_0xffffffff:
   sb x3, 125(x12) # perform store
   addi x12, x12, 125 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, E_sb_cg_cp_rs2_edges_0xffffffff, E_sb_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  sb x3, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x00000000fffffffe
@@ -987,18 +591,9 @@ E_sb_cg_cp_rs2_edges_0xfffffffe:
   sb x8, 762(x6) # perform store
   addi x6, x6, 762 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x14 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x14, E_sb_cg_cp_rs2_edges_0xfffffffe, E_sb_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  sb x8, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x0000000100000000
@@ -1008,18 +603,9 @@ E_sb_cg_cp_rs2_edges_0x100000000:
   sb x15, 1985(x9) # perform store
   addi x9, x9, 1985 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, E_sb_cg_cp_rs2_edges_0x100000000, E_sb_cg_cp_rs2_edges_0x100000000_str)
-#else
-  sb x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0x0000000100000001
@@ -1029,18 +615,9 @@ E_sb_cg_cp_rs2_edges_0x100000001:
   sb x2, -116(x15) # perform store
   addi x15, x15, -116 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x7 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x7, E_sb_cg_cp_rs2_edges_0x100000001, E_sb_cg_cp_rs2_edges_0x100000001_str)
-#else
-  sb x2, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_edges
@@ -1054,18 +631,9 @@ E_sb_cg_cp_imm_edges_0x0:
   sb x14, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x8, E_sb_cg_cp_imm_edges_0x0, E_sb_cg_cp_imm_edges_0x0_str)
-#else
-  sb x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xba443fbd53d862b0
@@ -1075,18 +643,9 @@ E_sb_cg_cp_imm_edges_0x1:
   sb x6, 1(x7) # perform store
   addi x7, x7, 1 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x11 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x11, E_sb_cg_cp_imm_edges_0x1, E_sb_cg_cp_imm_edges_0x1_str)
-#else
-  sb x6, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0x4a3217339988e780
@@ -1096,18 +655,9 @@ E_sb_cg_cp_imm_edges_0x2:
   sb x2, 2(x14) # perform store
   addi x14, x14, 2 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x6 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x6, E_sb_cg_cp_imm_edges_0x2, E_sb_cg_cp_imm_edges_0x2_str)
-#else
-  sb x2, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 3)
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xb460d56db1caf10d
@@ -1117,18 +667,9 @@ E_sb_cg_cp_imm_edges_0x3:
   sb x7, 3(x13) # perform store
   addi x13, x13, 3 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, E_sb_cg_cp_imm_edges_0x3, E_sb_cg_cp_imm_edges_0x3_str)
-#else
-  sb x7, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 4)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x481ad3197bcd5c35
@@ -1138,18 +679,9 @@ E_sb_cg_cp_imm_edges_0x4:
   sb x15, 4(x8) # perform store
   addi x8, x8, 4 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, E_sb_cg_cp_imm_edges_0x4, E_sb_cg_cp_imm_edges_0x4_str)
-#else
-  sb x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 8)
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x363c83bf35c60242
@@ -1159,18 +691,9 @@ E_sb_cg_cp_imm_edges_0x8:
   sb x3, 8(x13) # perform store
   addi x13, x13, 8 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, E_sb_cg_cp_imm_edges_0x8, E_sb_cg_cp_imm_edges_0x8_str)
-#else
-  sb x3, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 16)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x14185bda173139a6
@@ -1180,18 +703,9 @@ E_sb_cg_cp_imm_edges_0x10:
   sb x10, 16(x6) # perform store
   addi x6, x6, 16 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x12 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x12, E_sb_cg_cp_imm_edges_0x10, E_sb_cg_cp_imm_edges_0x10_str)
-#else
-  sb x10, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 32)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x5c84532d89b7fb11
@@ -1201,18 +715,9 @@ E_sb_cg_cp_imm_edges_0x20:
   sb x15, 32(x11) # perform store
   addi x11, x11, 32 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, E_sb_cg_cp_imm_edges_0x20, E_sb_cg_cp_imm_edges_0x20_str)
-#else
-  sb x15, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 64)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xce13ae93d129aadb
@@ -1222,18 +727,9 @@ E_sb_cg_cp_imm_edges_0x40:
   sb x6, 64(x9) # perform store
   addi x9, x9, 64 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, E_sb_cg_cp_imm_edges_0x40, E_sb_cg_cp_imm_edges_0x40_str)
-#else
-  sb x6, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 128)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x6ee73b9da08fea6c
@@ -1243,18 +739,9 @@ E_sb_cg_cp_imm_edges_0x80:
   sb x14, 128(x2) # perform store
   addi x2, x2, 128 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x13 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x13, E_sb_cg_cp_imm_edges_0x80, E_sb_cg_cp_imm_edges_0x80_str)
-#else
-  sb x14, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 256)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x7892a737391a7979
@@ -1264,18 +751,9 @@ E_sb_cg_cp_imm_edges_0x100:
   sb x10, 256(x7) # perform store
   addi x7, x7, 256 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x9 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x9, E_sb_cg_cp_imm_edges_0x100, E_sb_cg_cp_imm_edges_0x100_str)
-#else
-  sb x10, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 512)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x5a9b0f17e874c77a
@@ -1285,18 +763,9 @@ E_sb_cg_cp_imm_edges_0x200:
   sb x14, 512(x12) # perform store
   addi x12, x12, 512 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x15 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x15, E_sb_cg_cp_imm_edges_0x200, E_sb_cg_cp_imm_edges_0x200_str)
-#else
-  sb x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1023)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x18ab6bb3295d4898
@@ -1306,18 +775,9 @@ E_sb_cg_cp_imm_edges_0x3ff:
   sb x8, 1023(x11) # perform store
   addi x11, x11, 1023 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, E_sb_cg_cp_imm_edges_0x3ff, E_sb_cg_cp_imm_edges_0x3ff_str)
-#else
-  sb x8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1024)
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xb87296f14807c17b
@@ -1327,18 +787,9 @@ E_sb_cg_cp_imm_edges_0x400:
   sb x3, 1024(x6) # perform store
   addi x6, x6, 1024 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x15 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x15, E_sb_cg_cp_imm_edges_0x400, E_sb_cg_cp_imm_edges_0x400_str)
-#else
-  sb x3, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1795)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xfc115fa4a1e1a1db
@@ -1348,18 +799,9 @@ E_sb_cg_cp_imm_edges_0x703:
   sb x8, 1795(x13) # perform store
   addi x13, x13, 1795 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x10 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x10, E_sb_cg_cp_imm_edges_0x703, E_sb_cg_cp_imm_edges_0x703_str)
-#else
-  sb x8, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2047)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x2b353ffc8bc20452
@@ -1369,18 +811,9 @@ E_sb_cg_cp_imm_edges_0x7ff:
   sb x14, 2047(x3) # perform store
   addi x3, x3, 2047 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x10 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x10, E_sb_cg_cp_imm_edges_0x7ff, E_sb_cg_cp_imm_edges_0x7ff_str)
-#else
-  sb x14, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2048)
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x8fa9421545d82f5a
@@ -1391,18 +824,9 @@ E_sb_cg_cp_imm_edges_m0x800:
   sb x9, -2048(x11) # perform store
   addi x11, x11, -2048 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, E_sb_cg_cp_imm_edges_m0x800, E_sb_cg_cp_imm_edges_m0x800_str)
-#else
-  sb x9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2047)
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x7963cd1b10a71962
@@ -1412,18 +836,9 @@ E_sb_cg_cp_imm_edges_m0x7ff:
   sb x9, -2047(x14) # perform store
   addi x14, x14, -2047 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x10 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x10, E_sb_cg_cp_imm_edges_m0x7ff, E_sb_cg_cp_imm_edges_m0x7ff_str)
-#else
-  sb x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xe02957524ca0bf40
@@ -1433,18 +848,9 @@ E_sb_cg_cp_imm_edges_m0x2:
   sb x2, -2(x6) # perform store
   addi x6, x6, -2 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x9 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x9, E_sb_cg_cp_imm_edges_m0x2, E_sb_cg_cp_imm_edges_m0x2_str)
-#else
-  sb x2, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -1)
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x3185c956dcb28645
@@ -1454,18 +860,9 @@ E_sb_cg_cp_imm_edges_m0x1:
   sb x7, -1(x2) # perform store
   addi x2, x2, -1 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x3 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x3, E_sb_cg_cp_imm_edges_m0x1, E_sb_cg_cp_imm_edges_m0x1_str)
-#else
-  sb x7, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_align_byte
@@ -1476,144 +873,72 @@ E_sb_cg_cp_imm_edges_m0x1:
 E_sb_cg_cp_align_byte_b0:
   sb x9, 0(x2) # perform store
   addi x2, x2, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -8(x2) # load stored value for checking
   # Check if x12 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x12, E_sb_cg_cp_align_byte_b0, E_sb_cg_cp_align_byte_b0_str)
-#else
-  sb x9, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 001)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xa56335ff3b5546ad
 E_sb_cg_cp_align_byte_b1:
   sb x15, 1(x2) # perform store
   addi x2, x2, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -8(x2) # load stored value for checking
   # Check if x9 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x9, E_sb_cg_cp_align_byte_b1, E_sb_cg_cp_align_byte_b1_str)
-#else
-  sb x15, 1(x2) # repeat store so it is available for checking
-  addi x2, x2, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 010)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xbe9cc00c39646683
 E_sb_cg_cp_align_byte_b2:
   sb x14, 2(x2) # perform store
   addi x2, x2, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -8(x2) # load stored value for checking
   # Check if x6 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x6, E_sb_cg_cp_align_byte_b2, E_sb_cg_cp_align_byte_b2_str)
-#else
-  sb x14, 2(x2) # repeat store so it is available for checking
-  addi x2, x2, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 011)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x04cfe928ec9e800d
 E_sb_cg_cp_align_byte_b3:
   sb x10, 3(x2) # perform store
   addi x2, x2, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -8(x2) # load stored value for checking
   # Check if x13 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x13, E_sb_cg_cp_align_byte_b3, E_sb_cg_cp_align_byte_b3_str)
-#else
-  sb x10, 3(x2) # repeat store so it is available for checking
-  addi x2, x2, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 100)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xb48a672d6340d75a
 E_sb_cg_cp_align_byte_b4:
   sb x12, 4(x2) # perform store
   addi x2, x2, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -8(x2) # load stored value for checking
   # Check if x3 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x3, E_sb_cg_cp_align_byte_b4, E_sb_cg_cp_align_byte_b4_str)
-#else
-  sb x12, 4(x2) # repeat store so it is available for checking
-  addi x2, x2, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 101)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xed0718e33ae4887f
 E_sb_cg_cp_align_byte_b5:
   sb x6, 5(x2) # perform store
   addi x2, x2, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -8(x2) # load stored value for checking
   # Check if x7 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x7, E_sb_cg_cp_align_byte_b5, E_sb_cg_cp_align_byte_b5_str)
-#else
-  sb x6, 5(x2) # repeat store so it is available for checking
-  addi x2, x2, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 110)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x8089ee4bd55f2adc
 E_sb_cg_cp_align_byte_b6:
   sb x11, 6(x2) # perform store
   addi x2, x2, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -8(x2) # load stored value for checking
   # Check if x9 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x9, E_sb_cg_cp_align_byte_b6, E_sb_cg_cp_align_byte_b6_str)
-#else
-  sb x11, 6(x2) # repeat store so it is available for checking
-  addi x2, x2, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 111)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x1bbe4fa404ac2c2f
 E_sb_cg_cp_align_byte_b7:
   sb x13, 7(x2) # perform store
   addi x2, x2, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -8(x2) # load stored value for checking
   # Check if x8 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x8, E_sb_cg_cp_align_byte_b7, E_sb_cg_cp_align_byte_b7_str)
-#else
-  sb x13, 7(x2) # repeat store so it is available for checking
-  addi x2, x2, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 
 // Instantiate trap handlers and other epilog code, call RVMODEL_HALT at end of test

--- a/tests/rv64e/E/E-sd-00.S
+++ b/tests/rv64e/E/E-sd-00.S
@@ -41,18 +41,9 @@ E_sd_cg_cp_rs1_nx0_b1:
   sd x0, -405(x1) # perform store
   addi x1, x1, -405 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x9 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x9, E_sd_cg_cp_rs1_nx0_b1, E_sd_cg_cp_rs1_nx0_b1_str)
-#else
-  sd x0, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0x2e600b30a2fbefe1
@@ -62,18 +53,9 @@ E_sd_cg_cp_rs1_nx0_b2:
   sd x6, -568(x2) # perform store
   addi x2, x2, -568 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x7 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x7, E_sd_cg_cp_rs1_nx0_b2, E_sd_cg_cp_rs1_nx0_b2_str)
-#else
-  sd x6, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x10, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
@@ -84,18 +66,9 @@ E_sd_cg_cp_rs1_nx0_b3:
   sd x6, -1441(x3) # perform store
   addi x3, x3, -1441 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x8 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x8, E_sd_cg_cp_rs1_nx0_b3, E_sd_cg_cp_rs1_nx0_b3_str)
-#else
-  sd x6, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -107,18 +80,9 @@ E_sd_cg_cp_rs1_nx0_b4:
   sd x2, -464(x4) # perform store
   addi x4, x4, -464 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x12 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x12, E_sd_cg_cp_rs1_nx0_b4, E_sd_cg_cp_rs1_nx0_b4_str)
-#else
-  sd x2, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x10, x0) # load rs2: x0 = 0xd4c661fe4a966bd1
@@ -128,18 +92,9 @@ E_sd_cg_cp_rs1_nx0_b5:
   sd x0, 1481(x5) # perform store
   addi x5, x5, 1481 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x15 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x15, E_sd_cg_cp_rs1_nx0_b5, E_sd_cg_cp_rs1_nx0_b5_str)
-#else
-  sd x0, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x10, x4) # load rs2: x4 = 0x9748ca76c9e4682f
@@ -149,18 +104,9 @@ E_sd_cg_cp_rs1_nx0_b6:
   sd x4, -185(x6) # perform store
   addi x6, x6, -185 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x11 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x11, E_sd_cg_cp_rs1_nx0_b6, E_sd_cg_cp_rs1_nx0_b6_str)
-#else
-  sd x4, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x7 # switch temp register to avoid conflict with test
   mv x14, x8 # switch link pointer register to avoid conflict with test
@@ -172,18 +118,9 @@ E_sd_cg_cp_rs1_nx0_b7:
   sd x12, 1297(x7) # perform store
   addi x7, x7, 1297 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x8 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x8, E_sd_cg_cp_rs1_nx0_b7, E_sd_cg_cp_rs1_nx0_b7_str)
-#else
-  sd x12, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x10, x4) # load rs2: x4 = 0xa76498376f97009c
@@ -193,18 +130,9 @@ E_sd_cg_cp_rs1_nx0_b8:
   sd x4, -1029(x8) # perform store
   addi x8, x8, -1029 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x15 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x15, E_sd_cg_cp_rs1_nx0_b8, E_sd_cg_cp_rs1_nx0_b8_str)
-#else
-  sd x4, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x10, x11) # load rs2: x11 = 0x59e9463fabc5da1c
@@ -214,18 +142,9 @@ E_sd_cg_cp_rs1_nx0_b9:
   sd x11, -967(x9) # perform store
   addi x9, x9, -967 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x5 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x5, E_sd_cg_cp_rs1_nx0_b9, E_sd_cg_cp_rs1_nx0_b9_str)
-#else
-  sd x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x15, x10 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
@@ -236,18 +155,9 @@ E_sd_cg_cp_rs1_nx0_b10:
   sd x2, 1964(x10) # perform store
   addi x10, x10, 1964 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x7 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x7, E_sd_cg_cp_rs1_nx0_b10, E_sd_cg_cp_rs1_nx0_b10_str)
-#else
-  sd x2, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x15, x3) # load rs2: x3 = 0x00cc54eb2614414b
@@ -257,18 +167,9 @@ E_sd_cg_cp_rs1_nx0_b11:
   sd x3, -633(x11) # perform store
   addi x11, x11, -633 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x6 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x6, E_sd_cg_cp_rs1_nx0_b11, E_sd_cg_cp_rs1_nx0_b11_str)
-#else
-  sd x3, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x15, x1) # load rs2: x1 = 0x314b2b00a3c4c584
@@ -278,18 +179,9 @@ E_sd_cg_cp_rs1_nx0_b12:
   sd x1, -852(x12) # perform store
   addi x12, x12, -852 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x4 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x4, E_sd_cg_cp_rs1_nx0_b12, E_sd_cg_cp_rs1_nx0_b12_str)
-#else
-  sd x1, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -301,18 +193,9 @@ E_sd_cg_cp_rs1_nx0_b13:
   sd x9, -155(x13) # perform store
   addi x13, x13, -155 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x1 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x1, E_sd_cg_cp_rs1_nx0_b13, E_sd_cg_cp_rs1_nx0_b13_str)
-#else
-  sd x9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x15, x0) # load rs2: x0 = 0x165afe958ba715e9
@@ -322,18 +205,9 @@ E_sd_cg_cp_rs1_nx0_b14:
   sd x0, -1794(x14) # perform store
   addi x14, x14, -1794 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x10 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x10, E_sd_cg_cp_rs1_nx0_b14, E_sd_cg_cp_rs1_nx0_b14_str)
-#else
-  sd x0, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x10, x15 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
@@ -344,18 +218,9 @@ E_sd_cg_cp_rs1_nx0_b15:
   sd x12, 1654(x15) # perform store
   addi x15, x15, 1654 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x6 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x6, E_sd_cg_cp_rs1_nx0_b15, E_sd_cg_cp_rs1_nx0_b15_str)
-#else
-  sd x12, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2
@@ -369,18 +234,9 @@ E_sd_cg_cp_rs2_b0:
   sd x0, -232(x3) # perform store
   addi x3, x3, -232 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x1 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x1, E_sd_cg_cp_rs2_b0, E_sd_cg_cp_rs2_b0_str)
-#else
-  sd x0, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x10, x1) # load rs2: x1 = 0x74af5346a50fbbb3
@@ -390,18 +246,9 @@ E_sd_cg_cp_rs2_b1:
   sd x1, 1605(x7) # perform store
   addi x7, x7, 1605 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x9 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x9, E_sd_cg_cp_rs2_b1, E_sd_cg_cp_rs2_b1_str)
-#else
-  sd x1, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x10, x2) # load rs2: x2 = 0x9c362b51ef96a381
@@ -411,18 +258,9 @@ E_sd_cg_cp_rs2_b2:
   sd x2, 1781(x14) # perform store
   addi x14, x14, 1781 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, E_sd_cg_cp_rs2_b2, E_sd_cg_cp_rs2_b2_str)
-#else
-  sd x2, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x10, x3) # load rs2: x3 = 0xfffc782ea2c39670
@@ -432,18 +270,9 @@ E_sd_cg_cp_rs2_b3:
   sd x3, -1169(x11) # perform store
   addi x11, x11, -1169 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, E_sd_cg_cp_rs2_b3, E_sd_cg_cp_rs2_b3_str)
-#else
-  sd x3, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x4 # switch temp register to avoid conflict with test
   mv x14, x5 # switch link pointer register to avoid conflict with test
@@ -455,18 +284,9 @@ E_sd_cg_cp_rs2_b4:
   sd x4, 1341(x7) # perform store
   addi x7, x7, 1341 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x12 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x12, E_sd_cg_cp_rs2_b4, E_sd_cg_cp_rs2_b4_str)
-#else
-  sd x4, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x10, x5) # load rs2: x5 = 0x0dca87c7aeee00ad
@@ -476,18 +296,9 @@ E_sd_cg_cp_rs2_b5:
   sd x5, -1180(x15) # perform store
   addi x15, x15, -1180 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x3 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x15, x14, x13, x3, E_sd_cg_cp_rs2_b5, E_sd_cg_cp_rs2_b5_str)
-#else
-  sd x5, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x10, x6) # load rs2: x6 = 0xfd8dda41eece1f17
@@ -497,18 +308,9 @@ E_sd_cg_cp_rs2_b6:
   sd x6, -1692(x3) # perform store
   addi x3, x3, -1692 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x12 contains the expected result. x3 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x3, x14, x13, x12, E_sd_cg_cp_rs2_b6, E_sd_cg_cp_rs2_b6_str)
-#else
-  sd x6, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x10, x7) # load rs2: x7 = 0x6c46e66843ec2bd9
@@ -518,18 +320,9 @@ E_sd_cg_cp_rs2_b7:
   sd x7, -547(x12) # perform store
   addi x12, x12, -547 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x11, E_sd_cg_cp_rs2_b7, E_sd_cg_cp_rs2_b7_str)
-#else
-  sd x7, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x10, x8) # load rs2: x8 = 0xc27e6a550ab92bf7
@@ -539,18 +332,9 @@ E_sd_cg_cp_rs2_b8:
   sd x8, 1862(x6) # perform store
   addi x6, x6, 1862 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x1 contains the expected result. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x6, x14, x13, x1, E_sd_cg_cp_rs2_b8, E_sd_cg_cp_rs2_b8_str)
-#else
-  sd x8, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x10, x9) # load rs2: x9 = 0xa672e49888b7cec9
@@ -560,18 +344,9 @@ E_sd_cg_cp_rs2_b9:
   sd x9, -1612(x7) # perform store
   addi x7, x7, -1612 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x8 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x8, E_sd_cg_cp_rs2_b9, E_sd_cg_cp_rs2_b9_str)
-#else
-  sd x9, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x9, x10 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x10)
@@ -582,18 +357,9 @@ E_sd_cg_cp_rs2_b10:
   sd x10, -359(x1) # perform store
   addi x1, x1, -359 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x1, x14, x13, x15, E_sd_cg_cp_rs2_b10, E_sd_cg_cp_rs2_b10_str)
-#else
-  sd x10, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x9, x11) # load rs2: x11 = 0x57f0332b0e0ec2cb
@@ -603,18 +369,9 @@ E_sd_cg_cp_rs2_b11:
   sd x11, -347(x6) # perform store
   addi x6, x6, -347 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x3 contains the expected result. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x6, x14, x13, x3, E_sd_cg_cp_rs2_b11, E_sd_cg_cp_rs2_b11_str)
-#else
-  sd x11, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x9, x12) # load rs2: x12 = 0xa4561a09ee2ff618
@@ -624,18 +381,9 @@ E_sd_cg_cp_rs2_b12:
   sd x12, -697(x15) # perform store
   addi x15, x15, -697 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x5 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x15, x14, x13, x5, E_sd_cg_cp_rs2_b12, E_sd_cg_cp_rs2_b12_str)
-#else
-  sd x12, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x13 # switch temp register to avoid conflict with test
   mv x8, x14 # switch link pointer register to avoid conflict with test
@@ -647,18 +395,9 @@ E_sd_cg_cp_rs2_b13:
   sd x13, -1920(x1) # perform store
   addi x1, x1, -1920 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, E_sd_cg_cp_rs2_b13, E_sd_cg_cp_rs2_b13_str)
-#else
-  sd x13, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x9, x14) # load rs2: x14 = 0x5a99d888e3d9ea80
@@ -668,18 +407,9 @@ E_sd_cg_cp_rs2_b14:
   sd x14, -1996(x13) # perform store
   addi x13, x13, -1996 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x3 contains the expected result. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x13, x8, x7, x3, E_sd_cg_cp_rs2_b14, E_sd_cg_cp_rs2_b14_str)
-#else
-  sd x14, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x9, x15) # load rs2: x15 = 0x7e35d96dd2ab70f6
@@ -689,18 +419,9 @@ E_sd_cg_cp_rs2_b15:
   sd x15, -1084(x4) # perform store
   addi x4, x4, -1084 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x5 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x5, E_sd_cg_cp_rs2_b15, E_sd_cg_cp_rs2_b15_str)
-#else
-  sd x15, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -714,18 +435,9 @@ E_sd_cg_cp_rs2_edges_0x0:
   sd x5, 1785(x11) # perform store
   addi x11, x11, 1785 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x11, x8, x7, x14, E_sd_cg_cp_rs2_edges_0x0, E_sd_cg_cp_rs2_edges_0x0_str)
-#else
-  sd x5, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x9, x15) # load rs2: x15 = 0x0000000000000001
@@ -735,18 +447,9 @@ E_sd_cg_cp_rs2_edges_0x1:
   sd x15, -191(x14) # perform store
   addi x14, x14, -191 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x1 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x1, E_sd_cg_cp_rs2_edges_0x1, E_sd_cg_cp_rs2_edges_0x1_str)
-#else
-  sd x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x9, x4) # load rs2: x4 = 0x0000000000000002
@@ -756,18 +459,9 @@ E_sd_cg_cp_rs2_edges_0x2:
   sd x4, -1367(x11) # perform store
   addi x11, x11, -1367 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x1 contains the expected result. x11 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x11, x8, x7, x1, E_sd_cg_cp_rs2_edges_0x2, E_sd_cg_cp_rs2_edges_0x2_str)
-#else
-  sd x4, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x9, x6) # load rs2: x6 = 0x8000000000000000
@@ -777,18 +471,9 @@ E_sd_cg_cp_rs2_edges_0x8000000000000000:
   sd x6, 20(x10) # perform store
   addi x10, x10, 20 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x12, E_sd_cg_cp_rs2_edges_0x8000000000000000, E_sd_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  sd x6, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x9, x14) # load rs2: x14 = 0x8000000000000001
@@ -798,18 +483,9 @@ E_sd_cg_cp_rs2_edges_0x8000000000000001:
   sd x14, -1854(x1) # perform store
   addi x1, x1, -1854 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x15, E_sd_cg_cp_rs2_edges_0x8000000000000001, E_sd_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  sd x14, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x9, x2) # load rs2: x2 = 0x7fffffffffffffff
@@ -819,18 +495,9 @@ E_sd_cg_cp_rs2_edges_0x7fffffffffffffff:
   sd x2, -2020(x6) # perform store
   addi x6, x6, -2020 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x3 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x3, E_sd_cg_cp_rs2_edges_0x7fffffffffffffff, E_sd_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  sd x2, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x9, x4) # load rs2: x4 = 0x7ffffffffffffffe
@@ -840,18 +507,9 @@ E_sd_cg_cp_rs2_edges_0x7ffffffffffffffe:
   sd x4, 1901(x11) # perform store
   addi x11, x11, 1901 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x11, x8, x7, x13, E_sd_cg_cp_rs2_edges_0x7ffffffffffffffe, E_sd_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  sd x4, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x9, x15) # load rs2: x15 = 0xffffffffffffffff
@@ -861,18 +519,9 @@ E_sd_cg_cp_rs2_edges_0xffffffffffffffff:
   sd x15, -1471(x1) # perform store
   addi x1, x1, -1471 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x6, E_sd_cg_cp_rs2_edges_0xffffffffffffffff, E_sd_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  sd x15, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x9, x11) # load rs2: x11 = 0xfffffffffffffffe
@@ -882,18 +531,9 @@ E_sd_cg_cp_rs2_edges_0xfffffffffffffffe:
   sd x11, 1466(x5) # perform store
   addi x5, x5, 1466 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x13 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x13, E_sd_cg_cp_rs2_edges_0xfffffffffffffffe, E_sd_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  sd x11, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x9, x4) # load rs2: x4 = 0x5bbc887763ae86f2
@@ -903,18 +543,9 @@ E_sd_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   sd x4, 8(x14) # perform store
   addi x14, x14, 8 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x15 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x15, E_sd_cg_cp_rs2_edges_0x5bbc887763ae86f2, E_sd_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  sd x4, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x9, x6) # load rs2: x6 = 0xaaaaaaaaaaaaaaaa
@@ -924,18 +555,9 @@ E_sd_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   sd x6, -1596(x4) # perform store
   addi x4, x4, -1596 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x11 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x11, E_sd_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, E_sd_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  sd x6, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x9, x2) # load rs2: x2 = 0x5555555555555555
@@ -945,18 +567,9 @@ E_sd_cg_cp_rs2_edges_0x5555555555555555:
   sd x2, -2044(x15) # perform store
   addi x15, x15, -2044 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x1 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x15, x8, x7, x1, E_sd_cg_cp_rs2_edges_0x5555555555555555, E_sd_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  sd x2, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x9, x4) # load rs2: x4 = 0x00000000ffffffff
@@ -966,18 +579,9 @@ E_sd_cg_cp_rs2_edges_0xffffffff:
   sd x4, 755(x5) # perform store
   addi x5, x5, 755 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x1 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x1, E_sd_cg_cp_rs2_edges_0xffffffff, E_sd_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  sd x4, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x9, x10) # load rs2: x10 = 0x00000000fffffffe
@@ -987,18 +591,9 @@ E_sd_cg_cp_rs2_edges_0xfffffffe:
   sd x10, -1040(x15) # perform store
   addi x15, x15, -1040 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x1 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x15, x8, x7, x1, E_sd_cg_cp_rs2_edges_0xfffffffe, E_sd_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  sd x10, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x9, x5) # load rs2: x5 = 0x0000000100000000
@@ -1008,18 +603,9 @@ E_sd_cg_cp_rs2_edges_0x100000000:
   sd x5, 1315(x12) # perform store
   addi x12, x12, 1315 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x6 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x12, x8, x7, x6, E_sd_cg_cp_rs2_edges_0x100000000, E_sd_cg_cp_rs2_edges_0x100000000_str)
-#else
-  sd x5, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x9, x14) # load rs2: x14 = 0x0000000100000001
@@ -1029,18 +615,9 @@ E_sd_cg_cp_rs2_edges_0x100000001:
   sd x14, 2033(x6) # perform store
   addi x6, x6, 2033 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x15 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x15, E_sd_cg_cp_rs2_edges_0x100000001, E_sd_cg_cp_rs2_edges_0x100000001_str)
-#else
-  sd x14, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_edges
@@ -1054,18 +631,9 @@ E_sd_cg_cp_imm_edges_0x0:
   sd x12, 0(x5) # perform store
   addi x5, x5, 0 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x13 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x13, E_sd_cg_cp_imm_edges_0x0, E_sd_cg_cp_imm_edges_0x0_str)
-#else
-  sd x12, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1)
   RVTEST_TESTDATA_LOAD_INT(x9, x3) # load rs2: x3 = 0xea5545b28886fced
@@ -1075,18 +643,9 @@ E_sd_cg_cp_imm_edges_0x1:
   sd x3, 1(x6) # perform store
   addi x6, x6, 1 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x15 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x15, E_sd_cg_cp_imm_edges_0x1, E_sd_cg_cp_imm_edges_0x1_str)
-#else
-  sd x3, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2)
   RVTEST_TESTDATA_LOAD_INT(x9, x10) # load rs2: x10 = 0xfe9897396e7c8e5d
@@ -1096,18 +655,9 @@ E_sd_cg_cp_imm_edges_0x2:
   sd x10, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x12, x8, x7, x14, E_sd_cg_cp_imm_edges_0x2, E_sd_cg_cp_imm_edges_0x2_str)
-#else
-  sd x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 3)
   RVTEST_TESTDATA_LOAD_INT(x9, x5) # load rs2: x5 = 0x2e91297c1f568def
@@ -1117,18 +667,9 @@ E_sd_cg_cp_imm_edges_0x3:
   sd x5, 3(x15) # perform store
   addi x15, x15, 3 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x15, x8, x7, x14, E_sd_cg_cp_imm_edges_0x3, E_sd_cg_cp_imm_edges_0x3_str)
-#else
-  sd x5, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 4)
   RVTEST_TESTDATA_LOAD_INT(x9, x5) # load rs2: x5 = 0xab49de54be39d670
@@ -1138,18 +679,9 @@ E_sd_cg_cp_imm_edges_0x4:
   sd x5, 4(x11) # perform store
   addi x11, x11, 4 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x1 contains the expected result. x11 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x11, x8, x7, x1, E_sd_cg_cp_imm_edges_0x4, E_sd_cg_cp_imm_edges_0x4_str)
-#else
-  sd x5, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 8)
   RVTEST_TESTDATA_LOAD_INT(x9, x12) # load rs2: x12 = 0x26d8b4163396c3f8
@@ -1159,18 +691,9 @@ E_sd_cg_cp_imm_edges_0x8:
   sd x12, 8(x4) # perform store
   addi x4, x4, 8 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x5 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x5, E_sd_cg_cp_imm_edges_0x8, E_sd_cg_cp_imm_edges_0x8_str)
-#else
-  sd x12, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 16)
   RVTEST_TESTDATA_LOAD_INT(x9, x3) # load rs2: x3 = 0x9afb2bc0d75f6e93
@@ -1180,18 +703,9 @@ E_sd_cg_cp_imm_edges_0x10:
   sd x3, 16(x10) # perform store
   addi x10, x10, 16 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x1 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x1, E_sd_cg_cp_imm_edges_0x10, E_sd_cg_cp_imm_edges_0x10_str)
-#else
-  sd x3, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 32)
   RVTEST_TESTDATA_LOAD_INT(x9, x12) # load rs2: x12 = 0xf2e75c53780e59e3
@@ -1201,18 +715,9 @@ E_sd_cg_cp_imm_edges_0x20:
   sd x12, 32(x13) # perform store
   addi x13, x13, 32 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x13, x8, x7, x14, E_sd_cg_cp_imm_edges_0x20, E_sd_cg_cp_imm_edges_0x20_str)
-#else
-  sd x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 64)
   RVTEST_TESTDATA_LOAD_INT(x9, x11) # load rs2: x11 = 0xc70779b64825dd98
@@ -1222,18 +727,9 @@ E_sd_cg_cp_imm_edges_0x40:
   sd x11, 64(x4) # perform store
   addi x4, x4, 64 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x15 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x15, E_sd_cg_cp_imm_edges_0x40, E_sd_cg_cp_imm_edges_0x40_str)
-#else
-  sd x11, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 128)
   RVTEST_TESTDATA_LOAD_INT(x9, x5) # load rs2: x5 = 0xe23eefc16478a67c
@@ -1243,18 +739,9 @@ E_sd_cg_cp_imm_edges_0x80:
   sd x5, 128(x1) # perform store
   addi x1, x1, 128 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, E_sd_cg_cp_imm_edges_0x80, E_sd_cg_cp_imm_edges_0x80_str)
-#else
-  sd x5, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 256)
   RVTEST_TESTDATA_LOAD_INT(x9, x6) # load rs2: x6 = 0xdcb2f841bcf50543
@@ -1264,18 +751,9 @@ E_sd_cg_cp_imm_edges_0x100:
   sd x6, 256(x5) # perform store
   addi x5, x5, 256 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x3 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x3, E_sd_cg_cp_imm_edges_0x100, E_sd_cg_cp_imm_edges_0x100_str)
-#else
-  sd x6, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 512)
   RVTEST_TESTDATA_LOAD_INT(x9, x12) # load rs2: x12 = 0xc209c03066aed9b1
@@ -1285,18 +763,9 @@ E_sd_cg_cp_imm_edges_0x200:
   sd x12, 512(x13) # perform store
   addi x13, x13, 512 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x10 contains the expected result. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x13, x8, x7, x10, E_sd_cg_cp_imm_edges_0x200, E_sd_cg_cp_imm_edges_0x200_str)
-#else
-  sd x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1023)
   RVTEST_TESTDATA_LOAD_INT(x9, x6) # load rs2: x6 = 0x68510422bfe4449c
@@ -1306,18 +775,9 @@ E_sd_cg_cp_imm_edges_0x3ff:
   sd x6, 1023(x4) # perform store
   addi x4, x4, 1023 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x11 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x11, E_sd_cg_cp_imm_edges_0x3ff, E_sd_cg_cp_imm_edges_0x3ff_str)
-#else
-  sd x6, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1024)
   RVTEST_TESTDATA_LOAD_INT(x9, x2) # load rs2: x2 = 0x7d3b97979085c97c
@@ -1327,18 +787,9 @@ E_sd_cg_cp_imm_edges_0x400:
   sd x2, 1024(x14) # perform store
   addi x14, x14, 1024 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x12, E_sd_cg_cp_imm_edges_0x400, E_sd_cg_cp_imm_edges_0x400_str)
-#else
-  sd x2, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1795)
   RVTEST_TESTDATA_LOAD_INT(x9, x4) # load rs2: x4 = 0x7c892822153f4d68
@@ -1348,18 +799,9 @@ E_sd_cg_cp_imm_edges_0x703:
   sd x4, 1795(x13) # perform store
   addi x13, x13, 1795 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x1 contains the expected result. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x13, x8, x7, x1, E_sd_cg_cp_imm_edges_0x703, E_sd_cg_cp_imm_edges_0x703_str)
-#else
-  sd x4, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2047)
   RVTEST_TESTDATA_LOAD_INT(x9, x4) # load rs2: x4 = 0x6776d49604ebf64a
@@ -1369,18 +811,9 @@ E_sd_cg_cp_imm_edges_0x7ff:
   sd x4, 2047(x10) # perform store
   addi x10, x10, 2047 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x14, E_sd_cg_cp_imm_edges_0x7ff, E_sd_cg_cp_imm_edges_0x7ff_str)
-#else
-  sd x4, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2048)
   RVTEST_TESTDATA_LOAD_INT(x9, x4) # load rs2: x4 = 0xab52b5727e06a929
@@ -1391,18 +824,9 @@ E_sd_cg_cp_imm_edges_m0x800:
   sd x4, -2048(x11) # perform store
   addi x11, x11, -2048 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x3 contains the expected result. x11 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x11, x8, x7, x3, E_sd_cg_cp_imm_edges_m0x800, E_sd_cg_cp_imm_edges_m0x800_str)
-#else
-  sd x4, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2047)
   RVTEST_TESTDATA_LOAD_INT(x9, x3) # load rs2: x3 = 0xfe4c077dea75d6f2
@@ -1412,18 +836,9 @@ E_sd_cg_cp_imm_edges_m0x7ff:
   sd x3, -2047(x15) # perform store
   addi x15, x15, -2047 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x1 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x15, x8, x7, x1, E_sd_cg_cp_imm_edges_m0x7ff, E_sd_cg_cp_imm_edges_m0x7ff_str)
-#else
-  sd x3, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2)
   RVTEST_TESTDATA_LOAD_INT(x9, x4) # load rs2: x4 = 0x795cb37ed7f86d00
@@ -1433,18 +848,9 @@ E_sd_cg_cp_imm_edges_m0x2:
   sd x4, -2(x11) # perform store
   addi x11, x11, -2 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x3 contains the expected result. x11 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x11, x8, x7, x3, E_sd_cg_cp_imm_edges_m0x2, E_sd_cg_cp_imm_edges_m0x2_str)
-#else
-  sd x4, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -1)
   RVTEST_TESTDATA_LOAD_INT(x9, x4) # load rs2: x4 = 0xfa2f275157b87d16
@@ -1454,18 +860,9 @@ E_sd_cg_cp_imm_edges_m0x1:
   sd x4, -1(x6) # perform store
   addi x6, x6, -1 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x1 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x1, E_sd_cg_cp_imm_edges_m0x1, E_sd_cg_cp_imm_edges_m0x1_str)
-#else
-  sd x4, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x6 # restore signature pointer to default register for teardown
 

--- a/tests/rv64e/E/E-sh-00.S
+++ b/tests/rv64e/E/E-sh-00.S
@@ -41,18 +41,9 @@ E_sh_cg_cp_rs1_nx0_b1:
   sh x14, 289(x1) # perform store
   addi x1, x1, 289 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x15, E_sh_cg_cp_rs1_nx0_b1, E_sh_cg_cp_rs1_nx0_b1_str)
-#else
-  sh x14, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0xf294c5c460057e9e
@@ -62,18 +53,9 @@ E_sh_cg_cp_rs1_nx0_b2:
   sh x0, -1077(x2) # perform store
   addi x2, x2, -1077 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x9 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x9, E_sh_cg_cp_rs1_nx0_b2, E_sh_cg_cp_rs1_nx0_b2_str)
-#else
-  sh x0, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x11, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
@@ -84,18 +66,9 @@ E_sh_cg_cp_rs1_nx0_b3:
   sh x0, 1862(x3) # perform store
   addi x3, x3, 1862 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x8 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x8, E_sh_cg_cp_rs1_nx0_b3, E_sh_cg_cp_rs1_nx0_b3_str)
-#else
-  sh x0, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -107,18 +80,9 @@ E_sh_cg_cp_rs1_nx0_b4:
   sh x5, -476(x4) # perform store
   addi x4, x4, -476 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x1 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x1, E_sh_cg_cp_rs1_nx0_b4, E_sh_cg_cp_rs1_nx0_b4_str)
-#else
-  sh x5, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0x6e385eb1a0c75f7c
@@ -128,18 +92,9 @@ E_sh_cg_cp_rs1_nx0_b5:
   sh x14, -1495(x5) # perform store
   addi x5, x5, -1495 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x10 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x10, E_sh_cg_cp_rs1_nx0_b5, E_sh_cg_cp_rs1_nx0_b5_str)
-#else
-  sh x14, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x11, x15) # load rs2: x15 = 0xbbfe28184f14438c
@@ -149,18 +104,9 @@ E_sh_cg_cp_rs1_nx0_b6:
   sh x15, -1507(x6) # perform store
   addi x6, x6, -1507 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x1 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x1, E_sh_cg_cp_rs1_nx0_b6, E_sh_cg_cp_rs1_nx0_b6_str)
-#else
-  sh x15, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x7 # switch temp register to avoid conflict with test
   mv x14, x8 # switch link pointer register to avoid conflict with test
@@ -172,18 +118,9 @@ E_sh_cg_cp_rs1_nx0_b7:
   sh x8, -1507(x7) # perform store
   addi x7, x7, -1507 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x5 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x5, E_sh_cg_cp_rs1_nx0_b7, E_sh_cg_cp_rs1_nx0_b7_str)
-#else
-  sh x8, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x11, x2) # load rs2: x2 = 0xd5e61c1f4b69d3fc
@@ -193,18 +130,9 @@ E_sh_cg_cp_rs1_nx0_b8:
   sh x2, 1696(x8) # perform store
   addi x8, x8, 1696 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x6 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x6, E_sh_cg_cp_rs1_nx0_b8, E_sh_cg_cp_rs1_nx0_b8_str)
-#else
-  sh x2, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x11, x1) # load rs2: x1 = 0x0f45d4d787d1466d
@@ -214,18 +142,9 @@ E_sh_cg_cp_rs1_nx0_b9:
   sh x1, 933(x9) # perform store
   addi x9, x9, 933 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x12, E_sh_cg_cp_rs1_nx0_b9, E_sh_cg_cp_rs1_nx0_b9_str)
-#else
-  sh x1, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x11, x15) # load rs2: x15 = 0xb7ff9d3460b90b9d
@@ -235,18 +154,9 @@ E_sh_cg_cp_rs1_nx0_b10:
   sh x15, 389(x10) # perform store
   addi x10, x10, 389 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x6 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x6, E_sh_cg_cp_rs1_nx0_b10, E_sh_cg_cp_rs1_nx0_b10_str)
-#else
-  sh x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x3, x11 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
@@ -257,18 +167,9 @@ E_sh_cg_cp_rs1_nx0_b11:
   sh x6, 1831(x11) # perform store
   addi x11, x11, 1831 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x12, E_sh_cg_cp_rs1_nx0_b11, E_sh_cg_cp_rs1_nx0_b11_str)
-#else
-  sh x6, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x1b2efb9212e44b5f
@@ -278,18 +179,9 @@ E_sh_cg_cp_rs1_nx0_b12:
   sh x8, -910(x12) # perform store
   addi x12, x12, -910 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x7 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x7, E_sh_cg_cp_rs1_nx0_b12, E_sh_cg_cp_rs1_nx0_b12_str)
-#else
-  sh x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -301,18 +193,9 @@ E_sh_cg_cp_rs1_nx0_b13:
   sh x2, -1881(x13) # perform store
   addi x13, x13, -1881 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x6 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x6, E_sh_cg_cp_rs1_nx0_b13, E_sh_cg_cp_rs1_nx0_b13_str)
-#else
-  sh x2, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xa4bea8871e970726
@@ -322,18 +205,9 @@ E_sh_cg_cp_rs1_nx0_b14:
   sh x11, 124(x14) # perform store
   addi x14, x14, 124 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, E_sh_cg_cp_rs1_nx0_b14, E_sh_cg_cp_rs1_nx0_b14_str)
-#else
-  sh x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0xb82357e8acbd6f02
@@ -343,18 +217,9 @@ E_sh_cg_cp_rs1_nx0_b15:
   sh x6, 747(x15) # perform store
   addi x15, x15, 747 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x7 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x7, E_sh_cg_cp_rs1_nx0_b15, E_sh_cg_cp_rs1_nx0_b15_str)
-#else
-  sh x6, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2
@@ -368,18 +233,9 @@ E_sh_cg_cp_rs2_b0:
   sh x0, 1152(x12) # perform store
   addi x12, x12, 1152 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x7 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x7, E_sh_cg_cp_rs2_b0, E_sh_cg_cp_rs2_b0_str)
-#else
-  sh x0, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0x210bfbaff78e04c6
@@ -389,18 +245,9 @@ E_sh_cg_cp_rs2_b1:
   sh x1, -1028(x10) # perform store
   addi x10, x10, -1028 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, E_sh_cg_cp_rs2_b1, E_sh_cg_cp_rs2_b1_str)
-#else
-  sh x1, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0xa94829adfd20c1a4
@@ -410,18 +257,9 @@ E_sh_cg_cp_rs2_b2:
   sh x2, 793(x13) # perform store
   addi x13, x13, 793 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, E_sh_cg_cp_rs2_b2, E_sh_cg_cp_rs2_b2_str)
-#else
-  sh x2, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x11, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x3)
@@ -432,18 +270,9 @@ E_sh_cg_cp_rs2_b3:
   sh x3, -529(x6) # perform store
   addi x6, x6, -529 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x15 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x15, E_sh_cg_cp_rs2_b3, E_sh_cg_cp_rs2_b3_str)
-#else
-  sh x3, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -455,18 +284,9 @@ E_sh_cg_cp_rs2_b4:
   sh x4, -987(x9) # perform store
   addi x9, x9, -987 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, E_sh_cg_cp_rs2_b4, E_sh_cg_cp_rs2_b4_str)
-#else
-  sh x4, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0x20bda1f4eeda76a6
@@ -476,18 +296,9 @@ E_sh_cg_cp_rs2_b5:
   sh x5, 1887(x6) # perform store
   addi x6, x6, 1887 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x3 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x3, E_sh_cg_cp_rs2_b5, E_sh_cg_cp_rs2_b5_str)
-#else
-  sh x5, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x6 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x6)
@@ -498,18 +309,9 @@ E_sh_cg_cp_rs2_b6:
   sh x6, -827(x9) # perform store
   addi x9, x9, -827 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, E_sh_cg_cp_rs2_b6, E_sh_cg_cp_rs2_b6_str)
-#else
-  sh x6, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x7 # switch temp register to avoid conflict with test
   mv x5, x8 # switch link pointer register to avoid conflict with test
@@ -521,18 +323,9 @@ E_sh_cg_cp_rs2_b7:
   sh x7, -1710(x8) # perform store
   addi x8, x8, -1710 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, E_sh_cg_cp_rs2_b7, E_sh_cg_cp_rs2_b7_str)
-#else
-  sh x7, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x8 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x8)
@@ -543,18 +336,9 @@ E_sh_cg_cp_rs2_b8:
   sh x8, -1490(x14) # perform store
   addi x14, x14, -1490 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, E_sh_cg_cp_rs2_b8, E_sh_cg_cp_rs2_b8_str)
-#else
-  sh x8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0x0314b4f994c53066
@@ -564,18 +348,9 @@ E_sh_cg_cp_rs2_b9:
   sh x9, 408(x7) # perform store
   addi x7, x7, 408 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x12 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x12, E_sh_cg_cp_rs2_b9, E_sh_cg_cp_rs2_b9_str)
-#else
-  sh x9, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x11, x10) # load rs2: x10 = 0xabe0d041f25d06a6
@@ -585,18 +360,9 @@ E_sh_cg_cp_rs2_b10:
   sh x10, -258(x14) # perform store
   addi x14, x14, -258 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, E_sh_cg_cp_rs2_b10, E_sh_cg_cp_rs2_b10_str)
-#else
-  sh x10, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x1, x11 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x11)
@@ -607,18 +373,9 @@ E_sh_cg_cp_rs2_b11:
   sh x11, 1192(x3) # perform store
   addi x3, x3, 1192 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x6 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x6, E_sh_cg_cp_rs2_b11, E_sh_cg_cp_rs2_b11_str)
-#else
-  sh x11, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xc5e37c88932946e8
@@ -628,18 +385,9 @@ E_sh_cg_cp_rs2_b12:
   sh x12, -1170(x7) # perform store
   addi x7, x7, -1170 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x10 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x10, E_sh_cg_cp_rs2_b12, E_sh_cg_cp_rs2_b12_str)
-#else
-  sh x12, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xebc553c306f1f765
@@ -649,18 +397,9 @@ E_sh_cg_cp_rs2_b13:
   sh x13, 1604(x8) # perform store
   addi x8, x8, 1604 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, E_sh_cg_cp_rs2_b13, E_sh_cg_cp_rs2_b13_str)
-#else
-  sh x13, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x624ddb3de6671703
@@ -670,18 +409,9 @@ E_sh_cg_cp_rs2_b14:
   sh x14, -115(x7) # perform store
   addi x7, x7, -115 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x9 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x9, E_sh_cg_cp_rs2_b14, E_sh_cg_cp_rs2_b14_str)
-#else
-  sh x14, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x8dce2e4824bdcefe
@@ -691,18 +421,9 @@ E_sh_cg_cp_rs2_b15:
   sh x15, -1359(x8) # perform store
   addi x8, x8, -1359 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, E_sh_cg_cp_rs2_b15, E_sh_cg_cp_rs2_b15_str)
-#else
-  sh x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -716,18 +437,9 @@ E_sh_cg_cp_rs2_edges_0x0:
   sh x14, -560(x3) # perform store
   addi x3, x3, -560 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x12 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x12, E_sh_cg_cp_rs2_edges_0x0, E_sh_cg_cp_rs2_edges_0x0_str)
-#else
-  sh x14, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x0000000000000001
@@ -737,18 +449,9 @@ E_sh_cg_cp_rs2_edges_0x1:
   sh x6, 1338(x13) # perform store
   addi x13, x13, 1338 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, E_sh_cg_cp_rs2_edges_0x1, E_sh_cg_cp_rs2_edges_0x1_str)
-#else
-  sh x6, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x0000000000000002
@@ -758,18 +461,9 @@ E_sh_cg_cp_rs2_edges_0x2:
   sh x15, -1650(x6) # perform store
   addi x6, x6, -1650 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x9 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x9, E_sh_cg_cp_rs2_edges_0x2, E_sh_cg_cp_rs2_edges_0x2_str)
-#else
-  sh x15, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x8000000000000000
@@ -779,18 +473,9 @@ E_sh_cg_cp_rs2_edges_0x8000000000000000:
   sh x15, -1522(x8) # perform store
   addi x8, x8, -1522 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, E_sh_cg_cp_rs2_edges_0x8000000000000000, E_sh_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  sh x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x8000000000000001
@@ -800,18 +485,9 @@ E_sh_cg_cp_rs2_edges_0x8000000000000001:
   sh x14, -1010(x15) # perform store
   addi x15, x15, -1010 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x9 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x9, E_sh_cg_cp_rs2_edges_0x8000000000000001, E_sh_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  sh x14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x7fffffffffffffff
@@ -821,18 +497,9 @@ E_sh_cg_cp_rs2_edges_0x7fffffffffffffff:
   sh x10, 1818(x2) # perform store
   addi x2, x2, 1818 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x8 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x8, E_sh_cg_cp_rs2_edges_0x7fffffffffffffff, E_sh_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  sh x10, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x7ffffffffffffffe
@@ -842,18 +509,9 @@ E_sh_cg_cp_rs2_edges_0x7ffffffffffffffe:
   sh x15, -1034(x9) # perform store
   addi x9, x9, -1034 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, E_sh_cg_cp_rs2_edges_0x7ffffffffffffffe, E_sh_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  sh x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xffffffffffffffff
@@ -863,18 +521,9 @@ E_sh_cg_cp_rs2_edges_0xffffffffffffffff:
   sh x11, -906(x8) # perform store
   addi x8, x8, -906 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, E_sh_cg_cp_rs2_edges_0xffffffffffffffff, E_sh_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  sh x11, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xfffffffffffffffe
@@ -884,18 +533,9 @@ E_sh_cg_cp_rs2_edges_0xfffffffffffffffe:
   sh x11, -175(x3) # perform store
   addi x3, x3, -175 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x15 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x15, E_sh_cg_cp_rs2_edges_0xfffffffffffffffe, E_sh_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  sh x11, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0x5bbc887763ae86f2
@@ -905,18 +545,9 @@ E_sh_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   sh x2, -886(x10) # perform store
   addi x10, x10, -886 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, E_sh_cg_cp_rs2_edges_0x5bbc887763ae86f2, E_sh_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  sh x2, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xaaaaaaaaaaaaaaaa
@@ -926,18 +557,9 @@ E_sh_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   sh x2, -762(x12) # perform store
   addi x12, x12, -762 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x6 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x6, E_sh_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, E_sh_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  sh x2, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x5555555555555555
@@ -947,18 +569,9 @@ E_sh_cg_cp_rs2_edges_0x5555555555555555:
   sh x8, 234(x7) # perform store
   addi x7, x7, 234 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x15 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x15, E_sh_cg_cp_rs2_edges_0x5555555555555555, E_sh_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  sh x8, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x00000000ffffffff
@@ -968,18 +581,9 @@ E_sh_cg_cp_rs2_edges_0xffffffff:
   sh x10, -521(x12) # perform store
   addi x12, x12, -521 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, E_sh_cg_cp_rs2_edges_0xffffffff, E_sh_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  sh x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x00000000fffffffe
@@ -989,18 +593,9 @@ E_sh_cg_cp_rs2_edges_0xfffffffe:
   sh x11, -658(x3) # perform store
   addi x3, x3, -658 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x7 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x7, E_sh_cg_cp_rs2_edges_0xfffffffe, E_sh_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  sh x11, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0x0000000100000000
@@ -1010,18 +605,9 @@ E_sh_cg_cp_rs2_edges_0x100000000:
   sh x2, 213(x13) # perform store
   addi x13, x13, 213 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, E_sh_cg_cp_rs2_edges_0x100000000, E_sh_cg_cp_rs2_edges_0x100000000_str)
-#else
-  sh x2, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x0000000100000001
@@ -1031,18 +617,9 @@ E_sh_cg_cp_rs2_edges_0x100000001:
   sh x8, -855(x14) # perform store
   addi x14, x14, -855 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x3 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x3, E_sh_cg_cp_rs2_edges_0x100000001, E_sh_cg_cp_rs2_edges_0x100000001_str)
-#else
-  sh x8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_edges
@@ -1056,18 +633,9 @@ E_sh_cg_cp_imm_edges_0x0:
   sh x9, 0(x3) # perform store
   addi x3, x3, 0 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x10 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x10, E_sh_cg_cp_imm_edges_0x0, E_sh_cg_cp_imm_edges_0x0_str)
-#else
-  sh x9, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x9114f3859a59fa2f
@@ -1077,18 +645,9 @@ E_sh_cg_cp_imm_edges_0x1:
   sh x10, 1(x12) # perform store
   addi x12, x12, 1 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x7 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x7, E_sh_cg_cp_imm_edges_0x1, E_sh_cg_cp_imm_edges_0x1_str)
-#else
-  sh x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x5a20c82a555554fa
@@ -1098,18 +657,9 @@ E_sh_cg_cp_imm_edges_0x2:
   sh x15, 2(x3) # perform store
   addi x3, x3, 2 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x11 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x11, E_sh_cg_cp_imm_edges_0x2, E_sh_cg_cp_imm_edges_0x2_str)
-#else
-  sh x15, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 3)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xdbd93942347389b6
@@ -1119,18 +669,9 @@ E_sh_cg_cp_imm_edges_0x3:
   sh x2, 3(x12) # perform store
   addi x12, x12, 3 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, E_sh_cg_cp_imm_edges_0x3, E_sh_cg_cp_imm_edges_0x3_str)
-#else
-  sh x2, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 4)
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x1cb46f5fe0ce99e4
@@ -1140,18 +681,9 @@ E_sh_cg_cp_imm_edges_0x4:
   sh x9, 4(x10) # perform store
   addi x10, x10, 4 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x3 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x3, E_sh_cg_cp_imm_edges_0x4, E_sh_cg_cp_imm_edges_0x4_str)
-#else
-  sh x9, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 8)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x51269c054a91bba2
@@ -1161,18 +693,9 @@ E_sh_cg_cp_imm_edges_0x8:
   sh x11, 8(x8) # perform store
   addi x8, x8, 8 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x7 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x7, E_sh_cg_cp_imm_edges_0x8, E_sh_cg_cp_imm_edges_0x8_str)
-#else
-  sh x11, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 16)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xf279e98a4414b588
@@ -1182,18 +705,9 @@ E_sh_cg_cp_imm_edges_0x10:
   sh x6, 16(x3) # perform store
   addi x3, x3, 16 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x11 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x11, E_sh_cg_cp_imm_edges_0x10, E_sh_cg_cp_imm_edges_0x10_str)
-#else
-  sh x6, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 32)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x27d2bdae4837ecf2
@@ -1203,18 +717,9 @@ E_sh_cg_cp_imm_edges_0x20:
   sh x8, 32(x11) # perform store
   addi x11, x11, 32 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, E_sh_cg_cp_imm_edges_0x20, E_sh_cg_cp_imm_edges_0x20_str)
-#else
-  sh x8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 64)
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x09049e9b8de8ef6f
@@ -1224,18 +729,9 @@ E_sh_cg_cp_imm_edges_0x40:
   sh x3, 64(x12) # perform store
   addi x12, x12, 64 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x6 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x6, E_sh_cg_cp_imm_edges_0x40, E_sh_cg_cp_imm_edges_0x40_str)
-#else
-  sh x3, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 128)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x654202dabc0e4cd5
@@ -1245,18 +741,9 @@ E_sh_cg_cp_imm_edges_0x80:
   sh x10, 128(x11) # perform store
   addi x11, x11, 128 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, E_sh_cg_cp_imm_edges_0x80, E_sh_cg_cp_imm_edges_0x80_str)
-#else
-  sh x10, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 256)
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x146b4f7c5503f5b3
@@ -1266,18 +753,9 @@ E_sh_cg_cp_imm_edges_0x100:
   sh x7, 256(x2) # perform store
   addi x2, x2, 256 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x9 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x9, E_sh_cg_cp_imm_edges_0x100, E_sh_cg_cp_imm_edges_0x100_str)
-#else
-  sh x7, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 512)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x4280ca38e58c11e5
@@ -1287,18 +765,9 @@ E_sh_cg_cp_imm_edges_0x200:
   sh x14, 512(x12) # perform store
   addi x12, x12, 512 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x3 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x3, E_sh_cg_cp_imm_edges_0x200, E_sh_cg_cp_imm_edges_0x200_str)
-#else
-  sh x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1023)
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xbe6f88a53be735ed
@@ -1308,18 +777,9 @@ E_sh_cg_cp_imm_edges_0x3ff:
   sh x3, 1023(x8) # perform store
   addi x8, x8, 1023 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x6 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x6, E_sh_cg_cp_imm_edges_0x3ff, E_sh_cg_cp_imm_edges_0x3ff_str)
-#else
-  sh x3, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1024)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xcf2793655c9632db
@@ -1329,18 +789,9 @@ E_sh_cg_cp_imm_edges_0x400:
   sh x10, 1024(x7) # perform store
   addi x7, x7, 1024 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x15 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x15, E_sh_cg_cp_imm_edges_0x400, E_sh_cg_cp_imm_edges_0x400_str)
-#else
-  sh x10, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1795)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xb37408322ab19f97
@@ -1350,18 +801,9 @@ E_sh_cg_cp_imm_edges_0x703:
   sh x8, 1795(x2) # perform store
   addi x2, x2, 1795 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x9 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x9, E_sh_cg_cp_imm_edges_0x703, E_sh_cg_cp_imm_edges_0x703_str)
-#else
-  sh x8, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2047)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x1e019cc88d2097c9
@@ -1371,18 +813,9 @@ E_sh_cg_cp_imm_edges_0x7ff:
   sh x6, 2047(x12) # perform store
   addi x12, x12, 2047 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, E_sh_cg_cp_imm_edges_0x7ff, E_sh_cg_cp_imm_edges_0x7ff_str)
-#else
-  sh x6, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2048)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x99fea04f88474335
@@ -1393,18 +826,9 @@ E_sh_cg_cp_imm_edges_m0x800:
   sh x10, -2048(x3) # perform store
   addi x3, x3, -2048 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x11 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x11, E_sh_cg_cp_imm_edges_m0x800, E_sh_cg_cp_imm_edges_m0x800_str)
-#else
-  sh x10, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2047)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xee715c2c35f790b5
@@ -1414,18 +838,9 @@ E_sh_cg_cp_imm_edges_m0x7ff:
   sh x14, -2047(x11) # perform store
   addi x11, x11, -2047 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, E_sh_cg_cp_imm_edges_m0x7ff, E_sh_cg_cp_imm_edges_m0x7ff_str)
-#else
-  sh x14, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xee1189fb33f24d6a
@@ -1435,18 +850,9 @@ E_sh_cg_cp_imm_edges_m0x2:
   sh x12, -2(x3) # perform store
   addi x3, x3, -2 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x10 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x10, E_sh_cg_cp_imm_edges_m0x2, E_sh_cg_cp_imm_edges_m0x2_str)
-#else
-  sh x12, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -1)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x1b79818b5a75c2d4
@@ -1456,18 +862,9 @@ E_sh_cg_cp_imm_edges_m0x1:
   sh x15, -1(x8) # perform store
   addi x8, x8, -1 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, E_sh_cg_cp_imm_edges_m0x1, E_sh_cg_cp_imm_edges_m0x1_str)
-#else
-  sh x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_align_hword
@@ -1478,72 +875,36 @@ E_sh_cg_cp_imm_edges_m0x1:
 E_sh_cg_cp_align_hword_b0:
   sh x11, 0(x8) # perform store
   addi x8, x8, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -8(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, E_sh_cg_cp_align_hword_b0, E_sh_cg_cp_align_hword_b0_str)
-#else
-  sh x11, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_hword (imm[2:0] = 010)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xa41e7bb385ad9488
 E_sh_cg_cp_align_hword_b2:
   sh x2, 2(x8) # perform store
   addi x8, x8, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -8(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, E_sh_cg_cp_align_hword_b2, E_sh_cg_cp_align_hword_b2_str)
-#else
-  sh x2, 2(x8) # repeat store so it is available for checking
-  addi x8, x8, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_hword (imm[2:0] = 100)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x2768960cdb5130b0
 E_sh_cg_cp_align_hword_b4:
   sh x12, 4(x8) # perform store
   addi x8, x8, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -8(x8) # load stored value for checking
   # Check if x6 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x6, E_sh_cg_cp_align_hword_b4, E_sh_cg_cp_align_hword_b4_str)
-#else
-  sh x12, 4(x8) # repeat store so it is available for checking
-  addi x8, x8, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_hword (imm[2:0] = 110)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xce53cef169a1ca12
 E_sh_cg_cp_align_hword_b6:
   sh x10, 6(x8) # perform store
   addi x8, x8, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -8(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, E_sh_cg_cp_align_hword_b6, E_sh_cg_cp_align_hword_b6_str)
-#else
-  sh x10, 6(x8) # repeat store so it is available for checking
-  addi x8, x8, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 
   mv x2, x8 # restore signature pointer to default register for teardown

--- a/tests/rv64e/E/E-sw-00.S
+++ b/tests/rv64e/E/E-sw-00.S
@@ -41,18 +41,9 @@ E_sw_cg_cp_rs1_nx0_b1:
   sw x8, -984(x1) # perform store
   addi x1, x1, -984 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x14 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x14, E_sw_cg_cp_rs1_nx0_b1, E_sw_cg_cp_rs1_nx0_b1_str)
-#else
-  sw x8, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x89522d030654ee87
@@ -62,18 +53,9 @@ E_sw_cg_cp_rs1_nx0_b2:
   sw x9, -897(x2) # perform store
   addi x2, x2, -897 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x6 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x6, E_sw_cg_cp_rs1_nx0_b2, E_sw_cg_cp_rs1_nx0_b2_str)
-#else
-  sw x9, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x11, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
@@ -84,18 +66,9 @@ E_sw_cg_cp_rs1_nx0_b3:
   sw x9, 1117(x3) # perform store
   addi x3, x3, 1117 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x15 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x15, E_sw_cg_cp_rs1_nx0_b3, E_sw_cg_cp_rs1_nx0_b3_str)
-#else
-  sw x9, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -107,18 +80,9 @@ E_sw_cg_cp_rs1_nx0_b4:
   sw x6, 732(x4) # perform store
   addi x4, x4, 732 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x14 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x14, E_sw_cg_cp_rs1_nx0_b4, E_sw_cg_cp_rs1_nx0_b4_str)
-#else
-  sw x6, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x11, x2) # load rs2: x2 = 0x9345bd531b80ae9d
@@ -128,18 +92,9 @@ E_sw_cg_cp_rs1_nx0_b5:
   sw x2, 1931(x5) # perform store
   addi x5, x5, 1931 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x1 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x1, E_sw_cg_cp_rs1_nx0_b5, E_sw_cg_cp_rs1_nx0_b5_str)
-#else
-  sw x2, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x11, x1) # load rs2: x1 = 0xaf3b9d36f4dc0be9
@@ -149,18 +104,9 @@ E_sw_cg_cp_rs1_nx0_b6:
   sw x1, -823(x6) # perform store
   addi x6, x6, -823 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x15 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x15, E_sw_cg_cp_rs1_nx0_b6, E_sw_cg_cp_rs1_nx0_b6_str)
-#else
-  sw x1, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x7 # switch temp register to avoid conflict with test
   mv x14, x8 # switch link pointer register to avoid conflict with test
@@ -172,18 +118,9 @@ E_sw_cg_cp_rs1_nx0_b7:
   sw x15, 1534(x7) # perform store
   addi x7, x7, 1534 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x10 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x10, E_sw_cg_cp_rs1_nx0_b7, E_sw_cg_cp_rs1_nx0_b7_str)
-#else
-  sw x15, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0x0c31c85f4059c329
@@ -193,18 +130,9 @@ E_sw_cg_cp_rs1_nx0_b8:
   sw x4, 773(x8) # perform store
   addi x8, x8, 773 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x12, E_sw_cg_cp_rs1_nx0_b8, E_sw_cg_cp_rs1_nx0_b8_str)
-#else
-  sw x4, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x11, x7) # load rs2: x7 = 0xec067fa0ea1b6ba8
@@ -214,18 +142,9 @@ E_sw_cg_cp_rs1_nx0_b9:
   sw x7, 1240(x9) # perform store
   addi x9, x9, 1240 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x12, E_sw_cg_cp_rs1_nx0_b9, E_sw_cg_cp_rs1_nx0_b9_str)
-#else
-  sw x7, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x11, x8) # load rs2: x8 = 0x5bea27e2dcecf551
@@ -235,18 +154,9 @@ E_sw_cg_cp_rs1_nx0_b10:
   sw x8, -1195(x10) # perform store
   addi x10, x10, -1195 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x15, E_sw_cg_cp_rs1_nx0_b10, E_sw_cg_cp_rs1_nx0_b10_str)
-#else
-  sw x8, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x6, x11 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
@@ -257,18 +167,9 @@ E_sw_cg_cp_rs1_nx0_b11:
   sw x5, -194(x11) # perform store
   addi x11, x11, -194 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x3 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x3, E_sw_cg_cp_rs1_nx0_b11, E_sw_cg_cp_rs1_nx0_b11_str)
-#else
-  sw x5, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x6, x3) # load rs2: x3 = 0x3ba23e0d82028e86
@@ -278,18 +179,9 @@ E_sw_cg_cp_rs1_nx0_b12:
   sw x3, 1247(x12) # perform store
   addi x12, x12, 1247 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x5 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x5, E_sw_cg_cp_rs1_nx0_b12, E_sw_cg_cp_rs1_nx0_b12_str)
-#else
-  sw x3, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -301,18 +193,9 @@ E_sw_cg_cp_rs1_nx0_b13:
   sw x7, 518(x13) # perform store
   addi x13, x13, 518 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x10 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x10, E_sw_cg_cp_rs1_nx0_b13, E_sw_cg_cp_rs1_nx0_b13_str)
-#else
-  sw x7, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x6, x9) # load rs2: x9 = 0x40639bae9c46ca0b
@@ -322,18 +205,9 @@ E_sw_cg_cp_rs1_nx0_b14:
   sw x9, 108(x14) # perform store
   addi x14, x14, 108 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x1 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x1, E_sw_cg_cp_rs1_nx0_b14, E_sw_cg_cp_rs1_nx0_b14_str)
-#else
-  sw x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x6, x12) # load rs2: x12 = 0xcf11ae8d9a38fa63
@@ -343,18 +217,9 @@ E_sw_cg_cp_rs1_nx0_b15:
   sw x12, -76(x15) # perform store
   addi x15, x15, -76 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x1 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x1, E_sw_cg_cp_rs1_nx0_b15, E_sw_cg_cp_rs1_nx0_b15_str)
-#else
-  sw x12, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2
@@ -368,18 +233,9 @@ E_sw_cg_cp_rs2_b0:
   sw x0, 1417(x13) # perform store
   addi x13, x13, 1417 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x1 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x1, E_sw_cg_cp_rs2_b0, E_sw_cg_cp_rs2_b0_str)
-#else
-  sw x0, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x6, x1) # load rs2: x1 = 0x499f7e50dd8db439
@@ -389,18 +245,9 @@ E_sw_cg_cp_rs2_b1:
   sw x1, 2039(x9) # perform store
   addi x9, x9, 2039 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, E_sw_cg_cp_rs2_b1, E_sw_cg_cp_rs2_b1_str)
-#else
-  sw x1, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x6, x2) # load rs2: x2 = 0x4bdc46e469a7a229
@@ -410,18 +257,9 @@ E_sw_cg_cp_rs2_b2:
   sw x2, 472(x12) # perform store
   addi x12, x12, 472 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x13 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x13, E_sw_cg_cp_rs2_b2, E_sw_cg_cp_rs2_b2_str)
-#else
-  sw x2, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x6, x3) # load rs2: x3 = 0xdb1de6f348c20518
@@ -431,18 +269,9 @@ E_sw_cg_cp_rs2_b3:
   sw x3, -295(x8) # perform store
   addi x8, x8, -295 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, E_sw_cg_cp_rs2_b3, E_sw_cg_cp_rs2_b3_str)
-#else
-  sw x3, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x4 # switch temp register to avoid conflict with test
   mv x14, x5 # switch link pointer register to avoid conflict with test
@@ -454,18 +283,9 @@ E_sw_cg_cp_rs2_b4:
   sw x4, -212(x7) # perform store
   addi x7, x7, -212 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x3 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x3, E_sw_cg_cp_rs2_b4, E_sw_cg_cp_rs2_b4_str)
-#else
-  sw x4, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x6, x5) # load rs2: x5 = 0x41beb1233f7e8525
@@ -475,18 +295,9 @@ E_sw_cg_cp_rs2_b5:
   sw x5, 788(x10) # perform store
   addi x10, x10, 788 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x3 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x3, E_sw_cg_cp_rs2_b5, E_sw_cg_cp_rs2_b5_str)
-#else
-  sw x5, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x6 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x6)
@@ -497,18 +308,9 @@ E_sw_cg_cp_rs2_b6:
   sw x6, 1114(x3) # perform store
   addi x3, x3, 1114 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x4 contains the expected result. x3 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x3, x14, x13, x4, E_sw_cg_cp_rs2_b6, E_sw_cg_cp_rs2_b6_str)
-#else
-  sw x6, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x2, x7) # load rs2: x7 = 0xeb80dff54079cd0a
@@ -518,18 +320,9 @@ E_sw_cg_cp_rs2_b7:
   sw x7, -1460(x1) # perform store
   addi x1, x1, -1460 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x8 contains the expected result. x1 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x1, x14, x13, x8, E_sw_cg_cp_rs2_b7, E_sw_cg_cp_rs2_b7_str)
-#else
-  sw x7, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x2, x8) # load rs2: x8 = 0x3639642513c45c3f
@@ -539,18 +332,9 @@ E_sw_cg_cp_rs2_b8:
   sw x8, 559(x9) # perform store
   addi x9, x9, 559 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x6, E_sw_cg_cp_rs2_b8, E_sw_cg_cp_rs2_b8_str)
-#else
-  sw x8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x3, x9 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x9)
@@ -561,18 +345,9 @@ E_sw_cg_cp_rs2_b9:
   sw x9, -121(x6) # perform store
   addi x6, x6, -121 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x15 contains the expected result. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x6, x14, x13, x15, E_sw_cg_cp_rs2_b9, E_sw_cg_cp_rs2_b9_str)
-#else
-  sw x9, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x2, x10) # load rs2: x10 = 0x5f360834441b81d2
@@ -582,18 +357,9 @@ E_sw_cg_cp_rs2_b10:
   sw x10, -139(x3) # perform store
   addi x3, x3, -139 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x1 contains the expected result. x3 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x3, x14, x13, x1, E_sw_cg_cp_rs2_b10, E_sw_cg_cp_rs2_b10_str)
-#else
-  sw x10, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load rs2: x11 = 0x32087164ea963781
@@ -603,18 +369,9 @@ E_sw_cg_cp_rs2_b11:
   sw x11, 1295(x7) # perform store
   addi x7, x7, 1295 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x8 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x8, E_sw_cg_cp_rs2_b11, E_sw_cg_cp_rs2_b11_str)
-#else
-  sw x11, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x2, x12) # load rs2: x12 = 0x0af2743f60ae233c
@@ -624,18 +381,9 @@ E_sw_cg_cp_rs2_b12:
   sw x12, 134(x8) # perform store
   addi x8, x8, 134 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x3 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x3, E_sw_cg_cp_rs2_b12, E_sw_cg_cp_rs2_b12_str)
-#else
-  sw x12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -647,18 +395,9 @@ E_sw_cg_cp_rs2_b13:
   sw x13, -354(x12) # perform store
   addi x12, x12, -354 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, E_sw_cg_cp_rs2_b13, E_sw_cg_cp_rs2_b13_str)
-#else
-  sw x13, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x2, x14) # load rs2: x14 = 0x5a114ff00d5d47bb
@@ -668,18 +407,9 @@ E_sw_cg_cp_rs2_b14:
   sw x14, 933(x3) # perform store
   addi x3, x3, 933 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x6 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x6, E_sw_cg_cp_rs2_b14, E_sw_cg_cp_rs2_b14_str)
-#else
-  sw x14, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x2, x15) # load rs2: x15 = 0x9429b87619f718ac
@@ -689,18 +419,9 @@ E_sw_cg_cp_rs2_b15:
   sw x15, -1112(x13) # perform store
   addi x13, x13, -1112 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x7 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x7, E_sw_cg_cp_rs2_b15, E_sw_cg_cp_rs2_b15_str)
-#else
-  sw x15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -714,18 +435,9 @@ E_sw_cg_cp_rs2_edges_0x0:
   sw x7, -1031(x8) # perform store
   addi x8, x8, -1031 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, E_sw_cg_cp_rs2_edges_0x0, E_sw_cg_cp_rs2_edges_0x0_str)
-#else
-  sw x7, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x2, x9) # load rs2: x9 = 0x0000000000000001
@@ -735,18 +447,9 @@ E_sw_cg_cp_rs2_edges_0x1:
   sw x9, 13(x13) # perform store
   addi x13, x13, 13 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x3 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x3, E_sw_cg_cp_rs2_edges_0x1, E_sw_cg_cp_rs2_edges_0x1_str)
-#else
-  sw x9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x2, x7) # load rs2: x7 = 0x0000000000000002
@@ -756,18 +459,9 @@ E_sw_cg_cp_rs2_edges_0x2:
   sw x7, 1102(x3) # perform store
   addi x3, x3, 1102 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x10 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x10, E_sw_cg_cp_rs2_edges_0x2, E_sw_cg_cp_rs2_edges_0x2_str)
-#else
-  sw x7, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x2, x15) # load rs2: x15 = 0x8000000000000000
@@ -777,18 +471,9 @@ E_sw_cg_cp_rs2_edges_0x8000000000000000:
   sw x15, -2004(x7) # perform store
   addi x7, x7, -2004 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x6 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x6, E_sw_cg_cp_rs2_edges_0x8000000000000000, E_sw_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  sw x15, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x2, x3) # load rs2: x3 = 0x8000000000000001
@@ -798,18 +483,9 @@ E_sw_cg_cp_rs2_edges_0x8000000000000001:
   sw x3, -1315(x12) # perform store
   addi x12, x12, -1315 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x6 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x6, E_sw_cg_cp_rs2_edges_0x8000000000000001, E_sw_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  sw x3, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x2, x14) # load rs2: x14 = 0x7fffffffffffffff
@@ -819,18 +495,9 @@ E_sw_cg_cp_rs2_edges_0x7fffffffffffffff:
   sw x14, -633(x8) # perform store
   addi x8, x8, -633 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, E_sw_cg_cp_rs2_edges_0x7fffffffffffffff, E_sw_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  sw x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load rs2: x11 = 0x7ffffffffffffffe
@@ -840,18 +507,9 @@ E_sw_cg_cp_rs2_edges_0x7ffffffffffffffe:
   sw x11, -1966(x9) # perform store
   addi x9, x9, -1966 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x1 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x1, E_sw_cg_cp_rs2_edges_0x7ffffffffffffffe, E_sw_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  sw x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x2, x3) # load rs2: x3 = 0xffffffffffffffff
@@ -861,18 +519,9 @@ E_sw_cg_cp_rs2_edges_0xffffffffffffffff:
   sw x3, 455(x6) # perform store
   addi x6, x6, 455 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x8 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x8, E_sw_cg_cp_rs2_edges_0xffffffffffffffff, E_sw_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  sw x3, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x2, x3) # load rs2: x3 = 0xfffffffffffffffe
@@ -882,18 +531,9 @@ E_sw_cg_cp_rs2_edges_0xfffffffffffffffe:
   sw x3, -86(x11) # perform store
   addi x11, x11, -86 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, E_sw_cg_cp_rs2_edges_0xfffffffffffffffe, E_sw_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  sw x3, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load rs2: x6 = 0x5bbc887763ae86f2
@@ -903,18 +543,9 @@ E_sw_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   sw x6, 1046(x10) # perform store
   addi x10, x10, 1046 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x3 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x3, E_sw_cg_cp_rs2_edges_0x5bbc887763ae86f2, E_sw_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  sw x6, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x2, x14) # load rs2: x14 = 0xaaaaaaaaaaaaaaaa
@@ -924,18 +555,9 @@ E_sw_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   sw x14, 956(x15) # perform store
   addi x15, x15, 956 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, E_sw_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, E_sw_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  sw x14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x2, x14) # load rs2: x14 = 0x5555555555555555
@@ -945,18 +567,9 @@ E_sw_cg_cp_rs2_edges_0x5555555555555555:
   sw x14, 781(x12) # perform store
   addi x12, x12, 781 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, E_sw_cg_cp_rs2_edges_0x5555555555555555, E_sw_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  sw x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x2, x15) # load rs2: x15 = 0x00000000ffffffff
@@ -966,18 +579,9 @@ E_sw_cg_cp_rs2_edges_0xffffffff:
   sw x15, 805(x9) # perform store
   addi x9, x9, 805 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, E_sw_cg_cp_rs2_edges_0xffffffff, E_sw_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  sw x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x2, x13) # load rs2: x13 = 0x00000000fffffffe
@@ -987,18 +591,9 @@ E_sw_cg_cp_rs2_edges_0xfffffffe:
   sw x13, -370(x8) # perform store
   addi x8, x8, -370 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x7 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x7, E_sw_cg_cp_rs2_edges_0xfffffffe, E_sw_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  sw x13, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x2, x7) # load rs2: x7 = 0x0000000100000000
@@ -1008,18 +603,9 @@ E_sw_cg_cp_rs2_edges_0x100000000:
   sw x7, 355(x11) # perform store
   addi x11, x11, 355 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, E_sw_cg_cp_rs2_edges_0x100000000, E_sw_cg_cp_rs2_edges_0x100000000_str)
-#else
-  sw x7, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x2, x14) # load rs2: x14 = 0x0000000100000001
@@ -1029,18 +615,9 @@ E_sw_cg_cp_rs2_edges_0x100000001:
   sw x14, 925(x10) # perform store
   addi x10, x10, 925 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x1 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x1, E_sw_cg_cp_rs2_edges_0x100000001, E_sw_cg_cp_rs2_edges_0x100000001_str)
-#else
-  sw x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_edges
@@ -1054,18 +631,9 @@ E_sw_cg_cp_imm_edges_0x0:
   sw x3, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, E_sw_cg_cp_imm_edges_0x0, E_sw_cg_cp_imm_edges_0x0_str)
-#else
-  sw x3, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1)
   RVTEST_TESTDATA_LOAD_INT(x2, x1) # load rs2: x1 = 0x58367654cb95f1a7
@@ -1075,18 +643,9 @@ E_sw_cg_cp_imm_edges_0x1:
   sw x1, 1(x3) # perform store
   addi x3, x3, 1 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x12 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x12, E_sw_cg_cp_imm_edges_0x1, E_sw_cg_cp_imm_edges_0x1_str)
-#else
-  sw x1, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2)
   RVTEST_TESTDATA_LOAD_INT(x2, x10) # load rs2: x10 = 0x0f19ff318b5b3ae0
@@ -1096,18 +655,9 @@ E_sw_cg_cp_imm_edges_0x2:
   sw x10, 2(x1) # perform store
   addi x1, x1, 2 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x7 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x7, E_sw_cg_cp_imm_edges_0x2, E_sw_cg_cp_imm_edges_0x2_str)
-#else
-  sw x10, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 3)
   RVTEST_TESTDATA_LOAD_INT(x2, x7) # load rs2: x7 = 0x39a5ed4a68479717
@@ -1117,18 +667,9 @@ E_sw_cg_cp_imm_edges_0x3:
   sw x7, 3(x14) # perform store
   addi x14, x14, 3 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, E_sw_cg_cp_imm_edges_0x3, E_sw_cg_cp_imm_edges_0x3_str)
-#else
-  sw x7, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 4)
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load rs2: x11 = 0x0994ddb353262101
@@ -1138,18 +679,9 @@ E_sw_cg_cp_imm_edges_0x4:
   sw x11, 4(x12) # perform store
   addi x12, x12, 4 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x6 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x6, E_sw_cg_cp_imm_edges_0x4, E_sw_cg_cp_imm_edges_0x4_str)
-#else
-  sw x11, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 8)
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load rs2: x11 = 0x01a60889c725ee15
@@ -1159,18 +691,9 @@ E_sw_cg_cp_imm_edges_0x8:
   sw x11, 8(x1) # perform store
   addi x1, x1, 8 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x6 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x6, E_sw_cg_cp_imm_edges_0x8, E_sw_cg_cp_imm_edges_0x8_str)
-#else
-  sw x11, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 16)
   RVTEST_TESTDATA_LOAD_INT(x2, x7) # load rs2: x7 = 0xffc3eac30ec858c6
@@ -1180,18 +703,9 @@ E_sw_cg_cp_imm_edges_0x10:
   sw x7, 16(x14) # perform store
   addi x14, x14, 16 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x6 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x6, E_sw_cg_cp_imm_edges_0x10, E_sw_cg_cp_imm_edges_0x10_str)
-#else
-  sw x7, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 32)
   RVTEST_TESTDATA_LOAD_INT(x2, x15) # load rs2: x15 = 0x66fd65524ade7366
@@ -1201,18 +715,9 @@ E_sw_cg_cp_imm_edges_0x20:
   sw x15, 32(x12) # perform store
   addi x12, x12, 32 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x10 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x10, E_sw_cg_cp_imm_edges_0x20, E_sw_cg_cp_imm_edges_0x20_str)
-#else
-  sw x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 64)
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load rs2: x6 = 0x149099d8a7b9011f
@@ -1222,18 +727,9 @@ E_sw_cg_cp_imm_edges_0x40:
   sw x6, 64(x13) # perform store
   addi x13, x13, 64 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, E_sw_cg_cp_imm_edges_0x40, E_sw_cg_cp_imm_edges_0x40_str)
-#else
-  sw x6, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 128)
   RVTEST_TESTDATA_LOAD_INT(x2, x1) # load rs2: x1 = 0x6bda5c4edb75c4d2
@@ -1243,18 +739,9 @@ E_sw_cg_cp_imm_edges_0x80:
   sw x1, 128(x7) # perform store
   addi x7, x7, 128 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x14 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x14, E_sw_cg_cp_imm_edges_0x80, E_sw_cg_cp_imm_edges_0x80_str)
-#else
-  sw x1, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 256)
   RVTEST_TESTDATA_LOAD_INT(x2, x3) # load rs2: x3 = 0x59c601abffc26a6f
@@ -1264,18 +751,9 @@ E_sw_cg_cp_imm_edges_0x100:
   sw x3, 256(x8) # perform store
   addi x8, x8, 256 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x1 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x1, E_sw_cg_cp_imm_edges_0x100, E_sw_cg_cp_imm_edges_0x100_str)
-#else
-  sw x3, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 512)
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load rs2: x6 = 0x88d553b37ca89ab8
@@ -1285,18 +763,9 @@ E_sw_cg_cp_imm_edges_0x200:
   sw x6, 512(x3) # perform store
   addi x3, x3, 512 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x15 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x15, E_sw_cg_cp_imm_edges_0x200, E_sw_cg_cp_imm_edges_0x200_str)
-#else
-  sw x6, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1023)
   RVTEST_TESTDATA_LOAD_INT(x2, x8) # load rs2: x8 = 0x1d6bc66adac5997c
@@ -1306,18 +775,9 @@ E_sw_cg_cp_imm_edges_0x3ff:
   sw x8, 1023(x10) # perform store
   addi x10, x10, 1023 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, E_sw_cg_cp_imm_edges_0x3ff, E_sw_cg_cp_imm_edges_0x3ff_str)
-#else
-  sw x8, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1024)
   RVTEST_TESTDATA_LOAD_INT(x2, x1) # load rs2: x1 = 0x2906783c507c61a9
@@ -1327,18 +787,9 @@ E_sw_cg_cp_imm_edges_0x400:
   sw x1, 1024(x7) # perform store
   addi x7, x7, 1024 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x6 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x6, E_sw_cg_cp_imm_edges_0x400, E_sw_cg_cp_imm_edges_0x400_str)
-#else
-  sw x1, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1795)
   RVTEST_TESTDATA_LOAD_INT(x2, x15) # load rs2: x15 = 0x1821b50349a6ec4b
@@ -1348,18 +799,9 @@ E_sw_cg_cp_imm_edges_0x703:
   sw x15, 1795(x3) # perform store
   addi x3, x3, 1795 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x8 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x8, E_sw_cg_cp_imm_edges_0x703, E_sw_cg_cp_imm_edges_0x703_str)
-#else
-  sw x15, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2047)
   RVTEST_TESTDATA_LOAD_INT(x2, x1) # load rs2: x1 = 0x970e2313040f2ca6
@@ -1369,18 +811,9 @@ E_sw_cg_cp_imm_edges_0x7ff:
   sw x1, 2047(x14) # perform store
   addi x14, x14, 2047 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, E_sw_cg_cp_imm_edges_0x7ff, E_sw_cg_cp_imm_edges_0x7ff_str)
-#else
-  sw x1, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2048)
   RVTEST_TESTDATA_LOAD_INT(x2, x8) # load rs2: x8 = 0x5cb22cdc501cf4ed
@@ -1391,18 +824,9 @@ E_sw_cg_cp_imm_edges_m0x800:
   sw x8, -2048(x3) # perform store
   addi x3, x3, -2048 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x12 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x12, E_sw_cg_cp_imm_edges_m0x800, E_sw_cg_cp_imm_edges_m0x800_str)
-#else
-  sw x8, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2047)
   RVTEST_TESTDATA_LOAD_INT(x2, x14) # load rs2: x14 = 0x171c35d24f793b23
@@ -1412,18 +836,9 @@ E_sw_cg_cp_imm_edges_m0x7ff:
   sw x14, -2047(x6) # perform store
   addi x6, x6, -2047 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x10 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x10, E_sw_cg_cp_imm_edges_m0x7ff, E_sw_cg_cp_imm_edges_m0x7ff_str)
-#else
-  sw x14, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2)
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load rs2: x11 = 0xc219295c531542eb
@@ -1433,18 +848,9 @@ E_sw_cg_cp_imm_edges_m0x2:
   sw x11, -2(x3) # perform store
   addi x3, x3, -2 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x14 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x14, E_sw_cg_cp_imm_edges_m0x2, E_sw_cg_cp_imm_edges_m0x2_str)
-#else
-  sw x11, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -1)
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load rs2: x6 = 0x32cb46f4cee69bb1
@@ -1454,18 +860,9 @@ E_sw_cg_cp_imm_edges_m0x1:
   sw x6, -1(x7) # perform store
   addi x7, x7, -1 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x8 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x8, E_sw_cg_cp_imm_edges_m0x1, E_sw_cg_cp_imm_edges_m0x1_str)
-#else
-  sw x6, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_align_word
@@ -1476,36 +873,18 @@ E_sw_cg_cp_imm_edges_m0x1:
 E_sw_cg_cp_align_word_b0:
   sw x6, 0(x7) # perform store
   addi x7, x7, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -8(x7) # load stored value for checking
   # Check if x1 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x1, E_sw_cg_cp_align_word_b0, E_sw_cg_cp_align_word_b0_str)
-#else
-  sw x6, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_word (imm[2:0] = 100)
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load rs2: x6 = 0xbc1e0991e9b407ee
 E_sw_cg_cp_align_word_b4:
   sw x6, 4(x7) # perform store
   addi x7, x7, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -8(x7) # load stored value for checking
   # Check if x1 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x1, E_sw_cg_cp_align_word_b4, E_sw_cg_cp_align_word_b4_str)
-#else
-  sw x6, 4(x7) # repeat store so it is available for checking
-  addi x7, x7, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 
   mv x2, x7 # restore signature pointer to default register for teardown

--- a/tests/rv64e/Zca/Zca-c.sd-00.S
+++ b/tests/rv64e/Zca/Zca-c.sd-00.S
@@ -41,18 +41,9 @@ Zca_c_sd_cg_cp_rs1_p_b8:
   c.sd x11, 40(x8) # perform store
   addi x8, x8, 40 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zca_c_sd_cg_cp_rs1_p_b8, Zca_c_sd_cg_cp_rs1_p_b8_str)
-#else
-  c.sd x11, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x9fb87b460ae752d8
@@ -62,18 +53,9 @@ Zca_c_sd_cg_cp_rs1_p_b9:
   c.sd x13, 24(x9) # perform store
   addi x9, x9, 24 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sd_cg_cp_rs1_p_b9, Zca_c_sd_cg_cp_rs1_p_b9_str)
-#else
-  c.sd x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x8f5927d2632c188e
@@ -83,18 +65,9 @@ Zca_c_sd_cg_cp_rs1_p_b10:
   c.sd x11, 208(x10) # perform store
   addi x10, x10, 208 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, Zca_c_sd_cg_cp_rs1_p_b10, Zca_c_sd_cg_cp_rs1_p_b10_str)
-#else
-  c.sd x11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x912f0e76fc9eb21d
@@ -104,18 +77,9 @@ Zca_c_sd_cg_cp_rs1_p_b11:
   c.sd x15, 240(x11) # perform store
   addi x11, x11, 240 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_sd_cg_cp_rs1_p_b11, Zca_c_sd_cg_cp_rs1_p_b11_str)
-#else
-  c.sd x15, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x2f83f3bcedadc459
@@ -125,18 +89,9 @@ Zca_c_sd_cg_cp_rs1_p_b12:
   c.sd x8, 88(x12) # perform store
   addi x12, x12, 88 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x10 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x10, Zca_c_sd_cg_cp_rs1_p_b12, Zca_c_sd_cg_cp_rs1_p_b12_str)
-#else
-  c.sd x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x0117a431d128fd4c
@@ -146,18 +101,9 @@ Zca_c_sd_cg_cp_rs1_p_b13:
   c.sd x8, 216(x13) # perform store
   addi x13, x13, 216 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, Zca_c_sd_cg_cp_rs1_p_b13, Zca_c_sd_cg_cp_rs1_p_b13_str)
-#else
-  c.sd x8, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x0137b2a2f22b88ca
@@ -167,18 +113,9 @@ Zca_c_sd_cg_cp_rs1_p_b14:
   c.sd x9, 160(x14) # perform store
   addi x14, x14, 160 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x15 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x15, Zca_c_sd_cg_cp_rs1_p_b14, Zca_c_sd_cg_cp_rs1_p_b14_str)
-#else
-  c.sd x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xab0ef85921f8c339
@@ -188,18 +125,9 @@ Zca_c_sd_cg_cp_rs1_p_b15:
   c.sd x13, 136(x15) # perform store
   addi x15, x15, 136 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, Zca_c_sd_cg_cp_rs1_p_b15, Zca_c_sd_cg_cp_rs1_p_b15_str)
-#else
-  c.sd x13, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_p
@@ -213,18 +141,9 @@ Zca_c_sd_cg_cp_rs2_p_b8:
   c.sd x8, 192(x14) # perform store
   addi x14, x14, 192 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zca_c_sd_cg_cp_rs2_p_b8, Zca_c_sd_cg_cp_rs2_p_b8_str)
-#else
-  c.sd x8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xb537c7b1a9d97843
@@ -234,18 +153,9 @@ Zca_c_sd_cg_cp_rs2_p_b9:
   c.sd x9, 136(x8) # perform store
   addi x8, x8, 136 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zca_c_sd_cg_cp_rs2_p_b9, Zca_c_sd_cg_cp_rs2_p_b9_str)
-#else
-  c.sd x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xab38713554dcd8d7
@@ -255,18 +165,9 @@ Zca_c_sd_cg_cp_rs2_p_b10:
   c.sd x10, 144(x13) # perform store
   addi x13, x13, 144 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, Zca_c_sd_cg_cp_rs2_p_b10, Zca_c_sd_cg_cp_rs2_p_b10_str)
-#else
-  c.sd x10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x5b5f45052ecaa215
@@ -276,18 +177,9 @@ Zca_c_sd_cg_cp_rs2_p_b11:
   c.sd x11, 168(x14) # perform store
   addi x14, x14, 168 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zca_c_sd_cg_cp_rs2_p_b11, Zca_c_sd_cg_cp_rs2_p_b11_str)
-#else
-  c.sd x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x20426f8c90a8d37e
@@ -297,18 +189,9 @@ Zca_c_sd_cg_cp_rs2_p_b12:
   c.sd x12, 64(x11) # perform store
   addi x11, x11, 64 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_sd_cg_cp_rs2_p_b12, Zca_c_sd_cg_cp_rs2_p_b12_str)
-#else
-  c.sd x12, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x1ec3c1caa24cb0f8
@@ -318,18 +201,9 @@ Zca_c_sd_cg_cp_rs2_p_b13:
   c.sd x13, 184(x10) # perform store
   addi x10, x10, 184 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, Zca_c_sd_cg_cp_rs2_p_b13, Zca_c_sd_cg_cp_rs2_p_b13_str)
-#else
-  c.sd x13, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x64cff40ad75a8a45
@@ -339,18 +213,9 @@ Zca_c_sd_cg_cp_rs2_p_b14:
   c.sd x14, 0(x12) # perform store
   addi x12, x12, 0 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_sd_cg_cp_rs2_p_b14, Zca_c_sd_cg_cp_rs2_p_b14_str)
-#else
-  c.sd x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xed01605e463760d3
@@ -360,18 +225,9 @@ Zca_c_sd_cg_cp_rs2_p_b15:
   c.sd x15, 232(x9) # perform store
   addi x9, x9, 232 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sd_cg_cp_rs2_p_b15, Zca_c_sd_cg_cp_rs2_p_b15_str)
-#else
-  c.sd x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -385,18 +241,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x0:
   c.sd x13, 8(x11) # perform store
   addi x11, x11, 8 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_sd_cg_cp_rs2_edges_0x0, Zca_c_sd_cg_cp_rs2_edges_0x0_str)
-#else
-  c.sd x13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x0000000000000001
@@ -406,18 +253,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x1:
   c.sd x13, 88(x12) # perform store
   addi x12, x12, 88 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zca_c_sd_cg_cp_rs2_edges_0x1, Zca_c_sd_cg_cp_rs2_edges_0x1_str)
-#else
-  c.sd x13, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x0000000000000002
@@ -427,18 +265,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x2:
   c.sd x15, 128(x13) # perform store
   addi x13, x13, 128 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, Zca_c_sd_cg_cp_rs2_edges_0x2, Zca_c_sd_cg_cp_rs2_edges_0x2_str)
-#else
-  c.sd x15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x8000000000000000
@@ -448,18 +277,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x8000000000000000:
   c.sd x14, 24(x10) # perform store
   addi x10, x10, 24 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x9 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x9, Zca_c_sd_cg_cp_rs2_edges_0x8000000000000000, Zca_c_sd_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  c.sd x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x8000000000000001
@@ -469,18 +289,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x8000000000000001:
   c.sd x14, 112(x15) # perform store
   addi x15, x15, 112 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x9 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x9, Zca_c_sd_cg_cp_rs2_edges_0x8000000000000001, Zca_c_sd_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  c.sd x14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x7fffffffffffffff
@@ -490,18 +301,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x7fffffffffffffff:
   c.sd x12, 40(x8) # perform store
   addi x8, x8, 40 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, Zca_c_sd_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_sd_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  c.sd x12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x7ffffffffffffffe
@@ -511,18 +313,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x7ffffffffffffffe:
   c.sd x14, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sd_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_sd_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  c.sd x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xffffffffffffffff
@@ -532,18 +325,9 @@ Zca_c_sd_cg_cp_rs2_edges_0xffffffffffffffff:
   c.sd x14, 104(x8) # perform store
   addi x8, x8, 104 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zca_c_sd_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_sd_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  c.sd x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xfffffffffffffffe
@@ -553,18 +337,9 @@ Zca_c_sd_cg_cp_rs2_edges_0xfffffffffffffffe:
   c.sd x15, 48(x14) # perform store
   addi x14, x14, 48 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zca_c_sd_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_sd_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  c.sd x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x5bbc887763ae86f2
@@ -574,18 +349,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   c.sd x11, 136(x9) # perform store
   addi x9, x9, 136 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sd_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_sd_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  c.sd x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xaaaaaaaaaaaaaaaa
@@ -595,18 +361,9 @@ Zca_c_sd_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   c.sd x13, 152(x15) # perform store
   addi x15, x15, 152 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zca_c_sd_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_sd_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  c.sd x13, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x5555555555555555
@@ -616,18 +373,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x5555555555555555:
   c.sd x9, 200(x8) # perform store
   addi x8, x8, 200 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zca_c_sd_cg_cp_rs2_edges_0x5555555555555555, Zca_c_sd_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  c.sd x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x00000000ffffffff
@@ -637,18 +385,9 @@ Zca_c_sd_cg_cp_rs2_edges_0xffffffff:
   c.sd x15, 120(x11) # perform store
   addi x11, x11, 120 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_sd_cg_cp_rs2_edges_0xffffffff, Zca_c_sd_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  c.sd x15, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x00000000fffffffe
@@ -658,18 +397,9 @@ Zca_c_sd_cg_cp_rs2_edges_0xfffffffe:
   c.sd x14, 104(x9) # perform store
   addi x9, x9, 104 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sd_cg_cp_rs2_edges_0xfffffffe, Zca_c_sd_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  c.sd x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x0000000100000000
@@ -679,18 +409,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x100000000:
   c.sd x13, 232(x12) # perform store
   addi x12, x12, 232 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zca_c_sd_cg_cp_rs2_edges_0x100000000, Zca_c_sd_cg_cp_rs2_edges_0x100000000_str)
-#else
-  c.sd x13, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x0000000100000001
@@ -700,18 +421,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x100000001:
   c.sd x10, 152(x15) # perform store
   addi x15, x15, 152 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zca_c_sd_cg_cp_rs2_edges_0x100000001, Zca_c_sd_cg_cp_rs2_edges_0x100000001_str)
-#else
-  c.sd x10, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_mul_8
@@ -725,18 +437,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x0:
   c.sd x9, 0(x14) # perform store
   addi x14, x14, 0 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x10 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x10, Zca_c_sd_cg_cp_imm_mul_8_b0x0, Zca_c_sd_cg_cp_imm_mul_8_b0x0_str)
-#else
-  c.sd x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=8
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xc548e12214302b5d
@@ -746,18 +449,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x8:
   c.sd x10, 8(x9) # perform store
   addi x9, x9, 8 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sd_cg_cp_imm_mul_8_b0x8, Zca_c_sd_cg_cp_imm_mul_8_b0x8_str)
-#else
-  c.sd x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=16
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xf348069f6dee3bae
@@ -767,18 +461,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x10:
   c.sd x13, 16(x8) # perform store
   addi x8, x8, 16 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, Zca_c_sd_cg_cp_imm_mul_8_b0x10, Zca_c_sd_cg_cp_imm_mul_8_b0x10_str)
-#else
-  c.sd x13, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=24
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x63d32df923a08b49
@@ -788,18 +473,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x18:
   c.sd x13, 24(x15) # perform store
   addi x15, x15, 24 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zca_c_sd_cg_cp_imm_mul_8_b0x18, Zca_c_sd_cg_cp_imm_mul_8_b0x18_str)
-#else
-  c.sd x13, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=32
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x9906e613cb12f9e6
@@ -809,18 +485,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x20:
   c.sd x13, 32(x8) # perform store
   addi x8, x8, 32 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, Zca_c_sd_cg_cp_imm_mul_8_b0x20, Zca_c_sd_cg_cp_imm_mul_8_b0x20_str)
-#else
-  c.sd x13, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=40
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xce40e27d2a628164
@@ -830,18 +497,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x28:
   c.sd x10, 40(x14) # perform store
   addi x14, x14, 40 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zca_c_sd_cg_cp_imm_mul_8_b0x28, Zca_c_sd_cg_cp_imm_mul_8_b0x28_str)
-#else
-  c.sd x10, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=48
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xf63175840fa39c87
@@ -851,18 +509,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x30:
   c.sd x13, 48(x15) # perform store
   addi x15, x15, 48 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x9 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x9, Zca_c_sd_cg_cp_imm_mul_8_b0x30, Zca_c_sd_cg_cp_imm_mul_8_b0x30_str)
-#else
-  c.sd x13, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=56
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x71204622dc3764e8
@@ -872,18 +521,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x38:
   c.sd x10, 56(x9) # perform store
   addi x9, x9, 56 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sd_cg_cp_imm_mul_8_b0x38, Zca_c_sd_cg_cp_imm_mul_8_b0x38_str)
-#else
-  c.sd x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=64
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xdc95e6a3aeac5b6b
@@ -893,18 +533,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x40:
   c.sd x12, 64(x8) # perform store
   addi x8, x8, 64 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, Zca_c_sd_cg_cp_imm_mul_8_b0x40, Zca_c_sd_cg_cp_imm_mul_8_b0x40_str)
-#else
-  c.sd x12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=72
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x67c31943e237de0d
@@ -914,18 +545,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x48:
   c.sd x13, 72(x9) # perform store
   addi x9, x9, 72 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sd_cg_cp_imm_mul_8_b0x48, Zca_c_sd_cg_cp_imm_mul_8_b0x48_str)
-#else
-  c.sd x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=80
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xb6444b43c0e28766
@@ -935,18 +557,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x50:
   c.sd x15, 80(x8) # perform store
   addi x8, x8, 80 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zca_c_sd_cg_cp_imm_mul_8_b0x50, Zca_c_sd_cg_cp_imm_mul_8_b0x50_str)
-#else
-  c.sd x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=88
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xbb88111e5d506790
@@ -956,18 +569,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x58:
   c.sd x11, 88(x13) # perform store
   addi x13, x13, 88 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, Zca_c_sd_cg_cp_imm_mul_8_b0x58, Zca_c_sd_cg_cp_imm_mul_8_b0x58_str)
-#else
-  c.sd x11, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=96
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x1cc2cbcd2a8dfe71
@@ -977,18 +581,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x60:
   c.sd x9, 96(x11) # perform store
   addi x11, x11, 96 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_sd_cg_cp_imm_mul_8_b0x60, Zca_c_sd_cg_cp_imm_mul_8_b0x60_str)
-#else
-  c.sd x9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=104
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x7d1e9c88dd25f640
@@ -998,18 +593,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x68:
   c.sd x8, 104(x15) # perform store
   addi x15, x15, 104 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x13, Zca_c_sd_cg_cp_imm_mul_8_b0x68, Zca_c_sd_cg_cp_imm_mul_8_b0x68_str)
-#else
-  c.sd x8, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=112
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xa125c69008fd8432
@@ -1019,18 +605,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x70:
   c.sd x12, 112(x11) # perform store
   addi x11, x11, 112 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_sd_cg_cp_imm_mul_8_b0x70, Zca_c_sd_cg_cp_imm_mul_8_b0x70_str)
-#else
-  c.sd x12, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=120
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xa0a98923099fd26d
@@ -1040,18 +617,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x78:
   c.sd x13, 120(x12) # perform store
   addi x12, x12, 120 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x15 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x15, Zca_c_sd_cg_cp_imm_mul_8_b0x78, Zca_c_sd_cg_cp_imm_mul_8_b0x78_str)
-#else
-  c.sd x13, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=128
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x137181878d7759d4
@@ -1061,18 +629,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x80:
   c.sd x15, 128(x9) # perform store
   addi x9, x9, 128 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sd_cg_cp_imm_mul_8_b0x80, Zca_c_sd_cg_cp_imm_mul_8_b0x80_str)
-#else
-  c.sd x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=136
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x3e9232057938f85b
@@ -1082,18 +641,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x88:
   c.sd x13, 136(x11) # perform store
   addi x11, x11, 136 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_sd_cg_cp_imm_mul_8_b0x88, Zca_c_sd_cg_cp_imm_mul_8_b0x88_str)
-#else
-  c.sd x13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=144
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xa6be663cdbd343bd
@@ -1103,18 +653,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x90:
   c.sd x15, 144(x10) # perform store
   addi x10, x10, 144 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zca_c_sd_cg_cp_imm_mul_8_b0x90, Zca_c_sd_cg_cp_imm_mul_8_b0x90_str)
-#else
-  c.sd x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=152
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x21d4e993166ecdf5
@@ -1124,18 +665,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x98:
   c.sd x15, 152(x9) # perform store
   addi x9, x9, 152 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sd_cg_cp_imm_mul_8_b0x98, Zca_c_sd_cg_cp_imm_mul_8_b0x98_str)
-#else
-  c.sd x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=160
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x5ad4b6ebc6550926
@@ -1145,18 +677,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xa0:
   c.sd x15, 160(x14) # perform store
   addi x14, x14, 160 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zca_c_sd_cg_cp_imm_mul_8_b0xa0, Zca_c_sd_cg_cp_imm_mul_8_b0xa0_str)
-#else
-  c.sd x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=168
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xe6ca12e44af10097
@@ -1166,18 +689,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xa8:
   c.sd x9, 168(x15) # perform store
   addi x15, x15, 168 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, Zca_c_sd_cg_cp_imm_mul_8_b0xa8, Zca_c_sd_cg_cp_imm_mul_8_b0xa8_str)
-#else
-  c.sd x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=176
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x5fad01301a98956c
@@ -1187,18 +701,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xb0:
   c.sd x14, 176(x12) # perform store
   addi x12, x12, 176 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zca_c_sd_cg_cp_imm_mul_8_b0xb0, Zca_c_sd_cg_cp_imm_mul_8_b0xb0_str)
-#else
-  c.sd x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=184
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x75176fafe5291907
@@ -1208,18 +713,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xb8:
   c.sd x13, 184(x14) # perform store
   addi x14, x14, 184 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x10 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x10, Zca_c_sd_cg_cp_imm_mul_8_b0xb8, Zca_c_sd_cg_cp_imm_mul_8_b0xb8_str)
-#else
-  c.sd x13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=192
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xf993f44bf78412a4
@@ -1229,18 +725,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xc0:
   c.sd x15, 192(x10) # perform store
   addi x10, x10, 192 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zca_c_sd_cg_cp_imm_mul_8_b0xc0, Zca_c_sd_cg_cp_imm_mul_8_b0xc0_str)
-#else
-  c.sd x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=200
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x31f9f7e02c0297e2
@@ -1250,18 +737,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xc8:
   c.sd x15, 200(x13) # perform store
   addi x13, x13, 200 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, Zca_c_sd_cg_cp_imm_mul_8_b0xc8, Zca_c_sd_cg_cp_imm_mul_8_b0xc8_str)
-#else
-  c.sd x15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=208
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x3ea33c558959d7e9
@@ -1271,18 +749,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xd0:
   c.sd x14, 208(x12) # perform store
   addi x12, x12, 208 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zca_c_sd_cg_cp_imm_mul_8_b0xd0, Zca_c_sd_cg_cp_imm_mul_8_b0xd0_str)
-#else
-  c.sd x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=216
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xd222b44df7b157ab
@@ -1292,18 +761,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xd8:
   c.sd x10, 216(x8) # perform store
   addi x8, x8, 216 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zca_c_sd_cg_cp_imm_mul_8_b0xd8, Zca_c_sd_cg_cp_imm_mul_8_b0xd8_str)
-#else
-  c.sd x10, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=224
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xbe1706d57ad81ab1
@@ -1313,18 +773,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xe0:
   c.sd x12, 224(x9) # perform store
   addi x9, x9, 224 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sd_cg_cp_imm_mul_8_b0xe0, Zca_c_sd_cg_cp_imm_mul_8_b0xe0_str)
-#else
-  c.sd x12, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=232
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x024e534f03cf1be0
@@ -1334,18 +785,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xe8:
   c.sd x14, 232(x11) # perform store
   addi x11, x11, 232 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_sd_cg_cp_imm_mul_8_b0xe8, Zca_c_sd_cg_cp_imm_mul_8_b0xe8_str)
-#else
-  c.sd x14, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=240
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x63f1adf0a9299293
@@ -1355,18 +797,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xf0:
   c.sd x13, 240(x14) # perform store
   addi x14, x14, 240 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zca_c_sd_cg_cp_imm_mul_8_b0xf0, Zca_c_sd_cg_cp_imm_mul_8_b0xf0_str)
-#else
-  c.sd x13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=248
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x70fe206ec0da7bc0
@@ -1376,18 +809,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xf8:
   c.sd x13, 248(x10) # perform store
   addi x10, x10, 248 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zca_c_sd_cg_cp_imm_mul_8_b0xf8, Zca_c_sd_cg_cp_imm_mul_8_b0xf8_str)
-#else
-  c.sd x13, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x10 # restore signature pointer to default register for teardown
 

--- a/tests/rv64e/Zca/Zca-c.sdsp-00.S
+++ b/tests/rv64e/Zca/Zca-c.sdsp-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 106
+#define SIGUPD_COUNT 202
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -40,6 +40,7 @@ RVTEST_BEGIN
 Zca_c_sdsp_cg_cp_rs2_b0:
   c.sdsp x0, 456(sp) # perform store
   LREG x15, 0(x10) # load stored value for checking
+  addi x10, x10, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_b0, Zca_c_sdsp_cg_cp_rs2_b0_str)
 
@@ -49,6 +50,7 @@ Zca_c_sdsp_cg_cp_rs2_b0:
 Zca_c_sdsp_cg_cp_rs2_b1:
   c.sdsp x1, 336(sp) # perform store
   LREG x9, 0(x10) # load stored value for checking
+  addi x10, x10, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x9, Zca_c_sdsp_cg_cp_rs2_b1, Zca_c_sdsp_cg_cp_rs2_b1_str)
 
@@ -58,6 +60,7 @@ Zca_c_sdsp_cg_cp_rs2_b1:
 Zca_c_sdsp_cg_cp_rs2_b2:
   c.sdsp x2, 184(sp) # perform store
   LREG x14, 0(x10) # load stored value for checking
+  addi x10, x10, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zca_c_sdsp_cg_cp_rs2_b2, Zca_c_sdsp_cg_cp_rs2_b2_str)
 
@@ -68,6 +71,7 @@ Zca_c_sdsp_cg_cp_rs2_b2:
 Zca_c_sdsp_cg_cp_rs2_b3:
   c.sdsp x3, 480(sp) # perform store
   LREG x13, 0(x10) # load stored value for checking
+  addi x10, x10, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zca_c_sdsp_cg_cp_rs2_b3, Zca_c_sdsp_cg_cp_rs2_b3_str)
 
@@ -79,6 +83,7 @@ Zca_c_sdsp_cg_cp_rs2_b3:
 Zca_c_sdsp_cg_cp_rs2_b4:
   c.sdsp x4, 344(sp) # perform store
   LREG x5, 0(x10) # load stored value for checking
+  addi x10, x10, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x5, Zca_c_sdsp_cg_cp_rs2_b4, Zca_c_sdsp_cg_cp_rs2_b4_str)
 
@@ -88,6 +93,7 @@ Zca_c_sdsp_cg_cp_rs2_b4:
 Zca_c_sdsp_cg_cp_rs2_b5:
   c.sdsp x5, 432(sp) # perform store
   LREG x3, 0(x10) # load stored value for checking
+  addi x10, x10, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x3, Zca_c_sdsp_cg_cp_rs2_b5, Zca_c_sdsp_cg_cp_rs2_b5_str)
 
@@ -97,6 +103,7 @@ Zca_c_sdsp_cg_cp_rs2_b5:
 Zca_c_sdsp_cg_cp_rs2_b6:
   c.sdsp x6, 344(sp) # perform store
   LREG x1, 0(x10) # load stored value for checking
+  addi x10, x10, SIG_STRIDE # increment signature pointer
   # Check if x1 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x1, Zca_c_sdsp_cg_cp_rs2_b6, Zca_c_sdsp_cg_cp_rs2_b6_str)
 
@@ -108,6 +115,7 @@ Zca_c_sdsp_cg_cp_rs2_b6:
 Zca_c_sdsp_cg_cp_rs2_b7:
   c.sdsp x7, 448(sp) # perform store
   LREG x12, 0(x10) # load stored value for checking
+  addi x10, x10, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x12, Zca_c_sdsp_cg_cp_rs2_b7, Zca_c_sdsp_cg_cp_rs2_b7_str)
 
@@ -117,6 +125,7 @@ Zca_c_sdsp_cg_cp_rs2_b7:
 Zca_c_sdsp_cg_cp_rs2_b8:
   c.sdsp x8, 304(sp) # perform store
   LREG x15, 0(x10) # load stored value for checking
+  addi x10, x10, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x15, Zca_c_sdsp_cg_cp_rs2_b8, Zca_c_sdsp_cg_cp_rs2_b8_str)
 
@@ -127,6 +136,7 @@ Zca_c_sdsp_cg_cp_rs2_b8:
 Zca_c_sdsp_cg_cp_rs2_b9:
   c.sdsp x9, 160(sp) # perform store
   LREG x3, 0(x10) # load stored value for checking
+  addi x10, x10, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x3, Zca_c_sdsp_cg_cp_rs2_b9, Zca_c_sdsp_cg_cp_rs2_b9_str)
 
@@ -137,6 +147,7 @@ Zca_c_sdsp_cg_cp_rs2_b9:
 Zca_c_sdsp_cg_cp_rs2_b10:
   c.sdsp x10, 168(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x11, Zca_c_sdsp_cg_cp_rs2_b10, Zca_c_sdsp_cg_cp_rs2_b10_str)
 
@@ -146,6 +157,7 @@ Zca_c_sdsp_cg_cp_rs2_b10:
 Zca_c_sdsp_cg_cp_rs2_b11:
   c.sdsp x11, 64(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x3, Zca_c_sdsp_cg_cp_rs2_b11, Zca_c_sdsp_cg_cp_rs2_b11_str)
 
@@ -155,6 +167,7 @@ Zca_c_sdsp_cg_cp_rs2_b11:
 Zca_c_sdsp_cg_cp_rs2_b12:
   c.sdsp x12, 120(sp) # perform store
   LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x5, Zca_c_sdsp_cg_cp_rs2_b12, Zca_c_sdsp_cg_cp_rs2_b12_str)
 
@@ -166,6 +179,7 @@ Zca_c_sdsp_cg_cp_rs2_b12:
 Zca_c_sdsp_cg_cp_rs2_b13:
   c.sdsp x13, 472(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_rs2_b13, Zca_c_sdsp_cg_cp_rs2_b13_str)
 
@@ -175,6 +189,7 @@ Zca_c_sdsp_cg_cp_rs2_b13:
 Zca_c_sdsp_cg_cp_rs2_b14:
   c.sdsp x14, 56(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_rs2_b14, Zca_c_sdsp_cg_cp_rs2_b14_str)
 
@@ -185,6 +200,7 @@ Zca_c_sdsp_cg_cp_rs2_b14:
 Zca_c_sdsp_cg_cp_rs2_b15:
   c.sdsp x15, 144(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_rs2_b15, Zca_c_sdsp_cg_cp_rs2_b15_str)
 
@@ -198,6 +214,7 @@ Zca_c_sdsp_cg_cp_rs2_b15:
 Zca_c_sdsp_cg_cp_rs2_edges_0x0:
   c.sdsp x13, 368(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_rs2_edges_0x0, Zca_c_sdsp_cg_cp_rs2_edges_0x0_str)
 
@@ -207,6 +224,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x0:
 Zca_c_sdsp_cg_cp_rs2_edges_0x1:
   c.sdsp x11, 24(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_rs2_edges_0x1, Zca_c_sdsp_cg_cp_rs2_edges_0x1_str)
 
@@ -216,6 +234,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x1:
 Zca_c_sdsp_cg_cp_rs2_edges_0x2:
   c.sdsp x11, 392(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_rs2_edges_0x2, Zca_c_sdsp_cg_cp_rs2_edges_0x2_str)
 
@@ -225,6 +244,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x2:
 Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000:
   c.sdsp x14, 16(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000_str)
 
@@ -234,6 +254,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000:
 Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001:
   c.sdsp x6, 240(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001_str)
 
@@ -243,6 +264,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001:
 Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff:
   c.sdsp x13, 24(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff_str)
 
@@ -252,6 +274,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff:
 Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
   c.sdsp x8, 48(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
 
@@ -261,6 +284,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
 Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff:
   c.sdsp x15, 368(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff_str)
 
@@ -270,6 +294,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff:
 Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe:
   c.sdsp x6, 232(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe_str)
 
@@ -279,6 +304,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe:
 Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   c.sdsp x3, 0(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
 
@@ -288,6 +314,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
 Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   c.sdsp x11, 200(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
 
@@ -297,6 +324,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
 Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555:
   c.sdsp x8, 480(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555, Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555_str)
 
@@ -306,6 +334,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555:
 Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff:
   c.sdsp x8, 240(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff_str)
 
@@ -315,6 +344,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff:
 Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe:
   c.sdsp x13, 280(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe_str)
 
@@ -324,6 +354,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe:
 Zca_c_sdsp_cg_cp_rs2_edges_0x100000000:
   c.sdsp x6, 0(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_rs2_edges_0x100000000, Zca_c_sdsp_cg_cp_rs2_edges_0x100000000_str)
 
@@ -333,6 +364,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x100000000:
 Zca_c_sdsp_cg_cp_rs2_edges_0x100000001:
   c.sdsp x15, 24(sp) # perform store
   LREG x8, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_rs2_edges_0x100000001, Zca_c_sdsp_cg_cp_rs2_edges_0x100000001_str)
 
@@ -346,6 +378,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x100000001:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0:
   c.sdsp x13, 0(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0_str)
 
@@ -355,6 +388,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8:
   c.sdsp x12, 8(sp) # perform store
   LREG x13, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8_str)
 
@@ -364,6 +398,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10:
   c.sdsp x14, 16(sp) # perform store
   LREG x8, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10_str)
 
@@ -373,6 +408,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18:
   c.sdsp x10, 24(sp) # perform store
   LREG x8, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18_str)
 
@@ -382,6 +418,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20:
   c.sdsp x15, 32(sp) # perform store
   LREG x13, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20_str)
 
@@ -391,6 +428,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28:
   c.sdsp x11, 40(sp) # perform store
   LREG x7, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28_str)
 
@@ -400,6 +438,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30:
   c.sdsp x10, 48(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30_str)
 
@@ -409,6 +448,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38:
   c.sdsp x14, 56(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38_str)
 
@@ -418,6 +458,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40:
   c.sdsp x14, 64(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40_str)
 
@@ -427,6 +468,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48:
   c.sdsp x10, 72(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48_str)
 
@@ -436,6 +478,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50:
   c.sdsp x2, 80(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50_str)
 
@@ -445,6 +488,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58:
   c.sdsp x8, 88(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58_str)
 
@@ -454,6 +498,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60:
   c.sdsp x7, 96(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60_str)
 
@@ -463,6 +508,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68:
   c.sdsp x3, 104(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68_str)
 
@@ -472,6 +518,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70:
   c.sdsp x10, 112(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70_str)
 
@@ -481,6 +528,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78:
   c.sdsp x0, 120(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78_str)
 
@@ -490,6 +538,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80:
   c.sdsp x2, 128(sp) # perform store
   LREG x8, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80_str)
 
@@ -499,6 +548,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88:
   c.sdsp x0, 136(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88_str)
 
@@ -508,6 +558,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90:
   c.sdsp x3, 144(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90_str)
 
@@ -517,6 +568,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98:
   c.sdsp x2, 152(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98_str)
 
@@ -526,6 +578,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0:
   c.sdsp x11, 160(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0_str)
 
@@ -535,6 +588,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8:
   c.sdsp x6, 168(sp) # perform store
   LREG x8, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8_str)
 
@@ -544,6 +598,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0:
   c.sdsp x8, 176(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0_str)
 
@@ -553,6 +608,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8:
   c.sdsp x14, 184(sp) # perform store
   LREG x7, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8_str)
 
@@ -562,6 +618,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0:
   c.sdsp x3, 192(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0_str)
 
@@ -571,6 +628,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8:
   c.sdsp x6, 200(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8_str)
 
@@ -580,6 +638,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0:
   c.sdsp x14, 208(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0_str)
 
@@ -589,6 +648,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8:
   c.sdsp x10, 216(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8_str)
 
@@ -598,6 +658,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0:
   c.sdsp x10, 224(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0_str)
 
@@ -607,6 +668,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8:
   c.sdsp x2, 232(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8_str)
 
@@ -616,6 +678,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0:
   c.sdsp x8, 240(sp) # perform store
   LREG x7, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0_str)
 
@@ -625,6 +688,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8:
   c.sdsp x11, 248(sp) # perform store
   LREG x7, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8_str)
 
@@ -634,6 +698,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100:
   c.sdsp x7, 256(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100_str)
 
@@ -643,6 +708,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108:
   c.sdsp x7, 264(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108_str)
 
@@ -652,6 +718,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110:
   c.sdsp x8, 272(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110_str)
 
@@ -661,6 +728,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118:
   c.sdsp x15, 280(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118_str)
 
@@ -670,6 +738,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120:
   c.sdsp x6, 288(sp) # perform store
   LREG x8, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120_str)
 
@@ -679,6 +748,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128:
   c.sdsp x6, 296(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128_str)
 
@@ -688,6 +758,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130:
   c.sdsp x13, 304(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130_str)
 
@@ -697,6 +768,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138:
   c.sdsp x15, 312(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138_str)
 
@@ -706,6 +778,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140:
   c.sdsp x6, 320(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140_str)
 
@@ -715,6 +788,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148:
   c.sdsp x10, 328(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148_str)
 
@@ -724,6 +798,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150:
   c.sdsp x2, 336(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150_str)
 
@@ -733,6 +808,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158:
   c.sdsp x10, 344(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158_str)
 
@@ -742,6 +818,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160:
   c.sdsp x14, 352(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160_str)
 
@@ -751,6 +828,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168:
   c.sdsp x3, 360(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168_str)
 
@@ -760,6 +838,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170:
   c.sdsp x2, 368(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170_str)
 
@@ -769,6 +848,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178:
   c.sdsp x14, 376(sp) # perform store
   LREG x13, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178_str)
 
@@ -778,6 +858,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180:
   c.sdsp x11, 384(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180_str)
 
@@ -787,6 +868,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188:
   c.sdsp x10, 392(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188_str)
 
@@ -796,6 +878,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190:
   c.sdsp x11, 400(sp) # perform store
   LREG x7, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190_str)
 
@@ -805,6 +888,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198:
   c.sdsp x6, 408(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198_str)
 
@@ -814,6 +898,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0:
   c.sdsp x8, 416(sp) # perform store
   LREG x13, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0_str)
 
@@ -823,6 +908,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8:
   c.sdsp x14, 424(sp) # perform store
   LREG x8, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8_str)
 
@@ -832,6 +918,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0:
   c.sdsp x0, 432(sp) # perform store
   LREG x7, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0_str)
 
@@ -841,6 +928,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8:
   c.sdsp x6, 440(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8_str)
 
@@ -850,6 +938,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0:
   c.sdsp x12, 448(sp) # perform store
   LREG x8, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0_str)
 
@@ -859,6 +948,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8:
   c.sdsp x13, 456(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8_str)
 
@@ -868,6 +958,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0:
   c.sdsp x10, 464(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0_str)
 
@@ -877,6 +968,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8:
   c.sdsp x15, 472(sp) # perform store
   LREG x7, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8_str)
 
@@ -886,6 +978,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0:
   c.sdsp x13, 480(sp) # perform store
   LREG x7, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0_str)
 
@@ -895,6 +988,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8:
   c.sdsp x3, 488(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8_str)
 
@@ -904,6 +998,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0:
   c.sdsp x13, 496(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0_str)
 
@@ -913,6 +1008,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8:
   c.sdsp x15, 504(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8_str)
 

--- a/tests/rv64e/Zca/Zca-c.sdsp-00.S
+++ b/tests/rv64e/Zca/Zca-c.sdsp-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 202
+#define SIGUPD_COUNT 106
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -39,57 +39,27 @@ RVTEST_BEGIN
   addi sp, x10, -456  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b0:
   c.sdsp x0, 456(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_b0, Zca_c_sdsp_cg_cp_rs2_b0_str)
-#else
-  addi sp, sp, 456 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x0, 0(sp) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0x1b1fcbf9782b1154
   addi sp, x10, -336  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b1:
   c.sdsp x1, 336(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x10) # load stored value for checking
   # Check if x9 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x9, Zca_c_sdsp_cg_cp_rs2_b1, Zca_c_sdsp_cg_cp_rs2_b1_str)
-#else
-  addi sp, sp, 336 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x1, 0(sp) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0x0c77aa25a7ebb27e
   addi sp, x10, -184  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b2:
   c.sdsp x2, 184(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zca_c_sdsp_cg_cp_rs2_b2, Zca_c_sdsp_cg_cp_rs2_b2_str)
-#else
-  addi sp, sp, 184 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x2, 0(sp) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x9, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x3)
@@ -97,19 +67,9 @@ Zca_c_sdsp_cg_cp_rs2_b2:
   addi sp, x10, -480  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b3:
   c.sdsp x3, 480(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zca_c_sdsp_cg_cp_rs2_b3, Zca_c_sdsp_cg_cp_rs2_b3_str)
-#else
-  addi sp, sp, 480 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x3, 0(sp) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -118,57 +78,27 @@ Zca_c_sdsp_cg_cp_rs2_b3:
   addi sp, x10, -344  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b4:
   c.sdsp x4, 344(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x10) # load stored value for checking
   # Check if x5 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x5, Zca_c_sdsp_cg_cp_rs2_b4, Zca_c_sdsp_cg_cp_rs2_b4_str)
-#else
-  addi sp, sp, 344 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x4, 0(sp) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x9, x5) # load rs2: x5 = 0x984a9370361b5e33
   addi sp, x10, -432  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b5:
   c.sdsp x5, 432(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x10) # load stored value for checking
   # Check if x3 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x3, Zca_c_sdsp_cg_cp_rs2_b5, Zca_c_sdsp_cg_cp_rs2_b5_str)
-#else
-  addi sp, sp, 432 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x5, 0(sp) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x9, x6) # load rs2: x6 = 0x016624bc4d18b88e
   addi sp, x10, -344  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b6:
   c.sdsp x6, 344(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x1, 0(x10) # load stored value for checking
   # Check if x1 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x1, Zca_c_sdsp_cg_cp_rs2_b6, Zca_c_sdsp_cg_cp_rs2_b6_str)
-#else
-  addi sp, sp, 344 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x6, 0(sp) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x13, x7 # switch temp register to avoid conflict with test
   mv x14, x8 # switch link pointer register to avoid conflict with test
@@ -177,38 +107,18 @@ Zca_c_sdsp_cg_cp_rs2_b6:
   addi sp, x10, -448  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b7:
   c.sdsp x7, 448(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x12, Zca_c_sdsp_cg_cp_rs2_b7, Zca_c_sdsp_cg_cp_rs2_b7_str)
-#else
-  addi sp, sp, 448 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x7, 0(sp) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x9, x8) # load rs2: x8 = 0xe5e43cceb74336b4
   addi sp, x10, -304  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b8:
   c.sdsp x8, 304(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x15, Zca_c_sdsp_cg_cp_rs2_b8, Zca_c_sdsp_cg_cp_rs2_b8_str)
-#else
-  addi sp, sp, 304 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x8, 0(sp) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x15, x9 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x9)
@@ -216,19 +126,9 @@ Zca_c_sdsp_cg_cp_rs2_b8:
   addi sp, x10, -160  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b9:
   c.sdsp x9, 160(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x10) # load stored value for checking
   # Check if x3 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x3, Zca_c_sdsp_cg_cp_rs2_b9, Zca_c_sdsp_cg_cp_rs2_b9_str)
-#else
-  addi sp, sp, 160 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x9, 0(sp) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x9, x10 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x10)
@@ -236,57 +136,27 @@ Zca_c_sdsp_cg_cp_rs2_b9:
   addi sp, x9, -168  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b10:
   c.sdsp x10, 168(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x11, Zca_c_sdsp_cg_cp_rs2_b10, Zca_c_sdsp_cg_cp_rs2_b10_str)
-#else
-  addi sp, sp, 168 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x15, x11) # load rs2: x11 = 0x585d7cb412b34f9b
   addi sp, x9, -64  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b11:
   c.sdsp x11, 64(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x3, Zca_c_sdsp_cg_cp_rs2_b11, Zca_c_sdsp_cg_cp_rs2_b11_str)
-#else
-  addi sp, sp, 64 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x11, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rs2: x12 = 0x01693d06427ddf2d
   addi sp, x9, -120  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b12:
   c.sdsp x12, 120(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x9) # load stored value for checking
   # Check if x5 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x5, Zca_c_sdsp_cg_cp_rs2_b12, Zca_c_sdsp_cg_cp_rs2_b12_str)
-#else
-  addi sp, sp, 120 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x12, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -295,38 +165,18 @@ Zca_c_sdsp_cg_cp_rs2_b12:
   addi sp, x9, -472  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b13:
   c.sdsp x13, 472(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_rs2_b13, Zca_c_sdsp_cg_cp_rs2_b13_str)
-#else
-  addi sp, sp, 472 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x13, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x15, x14) # load rs2: x14 = 0xeae1f7d75a5c5842
   addi sp, x9, -56  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b14:
   c.sdsp x14, 56(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_rs2_b14, Zca_c_sdsp_cg_cp_rs2_b14_str)
-#else
-  addi sp, sp, 56 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x1, x15 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x15)
@@ -334,19 +184,9 @@ Zca_c_sdsp_cg_cp_rs2_b14:
   addi sp, x9, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b15:
   c.sdsp x15, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_rs2_b15, Zca_c_sdsp_cg_cp_rs2_b15_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -357,304 +197,144 @@ Zca_c_sdsp_cg_cp_rs2_b15:
   addi sp, x9, -368  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x0:
   c.sdsp x13, 368(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_rs2_edges_0x0, Zca_c_sdsp_cg_cp_rs2_edges_0x0_str)
-#else
-  addi sp, sp, 368 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x13, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x0000000000000001
   addi sp, x9, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x1:
   c.sdsp x11, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_rs2_edges_0x1, Zca_c_sdsp_cg_cp_rs2_edges_0x1_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x11, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x0000000000000002
   addi sp, x9, -392  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x2:
   c.sdsp x11, 392(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_rs2_edges_0x2, Zca_c_sdsp_cg_cp_rs2_edges_0x2_str)
-#else
-  addi sp, sp, 392 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x11, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x8000000000000000
   addi sp, x9, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000:
   c.sdsp x14, 16(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  addi sp, sp, 16 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x8000000000000001
   addi sp, x9, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001:
   c.sdsp x6, 240(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  addi sp, sp, 240 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x7fffffffffffffff
   addi sp, x9, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff:
   c.sdsp x13, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x13, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x7ffffffffffffffe
   addi sp, x9, -48  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
   c.sdsp x8, 48(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  addi sp, sp, 48 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x8, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xffffffffffffffff
   addi sp, x9, -368  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff:
   c.sdsp x15, 368(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  addi sp, sp, 368 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xfffffffffffffffe
   addi sp, x9, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe:
   c.sdsp x6, 232(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  addi sp, sp, 232 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x5bbc887763ae86f2
   addi sp, x9, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   c.sdsp x3, 0(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  addi sp, sp, 0 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x3, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xaaaaaaaaaaaaaaaa
   addi sp, x9, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   c.sdsp x11, 200(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  addi sp, sp, 200 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x11, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x5555555555555555
   addi sp, x9, -480  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555:
   c.sdsp x8, 480(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555, Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  addi sp, sp, 480 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x8, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x00000000ffffffff
   addi sp, x9, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff:
   c.sdsp x8, 240(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  addi sp, sp, 240 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x8, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x00000000fffffffe
   addi sp, x9, -280  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe:
   c.sdsp x13, 280(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  addi sp, sp, 280 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x13, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x0000000100000000
   addi sp, x9, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x100000000:
   c.sdsp x6, 0(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_rs2_edges_0x100000000, Zca_c_sdsp_cg_cp_rs2_edges_0x100000000_str)
-#else
-  addi sp, sp, 0 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x0000000100000001
   addi sp, x9, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x100000001:
   c.sdsp x15, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x8, 0(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_rs2_edges_0x100000001, Zca_c_sdsp_cg_cp_rs2_edges_0x100000001_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_mul_8sp
@@ -665,1216 +345,576 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x100000001:
   addi sp, x9, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0:
   c.sdsp x13, 0(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0_str)
-#else
-  addi sp, sp, 0 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x13, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=8
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x67dec3de031accb0
   addi sp, x9, -8  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8:
   c.sdsp x12, 8(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8_str)
-#else
-  addi sp, sp, 8 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x12, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=16
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xe39a83545d97493f
   addi sp, x9, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10:
   c.sdsp x14, 16(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x8, 0(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10_str)
-#else
-  addi sp, sp, 16 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=24
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x2e327176756d4ebe
   addi sp, x9, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18:
   c.sdsp x10, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x8, 0(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=32
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x4168dcc8d4012311
   addi sp, x9, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20:
   c.sdsp x15, 32(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20_str)
-#else
-  addi sp, sp, 32 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=40
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x489a4340dbdf2615
   addi sp, x9, -40  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28:
   c.sdsp x11, 40(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28_str)
-#else
-  addi sp, sp, 40 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x11, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=48
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xdefd37874d7a166c
   addi sp, x9, -48  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30:
   c.sdsp x10, 48(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30_str)
-#else
-  addi sp, sp, 48 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=56
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x311f512377729429
   addi sp, x9, -56  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38:
   c.sdsp x14, 56(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38_str)
-#else
-  addi sp, sp, 56 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=64
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x42a631e63f18b79c
   addi sp, x9, -64  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40:
   c.sdsp x14, 64(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40_str)
-#else
-  addi sp, sp, 64 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=72
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x333c9b6b28a78fbb
   addi sp, x9, -72  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48:
   c.sdsp x10, 72(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48_str)
-#else
-  addi sp, sp, 72 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=80
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0x232143be4eaaf506
   addi sp, x9, -80  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50:
   c.sdsp x2, 80(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50_str)
-#else
-  addi sp, sp, 80 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x2, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=88
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xa770099d80f721f1
   addi sp, x9, -88  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58:
   c.sdsp x8, 88(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58_str)
-#else
-  addi sp, sp, 88 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x8, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=96
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xdf6920cd16583c5a
   addi sp, x9, -96  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60:
   c.sdsp x7, 96(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60_str)
-#else
-  addi sp, sp, 96 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x7, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=104
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x5d9b066998e4bf86
   addi sp, x9, -104  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68:
   c.sdsp x3, 104(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68_str)
-#else
-  addi sp, sp, 104 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x3, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=112
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x0eb58b177691c3e5
   addi sp, x9, -112  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70:
   c.sdsp x10, 112(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70_str)
-#else
-  addi sp, sp, 112 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=120
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x07617a39ce4dc4b9
   addi sp, x9, -120  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78:
   c.sdsp x0, 120(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78_str)
-#else
-  addi sp, sp, 120 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x0, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=128
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xcbccb4ad19434aba
   addi sp, x9, -128  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80:
   c.sdsp x2, 128(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x8, 0(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80_str)
-#else
-  addi sp, sp, 128 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x2, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=136
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x66f82a9b2160346f
   addi sp, x9, -136  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88:
   c.sdsp x0, 136(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88_str)
-#else
-  addi sp, sp, 136 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x0, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=144
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x40708a82cd1e787f
   addi sp, x9, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90:
   c.sdsp x3, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x3, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=152
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0x8bd07a7b6f7fa90f
   addi sp, x9, -152  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98:
   c.sdsp x2, 152(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98_str)
-#else
-  addi sp, sp, 152 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x2, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=160
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x71eb79a68484acb6
   addi sp, x9, -160  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0:
   c.sdsp x11, 160(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0_str)
-#else
-  addi sp, sp, 160 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x11, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=168
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x43dc93fe909e693f
   addi sp, x9, -168  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8:
   c.sdsp x6, 168(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x8, 0(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8_str)
-#else
-  addi sp, sp, 168 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=176
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xbb09c16e136367ad
   addi sp, x9, -176  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0:
   c.sdsp x8, 176(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0_str)
-#else
-  addi sp, sp, 176 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x8, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=184
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x54becd06dfcea75b
   addi sp, x9, -184  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8:
   c.sdsp x14, 184(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8_str)
-#else
-  addi sp, sp, 184 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=192
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xc4c3dd45bffa094b
   addi sp, x9, -192  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0:
   c.sdsp x3, 192(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0_str)
-#else
-  addi sp, sp, 192 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x3, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=200
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xa780478f2afafa33
   addi sp, x9, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8:
   c.sdsp x6, 200(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8_str)
-#else
-  addi sp, sp, 200 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=208
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xa2750e708238bbd2
   addi sp, x9, -208  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0:
   c.sdsp x14, 208(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0_str)
-#else
-  addi sp, sp, 208 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=216
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x6a625f4c69814353
   addi sp, x9, -216  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8:
   c.sdsp x10, 216(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8_str)
-#else
-  addi sp, sp, 216 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=224
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xc9298bb990d75b42
   addi sp, x9, -224  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0:
   c.sdsp x10, 224(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0_str)
-#else
-  addi sp, sp, 224 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=232
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xbe86c7acf7dd8daa
   addi sp, x9, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8:
   c.sdsp x2, 232(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8_str)
-#else
-  addi sp, sp, 232 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x2, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=240
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x8fcf8d3933dfa4fa
   addi sp, x9, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0:
   c.sdsp x8, 240(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0_str)
-#else
-  addi sp, sp, 240 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x8, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=248
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x43e8b457481285cb
   addi sp, x9, -248  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8:
   c.sdsp x11, 248(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8_str)
-#else
-  addi sp, sp, 248 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x11, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=256
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x83adbd6cd922a4a7
   addi sp, x9, -256  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100:
   c.sdsp x7, 256(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100_str)
-#else
-  addi sp, sp, 256 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x7, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=264
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xbcfd25131039b9b4
   addi sp, x9, -264  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108:
   c.sdsp x7, 264(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108_str)
-#else
-  addi sp, sp, 264 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x7, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=272
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x6b83664e78cedd7d
   addi sp, x9, -272  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110:
   c.sdsp x8, 272(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110_str)
-#else
-  addi sp, sp, 272 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x8, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=280
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x7c1250bdd773b3b4
   addi sp, x9, -280  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118:
   c.sdsp x15, 280(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118_str)
-#else
-  addi sp, sp, 280 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=288
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x24e7e2edab5fefb7
   addi sp, x9, -288  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120:
   c.sdsp x6, 288(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x8, 0(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120_str)
-#else
-  addi sp, sp, 288 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=296
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xb14be2d69bfa1eb0
   addi sp, x9, -296  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128:
   c.sdsp x6, 296(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128_str)
-#else
-  addi sp, sp, 296 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=304
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x3be7969e5f134560
   addi sp, x9, -304  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130:
   c.sdsp x13, 304(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130_str)
-#else
-  addi sp, sp, 304 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x13, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=312
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x5c4c533f712fdb1c
   addi sp, x9, -312  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138:
   c.sdsp x15, 312(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138_str)
-#else
-  addi sp, sp, 312 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=320
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x1cb6d0b40a9f66c7
   addi sp, x9, -320  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140:
   c.sdsp x6, 320(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140_str)
-#else
-  addi sp, sp, 320 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=328
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xb2cf3e88608bbe9f
   addi sp, x9, -328  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148:
   c.sdsp x10, 328(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148_str)
-#else
-  addi sp, sp, 328 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=336
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xffdc4787dffa9f28
   addi sp, x9, -336  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150:
   c.sdsp x2, 336(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150_str)
-#else
-  addi sp, sp, 336 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x2, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=344
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xbeb9843accce868d
   addi sp, x9, -344  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158:
   c.sdsp x10, 344(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158_str)
-#else
-  addi sp, sp, 344 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=352
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xe429acbb65619efe
   addi sp, x9, -352  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160:
   c.sdsp x14, 352(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x9) # load stored value for checking
   # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160_str)
-#else
-  addi sp, sp, 352 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=360
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xfbe81ddac1840952
   addi sp, x9, -360  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168:
   c.sdsp x3, 360(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168_str)
-#else
-  addi sp, sp, 360 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x3, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=368
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xbb16ad134fc321f1
   addi sp, x9, -368  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170:
   c.sdsp x2, 368(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170_str)
-#else
-  addi sp, sp, 368 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x2, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=376
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x6cf5e2123634e21b
   addi sp, x9, -376  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178:
   c.sdsp x14, 376(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178_str)
-#else
-  addi sp, sp, 376 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=384
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xd9b35d062ff04b89
   addi sp, x9, -384  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180:
   c.sdsp x11, 384(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180_str)
-#else
-  addi sp, sp, 384 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x11, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=392
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x45ecee9bcab93ac0
   addi sp, x9, -392  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188:
   c.sdsp x10, 392(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188_str)
-#else
-  addi sp, sp, 392 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=400
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xcee9d6eb418a2ed7
   addi sp, x9, -400  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190:
   c.sdsp x11, 400(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190_str)
-#else
-  addi sp, sp, 400 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x11, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=408
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x48d33b6a60c0fc0e
   addi sp, x9, -408  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198:
   c.sdsp x6, 408(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198_str)
-#else
-  addi sp, sp, 408 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=416
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xcfeffd6dfc6579f8
   addi sp, x9, -416  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0:
   c.sdsp x8, 416(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0_str)
-#else
-  addi sp, sp, 416 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x8, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=424
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x40ec2a7f005e2c7f
   addi sp, x9, -424  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8:
   c.sdsp x14, 424(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x8, 0(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8_str)
-#else
-  addi sp, sp, 424 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x14, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=432
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0xe5c64717a541dd19
   addi sp, x9, -432  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0:
   c.sdsp x0, 432(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0_str)
-#else
-  addi sp, sp, 432 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x0, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=440
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x7ca683507aa3f794
   addi sp, x9, -440  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8:
   c.sdsp x6, 440(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8_str)
-#else
-  addi sp, sp, 440 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=448
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xd9a36e80b18412ee
   addi sp, x9, -448  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0:
   c.sdsp x12, 448(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x8, 0(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0_str)
-#else
-  addi sp, sp, 448 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x12, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=456
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x4d38fb1f8bd439a8
   addi sp, x9, -456  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8:
   c.sdsp x13, 456(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8_str)
-#else
-  addi sp, sp, 456 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x13, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=464
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x4843cfefb8627336
   addi sp, x9, -464  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0:
   c.sdsp x10, 464(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0_str)
-#else
-  addi sp, sp, 464 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x10, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=472
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x52d08efc52ffdf73
   addi sp, x9, -472  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8:
   c.sdsp x15, 472(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8_str)
-#else
-  addi sp, sp, 472 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=480
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xe41a120a3e9f8d61
   addi sp, x9, -480  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0:
   c.sdsp x13, 480(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0_str)
-#else
-  addi sp, sp, 480 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x13, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=488
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x267c2ac16b65c89b
   addi sp, x9, -488  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8:
   c.sdsp x3, 488(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8_str)
-#else
-  addi sp, sp, 488 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x3, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=496
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x9a5400bbd95a9ab6
   addi sp, x9, -496  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0:
   c.sdsp x13, 496(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0_str)
-#else
-  addi sp, sp, 496 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x13, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=504
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x7e354eb1e8d863a7
   addi sp, x9, -504  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8:
   c.sdsp x15, 504(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8_str)
-#else
-  addi sp, sp, 504 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x15, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x2, x9 # restore signature pointer to default register for teardown
 

--- a/tests/rv64e/Zca/Zca-c.sw-00.S
+++ b/tests/rv64e/Zca/Zca-c.sw-00.S
@@ -41,18 +41,9 @@ Zca_c_sw_cg_cp_rs1_p_b8:
   c.sw x14, 80(x8) # perform store
   addi x8, x8, 80 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, Zca_c_sw_cg_cp_rs1_p_b8, Zca_c_sw_cg_cp_rs1_p_b8_str)
-#else
-  c.sw x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x7a898f641840338b
@@ -62,18 +53,9 @@ Zca_c_sw_cg_cp_rs1_p_b9:
   c.sw x15, 64(x9) # perform store
   addi x9, x9, 64 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sw_cg_cp_rs1_p_b9, Zca_c_sw_cg_cp_rs1_p_b9_str)
-#else
-  c.sw x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xa19584f5702212fd
@@ -83,18 +65,9 @@ Zca_c_sw_cg_cp_rs1_p_b10:
   c.sw x15, 96(x10) # perform store
   addi x10, x10, 96 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zca_c_sw_cg_cp_rs1_p_b10, Zca_c_sw_cg_cp_rs1_p_b10_str)
-#else
-  c.sw x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x4239ab23d928d8af
@@ -104,18 +77,9 @@ Zca_c_sw_cg_cp_rs1_p_b11:
   c.sw x14, 104(x11) # perform store
   addi x11, x11, 104 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_sw_cg_cp_rs1_p_b11, Zca_c_sw_cg_cp_rs1_p_b11_str)
-#else
-  c.sw x14, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xcd8d6d729c27445c
@@ -125,18 +89,9 @@ Zca_c_sw_cg_cp_rs1_p_b12:
   c.sw x10, 100(x12) # perform store
   addi x12, x12, 100 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zca_c_sw_cg_cp_rs1_p_b12, Zca_c_sw_cg_cp_rs1_p_b12_str)
-#else
-  c.sw x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x9f3fb1ec7231ea2f
@@ -146,18 +101,9 @@ Zca_c_sw_cg_cp_rs1_p_b13:
   c.sw x8, 100(x13) # perform store
   addi x13, x13, 100 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, Zca_c_sw_cg_cp_rs1_p_b13, Zca_c_sw_cg_cp_rs1_p_b13_str)
-#else
-  c.sw x8, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x92eb3e81c8c29810
@@ -167,18 +113,9 @@ Zca_c_sw_cg_cp_rs1_p_b14:
   c.sw x15, 32(x14) # perform store
   addi x14, x14, 32 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x11 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x11, Zca_c_sw_cg_cp_rs1_p_b14, Zca_c_sw_cg_cp_rs1_p_b14_str)
-#else
-  c.sw x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xa5ed539b1ec7d405
@@ -188,18 +125,9 @@ Zca_c_sw_cg_cp_rs1_p_b15:
   c.sw x9, 92(x15) # perform store
   addi x15, x15, 92 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x8 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x8, Zca_c_sw_cg_cp_rs1_p_b15, Zca_c_sw_cg_cp_rs1_p_b15_str)
-#else
-  c.sw x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_p
@@ -213,18 +141,9 @@ Zca_c_sw_cg_cp_rs2_p_b8:
   c.sw x8, 124(x12) # perform store
   addi x12, x12, 124 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zca_c_sw_cg_cp_rs2_p_b8, Zca_c_sw_cg_cp_rs2_p_b8_str)
-#else
-  c.sw x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x65cdd6a07bf89343
@@ -234,18 +153,9 @@ Zca_c_sw_cg_cp_rs2_p_b9:
   c.sw x9, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_sw_cg_cp_rs2_p_b9, Zca_c_sw_cg_cp_rs2_p_b9_str)
-#else
-  c.sw x9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xd17be87d5b60e7ff
@@ -255,18 +165,9 @@ Zca_c_sw_cg_cp_rs2_p_b10:
   c.sw x10, 88(x12) # perform store
   addi x12, x12, 88 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_sw_cg_cp_rs2_p_b10, Zca_c_sw_cg_cp_rs2_p_b10_str)
-#else
-  c.sw x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x7ea2a510614c03a4
@@ -276,18 +177,9 @@ Zca_c_sw_cg_cp_rs2_p_b11:
   c.sw x11, 120(x15) # perform store
   addi x15, x15, 120 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zca_c_sw_cg_cp_rs2_p_b11, Zca_c_sw_cg_cp_rs2_p_b11_str)
-#else
-  c.sw x11, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x4da605c36878612f
@@ -297,18 +189,9 @@ Zca_c_sw_cg_cp_rs2_p_b12:
   c.sw x12, 92(x10) # perform store
   addi x10, x10, 92 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zca_c_sw_cg_cp_rs2_p_b12, Zca_c_sw_cg_cp_rs2_p_b12_str)
-#else
-  c.sw x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x9ac406dd5fa2ab75
@@ -318,18 +201,9 @@ Zca_c_sw_cg_cp_rs2_p_b13:
   c.sw x13, 120(x8) # perform store
   addi x8, x8, 120 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zca_c_sw_cg_cp_rs2_p_b13, Zca_c_sw_cg_cp_rs2_p_b13_str)
-#else
-  c.sw x13, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x07249ef9fbb93992
@@ -339,18 +213,9 @@ Zca_c_sw_cg_cp_rs2_p_b14:
   c.sw x14, 92(x15) # perform store
   addi x15, x15, 92 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x9 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x9, Zca_c_sw_cg_cp_rs2_p_b14, Zca_c_sw_cg_cp_rs2_p_b14_str)
-#else
-  c.sw x14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x12, x15 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2_p (Test source rs2 = x15)
@@ -361,18 +226,9 @@ Zca_c_sw_cg_cp_rs2_p_b15:
   c.sw x15, 12(x13) # perform store
   addi x13, x13, 12 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zca_c_sw_cg_cp_rs2_p_b15, Zca_c_sw_cg_cp_rs2_p_b15_str)
-#else
-  c.sw x15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -386,18 +242,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x0:
   c.sw x8, 92(x9) # perform store
   addi x9, x9, 92 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sw_cg_cp_rs2_edges_0x0, Zca_c_sw_cg_cp_rs2_edges_0x0_str)
-#else
-  c.sw x8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x0000000000000001
@@ -407,18 +254,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x1:
   c.sw x14, 60(x8) # perform store
   addi x8, x8, 60 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0x1, Zca_c_sw_cg_cp_rs2_edges_0x1_str)
-#else
-  c.sw x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x0000000000000002
@@ -428,18 +266,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x2:
   c.sw x14, 4(x10) # perform store
   addi x10, x10, 4 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x11 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x11, Zca_c_sw_cg_cp_rs2_edges_0x2, Zca_c_sw_cg_cp_rs2_edges_0x2_str)
-#else
-  c.sw x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x8000000000000000
@@ -449,18 +278,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x8000000000000000:
   c.sw x14, 84(x11) # perform store
   addi x11, x11, 84 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0x8000000000000000, Zca_c_sw_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  c.sw x14, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x8000000000000001
@@ -470,18 +290,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x8000000000000001:
   c.sw x9, 48(x8) # perform store
   addi x8, x8, 48 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, Zca_c_sw_cg_cp_rs2_edges_0x8000000000000001, Zca_c_sw_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  c.sw x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x7fffffffffffffff
@@ -491,18 +302,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x7fffffffffffffff:
   c.sw x14, 104(x13) # perform store
   addi x13, x13, 104 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_sw_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  c.sw x14, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x7ffffffffffffffe
@@ -512,18 +314,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x7ffffffffffffffe:
   c.sw x8, 20(x15) # perform store
   addi x15, x15, 20 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zca_c_sw_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_sw_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  c.sw x8, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xffffffffffffffff
@@ -533,18 +326,9 @@ Zca_c_sw_cg_cp_rs2_edges_0xffffffffffffffff:
   c.sw x8, 28(x9) # perform store
   addi x9, x9, 28 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sw_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_sw_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  c.sw x8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xfffffffffffffffe
@@ -554,18 +338,9 @@ Zca_c_sw_cg_cp_rs2_edges_0xfffffffffffffffe:
   c.sw x8, 28(x13) # perform store
   addi x13, x13, 28 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, Zca_c_sw_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_sw_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  c.sw x8, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x5bbc887763ae86f2
@@ -575,18 +350,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   c.sw x9, 12(x15) # perform store
   addi x15, x15, 12 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_sw_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  c.sw x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xaaaaaaaaaaaaaaaa
@@ -596,18 +362,9 @@ Zca_c_sw_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   c.sw x14, 92(x9) # perform store
   addi x9, x9, 92 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_sw_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  c.sw x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x5555555555555555
@@ -617,18 +374,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x5555555555555555:
   c.sw x8, 0(x12) # perform store
   addi x12, x12, 0 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x13 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x13, Zca_c_sw_cg_cp_rs2_edges_0x5555555555555555, Zca_c_sw_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  c.sw x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x00000000ffffffff
@@ -638,18 +386,9 @@ Zca_c_sw_cg_cp_rs2_edges_0xffffffff:
   c.sw x11, 4(x9) # perform store
   addi x9, x9, 4 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sw_cg_cp_rs2_edges_0xffffffff, Zca_c_sw_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  c.sw x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x00000000fffffffe
@@ -659,18 +398,9 @@ Zca_c_sw_cg_cp_rs2_edges_0xfffffffe:
   c.sw x11, 72(x14) # perform store
   addi x14, x14, 72 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zca_c_sw_cg_cp_rs2_edges_0xfffffffe, Zca_c_sw_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  c.sw x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x0000000100000000
@@ -680,18 +410,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x100000000:
   c.sw x9, 72(x8) # perform store
   addi x8, x8, 72 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0x100000000, Zca_c_sw_cg_cp_rs2_edges_0x100000000_str)
-#else
-  c.sw x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x0000000100000001
@@ -701,18 +422,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x100000001:
   c.sw x14, 124(x15) # perform store
   addi x15, x15, 124 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, Zca_c_sw_cg_cp_rs2_edges_0x100000001, Zca_c_sw_cg_cp_rs2_edges_0x100000001_str)
-#else
-  c.sw x14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_mul
@@ -726,18 +438,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x0:
   c.sw x11, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x0, Zca_c_sw_cg_cp_imm_mul_b0x0_str)
-#else
-  c.sw x11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=4
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x54c5a6dfabf15ee5
@@ -747,18 +450,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x4:
   c.sw x15, 4(x8) # perform store
   addi x8, x8, 4 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zca_c_sw_cg_cp_imm_mul_b0x4, Zca_c_sw_cg_cp_imm_mul_b0x4_str)
-#else
-  c.sw x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=8
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x0c23901808487427
@@ -768,18 +462,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x8:
   c.sw x11, 8(x13) # perform store
   addi x13, x13, 8 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x8, Zca_c_sw_cg_cp_imm_mul_b0x8_str)
-#else
-  c.sw x11, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=12
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x6dd9e2ac2d9955c1
@@ -789,18 +474,9 @@ Zca_c_sw_cg_cp_imm_mul_b0xc:
   c.sw x14, 12(x9) # perform store
   addi x9, x9, 12 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sw_cg_cp_imm_mul_b0xc, Zca_c_sw_cg_cp_imm_mul_b0xc_str)
-#else
-  c.sw x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=16
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xa8e36e5419294280
@@ -810,18 +486,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x10:
   c.sw x13, 16(x11) # perform store
   addi x11, x11, 16 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x10, Zca_c_sw_cg_cp_imm_mul_b0x10_str)
-#else
-  c.sw x13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=20
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x2dc2b862168fbc82
@@ -831,18 +498,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x14:
   c.sw x14, 20(x9) # perform store
   addi x9, x9, 20 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x14, Zca_c_sw_cg_cp_imm_mul_b0x14_str)
-#else
-  c.sw x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=24
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x84785848451f04ac
@@ -852,18 +510,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x18:
   c.sw x15, 24(x12) # perform store
   addi x12, x12, 24 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zca_c_sw_cg_cp_imm_mul_b0x18, Zca_c_sw_cg_cp_imm_mul_b0x18_str)
-#else
-  c.sw x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=28
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x5207bd35e8d13401
@@ -873,18 +522,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x1c:
   c.sw x9, 28(x10) # perform store
   addi x10, x10, 28 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x1c, Zca_c_sw_cg_cp_imm_mul_b0x1c_str)
-#else
-  c.sw x9, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=32
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x41d1cf0ab126467c
@@ -894,18 +534,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x20:
   c.sw x15, 32(x12) # perform store
   addi x12, x12, 32 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x9 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x9, Zca_c_sw_cg_cp_imm_mul_b0x20, Zca_c_sw_cg_cp_imm_mul_b0x20_str)
-#else
-  c.sw x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=36
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x3d0911516de183d2
@@ -915,18 +546,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x24:
   c.sw x11, 36(x9) # perform store
   addi x9, x9, 36 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sw_cg_cp_imm_mul_b0x24, Zca_c_sw_cg_cp_imm_mul_b0x24_str)
-#else
-  c.sw x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=40
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xe1c5cf355a7d8f95
@@ -936,18 +558,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x28:
   c.sw x11, 40(x14) # perform store
   addi x14, x14, 40 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zca_c_sw_cg_cp_imm_mul_b0x28, Zca_c_sw_cg_cp_imm_mul_b0x28_str)
-#else
-  c.sw x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=44
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xada111f0e31e1d6e
@@ -957,18 +570,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x2c:
   c.sw x9, 44(x8) # perform store
   addi x8, x8, 44 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, Zca_c_sw_cg_cp_imm_mul_b0x2c, Zca_c_sw_cg_cp_imm_mul_b0x2c_str)
-#else
-  c.sw x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=48
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xc8bd824660f8c8dd
@@ -978,18 +582,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x30:
   c.sw x12, 48(x14) # perform store
   addi x14, x14, 48 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x15 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x15, Zca_c_sw_cg_cp_imm_mul_b0x30, Zca_c_sw_cg_cp_imm_mul_b0x30_str)
-#else
-  c.sw x12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=52
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x7eac658f4936a854
@@ -999,18 +594,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x34:
   c.sw x15, 52(x8) # perform store
   addi x8, x8, 52 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zca_c_sw_cg_cp_imm_mul_b0x34, Zca_c_sw_cg_cp_imm_mul_b0x34_str)
-#else
-  c.sw x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=56
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x7fb4aec408748137
@@ -1020,18 +606,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x38:
   c.sw x13, 56(x9) # perform store
   addi x9, x9, 56 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x38, Zca_c_sw_cg_cp_imm_mul_b0x38_str)
-#else
-  c.sw x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=60
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xa7779ac9fffa1c37
@@ -1041,18 +618,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x3c:
   c.sw x8, 60(x14) # perform store
   addi x14, x14, 60 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x10 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x10, Zca_c_sw_cg_cp_imm_mul_b0x3c, Zca_c_sw_cg_cp_imm_mul_b0x3c_str)
-#else
-  c.sw x8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=64
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xbb410b8c32b83326
@@ -1062,18 +630,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x40:
   c.sw x8, 64(x9) # perform store
   addi x9, x9, 64 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sw_cg_cp_imm_mul_b0x40, Zca_c_sw_cg_cp_imm_mul_b0x40_str)
-#else
-  c.sw x8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=68
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xd44784fd11b68aab
@@ -1083,18 +642,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x44:
   c.sw x11, 68(x12) # perform store
   addi x12, x12, 68 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x44, Zca_c_sw_cg_cp_imm_mul_b0x44_str)
-#else
-  c.sw x11, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=72
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xd01a226027faf4a2
@@ -1104,18 +654,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x48:
   c.sw x14, 72(x10) # perform store
   addi x10, x10, 72 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x9 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x9, Zca_c_sw_cg_cp_imm_mul_b0x48, Zca_c_sw_cg_cp_imm_mul_b0x48_str)
-#else
-  c.sw x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=76
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x10c065317ea175d4
@@ -1125,18 +666,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x4c:
   c.sw x14, 76(x15) # perform store
   addi x15, x15, 76 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x4c, Zca_c_sw_cg_cp_imm_mul_b0x4c_str)
-#else
-  c.sw x14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=80
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xad1a8c94cc1bad8f
@@ -1146,18 +678,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x50:
   c.sw x13, 80(x11) # perform store
   addi x11, x11, 80 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_sw_cg_cp_imm_mul_b0x50, Zca_c_sw_cg_cp_imm_mul_b0x50_str)
-#else
-  c.sw x13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=84
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xe433e05adc03cb9f
@@ -1167,18 +690,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x54:
   c.sw x10, 84(x9) # perform store
   addi x9, x9, 84 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x54, Zca_c_sw_cg_cp_imm_mul_b0x54_str)
-#else
-  c.sw x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=88
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x2f450c693dd059c1
@@ -1188,18 +702,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x58:
   c.sw x13, 88(x12) # perform store
   addi x12, x12, 88 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x58, Zca_c_sw_cg_cp_imm_mul_b0x58_str)
-#else
-  c.sw x13, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=92
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x7db92205ca7c00be
@@ -1209,18 +714,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x5c:
   c.sw x11, 92(x8) # perform store
   addi x8, x8, 92 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x5c, Zca_c_sw_cg_cp_imm_mul_b0x5c_str)
-#else
-  c.sw x11, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=96
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xadae6b9f73aef449
@@ -1230,18 +726,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x60:
   c.sw x9, 96(x14) # perform store
   addi x14, x14, 96 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x60, Zca_c_sw_cg_cp_imm_mul_b0x60_str)
-#else
-  c.sw x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=100
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x4b9c87aaee0afe7f
@@ -1251,18 +738,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x64:
   c.sw x15, 100(x11) # perform store
   addi x11, x11, 100 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_sw_cg_cp_imm_mul_b0x64, Zca_c_sw_cg_cp_imm_mul_b0x64_str)
-#else
-  c.sw x15, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=104
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xc7a891a2b80538d3
@@ -1272,18 +750,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x68:
   c.sw x13, 104(x10) # perform store
   addi x10, x10, 104 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x68, Zca_c_sw_cg_cp_imm_mul_b0x68_str)
-#else
-  c.sw x13, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=108
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x6db54a469e3cc4d0
@@ -1293,18 +762,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x6c:
   c.sw x9, 108(x11) # perform store
   addi x11, x11, 108 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x6c, Zca_c_sw_cg_cp_imm_mul_b0x6c_str)
-#else
-  c.sw x9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=112
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xab71333c1c7b9c84
@@ -1314,18 +774,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x70:
   c.sw x8, 112(x10) # perform store
   addi x10, x10, 112 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, Zca_c_sw_cg_cp_imm_mul_b0x70, Zca_c_sw_cg_cp_imm_mul_b0x70_str)
-#else
-  c.sw x8, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=116
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x4ae8e5192b9ae9ac
@@ -1335,18 +786,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x74:
   c.sw x8, 116(x11) # perform store
   addi x11, x11, 116 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, Zca_c_sw_cg_cp_imm_mul_b0x74, Zca_c_sw_cg_cp_imm_mul_b0x74_str)
-#else
-  c.sw x8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=120
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x3fb3480d3aa2f131
@@ -1356,18 +798,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x78:
   c.sw x12, 120(x13) # perform store
   addi x13, x13, 120 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x78, Zca_c_sw_cg_cp_imm_mul_b0x78_str)
-#else
-  c.sw x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=124
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x230332169b6831ac
@@ -1377,18 +810,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x7c:
   c.sw x11, 124(x12) # perform store
   addi x12, x12, 124 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x7c, Zca_c_sw_cg_cp_imm_mul_b0x7c_str)
-#else
-  c.sw x11, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x12 # restore signature pointer to default register for teardown
 

--- a/tests/rv64e/Zca/Zca-c.swsp-00.S
+++ b/tests/rv64e/Zca/Zca-c.swsp-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 106
+#define SIGUPD_COUNT 202
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -40,6 +40,7 @@ RVTEST_BEGIN
 Zca_c_swsp_cg_cp_rs2_b0:
   c.swsp x0, 32(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_swsp_cg_cp_rs2_b0, Zca_c_swsp_cg_cp_rs2_b0_str)
 
@@ -49,6 +50,7 @@ Zca_c_swsp_cg_cp_rs2_b0:
 Zca_c_swsp_cg_cp_rs2_b1:
   c.swsp x1, 64(sp) # perform store
   LREG x7, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_swsp_cg_cp_rs2_b1, Zca_c_swsp_cg_cp_rs2_b1_str)
 
@@ -58,6 +60,7 @@ Zca_c_swsp_cg_cp_rs2_b1:
 Zca_c_swsp_cg_cp_rs2_b2:
   c.swsp x2, 132(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_swsp_cg_cp_rs2_b2, Zca_c_swsp_cg_cp_rs2_b2_str)
 
@@ -68,6 +71,7 @@ Zca_c_swsp_cg_cp_rs2_b2:
 Zca_c_swsp_cg_cp_rs2_b3:
   c.swsp x3, 120(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_swsp_cg_cp_rs2_b3, Zca_c_swsp_cg_cp_rs2_b3_str)
 
@@ -79,6 +83,7 @@ Zca_c_swsp_cg_cp_rs2_b3:
 Zca_c_swsp_cg_cp_rs2_b4:
   c.swsp x4, 12(sp) # perform store
   LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x5, Zca_c_swsp_cg_cp_rs2_b4, Zca_c_swsp_cg_cp_rs2_b4_str)
 
@@ -88,6 +93,7 @@ Zca_c_swsp_cg_cp_rs2_b4:
 Zca_c_swsp_cg_cp_rs2_b5:
   c.swsp x5, 204(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x12, Zca_c_swsp_cg_cp_rs2_b5, Zca_c_swsp_cg_cp_rs2_b5_str)
 
@@ -98,6 +104,7 @@ Zca_c_swsp_cg_cp_rs2_b5:
 Zca_c_swsp_cg_cp_rs2_b6:
   c.swsp x6, 252(sp) # perform store
   LREG x7, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x7, Zca_c_swsp_cg_cp_rs2_b6, Zca_c_swsp_cg_cp_rs2_b6_str)
 
@@ -107,6 +114,7 @@ Zca_c_swsp_cg_cp_rs2_b6:
 Zca_c_swsp_cg_cp_rs2_b7:
   c.swsp x7, 104(sp) # perform store
   LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x5, Zca_c_swsp_cg_cp_rs2_b7, Zca_c_swsp_cg_cp_rs2_b7_str)
 
@@ -116,6 +124,7 @@ Zca_c_swsp_cg_cp_rs2_b7:
 Zca_c_swsp_cg_cp_rs2_b8:
   c.swsp x8, 200(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x15, Zca_c_swsp_cg_cp_rs2_b8, Zca_c_swsp_cg_cp_rs2_b8_str)
 
@@ -126,6 +135,7 @@ Zca_c_swsp_cg_cp_rs2_b8:
 Zca_c_swsp_cg_cp_rs2_b9:
   c.swsp x9, 24(sp) # perform store
   LREG x5, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x1 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x1, x14, x13, x5, Zca_c_swsp_cg_cp_rs2_b9, Zca_c_swsp_cg_cp_rs2_b9_str)
 
@@ -135,6 +145,7 @@ Zca_c_swsp_cg_cp_rs2_b9:
 Zca_c_swsp_cg_cp_rs2_b10:
   c.swsp x10, 136(sp) # perform store
   LREG x11, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x1 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x1, x14, x13, x11, Zca_c_swsp_cg_cp_rs2_b10, Zca_c_swsp_cg_cp_rs2_b10_str)
 
@@ -144,6 +155,7 @@ Zca_c_swsp_cg_cp_rs2_b10:
 Zca_c_swsp_cg_cp_rs2_b11:
   c.swsp x11, 100(sp) # perform store
   LREG x9, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x1 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x1, x14, x13, x9, Zca_c_swsp_cg_cp_rs2_b11, Zca_c_swsp_cg_cp_rs2_b11_str)
 
@@ -153,6 +165,7 @@ Zca_c_swsp_cg_cp_rs2_b11:
 Zca_c_swsp_cg_cp_rs2_b12:
   c.swsp x12, 72(sp) # perform store
   LREG x6, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x1 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x1, x14, x13, x6, Zca_c_swsp_cg_cp_rs2_b12, Zca_c_swsp_cg_cp_rs2_b12_str)
 
@@ -164,6 +177,7 @@ Zca_c_swsp_cg_cp_rs2_b12:
 Zca_c_swsp_cg_cp_rs2_b13:
   c.swsp x13, 0(sp) # perform store
   LREG x11, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_b13, Zca_c_swsp_cg_cp_rs2_b13_str)
 
@@ -173,6 +187,7 @@ Zca_c_swsp_cg_cp_rs2_b13:
 Zca_c_swsp_cg_cp_rs2_b14:
   c.swsp x14, 80(sp) # perform store
   LREG x15, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_rs2_b14, Zca_c_swsp_cg_cp_rs2_b14_str)
 
@@ -182,6 +197,7 @@ Zca_c_swsp_cg_cp_rs2_b14:
 Zca_c_swsp_cg_cp_rs2_b15:
   c.swsp x15, 172(sp) # perform store
   LREG x14, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_rs2_b15, Zca_c_swsp_cg_cp_rs2_b15_str)
 
@@ -195,6 +211,7 @@ Zca_c_swsp_cg_cp_rs2_b15:
 Zca_c_swsp_cg_cp_rs2_edges_0x0:
   c.swsp x5, 16(sp) # perform store
   LREG x4, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_rs2_edges_0x0, Zca_c_swsp_cg_cp_rs2_edges_0x0_str)
 
@@ -204,6 +221,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x0:
 Zca_c_swsp_cg_cp_rs2_edges_0x1:
   c.swsp x14, 144(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0x1, Zca_c_swsp_cg_cp_rs2_edges_0x1_str)
 
@@ -213,6 +231,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x1:
 Zca_c_swsp_cg_cp_rs2_edges_0x2:
   c.swsp x6, 44(sp) # perform store
   LREG x13, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_rs2_edges_0x2, Zca_c_swsp_cg_cp_rs2_edges_0x2_str)
 
@@ -222,6 +241,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x2:
 Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000:
   c.swsp x15, 236(sp) # perform store
   LREG x11, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000_str)
 
@@ -231,6 +251,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000:
 Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001:
   c.swsp x14, 4(sp) # perform store
   LREG x13, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001_str)
 
@@ -240,6 +261,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001:
 Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff:
   c.swsp x9, 52(sp) # perform store
   LREG x11, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff_str)
 
@@ -249,6 +271,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff:
 Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
   c.swsp x6, 204(sp) # perform store
   LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
 
@@ -258,6 +281,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
 Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff:
   c.swsp x11, 144(sp) # perform store
   LREG x14, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff_str)
 
@@ -267,6 +291,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff:
 Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe:
   c.swsp x15, 240(sp) # perform store
   LREG x9, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe_str)
 
@@ -276,6 +301,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe:
 Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   c.swsp x13, 144(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
 
@@ -285,6 +311,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
 Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   c.swsp x11, 252(sp) # perform store
   LREG x4, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
 
@@ -294,6 +321,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
 Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555:
   c.swsp x4, 228(sp) # perform store
   LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555, Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555_str)
 
@@ -303,6 +331,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555:
 Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
   c.swsp x10, 212(sp) # perform store
   LREG x4, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff_str)
 
@@ -312,6 +341,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
 Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
   c.swsp x5, 72(sp) # perform store
   LREG x4, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe_str)
 
@@ -321,6 +351,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
 Zca_c_swsp_cg_cp_rs2_edges_0x100000000:
   c.swsp x5, 232(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0x100000000, Zca_c_swsp_cg_cp_rs2_edges_0x100000000_str)
 
@@ -330,6 +361,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x100000000:
 Zca_c_swsp_cg_cp_rs2_edges_0x100000001:
   c.swsp x6, 104(sp) # perform store
   LREG x9, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_rs2_edges_0x100000001, Zca_c_swsp_cg_cp_rs2_edges_0x100000001_str)
 
@@ -343,6 +375,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x100000001:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0:
   c.swsp x9, 0(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0_str)
 
@@ -352,6 +385,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4:
   c.swsp x4, 4(sp) # perform store
   LREG x9, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4_str)
 
@@ -361,6 +395,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8:
   c.swsp x14, 8(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8_str)
 
@@ -370,6 +405,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc:
   c.swsp x11, 12(sp) # perform store
   LREG x5, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc_str)
 
@@ -379,6 +415,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10:
   c.swsp x12, 16(sp) # perform store
   LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10_str)
 
@@ -388,6 +425,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14:
   c.swsp x14, 20(sp) # perform store
   LREG x4, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14_str)
 
@@ -397,6 +435,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18:
   c.swsp x13, 24(sp) # perform store
   LREG x15, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18_str)
 
@@ -406,6 +445,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c:
   c.swsp x13, 28(sp) # perform store
   LREG x14, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c_str)
 
@@ -415,6 +455,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20:
   c.swsp x6, 32(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20_str)
 
@@ -424,6 +465,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24:
   c.swsp x14, 36(sp) # perform store
   LREG x4, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24_str)
 
@@ -433,6 +475,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28:
   c.swsp x15, 40(sp) # perform store
   LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28_str)
 
@@ -442,6 +485,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
   c.swsp x12, 44(sp) # perform store
   LREG x5, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c_str)
 
@@ -451,6 +495,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
   c.swsp x15, 48(sp) # perform store
   LREG x4, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30_str)
 
@@ -460,6 +505,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
   c.swsp x5, 52(sp) # perform store
   LREG x15, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34_str)
 
@@ -469,6 +515,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
   c.swsp x12, 56(sp) # perform store
   LREG x5, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38_str)
 
@@ -478,6 +525,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
   c.swsp x0, 60(sp) # perform store
   LREG x11, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c_str)
 
@@ -487,6 +535,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
   c.swsp x0, 64(sp) # perform store
   LREG x13, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40_str)
 
@@ -496,6 +545,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
   c.swsp x5, 68(sp) # perform store
   LREG x11, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44_str)
 
@@ -505,6 +555,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
   c.swsp x11, 72(sp) # perform store
   LREG x15, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48_str)
 
@@ -514,6 +565,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
   c.swsp x12, 76(sp) # perform store
   LREG x4, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c_str)
 
@@ -523,6 +575,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
   c.swsp x13, 80(sp) # perform store
   LREG x11, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50_str)
 
@@ -532,6 +585,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
   c.swsp x12, 84(sp) # perform store
   LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54_str)
 
@@ -541,6 +595,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
   c.swsp x14, 88(sp) # perform store
   LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58_str)
 
@@ -550,6 +605,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
   c.swsp x11, 92(sp) # perform store
   LREG x14, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c_str)
 
@@ -559,6 +615,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
   c.swsp x5, 96(sp) # perform store
   LREG x6, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60_str)
 
@@ -568,6 +625,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
   c.swsp x0, 100(sp) # perform store
   LREG x6, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64_str)
 
@@ -577,6 +635,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
   c.swsp x12, 104(sp) # perform store
   LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68_str)
 
@@ -586,6 +645,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
   c.swsp x15, 108(sp) # perform store
   LREG x5, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c_str)
 
@@ -595,6 +655,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
   c.swsp x6, 112(sp) # perform store
   LREG x5, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70_str)
 
@@ -604,6 +665,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
   c.swsp x14, 116(sp) # perform store
   LREG x11, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74_str)
 
@@ -613,6 +675,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
   c.swsp x5, 120(sp) # perform store
   LREG x14, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78_str)
 
@@ -622,6 +685,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
   c.swsp x2, 124(sp) # perform store
   LREG x9, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c_str)
 
@@ -631,6 +695,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
   c.swsp x15, 128(sp) # perform store
   LREG x9, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80_str)
 
@@ -640,6 +705,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
   c.swsp x11, 132(sp) # perform store
   LREG x14, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84_str)
 
@@ -649,6 +715,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
   c.swsp x9, 136(sp) # perform store
   LREG x15, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88_str)
 
@@ -658,6 +725,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
   c.swsp x4, 140(sp) # perform store
   LREG x6, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c_str)
 
@@ -667,6 +735,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
   c.swsp x9, 144(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90_str)
 
@@ -676,6 +745,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
   c.swsp x6, 148(sp) # perform store
   LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94_str)
 
@@ -685,6 +755,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
   c.swsp x12, 152(sp) # perform store
   LREG x4, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98_str)
 
@@ -694,6 +765,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
   c.swsp x14, 156(sp) # perform store
   LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c_str)
 
@@ -703,6 +775,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
   c.swsp x2, 160(sp) # perform store
   LREG x14, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0_str)
 
@@ -712,6 +785,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
   c.swsp x5, 164(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4_str)
 
@@ -721,6 +795,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
   c.swsp x2, 168(sp) # perform store
   LREG x11, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8_str)
 
@@ -730,6 +805,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
   c.swsp x15, 172(sp) # perform store
   LREG x13, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac_str)
 
@@ -739,6 +815,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
   c.swsp x2, 176(sp) # perform store
   LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0_str)
 
@@ -748,6 +825,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
   c.swsp x11, 180(sp) # perform store
   LREG x9, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4_str)
 
@@ -757,6 +835,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
   c.swsp x15, 184(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8_str)
 
@@ -766,6 +845,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
   c.swsp x11, 188(sp) # perform store
   LREG x14, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc_str)
 
@@ -775,6 +855,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
   c.swsp x13, 192(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0_str)
 
@@ -784,6 +865,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
   c.swsp x5, 196(sp) # perform store
   LREG x14, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4_str)
 
@@ -793,6 +875,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
   c.swsp x13, 200(sp) # perform store
   LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8_str)
 
@@ -802,6 +885,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
   c.swsp x0, 204(sp) # perform store
   LREG x15, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc_str)
 
@@ -811,6 +895,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
   c.swsp x15, 208(sp) # perform store
   LREG x6, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0_str)
 
@@ -820,6 +905,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
   c.swsp x10, 212(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4_str)
 
@@ -829,6 +915,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
   c.swsp x5, 216(sp) # perform store
   LREG x9, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8_str)
 
@@ -838,6 +925,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
   c.swsp x12, 220(sp) # perform store
   LREG x11, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc_str)
 
@@ -847,6 +935,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
   c.swsp x11, 224(sp) # perform store
   LREG x14, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0_str)
 
@@ -856,6 +945,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
   c.swsp x15, 228(sp) # perform store
   LREG x6, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4_str)
 
@@ -865,6 +955,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
   c.swsp x12, 232(sp) # perform store
   LREG x9, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8_str)
 
@@ -874,6 +965,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
   c.swsp x10, 236(sp) # perform store
   LREG x11, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec_str)
 
@@ -883,6 +975,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
   c.swsp x4, 240(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0_str)
 
@@ -892,6 +985,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
   c.swsp x5, 244(sp) # perform store
   LREG x15, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4_str)
 
@@ -901,6 +995,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
   c.swsp x11, 248(sp) # perform store
   LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8_str)
 
@@ -910,6 +1005,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc:
   c.swsp x9, 252(sp) # perform store
   LREG x14, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc_str)
 

--- a/tests/rv64e/Zca/Zca-c.swsp-00.S
+++ b/tests/rv64e/Zca/Zca-c.swsp-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 202
+#define SIGUPD_COUNT 106
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -39,57 +39,27 @@ RVTEST_BEGIN
   addi sp, x9, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b0:
   c.swsp x0, 32(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_swsp_cg_cp_rs2_b0, Zca_c_swsp_cg_cp_rs2_b0_str)
-#else
-  addi sp, sp, 32 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0x1ebc841f2300173d
   addi sp, x9, -64  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b1:
   c.swsp x1, 64(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_swsp_cg_cp_rs2_b1, Zca_c_swsp_cg_cp_rs2_b1_str)
-#else
-  addi sp, sp, 64 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x1, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0xc6079cbd44cb18e0
   addi sp, x9, -132  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b2:
   c.swsp x2, 132(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_swsp_cg_cp_rs2_b2, Zca_c_swsp_cg_cp_rs2_b2_str)
-#else
-  addi sp, sp, 132 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x2, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x6, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x3)
@@ -97,19 +67,9 @@ Zca_c_swsp_cg_cp_rs2_b2:
   addi sp, x9, -120  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b3:
   c.swsp x3, 120(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_swsp_cg_cp_rs2_b3, Zca_c_swsp_cg_cp_rs2_b3_str)
-#else
-  addi sp, sp, 120 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x13, x4 # switch temp register to avoid conflict with test
   mv x14, x5 # switch link pointer register to avoid conflict with test
@@ -118,38 +78,18 @@ Zca_c_swsp_cg_cp_rs2_b3:
   addi sp, x9, -12  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b4:
   c.swsp x4, 12(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x9) # load stored value for checking
   # Check if x5 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x5, Zca_c_swsp_cg_cp_rs2_b4, Zca_c_swsp_cg_cp_rs2_b4_str)
-#else
-  addi sp, sp, 12 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x4, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x6, x5) # load rs2: x5 = 0x555a5752982b4163
   addi sp, x9, -204  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b5:
   c.swsp x5, 204(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x12, Zca_c_swsp_cg_cp_rs2_b5, Zca_c_swsp_cg_cp_rs2_b5_str)
-#else
-  addi sp, sp, 204 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x3, x6 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x6)
@@ -157,57 +97,27 @@ Zca_c_swsp_cg_cp_rs2_b5:
   addi sp, x9, -252  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b6:
   c.swsp x6, 252(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x7, Zca_c_swsp_cg_cp_rs2_b6, Zca_c_swsp_cg_cp_rs2_b6_str)
-#else
-  addi sp, sp, 252 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x3, x7) # load rs2: x7 = 0x7ed368ac3b676084
   addi sp, x9, -104  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b7:
   c.swsp x7, 104(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x9) # load stored value for checking
   # Check if x5 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x5, Zca_c_swsp_cg_cp_rs2_b7, Zca_c_swsp_cg_cp_rs2_b7_str)
-#else
-  addi sp, sp, 104 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x7, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xe3ebf21b81755c47
   addi sp, x9, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b8:
   c.swsp x8, 200(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x15, Zca_c_swsp_cg_cp_rs2_b8, Zca_c_swsp_cg_cp_rs2_b8_str)
-#else
-  addi sp, sp, 200 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x8, 0(sp) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x1, x9 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x9)
@@ -215,76 +125,36 @@ Zca_c_swsp_cg_cp_rs2_b8:
   addi sp, x1, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b9:
   c.swsp x9, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x1) # load stored value for checking
   # Check if x5 contains the expected result. x1 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x1, x14, x13, x5, Zca_c_swsp_cg_cp_rs2_b9, Zca_c_swsp_cg_cp_rs2_b9_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x2f324ad7d04770f2
   addi sp, x1, -136  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b10:
   c.swsp x10, 136(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x1, x14, x13, x11, Zca_c_swsp_cg_cp_rs2_b10, Zca_c_swsp_cg_cp_rs2_b10_str)
-#else
-  addi sp, sp, 136 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xd30b461b7a97ab17
   addi sp, x1, -100  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b11:
   c.swsp x11, 100(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x1) # load stored value for checking
   # Check if x9 contains the expected result. x1 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x1, x14, x13, x9, Zca_c_swsp_cg_cp_rs2_b11, Zca_c_swsp_cg_cp_rs2_b11_str)
-#else
-  addi sp, sp, 100 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x4c38b7b2a73f0d5e
   addi sp, x1, -72  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b12:
   c.swsp x12, 72(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x1) # load stored value for checking
   # Check if x6 contains the expected result. x1 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x1, x14, x13, x6, Zca_c_swsp_cg_cp_rs2_b12, Zca_c_swsp_cg_cp_rs2_b12_str)
-#else
-  addi sp, sp, 72 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x7, x13 # switch temp register to avoid conflict with test
   mv x8, x14 # switch link pointer register to avoid conflict with test
@@ -293,57 +163,27 @@ Zca_c_swsp_cg_cp_rs2_b12:
   addi sp, x1, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b13:
   c.swsp x13, 0(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_b13, Zca_c_swsp_cg_cp_rs2_b13_str)
-#else
-  addi sp, sp, 0 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xcd35733839fdf264
   addi sp, x1, -80  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b14:
   c.swsp x14, 80(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_rs2_b14, Zca_c_swsp_cg_cp_rs2_b14_str)
-#else
-  addi sp, sp, 80 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x9c832527ff594c07
   addi sp, x1, -172  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b15:
   c.swsp x15, 172(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x1) # load stored value for checking
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_rs2_b15, Zca_c_swsp_cg_cp_rs2_b15_str)
-#else
-  addi sp, sp, 172 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -354,304 +194,144 @@ Zca_c_swsp_cg_cp_rs2_b15:
   addi sp, x1, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x0:
   c.swsp x5, 16(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x1) # load stored value for checking
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_rs2_edges_0x0, Zca_c_swsp_cg_cp_rs2_edges_0x0_str)
-#else
-  addi sp, sp, 16 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x0000000000000001
   addi sp, x1, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x1:
   c.swsp x14, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x1) # load stored value for checking
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0x1, Zca_c_swsp_cg_cp_rs2_edges_0x1_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0x0000000000000002
   addi sp, x1, -44  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x2:
   c.swsp x6, 44(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x1) # load stored value for checking
   # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_rs2_edges_0x2, Zca_c_swsp_cg_cp_rs2_edges_0x2_str)
-#else
-  addi sp, sp, 44 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x8000000000000000
   addi sp, x1, -236  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000:
   c.swsp x15, 236(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  addi sp, sp, 236 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x8000000000000001
   addi sp, x1, -4  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001:
   c.swsp x14, 4(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x1) # load stored value for checking
   # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  addi sp, sp, 4 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x7fffffffffffffff
   addi sp, x1, -52  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff:
   c.swsp x9, 52(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  addi sp, sp, 52 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0x7ffffffffffffffe
   addi sp, x1, -204  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
   c.swsp x6, 204(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x1) # load stored value for checking
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  addi sp, sp, 204 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xffffffffffffffff
   addi sp, x1, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff:
   c.swsp x11, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x1) # load stored value for checking
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xfffffffffffffffe
   addi sp, x1, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe:
   c.swsp x15, 240(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x1) # load stored value for checking
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  addi sp, sp, 240 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x5bbc887763ae86f2
   addi sp, x1, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   c.swsp x13, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x1) # load stored value for checking
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xaaaaaaaaaaaaaaaa
   addi sp, x1, -252  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   c.swsp x11, 252(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x1) # load stored value for checking
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  addi sp, sp, 252 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x3, x4) # load rs2: x4 = 0x5555555555555555
   addi sp, x1, -228  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555:
   c.swsp x4, 228(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x1) # load stored value for checking
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555, Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  addi sp, sp, 228 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x4, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x00000000ffffffff
   addi sp, x1, -212  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
   c.swsp x10, 212(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x1) # load stored value for checking
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  addi sp, sp, 212 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x00000000fffffffe
   addi sp, x1, -72  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
   c.swsp x5, 72(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x1) # load stored value for checking
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  addi sp, sp, 72 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x0000000100000000
   addi sp, x1, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x100000000:
   c.swsp x5, 232(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x1) # load stored value for checking
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0x100000000, Zca_c_swsp_cg_cp_rs2_edges_0x100000000_str)
-#else
-  addi sp, sp, 232 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0x0000000100000001
   addi sp, x1, -104  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x100000001:
   c.swsp x6, 104(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x1) # load stored value for checking
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_rs2_edges_0x100000001, Zca_c_swsp_cg_cp_rs2_edges_0x100000001_str)
-#else
-  addi sp, sp, 104 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_mul_4sp
@@ -662,1216 +342,576 @@ Zca_c_swsp_cg_cp_rs2_edges_0x100000001:
   addi sp, x1, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0:
   c.swsp x9, 0(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x1) # load stored value for checking
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0_str)
-#else
-  addi sp, sp, 0 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=4
   RVTEST_TESTDATA_LOAD_INT(x3, x4) # load rs2: x4 = 0xce44699c438312ff
   addi sp, x1, -4  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4:
   c.swsp x4, 4(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x1) # load stored value for checking
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4_str)
-#else
-  addi sp, sp, 4 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x4, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=8
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x4bebb042bb6b7680
   addi sp, x1, -8  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8:
   c.swsp x14, 8(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x1) # load stored value for checking
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8_str)
-#else
-  addi sp, sp, 8 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=12
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xb3a35dad89a83669
   addi sp, x1, -12  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc:
   c.swsp x11, 12(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x1) # load stored value for checking
   # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc_str)
-#else
-  addi sp, sp, 12 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=16
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xe8b95d8f77c9a307
   addi sp, x1, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10:
   c.swsp x12, 16(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x1) # load stored value for checking
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10_str)
-#else
-  addi sp, sp, 16 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=20
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x9c1fee450f68029b
   addi sp, x1, -20  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14:
   c.swsp x14, 20(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x1) # load stored value for checking
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14_str)
-#else
-  addi sp, sp, 20 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=24
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x6e9d4158bf1d20c7
   addi sp, x1, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18:
   c.swsp x13, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=28
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x025588f2e21db2f1
   addi sp, x1, -28  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c:
   c.swsp x13, 28(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x1) # load stored value for checking
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c_str)
-#else
-  addi sp, sp, 28 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=32
   RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0xb18ad02d8402a4fe
   addi sp, x1, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20:
   c.swsp x6, 32(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x1) # load stored value for checking
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20_str)
-#else
-  addi sp, sp, 32 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=36
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xdf3eea06bccafcad
   addi sp, x1, -36  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24:
   c.swsp x14, 36(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x1) # load stored value for checking
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24_str)
-#else
-  addi sp, sp, 36 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=40
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x2db624b0b45b2c8b
   addi sp, x1, -40  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28:
   c.swsp x15, 40(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x1) # load stored value for checking
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28_str)
-#else
-  addi sp, sp, 40 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=44
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x688d523781f6d56d
   addi sp, x1, -44  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
   c.swsp x12, 44(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x1) # load stored value for checking
   # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c_str)
-#else
-  addi sp, sp, 44 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=48
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x80dc5f589b13aa7d
   addi sp, x1, -48  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
   c.swsp x15, 48(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x1) # load stored value for checking
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30_str)
-#else
-  addi sp, sp, 48 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=52
   RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x007aeb44a84065b0
   addi sp, x1, -52  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
   c.swsp x5, 52(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34_str)
-#else
-  addi sp, sp, 52 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=56
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xbfcd51149a9509f6
   addi sp, x1, -56  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
   c.swsp x12, 56(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x1) # load stored value for checking
   # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38_str)
-#else
-  addi sp, sp, 56 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=60
   RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0xfc4e095f418c3264
   addi sp, x1, -60  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
   c.swsp x0, 60(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c_str)
-#else
-  addi sp, sp, 60 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=64
   RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0x823bf5eb1f15dcb8
   addi sp, x1, -64  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
   c.swsp x0, 64(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x1) # load stored value for checking
   # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40_str)
-#else
-  addi sp, sp, 64 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=68
   RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0xb5b23d03a5bff6fb
   addi sp, x1, -68  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
   c.swsp x5, 68(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44_str)
-#else
-  addi sp, sp, 68 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=72
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x77ecf227f0d53ddd
   addi sp, x1, -72  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
   c.swsp x11, 72(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48_str)
-#else
-  addi sp, sp, 72 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=76
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x1a324e134deab75c
   addi sp, x1, -76  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
   c.swsp x12, 76(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x1) # load stored value for checking
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c_str)
-#else
-  addi sp, sp, 76 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=80
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xd0f0cbd234461515
   addi sp, x1, -80  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
   c.swsp x13, 80(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50_str)
-#else
-  addi sp, sp, 80 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=84
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x408148003ab1aa06
   addi sp, x1, -84  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
   c.swsp x12, 84(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x1) # load stored value for checking
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54_str)
-#else
-  addi sp, sp, 84 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=88
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xfd7e6a452e04c112
   addi sp, x1, -88  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
   c.swsp x14, 88(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x1) # load stored value for checking
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58_str)
-#else
-  addi sp, sp, 88 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=92
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x5e38ff0ec964c067
   addi sp, x1, -92  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
   c.swsp x11, 92(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x1) # load stored value for checking
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c_str)
-#else
-  addi sp, sp, 92 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=96
   RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x72762c5712aecb88
   addi sp, x1, -96  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
   c.swsp x5, 96(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x1) # load stored value for checking
   # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60_str)
-#else
-  addi sp, sp, 96 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=100
   RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0x29602071330b5c12
   addi sp, x1, -100  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
   c.swsp x0, 100(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x1) # load stored value for checking
   # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64_str)
-#else
-  addi sp, sp, 100 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=104
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x9f2e744b3e6fd0d3
   addi sp, x1, -104  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
   c.swsp x12, 104(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x1) # load stored value for checking
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68_str)
-#else
-  addi sp, sp, 104 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=108
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xc76e4eac8b5a9947
   addi sp, x1, -108  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
   c.swsp x15, 108(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x1) # load stored value for checking
   # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c_str)
-#else
-  addi sp, sp, 108 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=112
   RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0xa5fdc85bc94a6e3a
   addi sp, x1, -112  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
   c.swsp x6, 112(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x1) # load stored value for checking
   # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70_str)
-#else
-  addi sp, sp, 112 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=116
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xec4e4dbb72f89694
   addi sp, x1, -116  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
   c.swsp x14, 116(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74_str)
-#else
-  addi sp, sp, 116 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=120
   RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0xfe63f0d7c5845e44
   addi sp, x1, -120  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
   c.swsp x5, 120(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x1) # load stored value for checking
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78_str)
-#else
-  addi sp, sp, 120 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=124
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0x350cf49aa81afa8d
   addi sp, x1, -124  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
   c.swsp x2, 124(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x1) # load stored value for checking
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c_str)
-#else
-  addi sp, sp, 124 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x2, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=128
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x3e20939298556e72
   addi sp, x1, -128  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
   c.swsp x15, 128(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x1) # load stored value for checking
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80_str)
-#else
-  addi sp, sp, 128 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=132
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x5091270428a81959
   addi sp, x1, -132  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
   c.swsp x11, 132(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x1) # load stored value for checking
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84_str)
-#else
-  addi sp, sp, 132 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=136
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xbcc1dfe0dc00883f
   addi sp, x1, -136  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
   c.swsp x9, 136(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88_str)
-#else
-  addi sp, sp, 136 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=140
   RVTEST_TESTDATA_LOAD_INT(x3, x4) # load rs2: x4 = 0xce57c134ecf3621e
   addi sp, x1, -140  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
   c.swsp x4, 140(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x1) # load stored value for checking
   # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c_str)
-#else
-  addi sp, sp, 140 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x4, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=144
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x009a13a349731787
   addi sp, x1, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
   c.swsp x9, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x1) # load stored value for checking
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=148
   RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0xc611b086d3bafe55
   addi sp, x1, -148  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
   c.swsp x6, 148(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x1) # load stored value for checking
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94_str)
-#else
-  addi sp, sp, 148 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=152
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x588e3e6ad1a5621b
   addi sp, x1, -152  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
   c.swsp x12, 152(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x1) # load stored value for checking
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98_str)
-#else
-  addi sp, sp, 152 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=156
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xd5c2575b996dee6f
   addi sp, x1, -156  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
   c.swsp x14, 156(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x1) # load stored value for checking
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c_str)
-#else
-  addi sp, sp, 156 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=160
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0x27cdf098599b04ff
   addi sp, x1, -160  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
   c.swsp x2, 160(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x1) # load stored value for checking
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0_str)
-#else
-  addi sp, sp, 160 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x2, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=164
   RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0xa5b58e75380c8b13
   addi sp, x1, -164  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
   c.swsp x5, 164(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x1) # load stored value for checking
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4_str)
-#else
-  addi sp, sp, 164 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=168
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0x770bf9210f2853d0
   addi sp, x1, -168  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
   c.swsp x2, 168(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8_str)
-#else
-  addi sp, sp, 168 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x2, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=172
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x6d820e62ea9d99e5
   addi sp, x1, -172  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
   c.swsp x15, 172(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x1) # load stored value for checking
   # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac_str)
-#else
-  addi sp, sp, 172 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=176
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0x5544a03f53edc834
   addi sp, x1, -176  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
   c.swsp x2, 176(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x1) # load stored value for checking
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0_str)
-#else
-  addi sp, sp, 176 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x2, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=180
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x5fcdd39f891356e9
   addi sp, x1, -180  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
   c.swsp x11, 180(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x1) # load stored value for checking
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4_str)
-#else
-  addi sp, sp, 180 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=184
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x672ed62396b2c907
   addi sp, x1, -184  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
   c.swsp x15, 184(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x1) # load stored value for checking
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8_str)
-#else
-  addi sp, sp, 184 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=188
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xf578d9a8accea683
   addi sp, x1, -188  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
   c.swsp x11, 188(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x1) # load stored value for checking
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc_str)
-#else
-  addi sp, sp, 188 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=192
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xc16b5051cd5bde9a
   addi sp, x1, -192  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
   c.swsp x13, 192(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x1) # load stored value for checking
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0_str)
-#else
-  addi sp, sp, 192 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=196
   RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x5e4fac3fa312586c
   addi sp, x1, -196  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
   c.swsp x5, 196(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x1) # load stored value for checking
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4_str)
-#else
-  addi sp, sp, 196 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=200
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x90a91e295406c510
   addi sp, x1, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
   c.swsp x13, 200(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x1) # load stored value for checking
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8_str)
-#else
-  addi sp, sp, 200 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=204
   RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0x438cec2bceb3bcf7
   addi sp, x1, -204  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
   c.swsp x0, 204(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc_str)
-#else
-  addi sp, sp, 204 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=208
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x731acb3086434034
   addi sp, x1, -208  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
   c.swsp x15, 208(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x1) # load stored value for checking
   # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0_str)
-#else
-  addi sp, sp, 208 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=212
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x3eb07ddda64eaff7
   addi sp, x1, -212  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
   c.swsp x10, 212(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x1) # load stored value for checking
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4_str)
-#else
-  addi sp, sp, 212 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=216
   RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x0b83aa5c2014e92e
   addi sp, x1, -216  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
   c.swsp x5, 216(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x1) # load stored value for checking
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8_str)
-#else
-  addi sp, sp, 216 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=220
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xf5322a13b5cf94f1
   addi sp, x1, -220  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
   c.swsp x12, 220(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc_str)
-#else
-  addi sp, sp, 220 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=224
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x8cc550d17707262c
   addi sp, x1, -224  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
   c.swsp x11, 224(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x1) # load stored value for checking
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0_str)
-#else
-  addi sp, sp, 224 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=228
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x9b4d49e88fb35ff3
   addi sp, x1, -228  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
   c.swsp x15, 228(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x1) # load stored value for checking
   # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4_str)
-#else
-  addi sp, sp, 228 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=232
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xeaaa04cc1ff917c8
   addi sp, x1, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
   c.swsp x12, 232(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x1) # load stored value for checking
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8_str)
-#else
-  addi sp, sp, 232 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=236
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xccafbae94bf0b9aa
   addi sp, x1, -236  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
   c.swsp x10, 236(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec_str)
-#else
-  addi sp, sp, 236 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=240
   RVTEST_TESTDATA_LOAD_INT(x3, x4) # load rs2: x4 = 0x40a8d8d0b51d61bd
   addi sp, x1, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
   c.swsp x4, 240(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x1) # load stored value for checking
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0_str)
-#else
-  addi sp, sp, 240 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x4, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=244
   RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x2966e1f9ea039ecc
   addi sp, x1, -244  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
   c.swsp x5, 244(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4_str)
-#else
-  addi sp, sp, 244 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=248
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x797ae270376a5013
   addi sp, x1, -248  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
   c.swsp x11, 248(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x1) # load stored value for checking
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8_str)
-#else
-  addi sp, sp, 248 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=252
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x49a50d91c8761ab8
   addi sp, x1, -252  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc:
   c.swsp x9, 252(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x1) # load stored value for checking
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc_str)
-#else
-  addi sp, sp, 252 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x2, x1 # restore signature pointer to default register for teardown
 

--- a/tests/rv64e/Zcb/Zcb-c.sb-00.S
+++ b/tests/rv64e/Zcb/Zcb-c.sb-00.S
@@ -41,18 +41,9 @@ Zcb_c_sb_cg_cp_rs1_p_b8:
   c.sb x15, 2(x8) # perform store
   addi x8, x8, 2 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, Zcb_c_sb_cg_cp_rs1_p_b8, Zcb_c_sb_cg_cp_rs1_p_b8_str)
-#else
-  c.sb x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x8499bc36dea9bad4
@@ -62,18 +53,9 @@ Zcb_c_sb_cg_cp_rs1_p_b9:
   c.sb x15, 3(x9) # perform store
   addi x9, x9, 3 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zcb_c_sb_cg_cp_rs1_p_b9, Zcb_c_sb_cg_cp_rs1_p_b9_str)
-#else
-  c.sb x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xd4354735d218636e
@@ -83,18 +65,9 @@ Zcb_c_sb_cg_cp_rs1_p_b10:
   c.sb x12, 2(x10) # perform store
   addi x10, x10, 2 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zcb_c_sb_cg_cp_rs1_p_b10, Zcb_c_sb_cg_cp_rs1_p_b10_str)
-#else
-  c.sb x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x316dd682503c9e93
@@ -104,18 +77,9 @@ Zcb_c_sb_cg_cp_rs1_p_b11:
   c.sb x14, 3(x11) # perform store
   addi x11, x11, 3 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zcb_c_sb_cg_cp_rs1_p_b11, Zcb_c_sb_cg_cp_rs1_p_b11_str)
-#else
-  c.sb x14, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xdee894b0537c556a
@@ -125,18 +89,9 @@ Zcb_c_sb_cg_cp_rs1_p_b12:
   c.sb x14, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x10 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x10, Zcb_c_sb_cg_cp_rs1_p_b12, Zcb_c_sb_cg_cp_rs1_p_b12_str)
-#else
-  c.sb x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x2bcb4b03d1c0b210
@@ -146,18 +101,9 @@ Zcb_c_sb_cg_cp_rs1_p_b13:
   c.sb x10, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, Zcb_c_sb_cg_cp_rs1_p_b13, Zcb_c_sb_cg_cp_rs1_p_b13_str)
-#else
-  c.sb x10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x8c59029c66a703fd
@@ -167,18 +113,9 @@ Zcb_c_sb_cg_cp_rs1_p_b14:
   c.sb x9, 3(x14) # perform store
   addi x14, x14, 3 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x11 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x11, Zcb_c_sb_cg_cp_rs1_p_b14, Zcb_c_sb_cg_cp_rs1_p_b14_str)
-#else
-  c.sb x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xb2f5b56884f01891
@@ -188,18 +125,9 @@ Zcb_c_sb_cg_cp_rs1_p_b15:
   c.sb x12, 2(x15) # perform store
   addi x15, x15, 2 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x8 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x8, Zcb_c_sb_cg_cp_rs1_p_b15, Zcb_c_sb_cg_cp_rs1_p_b15_str)
-#else
-  c.sb x12, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_p
@@ -213,18 +141,9 @@ Zcb_c_sb_cg_cp_rs2_p_b8:
   c.sb x8, 0(x12) # perform store
   addi x12, x12, 0 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zcb_c_sb_cg_cp_rs2_p_b8, Zcb_c_sb_cg_cp_rs2_p_b8_str)
-#else
-  c.sb x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x428801d9d52ee987
@@ -234,18 +153,9 @@ Zcb_c_sb_cg_cp_rs2_p_b9:
   c.sb x9, 2(x14) # perform store
   addi x14, x14, 2 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zcb_c_sb_cg_cp_rs2_p_b9, Zcb_c_sb_cg_cp_rs2_p_b9_str)
-#else
-  c.sb x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x814794f6e365f1e3
@@ -255,18 +165,9 @@ Zcb_c_sb_cg_cp_rs2_p_b10:
   c.sb x10, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zcb_c_sb_cg_cp_rs2_p_b10, Zcb_c_sb_cg_cp_rs2_p_b10_str)
-#else
-  c.sb x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x39e732759de3960a
@@ -276,18 +177,9 @@ Zcb_c_sb_cg_cp_rs2_p_b11:
   c.sb x11, 2(x13) # perform store
   addi x13, x13, 2 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, Zcb_c_sb_cg_cp_rs2_p_b11, Zcb_c_sb_cg_cp_rs2_p_b11_str)
-#else
-  c.sb x11, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x9631085ada15a429
@@ -297,18 +189,9 @@ Zcb_c_sb_cg_cp_rs2_p_b12:
   c.sb x12, 1(x8) # perform store
   addi x8, x8, 1 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, Zcb_c_sb_cg_cp_rs2_p_b12, Zcb_c_sb_cg_cp_rs2_p_b12_str)
-#else
-  c.sb x12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x79fceef222dd47ca
@@ -318,18 +201,9 @@ Zcb_c_sb_cg_cp_rs2_p_b13:
   c.sb x13, 2(x15) # perform store
   addi x15, x15, 2 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x11 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x11, Zcb_c_sb_cg_cp_rs2_p_b13, Zcb_c_sb_cg_cp_rs2_p_b13_str)
-#else
-  c.sb x13, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xc8fb752d9d863298
@@ -339,18 +213,9 @@ Zcb_c_sb_cg_cp_rs2_p_b14:
   c.sb x14, 1(x10) # perform store
   addi x10, x10, 1 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_p_b14, Zcb_c_sb_cg_cp_rs2_p_b14_str)
-#else
-  c.sb x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x17b893ad1d006e82
@@ -360,18 +225,9 @@ Zcb_c_sb_cg_cp_rs2_p_b15:
   c.sb x15, 1(x9) # perform store
   addi x9, x9, 1 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zcb_c_sb_cg_cp_rs2_p_b15, Zcb_c_sb_cg_cp_rs2_p_b15_str)
-#else
-  c.sb x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -385,18 +241,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x0:
   c.sb x8, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_edges_0x0, Zcb_c_sb_cg_cp_rs2_edges_0x0_str)
-#else
-  c.sb x8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x0000000000000001
@@ -406,18 +253,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x1:
   c.sb x15, 2(x10) # perform store
   addi x10, x10, 2 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zcb_c_sb_cg_cp_rs2_edges_0x1, Zcb_c_sb_cg_cp_rs2_edges_0x1_str)
-#else
-  c.sb x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x0000000000000002
@@ -427,18 +265,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x2:
   c.sb x14, 0(x8) # perform store
   addi x8, x8, 0 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zcb_c_sb_cg_cp_rs2_edges_0x2, Zcb_c_sb_cg_cp_rs2_edges_0x2_str)
-#else
-  c.sb x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x8000000000000000
@@ -448,18 +277,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x8000000000000000:
   c.sb x11, 3(x9) # perform store
   addi x9, x9, 3 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zcb_c_sb_cg_cp_rs2_edges_0x8000000000000000, Zcb_c_sb_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  c.sb x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x8000000000000001
@@ -469,18 +289,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x8000000000000001:
   c.sb x8, 1(x12) # perform store
   addi x12, x12, 1 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zcb_c_sb_cg_cp_rs2_edges_0x8000000000000001, Zcb_c_sb_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  c.sb x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x7fffffffffffffff
@@ -490,18 +301,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x7fffffffffffffff:
   c.sb x14, 1(x9) # perform store
   addi x9, x9, 1 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zcb_c_sb_cg_cp_rs2_edges_0x7fffffffffffffff, Zcb_c_sb_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  c.sb x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x7ffffffffffffffe
@@ -511,18 +313,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x7ffffffffffffffe:
   c.sb x10, 0(x8) # perform store
   addi x8, x8, 0 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_edges_0x7ffffffffffffffe, Zcb_c_sb_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  c.sb x10, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xffffffffffffffff
@@ -532,18 +325,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0xffffffffffffffff:
   c.sb x14, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zcb_c_sb_cg_cp_rs2_edges_0xffffffffffffffff, Zcb_c_sb_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  c.sb x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xfffffffffffffffe
@@ -553,18 +337,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0xfffffffffffffffe:
   c.sb x12, 1(x13) # perform store
   addi x13, x13, 1 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zcb_c_sb_cg_cp_rs2_edges_0xfffffffffffffffe, Zcb_c_sb_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  c.sb x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x5bbc887763ae86f2
@@ -574,18 +349,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   c.sb x15, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zcb_c_sb_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zcb_c_sb_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  c.sb x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xaaaaaaaaaaaaaaaa
@@ -595,18 +361,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   c.sb x9, 1(x8) # perform store
   addi x8, x8, 1 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zcb_c_sb_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zcb_c_sb_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  c.sb x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x5555555555555555
@@ -616,18 +373,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x5555555555555555:
   c.sb x10, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, Zcb_c_sb_cg_cp_rs2_edges_0x5555555555555555, Zcb_c_sb_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  c.sb x10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x00000000ffffffff
@@ -637,18 +385,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0xffffffff:
   c.sb x14, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x9 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x9, Zcb_c_sb_cg_cp_rs2_edges_0xffffffff, Zcb_c_sb_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  c.sb x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x00000000fffffffe
@@ -658,18 +397,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0xfffffffe:
   c.sb x15, 3(x11) # perform store
   addi x11, x11, 3 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zcb_c_sb_cg_cp_rs2_edges_0xfffffffe, Zcb_c_sb_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  c.sb x15, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x0000000100000000
@@ -679,18 +409,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x100000000:
   c.sb x9, 1(x8) # perform store
   addi x8, x8, 1 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_edges_0x100000000, Zcb_c_sb_cg_cp_rs2_edges_0x100000000_str)
-#else
-  c.sb x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x0000000100000001
@@ -700,18 +421,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x100000001:
   c.sb x15, 1(x13) # perform store
   addi x13, x13, 1 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x10 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x10, Zcb_c_sb_cg_cp_rs2_edges_0x100000001, Zcb_c_sb_cg_cp_rs2_edges_0x100000001_str)
-#else
-  c.sb x15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x13 # restore signature pointer to default register for teardown
 

--- a/tests/rv64e/Zcb/Zcb-c.sh-00.S
+++ b/tests/rv64e/Zcb/Zcb-c.sh-00.S
@@ -41,18 +41,9 @@ Zcb_c_sh_cg_cp_rs1_p_b8:
   c.sh x13, 2(x8) # perform store
   addi x8, x8, 2 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zcb_c_sh_cg_cp_rs1_p_b8, Zcb_c_sh_cg_cp_rs1_p_b8_str)
-#else
-  c.sh x13, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xf3676ccfd39a867e
@@ -62,18 +53,9 @@ Zcb_c_sh_cg_cp_rs1_p_b9:
   c.sh x14, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zcb_c_sh_cg_cp_rs1_p_b9, Zcb_c_sh_cg_cp_rs1_p_b9_str)
-#else
-  c.sh x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x112b1c6395c7a112
@@ -83,18 +65,9 @@ Zcb_c_sh_cg_cp_rs1_p_b10:
   c.sh x8, 2(x10) # perform store
   addi x10, x10, 2 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zcb_c_sh_cg_cp_rs1_p_b10, Zcb_c_sh_cg_cp_rs1_p_b10_str)
-#else
-  c.sh x8, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xd8bbf0d74259286d
@@ -104,18 +77,9 @@ Zcb_c_sh_cg_cp_rs1_p_b11:
   c.sh x13, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, Zcb_c_sh_cg_cp_rs1_p_b11, Zcb_c_sh_cg_cp_rs1_p_b11_str)
-#else
-  c.sh x13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x7df6acc5b6917598
@@ -125,18 +89,9 @@ Zcb_c_sh_cg_cp_rs1_p_b12:
   c.sh x9, 0(x12) # perform store
   addi x12, x12, 0 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zcb_c_sh_cg_cp_rs1_p_b12, Zcb_c_sh_cg_cp_rs1_p_b12_str)
-#else
-  c.sh x9, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xd67330968f41e2db
@@ -146,18 +101,9 @@ Zcb_c_sh_cg_cp_rs1_p_b13:
   c.sh x9, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zcb_c_sh_cg_cp_rs1_p_b13, Zcb_c_sh_cg_cp_rs1_p_b13_str)
-#else
-  c.sh x9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xaf65f4d88abeb76c
@@ -167,18 +113,9 @@ Zcb_c_sh_cg_cp_rs1_p_b14:
   c.sh x12, 2(x14) # perform store
   addi x14, x14, 2 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x15 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x15, Zcb_c_sh_cg_cp_rs1_p_b14, Zcb_c_sh_cg_cp_rs1_p_b14_str)
-#else
-  c.sh x12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xb5f18ed9dc8f00fc
@@ -188,18 +125,9 @@ Zcb_c_sh_cg_cp_rs1_p_b15:
   c.sh x11, 0(x15) # perform store
   addi x15, x15, 0 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, Zcb_c_sh_cg_cp_rs1_p_b15, Zcb_c_sh_cg_cp_rs1_p_b15_str)
-#else
-  c.sh x11, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_p
@@ -213,18 +141,9 @@ Zcb_c_sh_cg_cp_rs2_p_b8:
   c.sh x8, 0(x12) # perform store
   addi x12, x12, 0 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zcb_c_sh_cg_cp_rs2_p_b8, Zcb_c_sh_cg_cp_rs2_p_b8_str)
-#else
-  c.sh x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x3ed656cc12900675
@@ -234,18 +153,9 @@ Zcb_c_sh_cg_cp_rs2_p_b9:
   c.sh x9, 2(x13) # perform store
   addi x13, x13, 2 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_p_b9, Zcb_c_sh_cg_cp_rs2_p_b9_str)
-#else
-  c.sh x9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xaaa77ada0cea1e27
@@ -255,18 +165,9 @@ Zcb_c_sh_cg_cp_rs2_p_b10:
   c.sh x10, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zcb_c_sh_cg_cp_rs2_p_b10, Zcb_c_sh_cg_cp_rs2_p_b10_str)
-#else
-  c.sh x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x9f08f76c1bc8f8c8
@@ -276,18 +177,9 @@ Zcb_c_sh_cg_cp_rs2_p_b11:
   c.sh x11, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zcb_c_sh_cg_cp_rs2_p_b11, Zcb_c_sh_cg_cp_rs2_p_b11_str)
-#else
-  c.sh x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xa8095977d9d3a876
@@ -297,18 +189,9 @@ Zcb_c_sh_cg_cp_rs2_p_b12:
   c.sh x12, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zcb_c_sh_cg_cp_rs2_p_b12, Zcb_c_sh_cg_cp_rs2_p_b12_str)
-#else
-  c.sh x12, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xa81a03d8effb4b03
@@ -318,18 +201,9 @@ Zcb_c_sh_cg_cp_rs2_p_b13:
   c.sh x13, 2(x14) # perform store
   addi x14, x14, 2 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x15 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_p_b13, Zcb_c_sh_cg_cp_rs2_p_b13_str)
-#else
-  c.sh x13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x10, x14 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2_p (Test source rs2 = x14)
@@ -340,18 +214,9 @@ Zcb_c_sh_cg_cp_rs2_p_b14:
   c.sh x14, 0(x12) # perform store
   addi x12, x12, 0 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zcb_c_sh_cg_cp_rs2_p_b14, Zcb_c_sh_cg_cp_rs2_p_b14_str)
-#else
-  c.sh x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x434150b61f904267
@@ -361,18 +226,9 @@ Zcb_c_sh_cg_cp_rs2_p_b15:
   c.sh x15, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zcb_c_sh_cg_cp_rs2_p_b15, Zcb_c_sh_cg_cp_rs2_p_b15_str)
-#else
-  c.sh x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -386,18 +242,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x0:
   c.sh x15, 0(x14) # perform store
   addi x14, x14, 0 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x11 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x11, Zcb_c_sh_cg_cp_rs2_edges_0x0, Zcb_c_sh_cg_cp_rs2_edges_0x0_str)
-#else
-  c.sh x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x0000000000000001
@@ -407,18 +254,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x1:
   c.sh x10, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_edges_0x1, Zcb_c_sh_cg_cp_rs2_edges_0x1_str)
-#else
-  c.sh x10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x0000000000000002
@@ -428,18 +266,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x2:
   c.sh x12, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, Zcb_c_sh_cg_cp_rs2_edges_0x2, Zcb_c_sh_cg_cp_rs2_edges_0x2_str)
-#else
-  c.sh x12, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x8000000000000000
@@ -449,18 +278,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x8000000000000000:
   c.sh x10, 2(x9) # perform store
   addi x9, x9, 2 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zcb_c_sh_cg_cp_rs2_edges_0x8000000000000000, Zcb_c_sh_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  c.sh x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x8000000000000001
@@ -470,18 +290,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x8000000000000001:
   c.sh x8, 2(x10) # perform store
   addi x10, x10, 2 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zcb_c_sh_cg_cp_rs2_edges_0x8000000000000001, Zcb_c_sh_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  c.sh x8, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x7fffffffffffffff
@@ -491,18 +302,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x7fffffffffffffff:
   c.sh x11, 2(x15) # perform store
   addi x15, x15, 2 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zcb_c_sh_cg_cp_rs2_edges_0x7fffffffffffffff, Zcb_c_sh_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  c.sh x11, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x7ffffffffffffffe
@@ -512,18 +314,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x7ffffffffffffffe:
   c.sh x10, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x13 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x13, Zcb_c_sh_cg_cp_rs2_edges_0x7ffffffffffffffe, Zcb_c_sh_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  c.sh x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xffffffffffffffff
@@ -533,18 +326,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0xffffffffffffffff:
   c.sh x9, 0(x15) # perform store
   addi x15, x15, 0 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, Zcb_c_sh_cg_cp_rs2_edges_0xffffffffffffffff, Zcb_c_sh_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  c.sh x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xfffffffffffffffe
@@ -554,18 +338,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0xfffffffffffffffe:
   c.sh x14, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zcb_c_sh_cg_cp_rs2_edges_0xfffffffffffffffe, Zcb_c_sh_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  c.sh x14, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x5bbc887763ae86f2
@@ -575,18 +350,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   c.sh x13, 2(x9) # perform store
   addi x9, x9, 2 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zcb_c_sh_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  c.sh x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xaaaaaaaaaaaaaaaa
@@ -596,18 +362,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   c.sh x15, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zcb_c_sh_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zcb_c_sh_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  c.sh x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x5555555555555555
@@ -617,18 +374,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x5555555555555555:
   c.sh x9, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x8, Zcb_c_sh_cg_cp_rs2_edges_0x5555555555555555, Zcb_c_sh_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  c.sh x9, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x00000000ffffffff
@@ -638,18 +386,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0xffffffff:
   c.sh x8, 2(x11) # perform store
   addi x11, x11, 2 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zcb_c_sh_cg_cp_rs2_edges_0xffffffff, Zcb_c_sh_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  c.sh x8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x00000000fffffffe
@@ -659,18 +398,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0xfffffffe:
   c.sh x8, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x15 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_edges_0xfffffffe, Zcb_c_sh_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  c.sh x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x0000000100000000
@@ -680,18 +410,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x100000000:
   c.sh x8, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_edges_0x100000000, Zcb_c_sh_cg_cp_rs2_edges_0x100000000_str)
-#else
-  c.sh x8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x0000000100000001
@@ -701,18 +422,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x100000001:
   c.sh x15, 2(x14) # perform store
   addi x14, x14, 2 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zcb_c_sh_cg_cp_rs2_edges_0x100000001, Zcb_c_sh_cg_cp_rs2_edges_0x100000001_str)
-#else
-  c.sh x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x14 # restore signature pointer to default register for teardown
 

--- a/tests/rv64i/D/D-fsd-00.S
+++ b/tests/rv64i/D/D-fsd-00.S
@@ -42,18 +42,9 @@ D_fsd_cg_cp_rs1_nx0_b1:
   fsd f7, -907(x1) # perform store
   addi x1, x1, -907 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x26 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x26, D_fsd_cg_cp_rs1_nx0_b1, D_fsd_cg_cp_rs1_nx0_b1_str)
-#else
-  fsd f7, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, D_fsd_cg_cp_rs1_nx0_b1, D_fsd_cg_cp_rs1_nx0_b1_str)
 
@@ -66,18 +57,9 @@ D_fsd_cg_cp_rs1_nx0_b2:
   fsd f23, 465(x2) # perform store
   addi x2, x2, 465 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x30 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x30, D_fsd_cg_cp_rs1_nx0_b2, D_fsd_cg_cp_rs1_nx0_b2_str)
-#else
-  fsd f23, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, D_fsd_cg_cp_rs1_nx0_b2, D_fsd_cg_cp_rs1_nx0_b2_str)
 
@@ -91,18 +73,9 @@ D_fsd_cg_cp_rs1_nx0_b3:
   fsd f16, -1462(x3) # perform store
   addi x3, x3, -1462 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x20 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x20, D_fsd_cg_cp_rs1_nx0_b3, D_fsd_cg_cp_rs1_nx0_b3_str)
-#else
-  fsd f16, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, D_fsd_cg_cp_rs1_nx0_b3, D_fsd_cg_cp_rs1_nx0_b3_str)
 
@@ -117,18 +90,9 @@ D_fsd_cg_cp_rs1_nx0_b4:
   fsd f12, -1069(x4) # perform store
   addi x4, x4, -1069 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x16 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x16, D_fsd_cg_cp_rs1_nx0_b4, D_fsd_cg_cp_rs1_nx0_b4_str)
-#else
-  fsd f12, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x4, x8, x7, D_fsd_cg_cp_rs1_nx0_b4, D_fsd_cg_cp_rs1_nx0_b4_str)
 
@@ -141,18 +105,9 @@ D_fsd_cg_cp_rs1_nx0_b5:
   fsd f8, 1390(x5) # perform store
   addi x5, x5, 1390 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x16 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x16, D_fsd_cg_cp_rs1_nx0_b5, D_fsd_cg_cp_rs1_nx0_b5_str)
-#else
-  fsd f8, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x5, x8, x7, D_fsd_cg_cp_rs1_nx0_b5, D_fsd_cg_cp_rs1_nx0_b5_str)
 
@@ -165,18 +120,9 @@ D_fsd_cg_cp_rs1_nx0_b6:
   fsd f16, -1691(x6) # perform store
   addi x6, x6, -1691 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x15 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x15, D_fsd_cg_cp_rs1_nx0_b6, D_fsd_cg_cp_rs1_nx0_b6_str)
-#else
-  fsd f16, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x8, x7, D_fsd_cg_cp_rs1_nx0_b6, D_fsd_cg_cp_rs1_nx0_b6_str)
 
@@ -191,18 +137,9 @@ D_fsd_cg_cp_rs1_nx0_b7:
   fsd f7, -1741(x7) # perform store
   addi x7, x7, -1741 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x17 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x17, D_fsd_cg_cp_rs1_nx0_b7, D_fsd_cg_cp_rs1_nx0_b7_str)
-#else
-  fsd f7, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x14, x13, D_fsd_cg_cp_rs1_nx0_b7, D_fsd_cg_cp_rs1_nx0_b7_str)
 
@@ -215,18 +152,9 @@ D_fsd_cg_cp_rs1_nx0_b8:
   fsd f24, 746(x8) # perform store
   addi x8, x8, 746 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x26 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x26, D_fsd_cg_cp_rs1_nx0_b8, D_fsd_cg_cp_rs1_nx0_b8_str)
-#else
-  fsd f24, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x14, x13, D_fsd_cg_cp_rs1_nx0_b8, D_fsd_cg_cp_rs1_nx0_b8_str)
 
@@ -239,18 +167,9 @@ D_fsd_cg_cp_rs1_nx0_b9:
   fsd f30, 867(x9) # perform store
   addi x9, x9, 867 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x30 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x30, D_fsd_cg_cp_rs1_nx0_b9, D_fsd_cg_cp_rs1_nx0_b9_str)
-#else
-  fsd f30, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x14, x13, D_fsd_cg_cp_rs1_nx0_b9, D_fsd_cg_cp_rs1_nx0_b9_str)
 
@@ -263,18 +182,9 @@ D_fsd_cg_cp_rs1_nx0_b10:
   fsd f0, 1873(x10) # perform store
   addi x10, x10, 1873 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x18 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x18, D_fsd_cg_cp_rs1_nx0_b10, D_fsd_cg_cp_rs1_nx0_b10_str)
-#else
-  fsd f0, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x14, x13, D_fsd_cg_cp_rs1_nx0_b10, D_fsd_cg_cp_rs1_nx0_b10_str)
 
@@ -287,18 +197,9 @@ D_fsd_cg_cp_rs1_nx0_b11:
   fsd f5, -1242(x11) # perform store
   addi x11, x11, -1242 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x5 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x5, D_fsd_cg_cp_rs1_nx0_b11, D_fsd_cg_cp_rs1_nx0_b11_str)
-#else
-  fsd f5, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x14, x13, D_fsd_cg_cp_rs1_nx0_b11, D_fsd_cg_cp_rs1_nx0_b11_str)
 
@@ -311,18 +212,9 @@ D_fsd_cg_cp_rs1_nx0_b12:
   fsd f9, 2031(x12) # perform store
   addi x12, x12, 2031 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x7 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x7, D_fsd_cg_cp_rs1_nx0_b12, D_fsd_cg_cp_rs1_nx0_b12_str)
-#else
-  fsd f9, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x14, x13, D_fsd_cg_cp_rs1_nx0_b12, D_fsd_cg_cp_rs1_nx0_b12_str)
 
@@ -337,18 +229,9 @@ D_fsd_cg_cp_rs1_nx0_b13:
   fsd f29, 1148(x13) # perform store
   addi x13, x13, 1148 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x16 contains the expected result. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x13, x8, x7, x16, D_fsd_cg_cp_rs1_nx0_b13, D_fsd_cg_cp_rs1_nx0_b13_str)
-#else
-  fsd f29, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x8, x7, D_fsd_cg_cp_rs1_nx0_b13, D_fsd_cg_cp_rs1_nx0_b13_str)
 
@@ -361,18 +244,9 @@ D_fsd_cg_cp_rs1_nx0_b14:
   fsd f11, 52(x14) # perform store
   addi x14, x14, 52 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x19 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x19, D_fsd_cg_cp_rs1_nx0_b14, D_fsd_cg_cp_rs1_nx0_b14_str)
-#else
-  fsd f11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x8, x7, D_fsd_cg_cp_rs1_nx0_b14, D_fsd_cg_cp_rs1_nx0_b14_str)
 
@@ -385,18 +259,9 @@ D_fsd_cg_cp_rs1_nx0_b15:
   fsd f10, -536(x15) # perform store
   addi x15, x15, -536 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x27 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x15, x8, x7, x27, D_fsd_cg_cp_rs1_nx0_b15, D_fsd_cg_cp_rs1_nx0_b15_str)
-#else
-  fsd f10, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x8, x7, D_fsd_cg_cp_rs1_nx0_b15, D_fsd_cg_cp_rs1_nx0_b15_str)
 
@@ -409,18 +274,9 @@ D_fsd_cg_cp_rs1_nx0_b16:
   fsd f30, -1348(x16) # perform store
   addi x16, x16, -1348 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x27 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x16, x8, x7, x27, D_fsd_cg_cp_rs1_nx0_b16, D_fsd_cg_cp_rs1_nx0_b16_str)
-#else
-  fsd f30, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x8, x7, D_fsd_cg_cp_rs1_nx0_b16, D_fsd_cg_cp_rs1_nx0_b16_str)
 
@@ -433,18 +289,9 @@ D_fsd_cg_cp_rs1_nx0_b17:
   fsd f28, 1980(x17) # perform store
   addi x17, x17, 1980 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x4 contains the expected result. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x17, x8, x7, x4, D_fsd_cg_cp_rs1_nx0_b17, D_fsd_cg_cp_rs1_nx0_b17_str)
-#else
-  fsd f28, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x8, x7, D_fsd_cg_cp_rs1_nx0_b17, D_fsd_cg_cp_rs1_nx0_b17_str)
 
@@ -457,18 +304,9 @@ D_fsd_cg_cp_rs1_nx0_b18:
   fsd f26, -1294(x18) # perform store
   addi x18, x18, -1294 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x16 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x16, D_fsd_cg_cp_rs1_nx0_b18, D_fsd_cg_cp_rs1_nx0_b18_str)
-#else
-  fsd f26, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x8, x7, D_fsd_cg_cp_rs1_nx0_b18, D_fsd_cg_cp_rs1_nx0_b18_str)
 
@@ -481,18 +319,9 @@ D_fsd_cg_cp_rs1_nx0_b19:
   fsd f27, -1993(x19) # perform store
   addi x19, x19, -1993 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x28 contains the expected result. x19 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x19, x8, x7, x28, D_fsd_cg_cp_rs1_nx0_b19, D_fsd_cg_cp_rs1_nx0_b19_str)
-#else
-  fsd f27, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x8, x7, D_fsd_cg_cp_rs1_nx0_b19, D_fsd_cg_cp_rs1_nx0_b19_str)
 
@@ -505,18 +334,9 @@ D_fsd_cg_cp_rs1_nx0_b20:
   fsd f11, 1441(x20) # perform store
   addi x20, x20, 1441 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x9 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x9, D_fsd_cg_cp_rs1_nx0_b20, D_fsd_cg_cp_rs1_nx0_b20_str)
-#else
-  fsd f11, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x8, x7, D_fsd_cg_cp_rs1_nx0_b20, D_fsd_cg_cp_rs1_nx0_b20_str)
 
@@ -529,18 +349,9 @@ D_fsd_cg_cp_rs1_nx0_b21:
   fsd f2, -2042(x21) # perform store
   addi x21, x21, -2042 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x22 contains the expected result. x21 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x21, x8, x7, x22, D_fsd_cg_cp_rs1_nx0_b21, D_fsd_cg_cp_rs1_nx0_b21_str)
-#else
-  fsd f2, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x8, x7, D_fsd_cg_cp_rs1_nx0_b21, D_fsd_cg_cp_rs1_nx0_b21_str)
 
@@ -553,18 +364,9 @@ D_fsd_cg_cp_rs1_nx0_b22:
   fsd f31, 622(x22) # perform store
   addi x22, x22, 622 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x6 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x6, D_fsd_cg_cp_rs1_nx0_b22, D_fsd_cg_cp_rs1_nx0_b22_str)
-#else
-  fsd f31, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x8, x7, D_fsd_cg_cp_rs1_nx0_b22, D_fsd_cg_cp_rs1_nx0_b22_str)
 
@@ -577,18 +379,9 @@ D_fsd_cg_cp_rs1_nx0_b23:
   fsd f27, -1509(x23) # perform store
   addi x23, x23, -1509 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x16 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x16, D_fsd_cg_cp_rs1_nx0_b23, D_fsd_cg_cp_rs1_nx0_b23_str)
-#else
-  fsd f27, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x8, x7, D_fsd_cg_cp_rs1_nx0_b23, D_fsd_cg_cp_rs1_nx0_b23_str)
 
@@ -601,18 +394,9 @@ D_fsd_cg_cp_rs1_nx0_b24:
   fsd f28, 610(x24) # perform store
   addi x24, x24, 610 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x3 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x3, D_fsd_cg_cp_rs1_nx0_b24, D_fsd_cg_cp_rs1_nx0_b24_str)
-#else
-  fsd f28, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x8, x7, D_fsd_cg_cp_rs1_nx0_b24, D_fsd_cg_cp_rs1_nx0_b24_str)
 
@@ -626,18 +410,9 @@ D_fsd_cg_cp_rs1_nx0_b25:
   fsd f9, -1184(x25) # perform store
   addi x25, x25, -1184 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x14 contains the expected result. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x25, x8, x7, x14, D_fsd_cg_cp_rs1_nx0_b25, D_fsd_cg_cp_rs1_nx0_b25_str)
-#else
-  fsd f9, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x8, x7, D_fsd_cg_cp_rs1_nx0_b25, D_fsd_cg_cp_rs1_nx0_b25_str)
 
@@ -650,18 +425,9 @@ D_fsd_cg_cp_rs1_nx0_b26:
   fsd f3, 459(x26) # perform store
   addi x26, x26, 459 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x6 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x6, D_fsd_cg_cp_rs1_nx0_b26, D_fsd_cg_cp_rs1_nx0_b26_str)
-#else
-  fsd f3, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x8, x7, D_fsd_cg_cp_rs1_nx0_b26, D_fsd_cg_cp_rs1_nx0_b26_str)
 
@@ -674,18 +440,9 @@ D_fsd_cg_cp_rs1_nx0_b27:
   fsd f1, -126(x27) # perform store
   addi x27, x27, -126 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x12 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x27, x8, x7, x12, D_fsd_cg_cp_rs1_nx0_b27, D_fsd_cg_cp_rs1_nx0_b27_str)
-#else
-  fsd f1, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x8, x7, D_fsd_cg_cp_rs1_nx0_b27, D_fsd_cg_cp_rs1_nx0_b27_str)
 
@@ -698,18 +455,9 @@ D_fsd_cg_cp_rs1_nx0_b28:
   fsd f1, -1404(x28) # perform store
   addi x28, x28, -1404 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x17 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x17, D_fsd_cg_cp_rs1_nx0_b28, D_fsd_cg_cp_rs1_nx0_b28_str)
-#else
-  fsd f1, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x8, x7, D_fsd_cg_cp_rs1_nx0_b28, D_fsd_cg_cp_rs1_nx0_b28_str)
 
@@ -722,18 +470,9 @@ D_fsd_cg_cp_rs1_nx0_b29:
   fsd f22, 1035(x29) # perform store
   addi x29, x29, 1035 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x18 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x18, D_fsd_cg_cp_rs1_nx0_b29, D_fsd_cg_cp_rs1_nx0_b29_str)
-#else
-  fsd f22, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x8, x7, D_fsd_cg_cp_rs1_nx0_b29, D_fsd_cg_cp_rs1_nx0_b29_str)
 
@@ -746,18 +485,9 @@ D_fsd_cg_cp_rs1_nx0_b30:
   fsd f23, 1487(x30) # perform store
   addi x30, x30, 1487 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x25 contains the expected result. x30 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x30, x8, x7, x25, D_fsd_cg_cp_rs1_nx0_b30, D_fsd_cg_cp_rs1_nx0_b30_str)
-#else
-  fsd f23, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x8, x7, D_fsd_cg_cp_rs1_nx0_b30, D_fsd_cg_cp_rs1_nx0_b30_str)
 
@@ -770,18 +500,9 @@ D_fsd_cg_cp_rs1_nx0_b31:
   fsd f30, 1531(x31) # perform store
   addi x31, x31, 1531 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x23 contains the expected result. x31 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x31, x8, x7, x23, D_fsd_cg_cp_rs1_nx0_b31, D_fsd_cg_cp_rs1_nx0_b31_str)
-#else
-  fsd f30, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x8, x7, D_fsd_cg_cp_rs1_nx0_b31, D_fsd_cg_cp_rs1_nx0_b31_str)
 
@@ -798,18 +519,9 @@ D_fsd_cg_cp_imm_edges_0x0:
   fsd f13, 0(x16) # perform store
   addi x16, x16, 0 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x28 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x16, x8, x7, x28, D_fsd_cg_cp_imm_edges_0x0, D_fsd_cg_cp_imm_edges_0x0_str)
-#else
-  fsd f13, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x8, x7, D_fsd_cg_cp_imm_edges_0x0, D_fsd_cg_cp_imm_edges_0x0_str)
 
@@ -822,18 +534,9 @@ D_fsd_cg_cp_imm_edges_0x1:
   fsd f2, 1(x30) # perform store
   addi x30, x30, 1 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x25 contains the expected result. x30 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x30, x8, x7, x25, D_fsd_cg_cp_imm_edges_0x1, D_fsd_cg_cp_imm_edges_0x1_str)
-#else
-  fsd f2, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x8, x7, D_fsd_cg_cp_imm_edges_0x1, D_fsd_cg_cp_imm_edges_0x1_str)
 
@@ -846,18 +549,9 @@ D_fsd_cg_cp_imm_edges_0x2:
   fsd f27, 2(x17) # perform store
   addi x17, x17, 2 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x4 contains the expected result. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x17, x8, x7, x4, D_fsd_cg_cp_imm_edges_0x2, D_fsd_cg_cp_imm_edges_0x2_str)
-#else
-  fsd f27, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x8, x7, D_fsd_cg_cp_imm_edges_0x2, D_fsd_cg_cp_imm_edges_0x2_str)
 
@@ -870,18 +564,9 @@ D_fsd_cg_cp_imm_edges_0x3:
   fsd f31, 3(x11) # perform store
   addi x11, x11, 3 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x27 contains the expected result. x11 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x11, x8, x7, x27, D_fsd_cg_cp_imm_edges_0x3, D_fsd_cg_cp_imm_edges_0x3_str)
-#else
-  fsd f31, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x8, x7, D_fsd_cg_cp_imm_edges_0x3, D_fsd_cg_cp_imm_edges_0x3_str)
 
@@ -894,18 +579,9 @@ D_fsd_cg_cp_imm_edges_0x4:
   fsd f22, 4(x3) # perform store
   addi x3, x3, 4 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x5 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x3, x8, x7, x5, D_fsd_cg_cp_imm_edges_0x4, D_fsd_cg_cp_imm_edges_0x4_str)
-#else
-  fsd f22, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x8, x7, D_fsd_cg_cp_imm_edges_0x4, D_fsd_cg_cp_imm_edges_0x4_str)
 
@@ -918,18 +594,9 @@ D_fsd_cg_cp_imm_edges_0x8:
   fsd f21, 8(x10) # perform store
   addi x10, x10, 8 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x24 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x24, D_fsd_cg_cp_imm_edges_0x8, D_fsd_cg_cp_imm_edges_0x8_str)
-#else
-  fsd f21, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x8, x7, D_fsd_cg_cp_imm_edges_0x8, D_fsd_cg_cp_imm_edges_0x8_str)
 
@@ -942,18 +609,9 @@ D_fsd_cg_cp_imm_edges_0x10:
   fsd f16, 16(x22) # perform store
   addi x22, x22, 16 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x17 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x17, D_fsd_cg_cp_imm_edges_0x10, D_fsd_cg_cp_imm_edges_0x10_str)
-#else
-  fsd f16, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x8, x7, D_fsd_cg_cp_imm_edges_0x10, D_fsd_cg_cp_imm_edges_0x10_str)
 
@@ -966,18 +624,9 @@ D_fsd_cg_cp_imm_edges_0x20:
   fsd f12, 32(x10) # perform store
   addi x10, x10, 32 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x1 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x1, D_fsd_cg_cp_imm_edges_0x20, D_fsd_cg_cp_imm_edges_0x20_str)
-#else
-  fsd f12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x8, x7, D_fsd_cg_cp_imm_edges_0x20, D_fsd_cg_cp_imm_edges_0x20_str)
 
@@ -990,18 +639,9 @@ D_fsd_cg_cp_imm_edges_0x40:
   fsd f19, 64(x6) # perform store
   addi x6, x6, 64 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x11 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x11, D_fsd_cg_cp_imm_edges_0x40, D_fsd_cg_cp_imm_edges_0x40_str)
-#else
-  fsd f19, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x8, x7, D_fsd_cg_cp_imm_edges_0x40, D_fsd_cg_cp_imm_edges_0x40_str)
 
@@ -1014,18 +654,9 @@ D_fsd_cg_cp_imm_edges_0x80:
   fsd f22, 128(x19) # perform store
   addi x19, x19, 128 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x18 contains the expected result. x19 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x19, x8, x7, x18, D_fsd_cg_cp_imm_edges_0x80, D_fsd_cg_cp_imm_edges_0x80_str)
-#else
-  fsd f22, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x8, x7, D_fsd_cg_cp_imm_edges_0x80, D_fsd_cg_cp_imm_edges_0x80_str)
 
@@ -1038,18 +669,9 @@ D_fsd_cg_cp_imm_edges_0x100:
   fsd f10, 256(x23) # perform store
   addi x23, x23, 256 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x16 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x16, D_fsd_cg_cp_imm_edges_0x100, D_fsd_cg_cp_imm_edges_0x100_str)
-#else
-  fsd f10, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x8, x7, D_fsd_cg_cp_imm_edges_0x100, D_fsd_cg_cp_imm_edges_0x100_str)
 
@@ -1062,18 +684,9 @@ D_fsd_cg_cp_imm_edges_0x200:
   fsd f24, 512(x11) # perform store
   addi x11, x11, 512 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x11, x8, x7, x12, D_fsd_cg_cp_imm_edges_0x200, D_fsd_cg_cp_imm_edges_0x200_str)
-#else
-  fsd f24, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x8, x7, D_fsd_cg_cp_imm_edges_0x200, D_fsd_cg_cp_imm_edges_0x200_str)
 
@@ -1086,18 +699,9 @@ D_fsd_cg_cp_imm_edges_0x3ff:
   fsd f7, 1023(x4) # perform store
   addi x4, x4, 1023 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x12 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x12, D_fsd_cg_cp_imm_edges_0x3ff, D_fsd_cg_cp_imm_edges_0x3ff_str)
-#else
-  fsd f7, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x4, x8, x7, D_fsd_cg_cp_imm_edges_0x3ff, D_fsd_cg_cp_imm_edges_0x3ff_str)
 
@@ -1110,18 +714,9 @@ D_fsd_cg_cp_imm_edges_0x400:
   fsd f24, 1024(x25) # perform store
   addi x25, x25, 1024 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x23 contains the expected result. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x25, x8, x7, x23, D_fsd_cg_cp_imm_edges_0x400, D_fsd_cg_cp_imm_edges_0x400_str)
-#else
-  fsd f24, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x8, x7, D_fsd_cg_cp_imm_edges_0x400, D_fsd_cg_cp_imm_edges_0x400_str)
 
@@ -1134,18 +729,9 @@ D_fsd_cg_cp_imm_edges_0x703:
   fsd f1, 1795(x3) # perform store
   addi x3, x3, 1795 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x9 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x3, x8, x7, x9, D_fsd_cg_cp_imm_edges_0x703, D_fsd_cg_cp_imm_edges_0x703_str)
-#else
-  fsd f1, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x8, x7, D_fsd_cg_cp_imm_edges_0x703, D_fsd_cg_cp_imm_edges_0x703_str)
 
@@ -1158,18 +744,9 @@ D_fsd_cg_cp_imm_edges_0x7ff:
   fsd f9, 2047(x28) # perform store
   addi x28, x28, 2047 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x29 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x29, D_fsd_cg_cp_imm_edges_0x7ff, D_fsd_cg_cp_imm_edges_0x7ff_str)
-#else
-  fsd f9, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x8, x7, D_fsd_cg_cp_imm_edges_0x7ff, D_fsd_cg_cp_imm_edges_0x7ff_str)
 
@@ -1183,18 +760,9 @@ D_fsd_cg_cp_imm_edges_m0x800:
   fsd f11, -2048(x2) # perform store
   addi x2, x2, -2048 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x4 contains the expected result. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x2, x8, x7, x4, D_fsd_cg_cp_imm_edges_m0x800, D_fsd_cg_cp_imm_edges_m0x800_str)
-#else
-  fsd f11, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x8, x7, D_fsd_cg_cp_imm_edges_m0x800, D_fsd_cg_cp_imm_edges_m0x800_str)
 
@@ -1207,18 +775,9 @@ D_fsd_cg_cp_imm_edges_m0x7ff:
   fsd f22, -2047(x21) # perform store
   addi x21, x21, -2047 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x1 contains the expected result. x21 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x21, x8, x7, x1, D_fsd_cg_cp_imm_edges_m0x7ff, D_fsd_cg_cp_imm_edges_m0x7ff_str)
-#else
-  fsd f22, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x8, x7, D_fsd_cg_cp_imm_edges_m0x7ff, D_fsd_cg_cp_imm_edges_m0x7ff_str)
 
@@ -1231,18 +790,9 @@ D_fsd_cg_cp_imm_edges_m0x2:
   fsd f16, -2(x20) # perform store
   addi x20, x20, -2 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x27 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x27, D_fsd_cg_cp_imm_edges_m0x2, D_fsd_cg_cp_imm_edges_m0x2_str)
-#else
-  fsd f16, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x8, x7, D_fsd_cg_cp_imm_edges_m0x2, D_fsd_cg_cp_imm_edges_m0x2_str)
 
@@ -1255,18 +805,9 @@ D_fsd_cg_cp_imm_edges_m0x1:
   fsd f22, -1(x23) # perform store
   addi x23, x23, -1 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x22 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x22, D_fsd_cg_cp_imm_edges_m0x1, D_fsd_cg_cp_imm_edges_m0x1_str)
-#else
-  fsd f22, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x8, x7, D_fsd_cg_cp_imm_edges_m0x1, D_fsd_cg_cp_imm_edges_m0x1_str)
 
@@ -1283,18 +824,9 @@ D_fsd_cg_cp_fs2_b0:
   fsd f0, -1997(x16) # perform store
   addi x16, x16, -1997 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x9 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x16, x8, x7, x9, D_fsd_cg_cp_fs2_b0, D_fsd_cg_cp_fs2_b0_str)
-#else
-  fsd f0, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x8, x7, D_fsd_cg_cp_fs2_b0, D_fsd_cg_cp_fs2_b0_str)
 
@@ -1307,18 +839,9 @@ D_fsd_cg_cp_fs2_b1:
   fsd f1, -216(x24) # perform store
   addi x24, x24, -216 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x29 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x29, D_fsd_cg_cp_fs2_b1, D_fsd_cg_cp_fs2_b1_str)
-#else
-  fsd f1, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x8, x7, D_fsd_cg_cp_fs2_b1, D_fsd_cg_cp_fs2_b1_str)
 
@@ -1331,18 +854,9 @@ D_fsd_cg_cp_fs2_b2:
   fsd f2, 1396(x31) # perform store
   addi x31, x31, 1396 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x25 contains the expected result. x31 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x31, x8, x7, x25, D_fsd_cg_cp_fs2_b2, D_fsd_cg_cp_fs2_b2_str)
-#else
-  fsd f2, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x8, x7, D_fsd_cg_cp_fs2_b2, D_fsd_cg_cp_fs2_b2_str)
 
@@ -1355,18 +869,9 @@ D_fsd_cg_cp_fs2_b3:
   fsd f3, -342(x2) # perform store
   addi x2, x2, -342 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x13 contains the expected result. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x2, x8, x7, x13, D_fsd_cg_cp_fs2_b3, D_fsd_cg_cp_fs2_b3_str)
-#else
-  fsd f3, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x8, x7, D_fsd_cg_cp_fs2_b3, D_fsd_cg_cp_fs2_b3_str)
 
@@ -1379,18 +884,9 @@ D_fsd_cg_cp_fs2_b4:
   fsd f4, 2000(x16) # perform store
   addi x16, x16, 2000 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x22 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x16, x8, x7, x22, D_fsd_cg_cp_fs2_b4, D_fsd_cg_cp_fs2_b4_str)
-#else
-  fsd f4, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x8, x7, D_fsd_cg_cp_fs2_b4, D_fsd_cg_cp_fs2_b4_str)
 
@@ -1403,18 +899,9 @@ D_fsd_cg_cp_fs2_b5:
   fsd f5, -701(x31) # perform store
   addi x31, x31, -701 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x28 contains the expected result. x31 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x31, x8, x7, x28, D_fsd_cg_cp_fs2_b5, D_fsd_cg_cp_fs2_b5_str)
-#else
-  fsd f5, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x8, x7, D_fsd_cg_cp_fs2_b5, D_fsd_cg_cp_fs2_b5_str)
 
@@ -1427,18 +914,9 @@ D_fsd_cg_cp_fs2_b6:
   fsd f6, -839(x20) # perform store
   addi x20, x20, -839 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x14 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x14, D_fsd_cg_cp_fs2_b6, D_fsd_cg_cp_fs2_b6_str)
-#else
-  fsd f6, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x8, x7, D_fsd_cg_cp_fs2_b6, D_fsd_cg_cp_fs2_b6_str)
 
@@ -1451,18 +929,9 @@ D_fsd_cg_cp_fs2_b7:
   fsd f7, 1771(x26) # perform store
   addi x26, x26, 1771 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x21 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x21, D_fsd_cg_cp_fs2_b7, D_fsd_cg_cp_fs2_b7_str)
-#else
-  fsd f7, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x8, x7, D_fsd_cg_cp_fs2_b7, D_fsd_cg_cp_fs2_b7_str)
 
@@ -1475,18 +944,9 @@ D_fsd_cg_cp_fs2_b8:
   fsd f8, 1121(x6) # perform store
   addi x6, x6, 1121 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x24 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x24, D_fsd_cg_cp_fs2_b8, D_fsd_cg_cp_fs2_b8_str)
-#else
-  fsd f8, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x8, x7, D_fsd_cg_cp_fs2_b8, D_fsd_cg_cp_fs2_b8_str)
 
@@ -1499,18 +959,9 @@ D_fsd_cg_cp_fs2_b9:
   fsd f9, -479(x3) # perform store
   addi x3, x3, -479 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x1 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x3, x8, x7, x1, D_fsd_cg_cp_fs2_b9, D_fsd_cg_cp_fs2_b9_str)
-#else
-  fsd f9, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x8, x7, D_fsd_cg_cp_fs2_b9, D_fsd_cg_cp_fs2_b9_str)
 
@@ -1523,18 +974,9 @@ D_fsd_cg_cp_fs2_b10:
   fsd f10, 1966(x16) # perform store
   addi x16, x16, 1966 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x5 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x16, x8, x7, x5, D_fsd_cg_cp_fs2_b10, D_fsd_cg_cp_fs2_b10_str)
-#else
-  fsd f10, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x8, x7, D_fsd_cg_cp_fs2_b10, D_fsd_cg_cp_fs2_b10_str)
 
@@ -1547,18 +989,9 @@ D_fsd_cg_cp_fs2_b11:
   fsd f11, -1946(x20) # perform store
   addi x20, x20, -1946 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x31 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x31, D_fsd_cg_cp_fs2_b11, D_fsd_cg_cp_fs2_b11_str)
-#else
-  fsd f11, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x8, x7, D_fsd_cg_cp_fs2_b11, D_fsd_cg_cp_fs2_b11_str)
 
@@ -1571,18 +1004,9 @@ D_fsd_cg_cp_fs2_b12:
   fsd f12, -403(x2) # perform store
   addi x2, x2, -403 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x18 contains the expected result. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x2, x8, x7, x18, D_fsd_cg_cp_fs2_b12, D_fsd_cg_cp_fs2_b12_str)
-#else
-  fsd f12, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x8, x7, D_fsd_cg_cp_fs2_b12, D_fsd_cg_cp_fs2_b12_str)
 
@@ -1595,18 +1019,9 @@ D_fsd_cg_cp_fs2_b13:
   fsd f13, 1216(x27) # perform store
   addi x27, x27, 1216 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x21 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x27, x8, x7, x21, D_fsd_cg_cp_fs2_b13, D_fsd_cg_cp_fs2_b13_str)
-#else
-  fsd f13, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x8, x7, D_fsd_cg_cp_fs2_b13, D_fsd_cg_cp_fs2_b13_str)
 
@@ -1619,18 +1034,9 @@ D_fsd_cg_cp_fs2_b14:
   fsd f14, -331(x13) # perform store
   addi x13, x13, -331 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x23 contains the expected result. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x13, x8, x7, x23, D_fsd_cg_cp_fs2_b14, D_fsd_cg_cp_fs2_b14_str)
-#else
-  fsd f14, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x8, x7, D_fsd_cg_cp_fs2_b14, D_fsd_cg_cp_fs2_b14_str)
 
@@ -1643,18 +1049,9 @@ D_fsd_cg_cp_fs2_b15:
   fsd f15, -1721(x24) # perform store
   addi x24, x24, -1721 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x22 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x22, D_fsd_cg_cp_fs2_b15, D_fsd_cg_cp_fs2_b15_str)
-#else
-  fsd f15, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x8, x7, D_fsd_cg_cp_fs2_b15, D_fsd_cg_cp_fs2_b15_str)
 
@@ -1667,18 +1064,9 @@ D_fsd_cg_cp_fs2_b16:
   fsd f16, -1609(x27) # perform store
   addi x27, x27, -1609 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x18 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x27, x8, x7, x18, D_fsd_cg_cp_fs2_b16, D_fsd_cg_cp_fs2_b16_str)
-#else
-  fsd f16, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x8, x7, D_fsd_cg_cp_fs2_b16, D_fsd_cg_cp_fs2_b16_str)
 
@@ -1691,18 +1079,9 @@ D_fsd_cg_cp_fs2_b17:
   fsd f17, 239(x4) # perform store
   addi x4, x4, 239 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x14 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x14, D_fsd_cg_cp_fs2_b17, D_fsd_cg_cp_fs2_b17_str)
-#else
-  fsd f17, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x4, x8, x7, D_fsd_cg_cp_fs2_b17, D_fsd_cg_cp_fs2_b17_str)
 
@@ -1715,18 +1094,9 @@ D_fsd_cg_cp_fs2_b18:
   fsd f18, -831(x17) # perform store
   addi x17, x17, -831 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x6 contains the expected result. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x17, x8, x7, x6, D_fsd_cg_cp_fs2_b18, D_fsd_cg_cp_fs2_b18_str)
-#else
-  fsd f18, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x8, x7, D_fsd_cg_cp_fs2_b18, D_fsd_cg_cp_fs2_b18_str)
 
@@ -1739,18 +1109,9 @@ D_fsd_cg_cp_fs2_b19:
   fsd f19, 516(x25) # perform store
   addi x25, x25, 516 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x16 contains the expected result. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x25, x8, x7, x16, D_fsd_cg_cp_fs2_b19, D_fsd_cg_cp_fs2_b19_str)
-#else
-  fsd f19, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x8, x7, D_fsd_cg_cp_fs2_b19, D_fsd_cg_cp_fs2_b19_str)
 
@@ -1763,18 +1124,9 @@ D_fsd_cg_cp_fs2_b20:
   fsd f20, -1691(x26) # perform store
   addi x26, x26, -1691 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x28 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x28, D_fsd_cg_cp_fs2_b20, D_fsd_cg_cp_fs2_b20_str)
-#else
-  fsd f20, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x8, x7, D_fsd_cg_cp_fs2_b20, D_fsd_cg_cp_fs2_b20_str)
 
@@ -1787,18 +1139,9 @@ D_fsd_cg_cp_fs2_b21:
   fsd f21, 1914(x1) # perform store
   addi x1, x1, 1914 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x3 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x3, D_fsd_cg_cp_fs2_b21, D_fsd_cg_cp_fs2_b21_str)
-#else
-  fsd f21, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x8, x7, D_fsd_cg_cp_fs2_b21, D_fsd_cg_cp_fs2_b21_str)
 
@@ -1811,18 +1154,9 @@ D_fsd_cg_cp_fs2_b22:
   fsd f22, -1132(x25) # perform store
   addi x25, x25, -1132 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x27 contains the expected result. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x25, x8, x7, x27, D_fsd_cg_cp_fs2_b22, D_fsd_cg_cp_fs2_b22_str)
-#else
-  fsd f22, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x8, x7, D_fsd_cg_cp_fs2_b22, D_fsd_cg_cp_fs2_b22_str)
 
@@ -1835,18 +1169,9 @@ D_fsd_cg_cp_fs2_b23:
   fsd f23, 1807(x22) # perform store
   addi x22, x22, 1807 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x19 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x19, D_fsd_cg_cp_fs2_b23, D_fsd_cg_cp_fs2_b23_str)
-#else
-  fsd f23, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x8, x7, D_fsd_cg_cp_fs2_b23, D_fsd_cg_cp_fs2_b23_str)
 
@@ -1859,18 +1184,9 @@ D_fsd_cg_cp_fs2_b24:
   fsd f24, -295(x12) # perform store
   addi x12, x12, -295 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x18 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x12, x8, x7, x18, D_fsd_cg_cp_fs2_b24, D_fsd_cg_cp_fs2_b24_str)
-#else
-  fsd f24, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x8, x7, D_fsd_cg_cp_fs2_b24, D_fsd_cg_cp_fs2_b24_str)
 
@@ -1883,18 +1199,9 @@ D_fsd_cg_cp_fs2_b25:
   fsd f25, -285(x14) # perform store
   addi x14, x14, -285 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x19 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x19, D_fsd_cg_cp_fs2_b25, D_fsd_cg_cp_fs2_b25_str)
-#else
-  fsd f25, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x8, x7, D_fsd_cg_cp_fs2_b25, D_fsd_cg_cp_fs2_b25_str)
 
@@ -1907,18 +1214,9 @@ D_fsd_cg_cp_fs2_b26:
   fsd f26, -489(x6) # perform store
   addi x6, x6, -489 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x20 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x20, D_fsd_cg_cp_fs2_b26, D_fsd_cg_cp_fs2_b26_str)
-#else
-  fsd f26, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x8, x7, D_fsd_cg_cp_fs2_b26, D_fsd_cg_cp_fs2_b26_str)
 
@@ -1931,18 +1229,9 @@ D_fsd_cg_cp_fs2_b27:
   fsd f27, -1382(x18) # perform store
   addi x18, x18, -1382 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x25 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x25, D_fsd_cg_cp_fs2_b27, D_fsd_cg_cp_fs2_b27_str)
-#else
-  fsd f27, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x8, x7, D_fsd_cg_cp_fs2_b27, D_fsd_cg_cp_fs2_b27_str)
 
@@ -1955,18 +1244,9 @@ D_fsd_cg_cp_fs2_b28:
   fsd f28, -1257(x24) # perform store
   addi x24, x24, -1257 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x13 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x13, D_fsd_cg_cp_fs2_b28, D_fsd_cg_cp_fs2_b28_str)
-#else
-  fsd f28, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x8, x7, D_fsd_cg_cp_fs2_b28, D_fsd_cg_cp_fs2_b28_str)
 
@@ -1979,18 +1259,9 @@ D_fsd_cg_cp_fs2_b29:
   fsd f29, -1732(x10) # perform store
   addi x10, x10, -1732 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x13, D_fsd_cg_cp_fs2_b29, D_fsd_cg_cp_fs2_b29_str)
-#else
-  fsd f29, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x8, x7, D_fsd_cg_cp_fs2_b29, D_fsd_cg_cp_fs2_b29_str)
 
@@ -2003,18 +1274,9 @@ D_fsd_cg_cp_fs2_b30:
   fsd f30, 1737(x5) # perform store
   addi x5, x5, 1737 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x28 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x28, D_fsd_cg_cp_fs2_b30, D_fsd_cg_cp_fs2_b30_str)
-#else
-  fsd f30, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x5, x8, x7, D_fsd_cg_cp_fs2_b30, D_fsd_cg_cp_fs2_b30_str)
 
@@ -2027,18 +1289,9 @@ D_fsd_cg_cp_fs2_b31:
   fsd f31, -773(x10) # perform store
   addi x10, x10, -773 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x6 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x6, D_fsd_cg_cp_fs2_b31, D_fsd_cg_cp_fs2_b31_str)
-#else
-  fsd f31, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x8, x7, D_fsd_cg_cp_fs2_b31, D_fsd_cg_cp_fs2_b31_str)
 
@@ -2055,18 +1308,9 @@ D_fsd_cg_cp_fs2_edges_b0x0:
   fsd f5, -1308(x22) # perform store
   addi x22, x22, -1308 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x5 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x5, D_fsd_cg_cp_fs2_edges_b0x0, D_fsd_cg_cp_fs2_edges_b0x0_str)
-#else
-  fsd f5, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x8, x7, D_fsd_cg_cp_fs2_edges_b0x0, D_fsd_cg_cp_fs2_edges_b0x0_str)
 
@@ -2079,18 +1323,9 @@ D_fsd_cg_cp_fs2_edges_b0x80000000:
   fsd f27, 2018(x1) # perform store
   addi x1, x1, 2018 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x25 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x25, D_fsd_cg_cp_fs2_edges_b0x80000000, D_fsd_cg_cp_fs2_edges_b0x80000000_str)
-#else
-  fsd f27, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x8, x7, D_fsd_cg_cp_fs2_edges_b0x80000000, D_fsd_cg_cp_fs2_edges_b0x80000000_str)
 
@@ -2103,18 +1338,9 @@ D_fsd_cg_cp_fs2_edges_b0x3f800000:
   fsd f14, 1159(x23) # perform store
   addi x23, x23, 1159 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x10 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x10, D_fsd_cg_cp_fs2_edges_b0x3f800000, D_fsd_cg_cp_fs2_edges_b0x3f800000_str)
-#else
-  fsd f14, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x8, x7, D_fsd_cg_cp_fs2_edges_b0x3f800000, D_fsd_cg_cp_fs2_edges_b0x3f800000_str)
 
@@ -2127,18 +1353,9 @@ D_fsd_cg_cp_fs2_edges_b0xbf800000:
   fsd f9, -1322(x16) # perform store
   addi x16, x16, -1322 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x30 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x16, x8, x7, x30, D_fsd_cg_cp_fs2_edges_b0xbf800000, D_fsd_cg_cp_fs2_edges_b0xbf800000_str)
-#else
-  fsd f9, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x8, x7, D_fsd_cg_cp_fs2_edges_b0xbf800000, D_fsd_cg_cp_fs2_edges_b0xbf800000_str)
 
@@ -2151,18 +1368,9 @@ D_fsd_cg_cp_fs2_edges_b0x3fc00000:
   fsd f6, 906(x17) # perform store
   addi x17, x17, 906 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x5 contains the expected result. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x17, x8, x7, x5, D_fsd_cg_cp_fs2_edges_b0x3fc00000, D_fsd_cg_cp_fs2_edges_b0x3fc00000_str)
-#else
-  fsd f6, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x8, x7, D_fsd_cg_cp_fs2_edges_b0x3fc00000, D_fsd_cg_cp_fs2_edges_b0x3fc00000_str)
 
@@ -2175,18 +1383,9 @@ D_fsd_cg_cp_fs2_edges_b0xbfc00000:
   fsd f25, 1523(x19) # perform store
   addi x19, x19, 1523 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x27 contains the expected result. x19 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x19, x8, x7, x27, D_fsd_cg_cp_fs2_edges_b0xbfc00000, D_fsd_cg_cp_fs2_edges_b0xbfc00000_str)
-#else
-  fsd f25, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x8, x7, D_fsd_cg_cp_fs2_edges_b0xbfc00000, D_fsd_cg_cp_fs2_edges_b0xbfc00000_str)
 
@@ -2199,18 +1398,9 @@ D_fsd_cg_cp_fs2_edges_b0x40000000:
   fsd f14, 1197(x1) # perform store
   addi x1, x1, 1197 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x17 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x17, D_fsd_cg_cp_fs2_edges_b0x40000000, D_fsd_cg_cp_fs2_edges_b0x40000000_str)
-#else
-  fsd f14, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x8, x7, D_fsd_cg_cp_fs2_edges_b0x40000000, D_fsd_cg_cp_fs2_edges_b0x40000000_str)
 
@@ -2223,18 +1413,9 @@ D_fsd_cg_cp_fs2_edges_b0xc0000000:
   fsd f28, 624(x10) # perform store
   addi x10, x10, 624 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x25 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x25, D_fsd_cg_cp_fs2_edges_b0xc0000000, D_fsd_cg_cp_fs2_edges_b0xc0000000_str)
-#else
-  fsd f28, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x8, x7, D_fsd_cg_cp_fs2_edges_b0xc0000000, D_fsd_cg_cp_fs2_edges_b0xc0000000_str)
 
@@ -2247,18 +1428,9 @@ D_fsd_cg_cp_fs2_edges_b0x800000:
   fsd f11, 1314(x28) # perform store
   addi x28, x28, 1314 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x20 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x20, D_fsd_cg_cp_fs2_edges_b0x800000, D_fsd_cg_cp_fs2_edges_b0x800000_str)
-#else
-  fsd f11, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x8, x7, D_fsd_cg_cp_fs2_edges_b0x800000, D_fsd_cg_cp_fs2_edges_b0x800000_str)
 
@@ -2271,18 +1443,9 @@ D_fsd_cg_cp_fs2_edges_b0x80800000:
   fsd f19, 979(x21) # perform store
   addi x21, x21, 979 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x20 contains the expected result. x21 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x21, x8, x7, x20, D_fsd_cg_cp_fs2_edges_b0x80800000, D_fsd_cg_cp_fs2_edges_b0x80800000_str)
-#else
-  fsd f19, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x8, x7, D_fsd_cg_cp_fs2_edges_b0x80800000, D_fsd_cg_cp_fs2_edges_b0x80800000_str)
 
@@ -2295,18 +1458,9 @@ D_fsd_cg_cp_fs2_edges_b0x7f7fffff:
   fsd f16, 1635(x2) # perform store
   addi x2, x2, 1635 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x23 contains the expected result. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x2, x8, x7, x23, D_fsd_cg_cp_fs2_edges_b0x7f7fffff, D_fsd_cg_cp_fs2_edges_b0x7f7fffff_str)
-#else
-  fsd f16, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x8, x7, D_fsd_cg_cp_fs2_edges_b0x7f7fffff, D_fsd_cg_cp_fs2_edges_b0x7f7fffff_str)
 
@@ -2319,18 +1473,9 @@ D_fsd_cg_cp_fs2_edges_b0xff7fffff:
   fsd f27, -853(x14) # perform store
   addi x14, x14, -853 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x29 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x29, D_fsd_cg_cp_fs2_edges_b0xff7fffff, D_fsd_cg_cp_fs2_edges_b0xff7fffff_str)
-#else
-  fsd f27, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x8, x7, D_fsd_cg_cp_fs2_edges_b0xff7fffff, D_fsd_cg_cp_fs2_edges_b0xff7fffff_str)
 
@@ -2343,18 +1488,9 @@ D_fsd_cg_cp_fs2_edges_b0x7fffff:
   fsd f3, 823(x25) # perform store
   addi x25, x25, 823 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x27 contains the expected result. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x25, x8, x7, x27, D_fsd_cg_cp_fs2_edges_b0x7fffff, D_fsd_cg_cp_fs2_edges_b0x7fffff_str)
-#else
-  fsd f3, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x8, x7, D_fsd_cg_cp_fs2_edges_b0x7fffff, D_fsd_cg_cp_fs2_edges_b0x7fffff_str)
 
@@ -2367,18 +1503,9 @@ D_fsd_cg_cp_fs2_edges_b0x807fffff:
   fsd f30, 983(x23) # perform store
   addi x23, x23, 983 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x24 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x24, D_fsd_cg_cp_fs2_edges_b0x807fffff, D_fsd_cg_cp_fs2_edges_b0x807fffff_str)
-#else
-  fsd f30, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x8, x7, D_fsd_cg_cp_fs2_edges_b0x807fffff, D_fsd_cg_cp_fs2_edges_b0x807fffff_str)
 
@@ -2391,18 +1518,9 @@ D_fsd_cg_cp_fs2_edges_b0x400000:
   fsd f21, -352(x25) # perform store
   addi x25, x25, -352 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x30 contains the expected result. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x25, x8, x7, x30, D_fsd_cg_cp_fs2_edges_b0x400000, D_fsd_cg_cp_fs2_edges_b0x400000_str)
-#else
-  fsd f21, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x8, x7, D_fsd_cg_cp_fs2_edges_b0x400000, D_fsd_cg_cp_fs2_edges_b0x400000_str)
 
@@ -2415,18 +1533,9 @@ D_fsd_cg_cp_fs2_edges_b0x80400000:
   fsd f3, 1583(x3) # perform store
   addi x3, x3, 1583 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x24 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x3, x8, x7, x24, D_fsd_cg_cp_fs2_edges_b0x80400000, D_fsd_cg_cp_fs2_edges_b0x80400000_str)
-#else
-  fsd f3, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x8, x7, D_fsd_cg_cp_fs2_edges_b0x80400000, D_fsd_cg_cp_fs2_edges_b0x80400000_str)
 
@@ -2439,18 +1548,9 @@ D_fsd_cg_cp_fs2_edges_b0x1:
   fsd f12, -1157(x21) # perform store
   addi x21, x21, -1157 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x25 contains the expected result. x21 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x21, x8, x7, x25, D_fsd_cg_cp_fs2_edges_b0x1, D_fsd_cg_cp_fs2_edges_b0x1_str)
-#else
-  fsd f12, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x8, x7, D_fsd_cg_cp_fs2_edges_b0x1, D_fsd_cg_cp_fs2_edges_b0x1_str)
 
@@ -2463,18 +1563,9 @@ D_fsd_cg_cp_fs2_edges_b0x80000001:
   fsd f14, 1867(x22) # perform store
   addi x22, x22, 1867 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x11 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x11, D_fsd_cg_cp_fs2_edges_b0x80000001, D_fsd_cg_cp_fs2_edges_b0x80000001_str)
-#else
-  fsd f14, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x8, x7, D_fsd_cg_cp_fs2_edges_b0x80000001, D_fsd_cg_cp_fs2_edges_b0x80000001_str)
 
@@ -2487,18 +1578,9 @@ D_fsd_cg_cp_fs2_edges_b0x7f800000:
   fsd f11, 352(x5) # perform store
   addi x5, x5, 352 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x28 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x28, D_fsd_cg_cp_fs2_edges_b0x7f800000, D_fsd_cg_cp_fs2_edges_b0x7f800000_str)
-#else
-  fsd f11, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x5, x8, x7, D_fsd_cg_cp_fs2_edges_b0x7f800000, D_fsd_cg_cp_fs2_edges_b0x7f800000_str)
 
@@ -2511,18 +1593,9 @@ D_fsd_cg_cp_fs2_edges_b0xff800000:
   fsd f5, 1631(x20) # perform store
   addi x20, x20, 1631 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x22 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x22, D_fsd_cg_cp_fs2_edges_b0xff800000, D_fsd_cg_cp_fs2_edges_b0xff800000_str)
-#else
-  fsd f5, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x8, x7, D_fsd_cg_cp_fs2_edges_b0xff800000, D_fsd_cg_cp_fs2_edges_b0xff800000_str)
 
@@ -2535,18 +1608,9 @@ D_fsd_cg_cp_fs2_edges_b0x7fc00000:
   fsd f12, -595(x9) # perform store
   addi x9, x9, -595 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, D_fsd_cg_cp_fs2_edges_b0x7fc00000, D_fsd_cg_cp_fs2_edges_b0x7fc00000_str)
-#else
-  fsd f12, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x8, x7, D_fsd_cg_cp_fs2_edges_b0x7fc00000, D_fsd_cg_cp_fs2_edges_b0x7fc00000_str)
 
@@ -2559,18 +1623,9 @@ D_fsd_cg_cp_fs2_edges_b0x7fffffff:
   fsd f22, -1516(x5) # perform store
   addi x5, x5, -1516 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x14 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x14, D_fsd_cg_cp_fs2_edges_b0x7fffffff, D_fsd_cg_cp_fs2_edges_b0x7fffffff_str)
-#else
-  fsd f22, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x5, x8, x7, D_fsd_cg_cp_fs2_edges_b0x7fffffff, D_fsd_cg_cp_fs2_edges_b0x7fffffff_str)
 
@@ -2583,18 +1638,9 @@ D_fsd_cg_cp_fs2_edges_b0xffffffff:
   fsd f14, -943(x22) # perform store
   addi x22, x22, -943 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x9 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x9, D_fsd_cg_cp_fs2_edges_b0xffffffff, D_fsd_cg_cp_fs2_edges_b0xffffffff_str)
-#else
-  fsd f14, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x8, x7, D_fsd_cg_cp_fs2_edges_b0xffffffff, D_fsd_cg_cp_fs2_edges_b0xffffffff_str)
 
@@ -2607,18 +1653,9 @@ D_fsd_cg_cp_fs2_edges_b0x7f800001:
   fsd f1, -342(x27) # perform store
   addi x27, x27, -342 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x9 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x27, x8, x7, x9, D_fsd_cg_cp_fs2_edges_b0x7f800001, D_fsd_cg_cp_fs2_edges_b0x7f800001_str)
-#else
-  fsd f1, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x8, x7, D_fsd_cg_cp_fs2_edges_b0x7f800001, D_fsd_cg_cp_fs2_edges_b0x7f800001_str)
 
@@ -2631,18 +1668,9 @@ D_fsd_cg_cp_fs2_edges_b0x7fbfffff:
   fsd f15, -64(x29) # perform store
   addi x29, x29, -64 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x22 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x22, D_fsd_cg_cp_fs2_edges_b0x7fbfffff, D_fsd_cg_cp_fs2_edges_b0x7fbfffff_str)
-#else
-  fsd f15, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x8, x7, D_fsd_cg_cp_fs2_edges_b0x7fbfffff, D_fsd_cg_cp_fs2_edges_b0x7fbfffff_str)
 
@@ -2655,18 +1683,9 @@ D_fsd_cg_cp_fs2_edges_b0xffbfffff:
   fsd f17, -1802(x25) # perform store
   addi x25, x25, -1802 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x9 contains the expected result. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x25, x8, x7, x9, D_fsd_cg_cp_fs2_edges_b0xffbfffff, D_fsd_cg_cp_fs2_edges_b0xffbfffff_str)
-#else
-  fsd f17, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x8, x7, D_fsd_cg_cp_fs2_edges_b0xffbfffff, D_fsd_cg_cp_fs2_edges_b0xffbfffff_str)
 
@@ -2679,18 +1698,9 @@ D_fsd_cg_cp_fs2_edges_b0x7ef8654f:
   fsd f9, -1121(x28) # perform store
   addi x28, x28, -1121 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x5 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x5, D_fsd_cg_cp_fs2_edges_b0x7ef8654f, D_fsd_cg_cp_fs2_edges_b0x7ef8654f_str)
-#else
-  fsd f9, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x8, x7, D_fsd_cg_cp_fs2_edges_b0x7ef8654f, D_fsd_cg_cp_fs2_edges_b0x7ef8654f_str)
 
@@ -2703,18 +1713,9 @@ D_fsd_cg_cp_fs2_edges_b0x813d9ab0:
   fsd f27, -402(x17) # perform store
   addi x17, x17, -402 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x11 contains the expected result. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x17, x8, x7, x11, D_fsd_cg_cp_fs2_edges_b0x813d9ab0, D_fsd_cg_cp_fs2_edges_b0x813d9ab0_str)
-#else
-  fsd f27, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x8, x7, D_fsd_cg_cp_fs2_edges_b0x813d9ab0, D_fsd_cg_cp_fs2_edges_b0x813d9ab0_str)
 

--- a/tests/rv64i/D/D-fsw-00.S
+++ b/tests/rv64i/D/D-fsw-00.S
@@ -42,18 +42,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xffffefff00000000:
   fsw f19, 768(x28) # perform store
   addi x28, x28, 768 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x10 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x10, D_fsw_cg_cp_fs2_badNB_D_S_b0xffffefff00000000, D_fsw_cg_cp_fs2_badNB_D_S_b0xffffefff00000000_str)
-#else
-  fsw f19, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xffffefff00000000, D_fsw_cg_cp_fs2_badNB_D_S_b0xffffefff00000000_str)
 
@@ -66,18 +57,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xaaaaaaaa80000000:
   fsw f17, 1541(x14) # perform store
   addi x14, x14, 1541 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x26 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x26, D_fsw_cg_cp_fs2_badNB_D_S_b0xaaaaaaaa80000000, D_fsw_cg_cp_fs2_badNB_D_S_b0xaaaaaaaa80000000_str)
-#else
-  fsw f17, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xaaaaaaaa80000000, D_fsw_cg_cp_fs2_badNB_D_S_b0xaaaaaaaa80000000_str)
 
@@ -90,18 +72,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0x3f800000:
   fsw f26, -932(x21) # perform store
   addi x21, x21, -932 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x23 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x23, D_fsw_cg_cp_fs2_badNB_D_S_b0x3f800000, D_fsw_cg_cp_fs2_badNB_D_S_b0x3f800000_str)
-#else
-  fsw f26, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0x3f800000, D_fsw_cg_cp_fs2_badNB_D_S_b0x3f800000_str)
 
@@ -114,18 +87,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xdeadbeefbf800000:
   fsw f23, -1632(x14) # perform store
   addi x14, x14, -1632 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x15 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x15, D_fsw_cg_cp_fs2_badNB_D_S_b0xdeadbeefbf800000, D_fsw_cg_cp_fs2_badNB_D_S_b0xdeadbeefbf800000_str)
-#else
-  fsw f23, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xdeadbeefbf800000, D_fsw_cg_cp_fs2_badNB_D_S_b0xdeadbeefbf800000_str)
 
@@ -138,18 +102,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xa1b2c3d400800000:
   fsw f28, 243(x30) # perform store
   addi x30, x30, 243 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x21 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x21, D_fsw_cg_cp_fs2_badNB_D_S_b0xa1b2c3d400800000, D_fsw_cg_cp_fs2_badNB_D_S_b0xa1b2c3d400800000_str)
-#else
-  fsw f28, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xa1b2c3d400800000, D_fsw_cg_cp_fs2_badNB_D_S_b0xa1b2c3d400800000_str)
 
@@ -162,18 +117,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xffffffef80800000:
   fsw f31, -939(x22) # perform store
   addi x22, x22, -939 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x18 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x18, D_fsw_cg_cp_fs2_badNB_D_S_b0xffffffef80800000, D_fsw_cg_cp_fs2_badNB_D_S_b0xffffffef80800000_str)
-#else
-  fsw f31, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xffffffef80800000, D_fsw_cg_cp_fs2_badNB_D_S_b0xffffffef80800000_str)
 
@@ -186,18 +132,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffef7f7fffff:
   fsw f28, -422(x26) # perform store
   addi x26, x26, -422 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x21 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x21, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffef7f7fffff, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffef7f7fffff_str)
-#else
-  fsw f28, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffef7f7fffff, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffef7f7fffff_str)
 
@@ -210,18 +147,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0x7e7e7e7eff7fffff:
   fsw f8, -963(x20) # perform store
   addi x20, x20, -963 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x30 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x30, D_fsw_cg_cp_fs2_badNB_D_S_b0x7e7e7e7eff7fffff, D_fsw_cg_cp_fs2_badNB_D_S_b0x7e7e7e7eff7fffff_str)
-#else
-  fsw f8, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0x7e7e7e7eff7fffff, D_fsw_cg_cp_fs2_badNB_D_S_b0x7e7e7e7eff7fffff_str)
 
@@ -234,18 +162,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0x7fffffff7f800000:
   fsw f31, -651(x13) # perform store
   addi x13, x13, -651 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x16 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x16, D_fsw_cg_cp_fs2_badNB_D_S_b0x7fffffff7f800000, D_fsw_cg_cp_fs2_badNB_D_S_b0x7fffffff7f800000_str)
-#else
-  fsw f31, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0x7fffffff7f800000, D_fsw_cg_cp_fs2_badNB_D_S_b0x7fffffff7f800000_str)
 
@@ -258,18 +177,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffffeff800000:
   fsw f11, 1224(x22) # perform store
   addi x22, x22, 1224 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x10 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x10, D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffffeff800000, D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffffeff800000_str)
-#else
-  fsw f11, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffffeff800000, D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffffeff800000_str)
 
@@ -282,18 +192,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xfeedbee57fc00000:
   fsw f20, -1642(x31) # perform store
   addi x31, x31, -1642 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x9 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x9, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeedbee57fc00000, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeedbee57fc00000_str)
-#else
-  fsw f20, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeedbee57fc00000, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeedbee57fc00000_str)
 
@@ -306,18 +207,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xffc0deff7fffffff:
   fsw f9, -8(x13) # perform store
   addi x13, x13, -8 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x16 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x16, D_fsw_cg_cp_fs2_badNB_D_S_b0xffc0deff7fffffff, D_fsw_cg_cp_fs2_badNB_D_S_b0xffc0deff7fffffff_str)
-#else
-  fsw f9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xffc0deff7fffffff, D_fsw_cg_cp_fs2_badNB_D_S_b0xffc0deff7fffffff_str)
 
@@ -330,18 +222,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffff7f800001:
   fsw f26, -1705(x7) # perform store
   addi x7, x7, -1705 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x28 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x28, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffff7f800001, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffff7f800001_str)
-#else
-  fsw f26, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffff7f800001, D_fsw_cg_cp_fs2_badNB_D_S_b0xfeffffff7f800001_str)
 
@@ -354,18 +237,9 @@ D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffeff7fbfffff:
   fsw f16, 1691(x15) # perform store
   addi x15, x15, 1691 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x16 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x16, D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffeff7fbfffff, D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffeff7fbfffff_str)
-#else
-  fsw f16, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffeff7fbfffff, D_fsw_cg_cp_fs2_badNB_D_S_b0xfffffeff7fbfffff_str)
 

--- a/tests/rv64i/F/F-fsw-00.S
+++ b/tests/rv64i/F/F-fsw-00.S
@@ -42,18 +42,9 @@ F_fsw_cg_cp_rs1_nx0_b1:
   fsw f12, 1162(x1) # perform store
   addi x1, x1, 1162 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x30 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x30, F_fsw_cg_cp_rs1_nx0_b1, F_fsw_cg_cp_rs1_nx0_b1_str)
-#else
-  fsw f12, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, F_fsw_cg_cp_rs1_nx0_b1, F_fsw_cg_cp_rs1_nx0_b1_str)
 
@@ -66,18 +57,9 @@ F_fsw_cg_cp_rs1_nx0_b2:
   fsw f27, -122(x2) # perform store
   addi x2, x2, -122 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x26 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x26, F_fsw_cg_cp_rs1_nx0_b2, F_fsw_cg_cp_rs1_nx0_b2_str)
-#else
-  fsw f27, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, F_fsw_cg_cp_rs1_nx0_b2, F_fsw_cg_cp_rs1_nx0_b2_str)
 
@@ -91,18 +73,9 @@ F_fsw_cg_cp_rs1_nx0_b3:
   fsw f23, -170(x3) # perform store
   addi x3, x3, -170 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x15 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x15, F_fsw_cg_cp_rs1_nx0_b3, F_fsw_cg_cp_rs1_nx0_b3_str)
-#else
-  fsw f23, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, F_fsw_cg_cp_rs1_nx0_b3, F_fsw_cg_cp_rs1_nx0_b3_str)
 
@@ -117,18 +90,9 @@ F_fsw_cg_cp_rs1_nx0_b4:
   fsw f0, 729(x4) # perform store
   addi x4, x4, 729 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x17 contains the expected result. x4 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x4, x14, x13, x17, F_fsw_cg_cp_rs1_nx0_b4, F_fsw_cg_cp_rs1_nx0_b4_str)
-#else
-  fsw f0, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x4 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x4, x14, x13, F_fsw_cg_cp_rs1_nx0_b4, F_fsw_cg_cp_rs1_nx0_b4_str)
 
@@ -141,18 +105,9 @@ F_fsw_cg_cp_rs1_nx0_b5:
   fsw f8, -771(x5) # perform store
   addi x5, x5, -771 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x10 contains the expected result. x5 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x5, x14, x13, x10, F_fsw_cg_cp_rs1_nx0_b5, F_fsw_cg_cp_rs1_nx0_b5_str)
-#else
-  fsw f8, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x5 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x5, x14, x13, F_fsw_cg_cp_rs1_nx0_b5, F_fsw_cg_cp_rs1_nx0_b5_str)
 
@@ -165,18 +120,9 @@ F_fsw_cg_cp_rs1_nx0_b6:
   fsw f15, 982(x6) # perform store
   addi x6, x6, 982 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x23 contains the expected result. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x6, x14, x13, x23, F_fsw_cg_cp_rs1_nx0_b6, F_fsw_cg_cp_rs1_nx0_b6_str)
-#else
-  fsw f15, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x14, x13, F_fsw_cg_cp_rs1_nx0_b6, F_fsw_cg_cp_rs1_nx0_b6_str)
 
@@ -189,18 +135,9 @@ F_fsw_cg_cp_rs1_nx0_b7:
   fsw f14, 1918(x7) # perform store
   addi x7, x7, 1918 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x3 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x3, F_fsw_cg_cp_rs1_nx0_b7, F_fsw_cg_cp_rs1_nx0_b7_str)
-#else
-  fsw f14, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x14, x13, F_fsw_cg_cp_rs1_nx0_b7, F_fsw_cg_cp_rs1_nx0_b7_str)
 
@@ -213,18 +150,9 @@ F_fsw_cg_cp_rs1_nx0_b8:
   fsw f14, 313(x8) # perform store
   addi x8, x8, 313 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x5 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x5, F_fsw_cg_cp_rs1_nx0_b8, F_fsw_cg_cp_rs1_nx0_b8_str)
-#else
-  fsw f14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x14, x13, F_fsw_cg_cp_rs1_nx0_b8, F_fsw_cg_cp_rs1_nx0_b8_str)
 
@@ -237,18 +165,9 @@ F_fsw_cg_cp_rs1_nx0_b9:
   fsw f30, 1016(x9) # perform store
   addi x9, x9, 1016 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x29 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x29, F_fsw_cg_cp_rs1_nx0_b9, F_fsw_cg_cp_rs1_nx0_b9_str)
-#else
-  fsw f30, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x14, x13, F_fsw_cg_cp_rs1_nx0_b9, F_fsw_cg_cp_rs1_nx0_b9_str)
 
@@ -261,18 +180,9 @@ F_fsw_cg_cp_rs1_nx0_b10:
   fsw f20, 952(x10) # perform store
   addi x10, x10, 952 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x30 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x30, F_fsw_cg_cp_rs1_nx0_b10, F_fsw_cg_cp_rs1_nx0_b10_str)
-#else
-  fsw f20, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x14, x13, F_fsw_cg_cp_rs1_nx0_b10, F_fsw_cg_cp_rs1_nx0_b10_str)
 
@@ -285,18 +195,9 @@ F_fsw_cg_cp_rs1_nx0_b11:
   fsw f2, 1497(x11) # perform store
   addi x11, x11, 1497 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x5 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x5, F_fsw_cg_cp_rs1_nx0_b11, F_fsw_cg_cp_rs1_nx0_b11_str)
-#else
-  fsw f2, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x14, x13, F_fsw_cg_cp_rs1_nx0_b11, F_fsw_cg_cp_rs1_nx0_b11_str)
 
@@ -309,18 +210,9 @@ F_fsw_cg_cp_rs1_nx0_b12:
   fsw f2, -575(x12) # perform store
   addi x12, x12, -575 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x25 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x25, F_fsw_cg_cp_rs1_nx0_b12, F_fsw_cg_cp_rs1_nx0_b12_str)
-#else
-  fsw f2, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x14, x13, F_fsw_cg_cp_rs1_nx0_b12, F_fsw_cg_cp_rs1_nx0_b12_str)
 
@@ -335,18 +227,9 @@ F_fsw_cg_cp_rs1_nx0_b13:
   fsw f1, 1387(x13) # perform store
   addi x13, x13, 1387 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x1 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x1, F_fsw_cg_cp_rs1_nx0_b13, F_fsw_cg_cp_rs1_nx0_b13_str)
-#else
-  fsw f1, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, F_fsw_cg_cp_rs1_nx0_b13, F_fsw_cg_cp_rs1_nx0_b13_str)
 
@@ -359,18 +242,9 @@ F_fsw_cg_cp_rs1_nx0_b14:
   fsw f29, 729(x14) # perform store
   addi x14, x14, 729 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x18 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x18, F_fsw_cg_cp_rs1_nx0_b14, F_fsw_cg_cp_rs1_nx0_b14_str)
-#else
-  fsw f29, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, F_fsw_cg_cp_rs1_nx0_b14, F_fsw_cg_cp_rs1_nx0_b14_str)
 
@@ -383,18 +257,9 @@ F_fsw_cg_cp_rs1_nx0_b15:
   fsw f21, -1799(x15) # perform store
   addi x15, x15, -1799 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x17 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x17, F_fsw_cg_cp_rs1_nx0_b15, F_fsw_cg_cp_rs1_nx0_b15_str)
-#else
-  fsw f21, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, F_fsw_cg_cp_rs1_nx0_b15, F_fsw_cg_cp_rs1_nx0_b15_str)
 
@@ -407,18 +272,9 @@ F_fsw_cg_cp_rs1_nx0_b16:
   fsw f12, -1481(x16) # perform store
   addi x16, x16, -1481 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x19 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x19, F_fsw_cg_cp_rs1_nx0_b16, F_fsw_cg_cp_rs1_nx0_b16_str)
-#else
-  fsw f12, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, F_fsw_cg_cp_rs1_nx0_b16, F_fsw_cg_cp_rs1_nx0_b16_str)
 
@@ -431,18 +287,9 @@ F_fsw_cg_cp_rs1_nx0_b17:
   fsw f14, 1123(x17) # perform store
   addi x17, x17, 1123 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x3 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x3, F_fsw_cg_cp_rs1_nx0_b17, F_fsw_cg_cp_rs1_nx0_b17_str)
-#else
-  fsw f14, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, F_fsw_cg_cp_rs1_nx0_b17, F_fsw_cg_cp_rs1_nx0_b17_str)
 
@@ -455,18 +302,9 @@ F_fsw_cg_cp_rs1_nx0_b18:
   fsw f26, -418(x18) # perform store
   addi x18, x18, -418 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x1 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x1, F_fsw_cg_cp_rs1_nx0_b18, F_fsw_cg_cp_rs1_nx0_b18_str)
-#else
-  fsw f26, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, F_fsw_cg_cp_rs1_nx0_b18, F_fsw_cg_cp_rs1_nx0_b18_str)
 
@@ -479,18 +317,9 @@ F_fsw_cg_cp_rs1_nx0_b19:
   fsw f21, -1335(x19) # perform store
   addi x19, x19, -1335 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x12 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x12, F_fsw_cg_cp_rs1_nx0_b19, F_fsw_cg_cp_rs1_nx0_b19_str)
-#else
-  fsw f21, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, F_fsw_cg_cp_rs1_nx0_b19, F_fsw_cg_cp_rs1_nx0_b19_str)
 
@@ -503,18 +332,9 @@ F_fsw_cg_cp_rs1_nx0_b20:
   fsw f3, -1300(x20) # perform store
   addi x20, x20, -1300 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x12 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x12, F_fsw_cg_cp_rs1_nx0_b20, F_fsw_cg_cp_rs1_nx0_b20_str)
-#else
-  fsw f3, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, F_fsw_cg_cp_rs1_nx0_b20, F_fsw_cg_cp_rs1_nx0_b20_str)
 
@@ -527,18 +347,9 @@ F_fsw_cg_cp_rs1_nx0_b21:
   fsw f14, 969(x21) # perform store
   addi x21, x21, 969 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x11 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x11, F_fsw_cg_cp_rs1_nx0_b21, F_fsw_cg_cp_rs1_nx0_b21_str)
-#else
-  fsw f14, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, F_fsw_cg_cp_rs1_nx0_b21, F_fsw_cg_cp_rs1_nx0_b21_str)
 
@@ -551,18 +362,9 @@ F_fsw_cg_cp_rs1_nx0_b22:
   fsw f6, 799(x22) # perform store
   addi x22, x22, 799 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x23 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x23, F_fsw_cg_cp_rs1_nx0_b22, F_fsw_cg_cp_rs1_nx0_b22_str)
-#else
-  fsw f6, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, F_fsw_cg_cp_rs1_nx0_b22, F_fsw_cg_cp_rs1_nx0_b22_str)
 
@@ -575,18 +377,9 @@ F_fsw_cg_cp_rs1_nx0_b23:
   fsw f30, -147(x23) # perform store
   addi x23, x23, -147 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x26 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x26, F_fsw_cg_cp_rs1_nx0_b23, F_fsw_cg_cp_rs1_nx0_b23_str)
-#else
-  fsw f30, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, F_fsw_cg_cp_rs1_nx0_b23, F_fsw_cg_cp_rs1_nx0_b23_str)
 
@@ -599,18 +392,9 @@ F_fsw_cg_cp_rs1_nx0_b24:
   fsw f30, 659(x24) # perform store
   addi x24, x24, 659 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x3 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x3, F_fsw_cg_cp_rs1_nx0_b24, F_fsw_cg_cp_rs1_nx0_b24_str)
-#else
-  fsw f30, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, F_fsw_cg_cp_rs1_nx0_b24, F_fsw_cg_cp_rs1_nx0_b24_str)
 
@@ -623,18 +407,9 @@ F_fsw_cg_cp_rs1_nx0_b25:
   fsw f24, -358(x25) # perform store
   addi x25, x25, -358 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x16 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x16, F_fsw_cg_cp_rs1_nx0_b25, F_fsw_cg_cp_rs1_nx0_b25_str)
-#else
-  fsw f24, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, F_fsw_cg_cp_rs1_nx0_b25, F_fsw_cg_cp_rs1_nx0_b25_str)
 
@@ -647,18 +422,9 @@ F_fsw_cg_cp_rs1_nx0_b26:
   fsw f0, -1726(x26) # perform store
   addi x26, x26, -1726 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x18 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x18, F_fsw_cg_cp_rs1_nx0_b26, F_fsw_cg_cp_rs1_nx0_b26_str)
-#else
-  fsw f0, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, F_fsw_cg_cp_rs1_nx0_b26, F_fsw_cg_cp_rs1_nx0_b26_str)
 
@@ -671,18 +437,9 @@ F_fsw_cg_cp_rs1_nx0_b27:
   fsw f18, -1943(x27) # perform store
   addi x27, x27, -1943 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x14 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x14, F_fsw_cg_cp_rs1_nx0_b27, F_fsw_cg_cp_rs1_nx0_b27_str)
-#else
-  fsw f18, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, F_fsw_cg_cp_rs1_nx0_b27, F_fsw_cg_cp_rs1_nx0_b27_str)
 
@@ -695,18 +452,9 @@ F_fsw_cg_cp_rs1_nx0_b28:
   fsw f0, 526(x28) # perform store
   addi x28, x28, 526 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x20 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x20, F_fsw_cg_cp_rs1_nx0_b28, F_fsw_cg_cp_rs1_nx0_b28_str)
-#else
-  fsw f0, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, F_fsw_cg_cp_rs1_nx0_b28, F_fsw_cg_cp_rs1_nx0_b28_str)
 
@@ -719,18 +467,9 @@ F_fsw_cg_cp_rs1_nx0_b29:
   fsw f28, -356(x29) # perform store
   addi x29, x29, -356 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x22 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x22, F_fsw_cg_cp_rs1_nx0_b29, F_fsw_cg_cp_rs1_nx0_b29_str)
-#else
-  fsw f28, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, F_fsw_cg_cp_rs1_nx0_b29, F_fsw_cg_cp_rs1_nx0_b29_str)
 
@@ -743,18 +482,9 @@ F_fsw_cg_cp_rs1_nx0_b30:
   fsw f28, 848(x30) # perform store
   addi x30, x30, 848 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x24 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x24, F_fsw_cg_cp_rs1_nx0_b30, F_fsw_cg_cp_rs1_nx0_b30_str)
-#else
-  fsw f28, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, F_fsw_cg_cp_rs1_nx0_b30, F_fsw_cg_cp_rs1_nx0_b30_str)
 
@@ -768,18 +498,9 @@ F_fsw_cg_cp_rs1_nx0_b31:
   fsw f5, 1041(x31) # perform store
   addi x31, x31, 1041 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x13 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x13, F_fsw_cg_cp_rs1_nx0_b31, F_fsw_cg_cp_rs1_nx0_b31_str)
-#else
-  fsw f5, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, F_fsw_cg_cp_rs1_nx0_b31, F_fsw_cg_cp_rs1_nx0_b31_str)
 
@@ -796,18 +517,9 @@ F_fsw_cg_cp_imm_edges_0x0:
   fsw f6, 0(x19) # perform store
   addi x19, x19, 0 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x21 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x21, F_fsw_cg_cp_imm_edges_0x0, F_fsw_cg_cp_imm_edges_0x0_str)
-#else
-  fsw f6, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, F_fsw_cg_cp_imm_edges_0x0, F_fsw_cg_cp_imm_edges_0x0_str)
 
@@ -820,18 +532,9 @@ F_fsw_cg_cp_imm_edges_0x1:
   fsw f16, 1(x18) # perform store
   addi x18, x18, 1 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, F_fsw_cg_cp_imm_edges_0x1, F_fsw_cg_cp_imm_edges_0x1_str)
-#else
-  fsw f16, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, F_fsw_cg_cp_imm_edges_0x1, F_fsw_cg_cp_imm_edges_0x1_str)
 
@@ -844,18 +547,9 @@ F_fsw_cg_cp_imm_edges_0x2:
   fsw f3, 2(x28) # perform store
   addi x28, x28, 2 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x27 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x27, F_fsw_cg_cp_imm_edges_0x2, F_fsw_cg_cp_imm_edges_0x2_str)
-#else
-  fsw f3, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, F_fsw_cg_cp_imm_edges_0x2, F_fsw_cg_cp_imm_edges_0x2_str)
 
@@ -868,18 +562,9 @@ F_fsw_cg_cp_imm_edges_0x3:
   fsw f16, 3(x21) # perform store
   addi x21, x21, 3 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x19 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x19, F_fsw_cg_cp_imm_edges_0x3, F_fsw_cg_cp_imm_edges_0x3_str)
-#else
-  fsw f16, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, F_fsw_cg_cp_imm_edges_0x3, F_fsw_cg_cp_imm_edges_0x3_str)
 
@@ -892,18 +577,9 @@ F_fsw_cg_cp_imm_edges_0x4:
   fsw f13, 4(x18) # perform store
   addi x18, x18, 4 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, F_fsw_cg_cp_imm_edges_0x4, F_fsw_cg_cp_imm_edges_0x4_str)
-#else
-  fsw f13, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, F_fsw_cg_cp_imm_edges_0x4, F_fsw_cg_cp_imm_edges_0x4_str)
 
@@ -916,18 +592,9 @@ F_fsw_cg_cp_imm_edges_0x8:
   fsw f1, 8(x8) # perform store
   addi x8, x8, 8 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x17 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x17, F_fsw_cg_cp_imm_edges_0x8, F_fsw_cg_cp_imm_edges_0x8_str)
-#else
-  fsw f1, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, F_fsw_cg_cp_imm_edges_0x8, F_fsw_cg_cp_imm_edges_0x8_str)
 
@@ -940,18 +607,9 @@ F_fsw_cg_cp_imm_edges_0x10:
   fsw f7, 16(x15) # perform store
   addi x15, x15, 16 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, F_fsw_cg_cp_imm_edges_0x10, F_fsw_cg_cp_imm_edges_0x10_str)
-#else
-  fsw f7, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, F_fsw_cg_cp_imm_edges_0x10, F_fsw_cg_cp_imm_edges_0x10_str)
 
@@ -964,18 +622,9 @@ F_fsw_cg_cp_imm_edges_0x20:
   fsw f6, 32(x12) # perform store
   addi x12, x12, 32 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x3 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x3, F_fsw_cg_cp_imm_edges_0x20, F_fsw_cg_cp_imm_edges_0x20_str)
-#else
-  fsw f6, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, F_fsw_cg_cp_imm_edges_0x20, F_fsw_cg_cp_imm_edges_0x20_str)
 
@@ -988,18 +637,9 @@ F_fsw_cg_cp_imm_edges_0x40:
   fsw f3, 64(x23) # perform store
   addi x23, x23, 64 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x14 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x14, F_fsw_cg_cp_imm_edges_0x40, F_fsw_cg_cp_imm_edges_0x40_str)
-#else
-  fsw f3, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, F_fsw_cg_cp_imm_edges_0x40, F_fsw_cg_cp_imm_edges_0x40_str)
 
@@ -1012,18 +652,9 @@ F_fsw_cg_cp_imm_edges_0x80:
   fsw f11, 128(x30) # perform store
   addi x30, x30, 128 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x20 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x20, F_fsw_cg_cp_imm_edges_0x80, F_fsw_cg_cp_imm_edges_0x80_str)
-#else
-  fsw f11, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, F_fsw_cg_cp_imm_edges_0x80, F_fsw_cg_cp_imm_edges_0x80_str)
 
@@ -1036,18 +667,9 @@ F_fsw_cg_cp_imm_edges_0x100:
   fsw f13, 256(x2) # perform store
   addi x2, x2, 256 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x28 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x28, F_fsw_cg_cp_imm_edges_0x100, F_fsw_cg_cp_imm_edges_0x100_str)
-#else
-  fsw f13, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, F_fsw_cg_cp_imm_edges_0x100, F_fsw_cg_cp_imm_edges_0x100_str)
 
@@ -1060,18 +682,9 @@ F_fsw_cg_cp_imm_edges_0x200:
   fsw f14, 512(x14) # perform store
   addi x14, x14, 512 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x25 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x25, F_fsw_cg_cp_imm_edges_0x200, F_fsw_cg_cp_imm_edges_0x200_str)
-#else
-  fsw f14, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, F_fsw_cg_cp_imm_edges_0x200, F_fsw_cg_cp_imm_edges_0x200_str)
 
@@ -1084,18 +697,9 @@ F_fsw_cg_cp_imm_edges_0x3ff:
   fsw f20, 1023(x31) # perform store
   addi x31, x31, 1023 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x27 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x27, F_fsw_cg_cp_imm_edges_0x3ff, F_fsw_cg_cp_imm_edges_0x3ff_str)
-#else
-  fsw f20, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, F_fsw_cg_cp_imm_edges_0x3ff, F_fsw_cg_cp_imm_edges_0x3ff_str)
 
@@ -1108,18 +712,9 @@ F_fsw_cg_cp_imm_edges_0x400:
   fsw f21, 1024(x1) # perform store
   addi x1, x1, 1024 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x27 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x27, F_fsw_cg_cp_imm_edges_0x400, F_fsw_cg_cp_imm_edges_0x400_str)
-#else
-  fsw f21, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, F_fsw_cg_cp_imm_edges_0x400, F_fsw_cg_cp_imm_edges_0x400_str)
 
@@ -1132,18 +727,9 @@ F_fsw_cg_cp_imm_edges_0x703:
   fsw f1, 1795(x23) # perform store
   addi x23, x23, 1795 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x26 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x26, F_fsw_cg_cp_imm_edges_0x703, F_fsw_cg_cp_imm_edges_0x703_str)
-#else
-  fsw f1, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, F_fsw_cg_cp_imm_edges_0x703, F_fsw_cg_cp_imm_edges_0x703_str)
 
@@ -1156,18 +742,9 @@ F_fsw_cg_cp_imm_edges_0x7ff:
   fsw f19, 2047(x8) # perform store
   addi x8, x8, 2047 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x19 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x19, F_fsw_cg_cp_imm_edges_0x7ff, F_fsw_cg_cp_imm_edges_0x7ff_str)
-#else
-  fsw f19, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, F_fsw_cg_cp_imm_edges_0x7ff, F_fsw_cg_cp_imm_edges_0x7ff_str)
 
@@ -1181,18 +758,9 @@ F_fsw_cg_cp_imm_edges_m0x800:
   fsw f5, -2048(x2) # perform store
   addi x2, x2, -2048 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x26 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x26, F_fsw_cg_cp_imm_edges_m0x800, F_fsw_cg_cp_imm_edges_m0x800_str)
-#else
-  fsw f5, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, F_fsw_cg_cp_imm_edges_m0x800, F_fsw_cg_cp_imm_edges_m0x800_str)
 
@@ -1205,18 +773,9 @@ F_fsw_cg_cp_imm_edges_m0x7ff:
   fsw f11, -2047(x31) # perform store
   addi x31, x31, -2047 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x21 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x21, F_fsw_cg_cp_imm_edges_m0x7ff, F_fsw_cg_cp_imm_edges_m0x7ff_str)
-#else
-  fsw f11, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, F_fsw_cg_cp_imm_edges_m0x7ff, F_fsw_cg_cp_imm_edges_m0x7ff_str)
 
@@ -1229,18 +788,9 @@ F_fsw_cg_cp_imm_edges_m0x2:
   fsw f11, -2(x26) # perform store
   addi x26, x26, -2 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x7 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x7, F_fsw_cg_cp_imm_edges_m0x2, F_fsw_cg_cp_imm_edges_m0x2_str)
-#else
-  fsw f11, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, F_fsw_cg_cp_imm_edges_m0x2, F_fsw_cg_cp_imm_edges_m0x2_str)
 
@@ -1253,18 +803,9 @@ F_fsw_cg_cp_imm_edges_m0x1:
   fsw f20, -1(x17) # perform store
   addi x17, x17, -1 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x10 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x10, F_fsw_cg_cp_imm_edges_m0x1, F_fsw_cg_cp_imm_edges_m0x1_str)
-#else
-  fsw f20, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, F_fsw_cg_cp_imm_edges_m0x1, F_fsw_cg_cp_imm_edges_m0x1_str)
 
@@ -1281,18 +822,9 @@ F_fsw_cg_cp_fs2_b0:
   fsw f0, 2(x14) # perform store
   addi x14, x14, 2 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x28 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x28, F_fsw_cg_cp_fs2_b0, F_fsw_cg_cp_fs2_b0_str)
-#else
-  fsw f0, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, F_fsw_cg_cp_fs2_b0, F_fsw_cg_cp_fs2_b0_str)
 
@@ -1305,18 +837,9 @@ F_fsw_cg_cp_fs2_b1:
   fsw f1, 648(x30) # perform store
   addi x30, x30, 648 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x19 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x19, F_fsw_cg_cp_fs2_b1, F_fsw_cg_cp_fs2_b1_str)
-#else
-  fsw f1, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, F_fsw_cg_cp_fs2_b1, F_fsw_cg_cp_fs2_b1_str)
 
@@ -1329,18 +852,9 @@ F_fsw_cg_cp_fs2_b2:
   fsw f2, 1825(x7) # perform store
   addi x7, x7, 1825 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x10 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x10, F_fsw_cg_cp_fs2_b2, F_fsw_cg_cp_fs2_b2_str)
-#else
-  fsw f2, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, F_fsw_cg_cp_fs2_b2, F_fsw_cg_cp_fs2_b2_str)
 
@@ -1353,18 +867,9 @@ F_fsw_cg_cp_fs2_b3:
   fsw f3, -1014(x26) # perform store
   addi x26, x26, -1014 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x1 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x1, F_fsw_cg_cp_fs2_b3, F_fsw_cg_cp_fs2_b3_str)
-#else
-  fsw f3, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, F_fsw_cg_cp_fs2_b3, F_fsw_cg_cp_fs2_b3_str)
 
@@ -1377,18 +882,9 @@ F_fsw_cg_cp_fs2_b4:
   fsw f4, 1685(x24) # perform store
   addi x24, x24, 1685 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x7 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x7, F_fsw_cg_cp_fs2_b4, F_fsw_cg_cp_fs2_b4_str)
-#else
-  fsw f4, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, F_fsw_cg_cp_fs2_b4, F_fsw_cg_cp_fs2_b4_str)
 
@@ -1401,18 +897,9 @@ F_fsw_cg_cp_fs2_b5:
   fsw f5, -1566(x22) # perform store
   addi x22, x22, -1566 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x15 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x15, F_fsw_cg_cp_fs2_b5, F_fsw_cg_cp_fs2_b5_str)
-#else
-  fsw f5, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, F_fsw_cg_cp_fs2_b5, F_fsw_cg_cp_fs2_b5_str)
 
@@ -1425,18 +912,9 @@ F_fsw_cg_cp_fs2_b6:
   fsw f6, -1469(x15) # perform store
   addi x15, x15, -1469 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x25 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x25, F_fsw_cg_cp_fs2_b6, F_fsw_cg_cp_fs2_b6_str)
-#else
-  fsw f6, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, F_fsw_cg_cp_fs2_b6, F_fsw_cg_cp_fs2_b6_str)
 
@@ -1449,18 +927,9 @@ F_fsw_cg_cp_fs2_b7:
   fsw f7, -557(x31) # perform store
   addi x31, x31, -557 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x25 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x25, F_fsw_cg_cp_fs2_b7, F_fsw_cg_cp_fs2_b7_str)
-#else
-  fsw f7, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, F_fsw_cg_cp_fs2_b7, F_fsw_cg_cp_fs2_b7_str)
 
@@ -1473,18 +942,9 @@ F_fsw_cg_cp_fs2_b8:
   fsw f8, 882(x7) # perform store
   addi x7, x7, 882 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x29 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x29, F_fsw_cg_cp_fs2_b8, F_fsw_cg_cp_fs2_b8_str)
-#else
-  fsw f8, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, F_fsw_cg_cp_fs2_b8, F_fsw_cg_cp_fs2_b8_str)
 
@@ -1497,18 +957,9 @@ F_fsw_cg_cp_fs2_b9:
   fsw f9, 1821(x28) # perform store
   addi x28, x28, 1821 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x19 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x19, F_fsw_cg_cp_fs2_b9, F_fsw_cg_cp_fs2_b9_str)
-#else
-  fsw f9, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, F_fsw_cg_cp_fs2_b9, F_fsw_cg_cp_fs2_b9_str)
 
@@ -1521,18 +972,9 @@ F_fsw_cg_cp_fs2_b10:
   fsw f10, 1152(x20) # perform store
   addi x20, x20, 1152 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x1 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x1, F_fsw_cg_cp_fs2_b10, F_fsw_cg_cp_fs2_b10_str)
-#else
-  fsw f10, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, F_fsw_cg_cp_fs2_b10, F_fsw_cg_cp_fs2_b10_str)
 
@@ -1545,18 +987,9 @@ F_fsw_cg_cp_fs2_b11:
   fsw f11, 946(x21) # perform store
   addi x21, x21, 946 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x7 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x7, F_fsw_cg_cp_fs2_b11, F_fsw_cg_cp_fs2_b11_str)
-#else
-  fsw f11, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, F_fsw_cg_cp_fs2_b11, F_fsw_cg_cp_fs2_b11_str)
 
@@ -1570,18 +1003,9 @@ F_fsw_cg_cp_fs2_b12:
   fsw f12, -2048(x13) # perform store
   addi x13, x13, -2048 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x26 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x26, F_fsw_cg_cp_fs2_b12, F_fsw_cg_cp_fs2_b12_str)
-#else
-  fsw f12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, F_fsw_cg_cp_fs2_b12, F_fsw_cg_cp_fs2_b12_str)
 
@@ -1594,18 +1018,9 @@ F_fsw_cg_cp_fs2_b13:
   fsw f13, 321(x31) # perform store
   addi x31, x31, 321 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x7 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x7, F_fsw_cg_cp_fs2_b13, F_fsw_cg_cp_fs2_b13_str)
-#else
-  fsw f13, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, F_fsw_cg_cp_fs2_b13, F_fsw_cg_cp_fs2_b13_str)
 
@@ -1618,18 +1033,9 @@ F_fsw_cg_cp_fs2_b14:
   fsw f14, 224(x22) # perform store
   addi x22, x22, 224 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x17 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x17, F_fsw_cg_cp_fs2_b14, F_fsw_cg_cp_fs2_b14_str)
-#else
-  fsw f14, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, F_fsw_cg_cp_fs2_b14, F_fsw_cg_cp_fs2_b14_str)
 
@@ -1642,18 +1048,9 @@ F_fsw_cg_cp_fs2_b15:
   fsw f15, -5(x24) # perform store
   addi x24, x24, -5 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x10 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x10, F_fsw_cg_cp_fs2_b15, F_fsw_cg_cp_fs2_b15_str)
-#else
-  fsw f15, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, F_fsw_cg_cp_fs2_b15, F_fsw_cg_cp_fs2_b15_str)
 
@@ -1666,18 +1063,9 @@ F_fsw_cg_cp_fs2_b16:
   fsw f16, -1068(x2) # perform store
   addi x2, x2, -1068 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x29 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x29, F_fsw_cg_cp_fs2_b16, F_fsw_cg_cp_fs2_b16_str)
-#else
-  fsw f16, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, F_fsw_cg_cp_fs2_b16, F_fsw_cg_cp_fs2_b16_str)
 
@@ -1690,18 +1078,9 @@ F_fsw_cg_cp_fs2_b17:
   fsw f17, -1720(x29) # perform store
   addi x29, x29, -1720 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x15 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x15, F_fsw_cg_cp_fs2_b17, F_fsw_cg_cp_fs2_b17_str)
-#else
-  fsw f17, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, F_fsw_cg_cp_fs2_b17, F_fsw_cg_cp_fs2_b17_str)
 
@@ -1714,18 +1093,9 @@ F_fsw_cg_cp_fs2_b18:
   fsw f18, -19(x21) # perform store
   addi x21, x21, -19 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x3 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x3, F_fsw_cg_cp_fs2_b18, F_fsw_cg_cp_fs2_b18_str)
-#else
-  fsw f18, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, F_fsw_cg_cp_fs2_b18, F_fsw_cg_cp_fs2_b18_str)
 
@@ -1738,18 +1108,9 @@ F_fsw_cg_cp_fs2_b19:
   fsw f19, -349(x29) # perform store
   addi x29, x29, -349 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x8 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x8, F_fsw_cg_cp_fs2_b19, F_fsw_cg_cp_fs2_b19_str)
-#else
-  fsw f19, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, F_fsw_cg_cp_fs2_b19, F_fsw_cg_cp_fs2_b19_str)
 
@@ -1762,18 +1123,9 @@ F_fsw_cg_cp_fs2_b20:
   fsw f20, 740(x18) # perform store
   addi x18, x18, 740 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, F_fsw_cg_cp_fs2_b20, F_fsw_cg_cp_fs2_b20_str)
-#else
-  fsw f20, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, F_fsw_cg_cp_fs2_b20, F_fsw_cg_cp_fs2_b20_str)
 
@@ -1786,18 +1138,9 @@ F_fsw_cg_cp_fs2_b21:
   fsw f21, -654(x27) # perform store
   addi x27, x27, -654 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x11 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x11, F_fsw_cg_cp_fs2_b21, F_fsw_cg_cp_fs2_b21_str)
-#else
-  fsw f21, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, F_fsw_cg_cp_fs2_b21, F_fsw_cg_cp_fs2_b21_str)
 
@@ -1810,18 +1153,9 @@ F_fsw_cg_cp_fs2_b22:
   fsw f22, -2033(x11) # perform store
   addi x11, x11, -2033 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x19 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x19, F_fsw_cg_cp_fs2_b22, F_fsw_cg_cp_fs2_b22_str)
-#else
-  fsw f22, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, F_fsw_cg_cp_fs2_b22, F_fsw_cg_cp_fs2_b22_str)
 
@@ -1834,18 +1168,9 @@ F_fsw_cg_cp_fs2_b23:
   fsw f23, 1314(x7) # perform store
   addi x7, x7, 1314 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x18 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x18, F_fsw_cg_cp_fs2_b23, F_fsw_cg_cp_fs2_b23_str)
-#else
-  fsw f23, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, F_fsw_cg_cp_fs2_b23, F_fsw_cg_cp_fs2_b23_str)
 
@@ -1858,18 +1183,9 @@ F_fsw_cg_cp_fs2_b24:
   fsw f24, -1454(x13) # perform store
   addi x13, x13, -1454 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x25 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x25, F_fsw_cg_cp_fs2_b24, F_fsw_cg_cp_fs2_b24_str)
-#else
-  fsw f24, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, F_fsw_cg_cp_fs2_b24, F_fsw_cg_cp_fs2_b24_str)
 
@@ -1882,18 +1198,9 @@ F_fsw_cg_cp_fs2_b25:
   fsw f25, 1677(x30) # perform store
   addi x30, x30, 1677 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x14 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x14, F_fsw_cg_cp_fs2_b25, F_fsw_cg_cp_fs2_b25_str)
-#else
-  fsw f25, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, F_fsw_cg_cp_fs2_b25, F_fsw_cg_cp_fs2_b25_str)
 
@@ -1906,18 +1213,9 @@ F_fsw_cg_cp_fs2_b26:
   fsw f26, -474(x27) # perform store
   addi x27, x27, -474 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x18 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x18, F_fsw_cg_cp_fs2_b26, F_fsw_cg_cp_fs2_b26_str)
-#else
-  fsw f26, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, F_fsw_cg_cp_fs2_b26, F_fsw_cg_cp_fs2_b26_str)
 
@@ -1930,18 +1228,9 @@ F_fsw_cg_cp_fs2_b27:
   fsw f27, -1533(x8) # perform store
   addi x8, x8, -1533 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x23 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x23, F_fsw_cg_cp_fs2_b27, F_fsw_cg_cp_fs2_b27_str)
-#else
-  fsw f27, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, F_fsw_cg_cp_fs2_b27, F_fsw_cg_cp_fs2_b27_str)
 
@@ -1954,18 +1243,9 @@ F_fsw_cg_cp_fs2_b28:
   fsw f28, 2026(x15) # perform store
   addi x15, x15, 2026 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x21 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x21, F_fsw_cg_cp_fs2_b28, F_fsw_cg_cp_fs2_b28_str)
-#else
-  fsw f28, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, F_fsw_cg_cp_fs2_b28, F_fsw_cg_cp_fs2_b28_str)
 
@@ -1978,18 +1258,9 @@ F_fsw_cg_cp_fs2_b29:
   fsw f29, -327(x19) # perform store
   addi x19, x19, -327 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x1 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x1, F_fsw_cg_cp_fs2_b29, F_fsw_cg_cp_fs2_b29_str)
-#else
-  fsw f29, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, F_fsw_cg_cp_fs2_b29, F_fsw_cg_cp_fs2_b29_str)
 
@@ -2002,18 +1273,9 @@ F_fsw_cg_cp_fs2_b30:
   fsw f30, 76(x26) # perform store
   addi x26, x26, 76 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x13 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x13, F_fsw_cg_cp_fs2_b30, F_fsw_cg_cp_fs2_b30_str)
-#else
-  fsw f30, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, F_fsw_cg_cp_fs2_b30, F_fsw_cg_cp_fs2_b30_str)
 
@@ -2026,18 +1288,9 @@ F_fsw_cg_cp_fs2_b31:
   fsw f31, 1604(x17) # perform store
   addi x17, x17, 1604 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x21 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x21, F_fsw_cg_cp_fs2_b31, F_fsw_cg_cp_fs2_b31_str)
-#else
-  fsw f31, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, F_fsw_cg_cp_fs2_b31, F_fsw_cg_cp_fs2_b31_str)
 
@@ -2054,18 +1307,9 @@ F_fsw_cg_cp_fs2_edges_b0x0:
   fsw f11, 1373(x21) # perform store
   addi x21, x21, 1373 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x6 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x6, F_fsw_cg_cp_fs2_edges_b0x0, F_fsw_cg_cp_fs2_edges_b0x0_str)
-#else
-  fsw f11, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, F_fsw_cg_cp_fs2_edges_b0x0, F_fsw_cg_cp_fs2_edges_b0x0_str)
 
@@ -2078,18 +1322,9 @@ F_fsw_cg_cp_fs2_edges_b0x80000000:
   fsw f3, -148(x3) # perform store
   addi x3, x3, -148 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x13 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x13, F_fsw_cg_cp_fs2_edges_b0x80000000, F_fsw_cg_cp_fs2_edges_b0x80000000_str)
-#else
-  fsw f3, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, F_fsw_cg_cp_fs2_edges_b0x80000000, F_fsw_cg_cp_fs2_edges_b0x80000000_str)
 
@@ -2102,18 +1337,9 @@ F_fsw_cg_cp_fs2_edges_b0x3f800000:
   fsw f9, -426(x8) # perform store
   addi x8, x8, -426 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x1 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x1, F_fsw_cg_cp_fs2_edges_b0x3f800000, F_fsw_cg_cp_fs2_edges_b0x3f800000_str)
-#else
-  fsw f9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, F_fsw_cg_cp_fs2_edges_b0x3f800000, F_fsw_cg_cp_fs2_edges_b0x3f800000_str)
 
@@ -2126,18 +1352,9 @@ F_fsw_cg_cp_fs2_edges_b0xbf800000:
   fsw f22, 1044(x22) # perform store
   addi x22, x22, 1044 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x11 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x11, F_fsw_cg_cp_fs2_edges_b0xbf800000, F_fsw_cg_cp_fs2_edges_b0xbf800000_str)
-#else
-  fsw f22, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, F_fsw_cg_cp_fs2_edges_b0xbf800000, F_fsw_cg_cp_fs2_edges_b0xbf800000_str)
 
@@ -2150,18 +1367,9 @@ F_fsw_cg_cp_fs2_edges_b0x3fc00000:
   fsw f19, -1339(x26) # perform store
   addi x26, x26, -1339 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x29 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x29, F_fsw_cg_cp_fs2_edges_b0x3fc00000, F_fsw_cg_cp_fs2_edges_b0x3fc00000_str)
-#else
-  fsw f19, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, F_fsw_cg_cp_fs2_edges_b0x3fc00000, F_fsw_cg_cp_fs2_edges_b0x3fc00000_str)
 
@@ -2174,18 +1382,9 @@ F_fsw_cg_cp_fs2_edges_b0xbfc00000:
   fsw f2, 376(x19) # perform store
   addi x19, x19, 376 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x24 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x24, F_fsw_cg_cp_fs2_edges_b0xbfc00000, F_fsw_cg_cp_fs2_edges_b0xbfc00000_str)
-#else
-  fsw f2, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, F_fsw_cg_cp_fs2_edges_b0xbfc00000, F_fsw_cg_cp_fs2_edges_b0xbfc00000_str)
 
@@ -2198,18 +1397,9 @@ F_fsw_cg_cp_fs2_edges_b0x40000000:
   fsw f26, -1740(x26) # perform store
   addi x26, x26, -1740 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x9 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x9, F_fsw_cg_cp_fs2_edges_b0x40000000, F_fsw_cg_cp_fs2_edges_b0x40000000_str)
-#else
-  fsw f26, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, F_fsw_cg_cp_fs2_edges_b0x40000000, F_fsw_cg_cp_fs2_edges_b0x40000000_str)
 
@@ -2222,18 +1412,9 @@ F_fsw_cg_cp_fs2_edges_b0xc0000000:
   fsw f14, 926(x9) # perform store
   addi x9, x9, 926 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x25 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x25, F_fsw_cg_cp_fs2_edges_b0xc0000000, F_fsw_cg_cp_fs2_edges_b0xc0000000_str)
-#else
-  fsw f14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, F_fsw_cg_cp_fs2_edges_b0xc0000000, F_fsw_cg_cp_fs2_edges_b0xc0000000_str)
 
@@ -2246,18 +1427,9 @@ F_fsw_cg_cp_fs2_edges_b0x800000:
   fsw f24, -788(x11) # perform store
   addi x11, x11, -788 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, F_fsw_cg_cp_fs2_edges_b0x800000, F_fsw_cg_cp_fs2_edges_b0x800000_str)
-#else
-  fsw f24, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, F_fsw_cg_cp_fs2_edges_b0x800000, F_fsw_cg_cp_fs2_edges_b0x800000_str)
 
@@ -2270,18 +1442,9 @@ F_fsw_cg_cp_fs2_edges_b0x80800000:
   fsw f2, -755(x31) # perform store
   addi x31, x31, -755 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x27 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x27, F_fsw_cg_cp_fs2_edges_b0x80800000, F_fsw_cg_cp_fs2_edges_b0x80800000_str)
-#else
-  fsw f2, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, F_fsw_cg_cp_fs2_edges_b0x80800000, F_fsw_cg_cp_fs2_edges_b0x80800000_str)
 
@@ -2294,18 +1457,9 @@ F_fsw_cg_cp_fs2_edges_b0x7f7fffff:
   fsw f6, 1655(x23) # perform store
   addi x23, x23, 1655 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x10 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x10, F_fsw_cg_cp_fs2_edges_b0x7f7fffff, F_fsw_cg_cp_fs2_edges_b0x7f7fffff_str)
-#else
-  fsw f6, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, F_fsw_cg_cp_fs2_edges_b0x7f7fffff, F_fsw_cg_cp_fs2_edges_b0x7f7fffff_str)
 
@@ -2318,18 +1472,9 @@ F_fsw_cg_cp_fs2_edges_b0xff7fffff:
   fsw f19, 1719(x11) # perform store
   addi x11, x11, 1719 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x21 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x21, F_fsw_cg_cp_fs2_edges_b0xff7fffff, F_fsw_cg_cp_fs2_edges_b0xff7fffff_str)
-#else
-  fsw f19, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, F_fsw_cg_cp_fs2_edges_b0xff7fffff, F_fsw_cg_cp_fs2_edges_b0xff7fffff_str)
 
@@ -2342,18 +1487,9 @@ F_fsw_cg_cp_fs2_edges_b0x7fffff:
   fsw f3, -1756(x21) # perform store
   addi x21, x21, -1756 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x3 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x3, F_fsw_cg_cp_fs2_edges_b0x7fffff, F_fsw_cg_cp_fs2_edges_b0x7fffff_str)
-#else
-  fsw f3, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, F_fsw_cg_cp_fs2_edges_b0x7fffff, F_fsw_cg_cp_fs2_edges_b0x7fffff_str)
 
@@ -2366,18 +1502,9 @@ F_fsw_cg_cp_fs2_edges_b0x807fffff:
   fsw f9, -1864(x27) # perform store
   addi x27, x27, -1864 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x19 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x19, F_fsw_cg_cp_fs2_edges_b0x807fffff, F_fsw_cg_cp_fs2_edges_b0x807fffff_str)
-#else
-  fsw f9, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, F_fsw_cg_cp_fs2_edges_b0x807fffff, F_fsw_cg_cp_fs2_edges_b0x807fffff_str)
 
@@ -2390,18 +1517,9 @@ F_fsw_cg_cp_fs2_edges_b0x400000:
   fsw f10, -313(x25) # perform store
   addi x25, x25, -313 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x22 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x22, F_fsw_cg_cp_fs2_edges_b0x400000, F_fsw_cg_cp_fs2_edges_b0x400000_str)
-#else
-  fsw f10, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, F_fsw_cg_cp_fs2_edges_b0x400000, F_fsw_cg_cp_fs2_edges_b0x400000_str)
 
@@ -2414,18 +1532,9 @@ F_fsw_cg_cp_fs2_edges_b0x80400000:
   fsw f26, -1575(x8) # perform store
   addi x8, x8, -1575 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x1 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x1, F_fsw_cg_cp_fs2_edges_b0x80400000, F_fsw_cg_cp_fs2_edges_b0x80400000_str)
-#else
-  fsw f26, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, F_fsw_cg_cp_fs2_edges_b0x80400000, F_fsw_cg_cp_fs2_edges_b0x80400000_str)
 
@@ -2438,18 +1547,9 @@ F_fsw_cg_cp_fs2_edges_b0x1:
   fsw f14, -1720(x24) # perform store
   addi x24, x24, -1720 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x21 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x21, F_fsw_cg_cp_fs2_edges_b0x1, F_fsw_cg_cp_fs2_edges_b0x1_str)
-#else
-  fsw f14, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, F_fsw_cg_cp_fs2_edges_b0x1, F_fsw_cg_cp_fs2_edges_b0x1_str)
 
@@ -2462,18 +1562,9 @@ F_fsw_cg_cp_fs2_edges_b0x80000001:
   fsw f8, -88(x20) # perform store
   addi x20, x20, -88 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x10 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x10, F_fsw_cg_cp_fs2_edges_b0x80000001, F_fsw_cg_cp_fs2_edges_b0x80000001_str)
-#else
-  fsw f8, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, F_fsw_cg_cp_fs2_edges_b0x80000001, F_fsw_cg_cp_fs2_edges_b0x80000001_str)
 
@@ -2486,18 +1577,9 @@ F_fsw_cg_cp_fs2_edges_b0x7f800000:
   fsw f3, -1359(x10) # perform store
   addi x10, x10, -1359 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x22 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x22, F_fsw_cg_cp_fs2_edges_b0x7f800000, F_fsw_cg_cp_fs2_edges_b0x7f800000_str)
-#else
-  fsw f3, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, F_fsw_cg_cp_fs2_edges_b0x7f800000, F_fsw_cg_cp_fs2_edges_b0x7f800000_str)
 
@@ -2510,18 +1592,9 @@ F_fsw_cg_cp_fs2_edges_b0xff800000:
   fsw f21, 1326(x12) # perform store
   addi x12, x12, 1326 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x29 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x29, F_fsw_cg_cp_fs2_edges_b0xff800000, F_fsw_cg_cp_fs2_edges_b0xff800000_str)
-#else
-  fsw f21, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, F_fsw_cg_cp_fs2_edges_b0xff800000, F_fsw_cg_cp_fs2_edges_b0xff800000_str)
 
@@ -2534,18 +1607,9 @@ F_fsw_cg_cp_fs2_edges_b0x7fc00000:
   fsw f2, -621(x6) # perform store
   addi x6, x6, -621 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x26 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x26, F_fsw_cg_cp_fs2_edges_b0x7fc00000, F_fsw_cg_cp_fs2_edges_b0x7fc00000_str)
-#else
-  fsw f2, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, F_fsw_cg_cp_fs2_edges_b0x7fc00000, F_fsw_cg_cp_fs2_edges_b0x7fc00000_str)
 
@@ -2558,18 +1622,9 @@ F_fsw_cg_cp_fs2_edges_b0x7fffffff:
   fsw f25, -1454(x23) # perform store
   addi x23, x23, -1454 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x9 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x9, F_fsw_cg_cp_fs2_edges_b0x7fffffff, F_fsw_cg_cp_fs2_edges_b0x7fffffff_str)
-#else
-  fsw f25, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, F_fsw_cg_cp_fs2_edges_b0x7fffffff, F_fsw_cg_cp_fs2_edges_b0x7fffffff_str)
 
@@ -2582,18 +1637,9 @@ F_fsw_cg_cp_fs2_edges_b0xffffffff:
   fsw f19, 532(x26) # perform store
   addi x26, x26, 532 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x12 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x12, F_fsw_cg_cp_fs2_edges_b0xffffffff, F_fsw_cg_cp_fs2_edges_b0xffffffff_str)
-#else
-  fsw f19, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, F_fsw_cg_cp_fs2_edges_b0xffffffff, F_fsw_cg_cp_fs2_edges_b0xffffffff_str)
 
@@ -2606,18 +1652,9 @@ F_fsw_cg_cp_fs2_edges_b0x7f800001:
   fsw f11, 410(x9) # perform store
   addi x9, x9, 410 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, F_fsw_cg_cp_fs2_edges_b0x7f800001, F_fsw_cg_cp_fs2_edges_b0x7f800001_str)
-#else
-  fsw f11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, F_fsw_cg_cp_fs2_edges_b0x7f800001, F_fsw_cg_cp_fs2_edges_b0x7f800001_str)
 
@@ -2630,18 +1667,9 @@ F_fsw_cg_cp_fs2_edges_b0x7fbfffff:
   fsw f26, 1482(x24) # perform store
   addi x24, x24, 1482 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x22 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x22, F_fsw_cg_cp_fs2_edges_b0x7fbfffff, F_fsw_cg_cp_fs2_edges_b0x7fbfffff_str)
-#else
-  fsw f26, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, F_fsw_cg_cp_fs2_edges_b0x7fbfffff, F_fsw_cg_cp_fs2_edges_b0x7fbfffff_str)
 
@@ -2654,18 +1682,9 @@ F_fsw_cg_cp_fs2_edges_b0xffbfffff:
   fsw f3, 391(x14) # perform store
   addi x14, x14, 391 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, F_fsw_cg_cp_fs2_edges_b0xffbfffff, F_fsw_cg_cp_fs2_edges_b0xffbfffff_str)
-#else
-  fsw f3, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, F_fsw_cg_cp_fs2_edges_b0xffbfffff, F_fsw_cg_cp_fs2_edges_b0xffbfffff_str)
 
@@ -2678,18 +1697,9 @@ F_fsw_cg_cp_fs2_edges_b0x7ef8654f:
   fsw f11, -101(x13) # perform store
   addi x13, x13, -101 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x24 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x24, F_fsw_cg_cp_fs2_edges_b0x7ef8654f, F_fsw_cg_cp_fs2_edges_b0x7ef8654f_str)
-#else
-  fsw f11, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, F_fsw_cg_cp_fs2_edges_b0x7ef8654f, F_fsw_cg_cp_fs2_edges_b0x7ef8654f_str)
 
@@ -2702,18 +1712,9 @@ F_fsw_cg_cp_fs2_edges_b0x813d9ab0:
   fsw f15, -1072(x30) # perform store
   addi x30, x30, -1072 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x25 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x25, F_fsw_cg_cp_fs2_edges_b0x813d9ab0, F_fsw_cg_cp_fs2_edges_b0x813d9ab0_str)
-#else
-  fsw f15, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, F_fsw_cg_cp_fs2_edges_b0x813d9ab0, F_fsw_cg_cp_fs2_edges_b0x813d9ab0_str)
 

--- a/tests/rv64i/I/I-sb-00.S
+++ b/tests/rv64i/I/I-sb-00.S
@@ -41,18 +41,9 @@ I_sb_cg_cp_rs1_nx0_b1:
   sb x9, 1526(x1) # perform store
   addi x1, x1, 1526 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x21 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x21, I_sb_cg_cp_rs1_nx0_b1, I_sb_cg_cp_rs1_nx0_b1_str)
-#else
-  sb x9, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x24) # load rs2: x24 = 0x1eb3dee908eb4d46
@@ -62,18 +53,9 @@ I_sb_cg_cp_rs1_nx0_b2:
   sb x24, -413(x2) # perform store
   addi x2, x2, -413 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x29 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x29, I_sb_cg_cp_rs1_nx0_b2, I_sb_cg_cp_rs1_nx0_b2_str)
-#else
-  sb x24, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x19, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
@@ -84,18 +66,9 @@ I_sb_cg_cp_rs1_nx0_b3:
   sb x6, -1700(x3) # perform store
   addi x3, x3, -1700 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x20 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x20, I_sb_cg_cp_rs1_nx0_b3, I_sb_cg_cp_rs1_nx0_b3_str)
-#else
-  sb x6, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -107,18 +80,9 @@ I_sb_cg_cp_rs1_nx0_b4:
   sb x18, -756(x4) # perform store
   addi x4, x4, -756 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x14 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x14, I_sb_cg_cp_rs1_nx0_b4, I_sb_cg_cp_rs1_nx0_b4_str)
-#else
-  sb x18, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x19, x0) # load rs2: x0 = 0x2311cc5cd30fbdb6
@@ -128,18 +92,9 @@ I_sb_cg_cp_rs1_nx0_b5:
   sb x0, 1594(x5) # perform store
   addi x5, x5, 1594 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x14 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x14, I_sb_cg_cp_rs1_nx0_b5, I_sb_cg_cp_rs1_nx0_b5_str)
-#else
-  sb x0, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x19, x14) # load rs2: x14 = 0xcbd0956decb7de20
@@ -149,18 +104,9 @@ I_sb_cg_cp_rs1_nx0_b6:
   sb x14, 1805(x6) # perform store
   addi x6, x6, 1805 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x28 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x28, I_sb_cg_cp_rs1_nx0_b6, I_sb_cg_cp_rs1_nx0_b6_str)
-#else
-  sb x14, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x7 # switch temp register to avoid conflict with test
   mv x5, x8 # switch link pointer register to avoid conflict with test
@@ -172,18 +118,9 @@ I_sb_cg_cp_rs1_nx0_b7:
   sb x26, 25(x7) # perform store
   addi x7, x7, 25 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x11 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x11, I_sb_cg_cp_rs1_nx0_b7, I_sb_cg_cp_rs1_nx0_b7_str)
-#else
-  sb x26, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x19, x11) # load rs2: x11 = 0x8a175c73b57acc20
@@ -193,18 +130,9 @@ I_sb_cg_cp_rs1_nx0_b8:
   sb x11, 1514(x8) # perform store
   addi x8, x8, 1514 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x23 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x23, I_sb_cg_cp_rs1_nx0_b8, I_sb_cg_cp_rs1_nx0_b8_str)
-#else
-  sb x11, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x19, x31) # load rs2: x31 = 0x7d1e2cd0c3f70b96
@@ -214,18 +142,9 @@ I_sb_cg_cp_rs1_nx0_b9:
   sb x31, 1799(x9) # perform store
   addi x9, x9, 1799 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x17 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x17, I_sb_cg_cp_rs1_nx0_b9, I_sb_cg_cp_rs1_nx0_b9_str)
-#else
-  sb x31, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x19, x23) # load rs2: x23 = 0x97f8308bfe09a3cd
@@ -235,18 +154,9 @@ I_sb_cg_cp_rs1_nx0_b10:
   sb x23, -1004(x10) # perform store
   addi x10, x10, -1004 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, I_sb_cg_cp_rs1_nx0_b10, I_sb_cg_cp_rs1_nx0_b10_str)
-#else
-  sb x23, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x19, x14) # load rs2: x14 = 0x37cbbdd7a32ddf70
@@ -256,18 +166,9 @@ I_sb_cg_cp_rs1_nx0_b11:
   sb x14, -1281(x11) # perform store
   addi x11, x11, -1281 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x27, I_sb_cg_cp_rs1_nx0_b11, I_sb_cg_cp_rs1_nx0_b11_str)
-#else
-  sb x14, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x19, x31) # load rs2: x31 = 0xcd88a2d57652e2b2
@@ -277,18 +178,9 @@ I_sb_cg_cp_rs1_nx0_b12:
   sb x31, 629(x12) # perform store
   addi x12, x12, 629 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x22 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x22, I_sb_cg_cp_rs1_nx0_b12, I_sb_cg_cp_rs1_nx0_b12_str)
-#else
-  sb x31, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x19, x25) # load rs2: x25 = 0x4161613cdf145d6d
@@ -298,18 +190,9 @@ I_sb_cg_cp_rs1_nx0_b13:
   sb x25, -996(x13) # perform store
   addi x13, x13, -996 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x1 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x1, I_sb_cg_cp_rs1_nx0_b13, I_sb_cg_cp_rs1_nx0_b13_str)
-#else
-  sb x25, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x19, x28) # load rs2: x28 = 0x5a8fb48b168e1fd0
@@ -319,18 +202,9 @@ I_sb_cg_cp_rs1_nx0_b14:
   sb x28, 847(x14) # perform store
   addi x14, x14, 847 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x25 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x25, I_sb_cg_cp_rs1_nx0_b14, I_sb_cg_cp_rs1_nx0_b14_str)
-#else
-  sb x28, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x19, x10) # load rs2: x10 = 0x90c07965a13b4977
@@ -340,18 +214,9 @@ I_sb_cg_cp_rs1_nx0_b15:
   sb x10, -752(x15) # perform store
   addi x15, x15, -752 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x23 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x23, I_sb_cg_cp_rs1_nx0_b15, I_sb_cg_cp_rs1_nx0_b15_str)
-#else
-  sb x10, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x16)
   RVTEST_TESTDATA_LOAD_INT(x19, x2) # load rs2: x2 = 0xe87c95c2939c2df3
@@ -361,18 +226,9 @@ I_sb_cg_cp_rs1_nx0_b16:
   sb x2, 809(x16) # perform store
   addi x16, x16, 809 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x27 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x27, I_sb_cg_cp_rs1_nx0_b16, I_sb_cg_cp_rs1_nx0_b16_str)
-#else
-  sb x2, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x17)
   RVTEST_TESTDATA_LOAD_INT(x19, x3) # load rs2: x3 = 0x09b93b9c2d3e2ab6
@@ -382,18 +238,9 @@ I_sb_cg_cp_rs1_nx0_b17:
   sb x3, 600(x17) # perform store
   addi x17, x17, 600 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x13 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x13, I_sb_cg_cp_rs1_nx0_b17, I_sb_cg_cp_rs1_nx0_b17_str)
-#else
-  sb x3, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x18)
   RVTEST_TESTDATA_LOAD_INT(x19, x7) # load rs2: x7 = 0xb8c8491d72d7633e
@@ -403,18 +250,9 @@ I_sb_cg_cp_rs1_nx0_b18:
   sb x7, -1639(x18) # perform store
   addi x18, x18, -1639 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x6, I_sb_cg_cp_rs1_nx0_b18, I_sb_cg_cp_rs1_nx0_b18_str)
-#else
-  sb x7, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x3, x19 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x19)
@@ -425,18 +263,9 @@ I_sb_cg_cp_rs1_nx0_b19:
   sb x1, 1375(x19) # perform store
   addi x19, x19, 1375 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x29 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x29, I_sb_cg_cp_rs1_nx0_b19, I_sb_cg_cp_rs1_nx0_b19_str)
-#else
-  sb x1, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x20)
   RVTEST_TESTDATA_LOAD_INT(x3, x25) # load rs2: x25 = 0x135343d50fc0bc49
@@ -446,18 +275,9 @@ I_sb_cg_cp_rs1_nx0_b20:
   sb x25, 1615(x20) # perform store
   addi x20, x20, 1615 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x30 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x30, I_sb_cg_cp_rs1_nx0_b20, I_sb_cg_cp_rs1_nx0_b20_str)
-#else
-  sb x25, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x21)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xa32f97d934019764
@@ -467,18 +287,9 @@ I_sb_cg_cp_rs1_nx0_b21:
   sb x14, 359(x21) # perform store
   addi x21, x21, 359 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x19 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x19, I_sb_cg_cp_rs1_nx0_b21, I_sb_cg_cp_rs1_nx0_b21_str)
-#else
-  sb x14, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x22)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x43a2ab413a50ef76
@@ -488,18 +299,9 @@ I_sb_cg_cp_rs1_nx0_b22:
   sb x14, -1598(x22) # perform store
   addi x22, x22, -1598 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x9 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x9, I_sb_cg_cp_rs1_nx0_b22, I_sb_cg_cp_rs1_nx0_b22_str)
-#else
-  sb x14, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x23)
   RVTEST_TESTDATA_LOAD_INT(x3, x28) # load rs2: x28 = 0x1b672dcf7129d618
@@ -509,18 +311,9 @@ I_sb_cg_cp_rs1_nx0_b23:
   sb x28, 2043(x23) # perform store
   addi x23, x23, 2043 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x14 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x14, I_sb_cg_cp_rs1_nx0_b23, I_sb_cg_cp_rs1_nx0_b23_str)
-#else
-  sb x28, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x24)
   RVTEST_TESTDATA_LOAD_INT(x3, x19) # load rs2: x19 = 0x159ed46386d596fb
@@ -530,18 +323,9 @@ I_sb_cg_cp_rs1_nx0_b24:
   sb x19, 731(x24) # perform store
   addi x24, x24, 731 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x26 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x26, I_sb_cg_cp_rs1_nx0_b24, I_sb_cg_cp_rs1_nx0_b24_str)
-#else
-  sb x19, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x25)
   RVTEST_TESTDATA_LOAD_INT(x3, x17) # load rs2: x17 = 0x06a78fb551cd9ad4
@@ -551,18 +335,9 @@ I_sb_cg_cp_rs1_nx0_b25:
   sb x17, 1022(x25) # perform store
   addi x25, x25, 1022 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x10 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x10, I_sb_cg_cp_rs1_nx0_b25, I_sb_cg_cp_rs1_nx0_b25_str)
-#else
-  sb x17, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x26)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x3d948e2d425f4d46
@@ -572,18 +347,9 @@ I_sb_cg_cp_rs1_nx0_b26:
   sb x10, 1471(x26) # perform store
   addi x26, x26, 1471 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x12 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x12, I_sb_cg_cp_rs1_nx0_b26, I_sb_cg_cp_rs1_nx0_b26_str)
-#else
-  sb x10, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x27)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x7b44db501e0ba92e
@@ -593,18 +359,9 @@ I_sb_cg_cp_rs1_nx0_b27:
   sb x14, -687(x27) # perform store
   addi x27, x27, -687 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x30 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x30, I_sb_cg_cp_rs1_nx0_b27, I_sb_cg_cp_rs1_nx0_b27_str)
-#else
-  sb x14, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x28)
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0x667b591f78eb025c
@@ -614,18 +371,9 @@ I_sb_cg_cp_rs1_nx0_b28:
   sb x2, 1974(x28) # perform store
   addi x28, x28, 1974 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x25 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x25, I_sb_cg_cp_rs1_nx0_b28, I_sb_cg_cp_rs1_nx0_b28_str)
-#else
-  sb x2, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x29)
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0xc165309d2b7ebb12
@@ -635,18 +383,9 @@ I_sb_cg_cp_rs1_nx0_b29:
   sb x1, -120(x29) # perform store
   addi x29, x29, -120 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x30 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x30, I_sb_cg_cp_rs1_nx0_b29, I_sb_cg_cp_rs1_nx0_b29_str)
-#else
-  sb x1, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x30)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x89a938f05b6538f1
@@ -656,18 +395,9 @@ I_sb_cg_cp_rs1_nx0_b30:
   sb x10, -146(x30) # perform store
   addi x30, x30, -146 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x21 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x21, I_sb_cg_cp_rs1_nx0_b30, I_sb_cg_cp_rs1_nx0_b30_str)
-#else
-  sb x10, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x31)
   RVTEST_TESTDATA_LOAD_INT(x3, x19) # load rs2: x19 = 0xcaf6b5cc490d980e
@@ -677,18 +407,9 @@ I_sb_cg_cp_rs1_nx0_b31:
   sb x19, -1465(x31) # perform store
   addi x31, x31, -1465 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x7 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x7, I_sb_cg_cp_rs1_nx0_b31, I_sb_cg_cp_rs1_nx0_b31_str)
-#else
-  sb x19, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2
@@ -702,18 +423,9 @@ I_sb_cg_cp_rs2_b0:
   sb x0, -1464(x6) # perform store
   addi x6, x6, -1464 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x20 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x20, I_sb_cg_cp_rs2_b0, I_sb_cg_cp_rs2_b0_str)
-#else
-  sb x0, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0x308968140a7e8ad1
@@ -723,18 +435,9 @@ I_sb_cg_cp_rs2_b1:
   sb x1, 810(x11) # perform store
   addi x11, x11, 810 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x19 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x19, I_sb_cg_cp_rs2_b1, I_sb_cg_cp_rs2_b1_str)
-#else
-  sb x1, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0xba5a07169b1a6d75
@@ -744,18 +447,9 @@ I_sb_cg_cp_rs2_b2:
   sb x2, -1679(x31) # perform store
   addi x31, x31, -1679 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x7 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x7, I_sb_cg_cp_rs2_b2, I_sb_cg_cp_rs2_b2_str)
-#else
-  sb x2, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x23, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x3)
@@ -766,18 +460,9 @@ I_sb_cg_cp_rs2_b3:
   sb x3, -1349(x26) # perform store
   addi x26, x26, -1349 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x17 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x17, I_sb_cg_cp_rs2_b3, I_sb_cg_cp_rs2_b3_str)
-#else
-  sb x3, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x4 # switch temp register to avoid conflict with test
   mv x14, x5 # switch link pointer register to avoid conflict with test
@@ -789,18 +474,9 @@ I_sb_cg_cp_rs2_b4:
   sb x4, -1543(x22) # perform store
   addi x22, x22, -1543 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x15 contains the expected result. x22 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x22, x14, x13, x15, I_sb_cg_cp_rs2_b4, I_sb_cg_cp_rs2_b4_str)
-#else
-  sb x4, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x23, x5) # load rs2: x5 = 0x64d1f0695c48f5e1
@@ -810,18 +486,9 @@ I_sb_cg_cp_rs2_b5:
   sb x5, -431(x3) # perform store
   addi x3, x3, -431 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x30 contains the expected result. x3 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x3, x14, x13, x30, I_sb_cg_cp_rs2_b5, I_sb_cg_cp_rs2_b5_str)
-#else
-  sb x5, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x23, x6) # load rs2: x6 = 0x7024da73d4ebd155
@@ -831,18 +498,9 @@ I_sb_cg_cp_rs2_b6:
   sb x6, -691(x19) # perform store
   addi x19, x19, -691 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x25 contains the expected result. x19 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x19, x14, x13, x25, I_sb_cg_cp_rs2_b6, I_sb_cg_cp_rs2_b6_str)
-#else
-  sb x6, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x23, x7) # load rs2: x7 = 0x1cc820f208540f51
@@ -852,18 +510,9 @@ I_sb_cg_cp_rs2_b7:
   sb x7, 1745(x17) # perform store
   addi x17, x17, 1745 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x1 contains the expected result. x17 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x17, x14, x13, x1, I_sb_cg_cp_rs2_b7, I_sb_cg_cp_rs2_b7_str)
-#else
-  sb x7, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x23, x8) # load rs2: x8 = 0x99db68b60ebc7505
@@ -873,18 +522,9 @@ I_sb_cg_cp_rs2_b8:
   sb x8, -278(x4) # perform store
   addi x4, x4, -278 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x29 contains the expected result. x4 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x4, x14, x13, x29, I_sb_cg_cp_rs2_b8, I_sb_cg_cp_rs2_b8_str)
-#else
-  sb x8, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x23, x9) # load rs2: x9 = 0x821a7744d4b5c4df
@@ -894,18 +534,9 @@ I_sb_cg_cp_rs2_b9:
   sb x9, 1518(x17) # perform store
   addi x17, x17, 1518 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x26 contains the expected result. x17 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x17, x14, x13, x26, I_sb_cg_cp_rs2_b9, I_sb_cg_cp_rs2_b9_str)
-#else
-  sb x9, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x23, x10) # load rs2: x10 = 0xe216f9467f0736ae
@@ -915,18 +546,9 @@ I_sb_cg_cp_rs2_b10:
   sb x10, -225(x28) # perform store
   addi x28, x28, -225 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x16 contains the expected result. x28 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x28, x14, x13, x16, I_sb_cg_cp_rs2_b10, I_sb_cg_cp_rs2_b10_str)
-#else
-  sb x10, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x23, x11) # load rs2: x11 = 0x7a1da9e7690d3d3d
@@ -936,18 +558,9 @@ I_sb_cg_cp_rs2_b11:
   sb x11, -296(x16) # perform store
   addi x16, x16, -296 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x19 contains the expected result. x16 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x16, x14, x13, x19, I_sb_cg_cp_rs2_b11, I_sb_cg_cp_rs2_b11_str)
-#else
-  sb x11, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x23, x12) # load rs2: x12 = 0xf680a9fc2d516b8a
@@ -957,18 +570,9 @@ I_sb_cg_cp_rs2_b12:
   sb x12, -1123(x10) # perform store
   addi x10, x10, -1123 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x4 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x4, I_sb_cg_cp_rs2_b12, I_sb_cg_cp_rs2_b12_str)
-#else
-  sb x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x13 # switch temp register to avoid conflict with test
   mv x8, x14 # switch link pointer register to avoid conflict with test
@@ -980,18 +584,9 @@ I_sb_cg_cp_rs2_b13:
   sb x13, 1664(x18) # perform store
   addi x18, x18, 1664 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x24 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x24, I_sb_cg_cp_rs2_b13, I_sb_cg_cp_rs2_b13_str)
-#else
-  sb x13, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x23, x14) # load rs2: x14 = 0x4cc53de728a2a57b
@@ -1001,18 +596,9 @@ I_sb_cg_cp_rs2_b14:
   sb x14, -1121(x26) # perform store
   addi x26, x26, -1121 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x13 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x13, I_sb_cg_cp_rs2_b14, I_sb_cg_cp_rs2_b14_str)
-#else
-  sb x14, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x23, x15) # load rs2: x15 = 0xa38cbd1554262317
@@ -1022,18 +608,9 @@ I_sb_cg_cp_rs2_b15:
   sb x15, 1529(x13) # perform store
   addi x13, x13, 1529 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x5 contains the expected result. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x13, x8, x7, x5, I_sb_cg_cp_rs2_b15, I_sb_cg_cp_rs2_b15_str)
-#else
-  sb x15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x23, x16) # load rs2: x16 = 0xc05ebb9b438a7c76
@@ -1043,18 +620,9 @@ I_sb_cg_cp_rs2_b16:
   sb x16, -890(x27) # perform store
   addi x27, x27, -890 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x21 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x27, x8, x7, x21, I_sb_cg_cp_rs2_b16, I_sb_cg_cp_rs2_b16_str)
-#else
-  sb x16, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x23, x17) # load rs2: x17 = 0xcfef29674d133980
@@ -1064,18 +632,9 @@ I_sb_cg_cp_rs2_b17:
   sb x17, 115(x19) # perform store
   addi x19, x19, 115 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x16 contains the expected result. x19 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x19, x8, x7, x16, I_sb_cg_cp_rs2_b17, I_sb_cg_cp_rs2_b17_str)
-#else
-  sb x17, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x23, x18) # load rs2: x18 = 0xd836520532a54279
@@ -1085,18 +644,9 @@ I_sb_cg_cp_rs2_b18:
   sb x18, -980(x17) # perform store
   addi x17, x17, -980 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x29 contains the expected result. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x17, x8, x7, x29, I_sb_cg_cp_rs2_b18, I_sb_cg_cp_rs2_b18_str)
-#else
-  sb x18, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x23, x19) # load rs2: x19 = 0x92068e7cbf94df1e
@@ -1106,18 +656,9 @@ I_sb_cg_cp_rs2_b19:
   sb x19, -1969(x27) # perform store
   addi x27, x27, -1969 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x22 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x27, x8, x7, x22, I_sb_cg_cp_rs2_b19, I_sb_cg_cp_rs2_b19_str)
-#else
-  sb x19, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x23, x20) # load rs2: x20 = 0x3eb80fa4cb588926
@@ -1127,18 +668,9 @@ I_sb_cg_cp_rs2_b20:
   sb x20, -1511(x6) # perform store
   addi x6, x6, -1511 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x13 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x13, I_sb_cg_cp_rs2_b20, I_sb_cg_cp_rs2_b20_str)
-#else
-  sb x20, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x23, x21) # load rs2: x21 = 0x224c93ae8d9d3db5
@@ -1148,18 +680,9 @@ I_sb_cg_cp_rs2_b21:
   sb x21, -895(x16) # perform store
   addi x16, x16, -895 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x15 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x16, x8, x7, x15, I_sb_cg_cp_rs2_b21, I_sb_cg_cp_rs2_b21_str)
-#else
-  sb x21, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x23, x22) # load rs2: x22 = 0xecc22a34b3a5db2c
@@ -1169,18 +692,9 @@ I_sb_cg_cp_rs2_b22:
   sb x22, 1800(x27) # perform store
   addi x27, x27, 1800 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x9 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x27, x8, x7, x9, I_sb_cg_cp_rs2_b22, I_sb_cg_cp_rs2_b22_str)
-#else
-  sb x22, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x18, x23 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x23)
@@ -1191,18 +705,9 @@ I_sb_cg_cp_rs2_b23:
   sb x23, 279(x22) # perform store
   addi x22, x22, 279 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x13 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x13, I_sb_cg_cp_rs2_b23, I_sb_cg_cp_rs2_b23_str)
-#else
-  sb x23, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x18, x24) # load rs2: x24 = 0x695e5306f38b6090
@@ -1212,18 +717,9 @@ I_sb_cg_cp_rs2_b24:
   sb x24, -590(x20) # perform store
   addi x20, x20, -590 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x23 contains the expected result. x20 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x20, x8, x7, x23, I_sb_cg_cp_rs2_b24, I_sb_cg_cp_rs2_b24_str)
-#else
-  sb x24, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x18, x25) # load rs2: x25 = 0xe0e4f8761c010b99
@@ -1233,18 +729,9 @@ I_sb_cg_cp_rs2_b25:
   sb x25, -100(x4) # perform store
   addi x4, x4, -100 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x29 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x29, I_sb_cg_cp_rs2_b25, I_sb_cg_cp_rs2_b25_str)
-#else
-  sb x25, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x18, x26) # load rs2: x26 = 0x8fa0430eb18bad1b
@@ -1254,18 +741,9 @@ I_sb_cg_cp_rs2_b26:
   sb x26, 326(x24) # perform store
   addi x24, x24, 326 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x30 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x30, I_sb_cg_cp_rs2_b26, I_sb_cg_cp_rs2_b26_str)
-#else
-  sb x26, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x18, x27) # load rs2: x27 = 0xb16a4506ba692420
@@ -1275,18 +753,9 @@ I_sb_cg_cp_rs2_b27:
   sb x27, 998(x17) # perform store
   addi x17, x17, 998 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x3 contains the expected result. x17 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x17, x8, x7, x3, I_sb_cg_cp_rs2_b27, I_sb_cg_cp_rs2_b27_str)
-#else
-  sb x27, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x18, x28) # load rs2: x28 = 0x70a534a2b442e065
@@ -1296,18 +765,9 @@ I_sb_cg_cp_rs2_b28:
   sb x28, 1342(x4) # perform store
   addi x4, x4, 1342 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x19 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x19, I_sb_cg_cp_rs2_b28, I_sb_cg_cp_rs2_b28_str)
-#else
-  sb x28, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x18, x29) # load rs2: x29 = 0x91542caee6b0acbe
@@ -1317,18 +777,9 @@ I_sb_cg_cp_rs2_b29:
   sb x29, -1258(x21) # perform store
   addi x21, x21, -1258 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x12 contains the expected result. x21 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x21, x8, x7, x12, I_sb_cg_cp_rs2_b29, I_sb_cg_cp_rs2_b29_str)
-#else
-  sb x29, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x18, x30) # load rs2: x30 = 0x306590ea137bf3ef
@@ -1338,18 +789,9 @@ I_sb_cg_cp_rs2_b30:
   sb x30, 26(x6) # perform store
   addi x6, x6, 26 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x14 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x14, I_sb_cg_cp_rs2_b30, I_sb_cg_cp_rs2_b30_str)
-#else
-  sb x30, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x18, x31) # load rs2: x31 = 0x105e7586fc0c9a33
@@ -1359,18 +801,9 @@ I_sb_cg_cp_rs2_b31:
   sb x31, 1156(x13) # perform store
   addi x13, x13, 1156 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x26 contains the expected result. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x13, x8, x7, x26, I_sb_cg_cp_rs2_b31, I_sb_cg_cp_rs2_b31_str)
-#else
-  sb x31, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -1384,18 +817,9 @@ I_sb_cg_cp_rs2_edges_0x0:
   sb x2, -89(x23) # perform store
   addi x23, x23, -89 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x22 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x22, I_sb_cg_cp_rs2_edges_0x0, I_sb_cg_cp_rs2_edges_0x0_str)
-#else
-  sb x2, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x18, x14) # load rs2: x14 = 0x0000000000000001
@@ -1405,18 +829,9 @@ I_sb_cg_cp_rs2_edges_0x1:
   sb x14, 1105(x2) # perform store
   addi x2, x2, 1105 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x24 contains the expected result. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x2, x8, x7, x24, I_sb_cg_cp_rs2_edges_0x1, I_sb_cg_cp_rs2_edges_0x1_str)
-#else
-  sb x14, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x18, x1) # load rs2: x1 = 0x0000000000000002
@@ -1426,18 +841,9 @@ I_sb_cg_cp_rs2_edges_0x2:
   sb x1, -1022(x23) # perform store
   addi x23, x23, -1022 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x12 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x12, I_sb_cg_cp_rs2_edges_0x2, I_sb_cg_cp_rs2_edges_0x2_str)
-#else
-  sb x1, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x18, x28) # load rs2: x28 = 0x8000000000000000
@@ -1447,18 +853,9 @@ I_sb_cg_cp_rs2_edges_0x8000000000000000:
   sb x28, 1800(x12) # perform store
   addi x12, x12, 1800 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x5 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x12, x8, x7, x5, I_sb_cg_cp_rs2_edges_0x8000000000000000, I_sb_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  sb x28, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x18, x11) # load rs2: x11 = 0x8000000000000001
@@ -1468,18 +865,9 @@ I_sb_cg_cp_rs2_edges_0x8000000000000001:
   sb x11, 1256(x10) # perform store
   addi x10, x10, 1256 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x20 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x20, I_sb_cg_cp_rs2_edges_0x8000000000000001, I_sb_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  sb x11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x18, x16) # load rs2: x16 = 0x7fffffffffffffff
@@ -1489,18 +877,9 @@ I_sb_cg_cp_rs2_edges_0x7fffffffffffffff:
   sb x16, 1604(x3) # perform store
   addi x3, x3, 1604 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x21 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x3, x8, x7, x21, I_sb_cg_cp_rs2_edges_0x7fffffffffffffff, I_sb_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  sb x16, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x18, x12) # load rs2: x12 = 0x7ffffffffffffffe
@@ -1510,18 +889,9 @@ I_sb_cg_cp_rs2_edges_0x7ffffffffffffffe:
   sb x12, -2002(x24) # perform store
   addi x24, x24, -2002 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x19 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x19, I_sb_cg_cp_rs2_edges_0x7ffffffffffffffe, I_sb_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  sb x12, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x18, x14) # load rs2: x14 = 0xffffffffffffffff
@@ -1531,18 +901,9 @@ I_sb_cg_cp_rs2_edges_0xffffffffffffffff:
   sb x14, -1676(x23) # perform store
   addi x23, x23, -1676 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x1 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x1, I_sb_cg_cp_rs2_edges_0xffffffffffffffff, I_sb_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  sb x14, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x18, x26) # load rs2: x26 = 0xfffffffffffffffe
@@ -1552,18 +913,9 @@ I_sb_cg_cp_rs2_edges_0xfffffffffffffffe:
   sb x26, -1920(x1) # perform store
   addi x1, x1, -1920 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x17 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x17, I_sb_cg_cp_rs2_edges_0xfffffffffffffffe, I_sb_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  sb x26, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x18, x24) # load rs2: x24 = 0x5bbc887763ae86f2
@@ -1573,18 +925,9 @@ I_sb_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   sb x24, -40(x27) # perform store
   addi x27, x27, -40 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x3 contains the expected result. x27 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x27, x8, x7, x3, I_sb_cg_cp_rs2_edges_0x5bbc887763ae86f2, I_sb_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  sb x24, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x18, x29) # load rs2: x29 = 0xaaaaaaaaaaaaaaaa
@@ -1594,18 +937,9 @@ I_sb_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   sb x29, -1507(x23) # perform store
   addi x23, x23, -1507 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x4 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x4, I_sb_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, I_sb_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  sb x29, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x18, x21) # load rs2: x21 = 0x5555555555555555
@@ -1615,18 +949,9 @@ I_sb_cg_cp_rs2_edges_0x5555555555555555:
   sb x21, 1297(x13) # perform store
   addi x13, x13, 1297 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x4 contains the expected result. x13 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x13, x8, x7, x4, I_sb_cg_cp_rs2_edges_0x5555555555555555, I_sb_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  sb x21, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x18, x4) # load rs2: x4 = 0x00000000ffffffff
@@ -1636,18 +961,9 @@ I_sb_cg_cp_rs2_edges_0xffffffff:
   sb x4, 522(x12) # perform store
   addi x12, x12, 522 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x6 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x12, x8, x7, x6, I_sb_cg_cp_rs2_edges_0xffffffff, I_sb_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  sb x4, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x18, x17) # load rs2: x17 = 0x00000000fffffffe
@@ -1657,18 +973,9 @@ I_sb_cg_cp_rs2_edges_0xfffffffe:
   sb x17, -441(x26) # perform store
   addi x26, x26, -441 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x15 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x15, I_sb_cg_cp_rs2_edges_0xfffffffe, I_sb_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  sb x17, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x18, x30) # load rs2: x30 = 0x0000000100000000
@@ -1678,18 +985,9 @@ I_sb_cg_cp_rs2_edges_0x100000000:
   sb x30, -667(x16) # perform store
   addi x16, x16, -667 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x29 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x16, x8, x7, x29, I_sb_cg_cp_rs2_edges_0x100000000, I_sb_cg_cp_rs2_edges_0x100000000_str)
-#else
-  sb x30, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x18, x23) # load rs2: x23 = 0x0000000100000001
@@ -1699,18 +997,9 @@ I_sb_cg_cp_rs2_edges_0x100000001:
   sb x23, 1985(x28) # perform store
   addi x28, x28, 1985 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x21 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x21, I_sb_cg_cp_rs2_edges_0x100000001, I_sb_cg_cp_rs2_edges_0x100000001_str)
-#else
-  sb x23, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_edges
@@ -1724,18 +1013,9 @@ I_sb_cg_cp_imm_edges_0x0:
   sb x24, 0(x15) # perform store
   addi x15, x15, 0 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x11 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x15, x8, x7, x11, I_sb_cg_cp_imm_edges_0x0, I_sb_cg_cp_imm_edges_0x0_str)
-#else
-  sb x24, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1)
   RVTEST_TESTDATA_LOAD_INT(x18, x6) # load rs2: x6 = 0xba443fbd53d862b0
@@ -1745,18 +1025,9 @@ I_sb_cg_cp_imm_edges_0x1:
   sb x6, 1(x10) # perform store
   addi x10, x10, 1 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x13, I_sb_cg_cp_imm_edges_0x1, I_sb_cg_cp_imm_edges_0x1_str)
-#else
-  sb x6, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2)
   RVTEST_TESTDATA_LOAD_INT(x18, x2) # load rs2: x2 = 0x4a3217339988e780
@@ -1766,18 +1037,9 @@ I_sb_cg_cp_imm_edges_0x2:
   sb x2, 2(x24) # perform store
   addi x24, x24, 2 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x4 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x4, I_sb_cg_cp_imm_edges_0x2, I_sb_cg_cp_imm_edges_0x2_str)
-#else
-  sb x2, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 3)
   RVTEST_TESTDATA_LOAD_INT(x18, x10) # load rs2: x10 = 0xb460d56db1caf10d
@@ -1787,18 +1049,9 @@ I_sb_cg_cp_imm_edges_0x3:
   sb x10, 3(x22) # perform store
   addi x22, x22, 3 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x30 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x30, I_sb_cg_cp_imm_edges_0x3, I_sb_cg_cp_imm_edges_0x3_str)
-#else
-  sb x10, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 4)
   RVTEST_TESTDATA_LOAD_INT(x18, x31) # load rs2: x31 = 0xf13043e88626bb04
@@ -1808,18 +1061,9 @@ I_sb_cg_cp_imm_edges_0x4:
   sb x31, 4(x5) # perform store
   addi x5, x5, 4 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x16 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x16, I_sb_cg_cp_imm_edges_0x4, I_sb_cg_cp_imm_edges_0x4_str)
-#else
-  sb x31, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 8)
   RVTEST_TESTDATA_LOAD_INT(x18, x22) # load rs2: x22 = 0x4800b4ed2d47bace
@@ -1829,18 +1073,9 @@ I_sb_cg_cp_imm_edges_0x8:
   sb x22, 8(x4) # perform store
   addi x4, x4, 8 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x15 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x15, I_sb_cg_cp_imm_edges_0x8, I_sb_cg_cp_imm_edges_0x8_str)
-#else
-  sb x22, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 16)
   RVTEST_TESTDATA_LOAD_INT(x18, x24) # load rs2: x24 = 0x526aeab55101ea73
@@ -1850,18 +1085,9 @@ I_sb_cg_cp_imm_edges_0x10:
   sb x24, 16(x14) # perform store
   addi x14, x14, 16 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x17 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x17, I_sb_cg_cp_imm_edges_0x10, I_sb_cg_cp_imm_edges_0x10_str)
-#else
-  sb x24, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 32)
   RVTEST_TESTDATA_LOAD_INT(x18, x15) # load rs2: x15 = 0xb79e99575f67ca05
@@ -1871,18 +1097,9 @@ I_sb_cg_cp_imm_edges_0x20:
   sb x15, 32(x1) # perform store
   addi x1, x1, 32 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x27 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x27, I_sb_cg_cp_imm_edges_0x20, I_sb_cg_cp_imm_edges_0x20_str)
-#else
-  sb x15, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 64)
   RVTEST_TESTDATA_LOAD_INT(x18, x12) # load rs2: x12 = 0x353e3454f2fbc22f
@@ -1892,18 +1109,9 @@ I_sb_cg_cp_imm_edges_0x40:
   sb x12, 64(x19) # perform store
   addi x19, x19, 64 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x6 contains the expected result. x19 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x19, x8, x7, x6, I_sb_cg_cp_imm_edges_0x40, I_sb_cg_cp_imm_edges_0x40_str)
-#else
-  sb x12, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 128)
   RVTEST_TESTDATA_LOAD_INT(x18, x13) # load rs2: x13 = 0x49b50ccb566a6afb
@@ -1913,18 +1121,9 @@ I_sb_cg_cp_imm_edges_0x80:
   sb x13, 128(x5) # perform store
   addi x5, x5, 128 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x3 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x3, I_sb_cg_cp_imm_edges_0x80, I_sb_cg_cp_imm_edges_0x80_str)
-#else
-  sb x13, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 256)
   RVTEST_TESTDATA_LOAD_INT(x18, x27) # load rs2: x27 = 0xf9a84ddf7a97066b
@@ -1934,18 +1133,9 @@ I_sb_cg_cp_imm_edges_0x100:
   sb x27, 256(x12) # perform store
   addi x12, x12, 256 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x20 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x12, x8, x7, x20, I_sb_cg_cp_imm_edges_0x100, I_sb_cg_cp_imm_edges_0x100_str)
-#else
-  sb x27, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 512)
   RVTEST_TESTDATA_LOAD_INT(x18, x1) # load rs2: x1 = 0x4d00029d42cac5c0
@@ -1955,18 +1145,9 @@ I_sb_cg_cp_imm_edges_0x200:
   sb x1, 512(x25) # perform store
   addi x25, x25, 512 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x14 contains the expected result. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x25, x8, x7, x14, I_sb_cg_cp_imm_edges_0x200, I_sb_cg_cp_imm_edges_0x200_str)
-#else
-  sb x1, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1023)
   RVTEST_TESTDATA_LOAD_INT(x18, x4) # load rs2: x4 = 0xbb0c753475255363
@@ -1976,18 +1157,9 @@ I_sb_cg_cp_imm_edges_0x3ff:
   sb x4, 1023(x24) # perform store
   addi x24, x24, 1023 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x12 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x12, I_sb_cg_cp_imm_edges_0x3ff, I_sb_cg_cp_imm_edges_0x3ff_str)
-#else
-  sb x4, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1024)
   RVTEST_TESTDATA_LOAD_INT(x18, x31) # load rs2: x31 = 0xbc734943a8b636a7
@@ -1997,18 +1169,9 @@ I_sb_cg_cp_imm_edges_0x400:
   sb x31, 1024(x12) # perform store
   addi x12, x12, 1024 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x12, x8, x7, x14, I_sb_cg_cp_imm_edges_0x400, I_sb_cg_cp_imm_edges_0x400_str)
-#else
-  sb x31, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1795)
   RVTEST_TESTDATA_LOAD_INT(x18, x4) # load rs2: x4 = 0x37694751e1b0c49a
@@ -2018,18 +1181,9 @@ I_sb_cg_cp_imm_edges_0x703:
   sb x4, 1795(x10) # perform store
   addi x10, x10, 1795 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x25 contains the expected result. x10 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x10, x8, x7, x25, I_sb_cg_cp_imm_edges_0x703, I_sb_cg_cp_imm_edges_0x703_str)
-#else
-  sb x4, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2047)
   RVTEST_TESTDATA_LOAD_INT(x18, x19) # load rs2: x19 = 0xd9c12983e0787ff9
@@ -2039,18 +1193,9 @@ I_sb_cg_cp_imm_edges_0x7ff:
   sb x19, 2047(x1) # perform store
   addi x1, x1, 2047 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x25 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x25, I_sb_cg_cp_imm_edges_0x7ff, I_sb_cg_cp_imm_edges_0x7ff_str)
-#else
-  sb x19, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2048)
   RVTEST_TESTDATA_LOAD_INT(x18, x31) # load rs2: x31 = 0x4e9f87dee0ea0cfd
@@ -2061,18 +1206,9 @@ I_sb_cg_cp_imm_edges_m0x800:
   sb x31, -2048(x22) # perform store
   addi x22, x22, -2048 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x10 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x22, x8, x7, x10, I_sb_cg_cp_imm_edges_m0x800, I_sb_cg_cp_imm_edges_m0x800_str)
-#else
-  sb x31, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2047)
   RVTEST_TESTDATA_LOAD_INT(x18, x19) # load rs2: x19 = 0x4805dad05f5d3ae9
@@ -2082,18 +1218,9 @@ I_sb_cg_cp_imm_edges_m0x7ff:
   sb x19, -2047(x11) # perform store
   addi x11, x11, -2047 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x11, x8, x7, x13, I_sb_cg_cp_imm_edges_m0x7ff, I_sb_cg_cp_imm_edges_m0x7ff_str)
-#else
-  sb x19, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2)
   RVTEST_TESTDATA_LOAD_INT(x18, x5) # load rs2: x5 = 0xcca0bf400e18247d
@@ -2103,18 +1230,9 @@ I_sb_cg_cp_imm_edges_m0x2:
   sb x5, -2(x31) # perform store
   addi x31, x31, -2 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x20 contains the expected result. x31 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x31, x8, x7, x20, I_sb_cg_cp_imm_edges_m0x2, I_sb_cg_cp_imm_edges_m0x2_str)
-#else
-  sb x5, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -1)
   RVTEST_TESTDATA_LOAD_INT(x18, x10) # load rs2: x10 = 0xe1c0e74a1e95cf61
@@ -2124,18 +1242,9 @@ I_sb_cg_cp_imm_edges_m0x1:
   sb x10, -1(x28) # perform store
   addi x28, x28, -1 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x29 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x29, I_sb_cg_cp_imm_edges_m0x1, I_sb_cg_cp_imm_edges_m0x1_str)
-#else
-  sb x10, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_align_byte
@@ -2146,144 +1255,72 @@ I_sb_cg_cp_imm_edges_m0x1:
 I_sb_cg_cp_align_byte_b0:
   sb x12, 0(x28) # perform store
   addi x28, x28, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -8(x28) # load stored value for checking
   # Check if x17 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x17, I_sb_cg_cp_align_byte_b0, I_sb_cg_cp_align_byte_b0_str)
-#else
-  sb x12, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 001)
   RVTEST_TESTDATA_LOAD_INT(x18, x23) # load rs2: x23 = 0xa56335ff3b5546ad
 I_sb_cg_cp_align_byte_b1:
   sb x23, 1(x28) # perform store
   addi x28, x28, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -8(x28) # load stored value for checking
   # Check if x12 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x12, I_sb_cg_cp_align_byte_b1, I_sb_cg_cp_align_byte_b1_str)
-#else
-  sb x23, 1(x28) # repeat store so it is available for checking
-  addi x28, x28, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 010)
   RVTEST_TESTDATA_LOAD_INT(x18, x4) # load rs2: x4 = 0x63f392759289d8fa
 I_sb_cg_cp_align_byte_b2:
   sb x4, 2(x28) # perform store
   addi x28, x28, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -8(x28) # load stored value for checking
   # Check if x26 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x26, I_sb_cg_cp_align_byte_b2, I_sb_cg_cp_align_byte_b2_str)
-#else
-  sb x4, 2(x28) # repeat store so it is available for checking
-  addi x28, x28, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 011)
   RVTEST_TESTDATA_LOAD_INT(x18, x10) # load rs2: x10 = 0x14545a7a3c1de390
 I_sb_cg_cp_align_byte_b3:
   sb x10, 3(x28) # perform store
   addi x28, x28, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -8(x28) # load stored value for checking
   # Check if x3 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x3, I_sb_cg_cp_align_byte_b3, I_sb_cg_cp_align_byte_b3_str)
-#else
-  sb x10, 3(x28) # repeat store so it is available for checking
-  addi x28, x28, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 100)
   RVTEST_TESTDATA_LOAD_INT(x18, x25) # load rs2: x25 = 0x54be38274584f3dd
 I_sb_cg_cp_align_byte_b4:
   sb x25, 4(x28) # perform store
   addi x28, x28, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -8(x28) # load stored value for checking
   # Check if x23 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x23, I_sb_cg_cp_align_byte_b4, I_sb_cg_cp_align_byte_b4_str)
-#else
-  sb x25, 4(x28) # repeat store so it is available for checking
-  addi x28, x28, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 101)
   RVTEST_TESTDATA_LOAD_INT(x18, x16) # load rs2: x16 = 0xb31c02a0348a672d
 I_sb_cg_cp_align_byte_b5:
   sb x16, 5(x28) # perform store
   addi x28, x28, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -8(x28) # load stored value for checking
   # Check if x19 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x19, I_sb_cg_cp_align_byte_b5, I_sb_cg_cp_align_byte_b5_str)
-#else
-  sb x16, 5(x28) # repeat store so it is available for checking
-  addi x28, x28, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 110)
   RVTEST_TESTDATA_LOAD_INT(x18, x26) # load rs2: x26 = 0x3358da3c7995ec3f
 I_sb_cg_cp_align_byte_b6:
   sb x26, 6(x28) # perform store
   addi x28, x28, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -8(x28) # load stored value for checking
   # Check if x19 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x19, I_sb_cg_cp_align_byte_b6, I_sb_cg_cp_align_byte_b6_str)
-#else
-  sb x26, 6(x28) # repeat store so it is available for checking
-  addi x28, x28, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_byte (imm[2:0] = 111)
   RVTEST_TESTDATA_LOAD_INT(x18, x14) # load rs2: x14 = 0x306b890c0d137961
 I_sb_cg_cp_align_byte_b7:
   sb x14, 7(x28) # perform store
   addi x28, x28, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -8(x28) # load stored value for checking
   # Check if x1 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x1, I_sb_cg_cp_align_byte_b7, I_sb_cg_cp_align_byte_b7_str)
-#else
-  sb x14, 7(x28) # repeat store so it is available for checking
-  addi x28, x28, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 
   mv x2, x28 # restore signature pointer to default register for teardown

--- a/tests/rv64i/I/I-sd-00.S
+++ b/tests/rv64i/I/I-sd-00.S
@@ -41,18 +41,9 @@ I_sd_cg_cp_rs1_nx0_b1:
   sd x6, -405(x1) # perform store
   addi x1, x1, -405 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x14 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x14, I_sd_cg_cp_rs1_nx0_b1, I_sd_cg_cp_rs1_nx0_b1_str)
-#else
-  sd x6, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x2e600b30a2fbefe1
@@ -62,18 +53,9 @@ I_sd_cg_cp_rs1_nx0_b2:
   sd x8, -568(x2) # perform store
   addi x2, x2, -568 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x7 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x7, I_sd_cg_cp_rs1_nx0_b2, I_sd_cg_cp_rs1_nx0_b2_str)
-#else
-  sd x8, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x22, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
@@ -84,18 +66,9 @@ I_sd_cg_cp_rs1_nx0_b3:
   sd x29, -493(x3) # perform store
   addi x3, x3, -493 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x31 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x31, I_sd_cg_cp_rs1_nx0_b3, I_sd_cg_cp_rs1_nx0_b3_str)
-#else
-  sd x29, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -107,18 +80,9 @@ I_sd_cg_cp_rs1_nx0_b4:
   sd x19, 28(x4) # perform store
   addi x4, x4, 28 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x15 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x15, I_sd_cg_cp_rs1_nx0_b4, I_sd_cg_cp_rs1_nx0_b4_str)
-#else
-  sd x19, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x22, x15) # load rs2: x15 = 0x595f3907f1cbee15
@@ -128,18 +92,9 @@ I_sd_cg_cp_rs1_nx0_b5:
   sd x15, -464(x5) # perform store
   addi x5, x5, -464 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x26 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x26, I_sd_cg_cp_rs1_nx0_b5, I_sd_cg_cp_rs1_nx0_b5_str)
-#else
-  sd x15, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x22, x1) # load rs2: x1 = 0xd4c661fe4a966bd1
@@ -149,18 +104,9 @@ I_sd_cg_cp_rs1_nx0_b6:
   sd x1, 1481(x6) # perform store
   addi x6, x6, 1481 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x25, I_sd_cg_cp_rs1_nx0_b6, I_sd_cg_cp_rs1_nx0_b6_str)
-#else
-  sd x1, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x7 # switch temp register to avoid conflict with test
   mv x14, x8 # switch link pointer register to avoid conflict with test
@@ -172,18 +118,9 @@ I_sd_cg_cp_rs1_nx0_b7:
   sd x31, -506(x7) # perform store
   addi x7, x7, -506 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x3 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x3, I_sd_cg_cp_rs1_nx0_b7, I_sd_cg_cp_rs1_nx0_b7_str)
-#else
-  sd x31, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x22, x28) # load rs2: x28 = 0xccf3cc2e80f3a775
@@ -193,18 +130,9 @@ I_sd_cg_cp_rs1_nx0_b8:
   sd x28, 217(x8) # perform store
   addi x8, x8, 217 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x25 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x25, I_sd_cg_cp_rs1_nx0_b8, I_sd_cg_cp_rs1_nx0_b8_str)
-#else
-  sd x28, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x22, x31) # load rs2: x31 = 0x41015aaa129518df
@@ -214,18 +142,9 @@ I_sd_cg_cp_rs1_nx0_b9:
   sd x31, 760(x9) # perform store
   addi x9, x9, 760 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x6 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x6, I_sd_cg_cp_rs1_nx0_b9, I_sd_cg_cp_rs1_nx0_b9_str)
-#else
-  sd x31, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x22, x2) # load rs2: x2 = 0x59e9463fabc5da1c
@@ -235,18 +154,9 @@ I_sd_cg_cp_rs1_nx0_b10:
   sd x2, -332(x10) # perform store
   addi x10, x10, -332 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x26 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x26, I_sd_cg_cp_rs1_nx0_b10, I_sd_cg_cp_rs1_nx0_b10_str)
-#else
-  sd x2, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x22, x17) # load rs2: x17 = 0xadc2710772ef84e7
@@ -256,18 +166,9 @@ I_sd_cg_cp_rs1_nx0_b11:
   sd x17, 767(x11) # perform store
   addi x11, x11, 767 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x8 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x8, I_sd_cg_cp_rs1_nx0_b11, I_sd_cg_cp_rs1_nx0_b11_str)
-#else
-  sd x17, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x22, x19) # load rs2: x19 = 0x7ed4b3ace72c2faf
@@ -277,18 +178,9 @@ I_sd_cg_cp_rs1_nx0_b12:
   sd x19, -1095(x12) # perform store
   addi x12, x12, -1095 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x6 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x6, I_sd_cg_cp_rs1_nx0_b12, I_sd_cg_cp_rs1_nx0_b12_str)
-#else
-  sd x19, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -300,18 +192,9 @@ I_sd_cg_cp_rs1_nx0_b13:
   sd x29, 1502(x13) # perform store
   addi x13, x13, 1502 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x21 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x21, I_sd_cg_cp_rs1_nx0_b13, I_sd_cg_cp_rs1_nx0_b13_str)
-#else
-  sd x29, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x22, x24) # load rs2: x24 = 0x55c2cc794fbbcd3f
@@ -321,18 +204,9 @@ I_sd_cg_cp_rs1_nx0_b14:
   sd x24, -1702(x14) # perform store
   addi x14, x14, -1702 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x15 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x15, I_sd_cg_cp_rs1_nx0_b14, I_sd_cg_cp_rs1_nx0_b14_str)
-#else
-  sd x24, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x22, x9) # load rs2: x9 = 0x24b723fd24eb3088
@@ -342,18 +216,9 @@ I_sd_cg_cp_rs1_nx0_b15:
   sd x9, -188(x15) # perform store
   addi x15, x15, -188 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x1 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x1, I_sd_cg_cp_rs1_nx0_b15, I_sd_cg_cp_rs1_nx0_b15_str)
-#else
-  sd x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x16)
   RVTEST_TESTDATA_LOAD_INT(x22, x1) # load rs2: x1 = 0x0fdc7a4953f2dcd1
@@ -363,18 +228,9 @@ I_sd_cg_cp_rs1_nx0_b16:
   sd x1, 1368(x16) # perform store
   addi x16, x16, 1368 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x10 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x10, I_sd_cg_cp_rs1_nx0_b16, I_sd_cg_cp_rs1_nx0_b16_str)
-#else
-  sd x1, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x17)
   RVTEST_TESTDATA_LOAD_INT(x22, x29) # load rs2: x29 = 0x8db05df908e7644d
@@ -384,18 +240,9 @@ I_sd_cg_cp_rs1_nx0_b17:
   sd x29, -578(x17) # perform store
   addi x17, x17, -578 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x27 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x27, I_sd_cg_cp_rs1_nx0_b17, I_sd_cg_cp_rs1_nx0_b17_str)
-#else
-  sd x29, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x18)
   RVTEST_TESTDATA_LOAD_INT(x22, x23) # load rs2: x23 = 0x5e54b06de9929d80
@@ -405,18 +252,9 @@ I_sd_cg_cp_rs1_nx0_b18:
   sd x23, 1138(x18) # perform store
   addi x18, x18, 1138 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x30 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x30, I_sd_cg_cp_rs1_nx0_b18, I_sd_cg_cp_rs1_nx0_b18_str)
-#else
-  sd x23, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x19)
   RVTEST_TESTDATA_LOAD_INT(x22, x13) # load rs2: x13 = 0x2a921a3331267bd6
@@ -426,18 +264,9 @@ I_sd_cg_cp_rs1_nx0_b19:
   sd x13, -325(x19) # perform store
   addi x19, x19, -325 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x24 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x24, I_sd_cg_cp_rs1_nx0_b19, I_sd_cg_cp_rs1_nx0_b19_str)
-#else
-  sd x13, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x20)
   RVTEST_TESTDATA_LOAD_INT(x22, x0) # load rs2: x0 = 0x4250c5dfaca0fc8a
@@ -447,18 +276,9 @@ I_sd_cg_cp_rs1_nx0_b20:
   sd x0, 293(x20) # perform store
   addi x20, x20, 293 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x26 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x26, I_sd_cg_cp_rs1_nx0_b20, I_sd_cg_cp_rs1_nx0_b20_str)
-#else
-  sd x0, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x21)
   RVTEST_TESTDATA_LOAD_INT(x22, x2) # load rs2: x2 = 0xd4e0e89a034b6214
@@ -468,18 +288,9 @@ I_sd_cg_cp_rs1_nx0_b21:
   sd x2, 1235(x21) # perform store
   addi x21, x21, 1235 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x15 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x15, I_sd_cg_cp_rs1_nx0_b21, I_sd_cg_cp_rs1_nx0_b21_str)
-#else
-  sd x2, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x1, x22 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x22)
@@ -490,18 +301,9 @@ I_sd_cg_cp_rs1_nx0_b22:
   sd x20, 1446(x22) # perform store
   addi x22, x22, 1446 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x29 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x29, I_sd_cg_cp_rs1_nx0_b22, I_sd_cg_cp_rs1_nx0_b22_str)
-#else
-  sd x20, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x23)
   RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rs2: x18 = 0xceac96e6e1ef34c0
@@ -511,18 +313,9 @@ I_sd_cg_cp_rs1_nx0_b23:
   sd x18, -959(x23) # perform store
   addi x23, x23, -959 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x27 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x27, I_sd_cg_cp_rs1_nx0_b23, I_sd_cg_cp_rs1_nx0_b23_str)
-#else
-  sd x18, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x24)
   RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x8dd3de29e58622e5
@@ -532,18 +325,9 @@ I_sd_cg_cp_rs1_nx0_b24:
   sd x16, 155(x24) # perform store
   addi x24, x24, 155 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x18 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x18, I_sd_cg_cp_rs1_nx0_b24, I_sd_cg_cp_rs1_nx0_b24_str)
-#else
-  sd x16, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x25)
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x4cf6465bb96dfa2c
@@ -553,18 +337,9 @@ I_sd_cg_cp_rs1_nx0_b25:
   sd x27, -1734(x25) # perform store
   addi x25, x25, -1734 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x15 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x15, I_sd_cg_cp_rs1_nx0_b25, I_sd_cg_cp_rs1_nx0_b25_str)
-#else
-  sd x27, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x26)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x29c9c14fe721d927
@@ -574,18 +349,9 @@ I_sd_cg_cp_rs1_nx0_b26:
   sd x11, 400(x26) # perform store
   addi x26, x26, 400 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x20 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x20, I_sd_cg_cp_rs1_nx0_b26, I_sd_cg_cp_rs1_nx0_b26_str)
-#else
-  sd x11, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x27)
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0x0c901504348dd9db
@@ -595,18 +361,9 @@ I_sd_cg_cp_rs1_nx0_b27:
   sd x19, 969(x27) # perform store
   addi x27, x27, 969 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x13 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x13, I_sd_cg_cp_rs1_nx0_b27, I_sd_cg_cp_rs1_nx0_b27_str)
-#else
-  sd x19, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x28)
   RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x4d4e24f14cfd55c7
@@ -616,18 +373,9 @@ I_sd_cg_cp_rs1_nx0_b28:
   sd x16, -209(x28) # perform store
   addi x28, x28, -209 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x11 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x11, I_sd_cg_cp_rs1_nx0_b28, I_sd_cg_cp_rs1_nx0_b28_str)
-#else
-  sd x16, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x29)
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0x6b60c1841af5835c
@@ -637,18 +385,9 @@ I_sd_cg_cp_rs1_nx0_b29:
   sd x19, -87(x29) # perform store
   addi x29, x29, -87 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x24 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x24, I_sd_cg_cp_rs1_nx0_b29, I_sd_cg_cp_rs1_nx0_b29_str)
-#else
-  sd x19, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x30)
   RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rs2: x18 = 0x94927e2cca713894
@@ -658,18 +397,9 @@ I_sd_cg_cp_rs1_nx0_b30:
   sd x18, -483(x30) # perform store
   addi x30, x30, -483 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x26 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x26, I_sd_cg_cp_rs1_nx0_b30, I_sd_cg_cp_rs1_nx0_b30_str)
-#else
-  sd x18, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x31)
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x086797580d752af2
@@ -679,18 +409,9 @@ I_sd_cg_cp_rs1_nx0_b31:
   sd x20, -325(x31) # perform store
   addi x31, x31, -325 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x23 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x23, I_sd_cg_cp_rs1_nx0_b31, I_sd_cg_cp_rs1_nx0_b31_str)
-#else
-  sd x20, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2
@@ -704,18 +425,9 @@ I_sd_cg_cp_rs2_b0:
   sd x0, -776(x26) # perform store
   addi x26, x26, -776 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x28 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x28, I_sd_cg_cp_rs2_b0, I_sd_cg_cp_rs2_b0_str)
-#else
-  sd x0, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x21, x1 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x1)
@@ -726,18 +438,9 @@ I_sd_cg_cp_rs2_b1:
   sd x1, 3(x25) # perform store
   addi x25, x25, 3 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x30 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x30, I_sd_cg_cp_rs2_b1, I_sd_cg_cp_rs2_b1_str)
-#else
-  sd x1, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x21, x2) # load rs2: x2 = 0xa81cae4e4ae1d8a7
@@ -747,18 +450,9 @@ I_sd_cg_cp_rs2_b2:
   sd x2, -568(x27) # perform store
   addi x27, x27, -568 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x23 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x23, I_sd_cg_cp_rs2_b2, I_sd_cg_cp_rs2_b2_str)
-#else
-  sd x2, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x21, x3) # load rs2: x3 = 0x80b40ff0f877b1b0
@@ -768,18 +462,9 @@ I_sd_cg_cp_rs2_b3:
   sd x3, -1146(x2) # perform store
   addi x2, x2, -1146 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x12 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x12, I_sd_cg_cp_rs2_b3, I_sd_cg_cp_rs2_b3_str)
-#else
-  sd x3, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -791,18 +476,9 @@ I_sd_cg_cp_rs2_b4:
   sd x4, 2047(x12) # perform store
   addi x12, x12, 2047 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x27 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x12, x8, x7, x27, I_sd_cg_cp_rs2_b4, I_sd_cg_cp_rs2_b4_str)
-#else
-  sd x4, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x21, x5) # load rs2: x5 = 0xe6b98853ff700ca9
@@ -812,18 +488,9 @@ I_sd_cg_cp_rs2_b5:
   sd x5, -71(x14) # perform store
   addi x14, x14, -71 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x25 contains the expected result. x14 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x14, x8, x7, x25, I_sd_cg_cp_rs2_b5, I_sd_cg_cp_rs2_b5_str)
-#else
-  sd x5, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x21, x6) # load rs2: x6 = 0x21e53afb28ee8cd9
@@ -833,18 +500,9 @@ I_sd_cg_cp_rs2_b6:
   sd x6, 432(x25) # perform store
   addi x25, x25, 432 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x28 contains the expected result. x25 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x25, x8, x7, x28, I_sd_cg_cp_rs2_b6, I_sd_cg_cp_rs2_b6_str)
-#else
-  sd x6, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x7 # switch temp register to avoid conflict with test
   mv x5, x8 # switch link pointer register to avoid conflict with test
@@ -856,18 +514,9 @@ I_sd_cg_cp_rs2_b7:
   sd x7, 1435(x3) # perform store
   addi x3, x3, 1435 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x6 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x6, I_sd_cg_cp_rs2_b7, I_sd_cg_cp_rs2_b7_str)
-#else
-  sd x7, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x21, x8) # load rs2: x8 = 0xc38a8b9a6fed6160
@@ -877,18 +526,9 @@ I_sd_cg_cp_rs2_b8:
   sd x8, 278(x25) # perform store
   addi x25, x25, 278 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x14 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x14, I_sd_cg_cp_rs2_b8, I_sd_cg_cp_rs2_b8_str)
-#else
-  sd x8, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x21, x9) # load rs2: x9 = 0x3604dc56963932c0
@@ -898,18 +538,9 @@ I_sd_cg_cp_rs2_b9:
   sd x9, 1862(x14) # perform store
   addi x14, x14, 1862 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x31 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x31, I_sd_cg_cp_rs2_b9, I_sd_cg_cp_rs2_b9_str)
-#else
-  sd x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x21, x10) # load rs2: x10 = 0xa672e49888b7cec9
@@ -919,18 +550,9 @@ I_sd_cg_cp_rs2_b10:
   sd x10, -1612(x17) # perform store
   addi x17, x17, -1612 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x15 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x15, I_sd_cg_cp_rs2_b10, I_sd_cg_cp_rs2_b10_str)
-#else
-  sd x10, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x21, x11) # load rs2: x11 = 0x810c6d85419bf68e
@@ -940,18 +562,9 @@ I_sd_cg_cp_rs2_b11:
   sd x11, -1811(x10) # perform store
   addi x10, x10, -1811 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, I_sd_cg_cp_rs2_b11, I_sd_cg_cp_rs2_b11_str)
-#else
-  sd x11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x21, x12) # load rs2: x12 = 0x8966b11edd800ee2
@@ -961,18 +574,9 @@ I_sd_cg_cp_rs2_b12:
   sd x12, 880(x26) # perform store
   addi x26, x26, 880 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x14 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x14, I_sd_cg_cp_rs2_b12, I_sd_cg_cp_rs2_b12_str)
-#else
-  sd x12, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x21, x13) # load rs2: x13 = 0x15bba857c34d9aee
@@ -982,18 +586,9 @@ I_sd_cg_cp_rs2_b13:
   sd x13, -74(x2) # perform store
   addi x2, x2, -74 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x23 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x23, I_sd_cg_cp_rs2_b13, I_sd_cg_cp_rs2_b13_str)
-#else
-  sd x13, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x21, x14) # load rs2: x14 = 0x5b11a2803eb52201
@@ -1003,18 +598,9 @@ I_sd_cg_cp_rs2_b14:
   sd x14, -1086(x3) # perform store
   addi x3, x3, -1086 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x16 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x16, I_sd_cg_cp_rs2_b14, I_sd_cg_cp_rs2_b14_str)
-#else
-  sd x14, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x21, x15) # load rs2: x15 = 0xb82310d5f2b78d2b
@@ -1024,18 +610,9 @@ I_sd_cg_cp_rs2_b15:
   sd x15, 1145(x13) # perform store
   addi x13, x13, 1145 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, I_sd_cg_cp_rs2_b15, I_sd_cg_cp_rs2_b15_str)
-#else
-  sd x15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x21, x16) # load rs2: x16 = 0xea422dfe8f5d6470
@@ -1045,18 +622,9 @@ I_sd_cg_cp_rs2_b16:
   sd x16, 1740(x25) # perform store
   addi x25, x25, 1740 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x8 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x8, I_sd_cg_cp_rs2_b16, I_sd_cg_cp_rs2_b16_str)
-#else
-  sd x16, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x21, x17) # load rs2: x17 = 0x3531f3afed5c0b7e
@@ -1066,18 +634,9 @@ I_sd_cg_cp_rs2_b17:
   sd x17, 1723(x7) # perform store
   addi x7, x7, 1723 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x12 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x12, I_sd_cg_cp_rs2_b17, I_sd_cg_cp_rs2_b17_str)
-#else
-  sd x17, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x21, x18) # load rs2: x18 = 0xad8bdf5bcf6c375d
@@ -1087,18 +646,9 @@ I_sd_cg_cp_rs2_b18:
   sd x18, -418(x31) # perform store
   addi x31, x31, -418 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x9 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x9, I_sd_cg_cp_rs2_b18, I_sd_cg_cp_rs2_b18_str)
-#else
-  sd x18, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x21, x19) # load rs2: x19 = 0xa45a4797eaaadd97
@@ -1108,18 +658,9 @@ I_sd_cg_cp_rs2_b19:
   sd x19, -629(x20) # perform store
   addi x20, x20, -629 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x9 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x9, I_sd_cg_cp_rs2_b19, I_sd_cg_cp_rs2_b19_str)
-#else
-  sd x19, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x31, x20 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x20)
@@ -1130,18 +671,9 @@ I_sd_cg_cp_rs2_b20:
   sd x20, -422(x18) # perform store
   addi x18, x18, -422 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x30 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x30, I_sd_cg_cp_rs2_b20, I_sd_cg_cp_rs2_b20_str)
-#else
-  sd x20, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x30, x21 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x21)
@@ -1152,18 +684,9 @@ I_sd_cg_cp_rs2_b21:
   sd x21, 2014(x1) # perform store
   addi x1, x1, 2014 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x29 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x29, I_sd_cg_cp_rs2_b21, I_sd_cg_cp_rs2_b21_str)
-#else
-  sd x21, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x30, x22) # load rs2: x22 = 0x6483e3783b7a210a
@@ -1173,18 +696,9 @@ I_sd_cg_cp_rs2_b22:
   sd x22, 1107(x16) # perform store
   addi x16, x16, 1107 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x31 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x31, I_sd_cg_cp_rs2_b22, I_sd_cg_cp_rs2_b22_str)
-#else
-  sd x22, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x30, x23) # load rs2: x23 = 0xacf6c3096736c5fa
@@ -1194,18 +708,9 @@ I_sd_cg_cp_rs2_b23:
   sd x23, -1241(x15) # perform store
   addi x15, x15, -1241 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x13, I_sd_cg_cp_rs2_b23, I_sd_cg_cp_rs2_b23_str)
-#else
-  sd x23, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x30, x24) # load rs2: x24 = 0x56dcf0dccc32b8f4
@@ -1215,18 +720,9 @@ I_sd_cg_cp_rs2_b24:
   sd x24, -1104(x2) # perform store
   addi x2, x2, -1104 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x3 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x3, I_sd_cg_cp_rs2_b24, I_sd_cg_cp_rs2_b24_str)
-#else
-  sd x24, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x30, x25) # load rs2: x25 = 0x4d366b995a136f3c
@@ -1236,18 +732,9 @@ I_sd_cg_cp_rs2_b25:
   sd x25, 1580(x12) # perform store
   addi x12, x12, 1580 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x28 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x28, I_sd_cg_cp_rs2_b25, I_sd_cg_cp_rs2_b25_str)
-#else
-  sd x25, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x30, x26) # load rs2: x26 = 0x362a3bdb34cf974c
@@ -1257,18 +744,9 @@ I_sd_cg_cp_rs2_b26:
   sd x26, 1204(x10) # perform store
   addi x10, x10, 1204 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x1 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x1, I_sd_cg_cp_rs2_b26, I_sd_cg_cp_rs2_b26_str)
-#else
-  sd x26, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x30, x27) # load rs2: x27 = 0x9e914078ff722bcc
@@ -1278,18 +756,9 @@ I_sd_cg_cp_rs2_b27:
   sd x27, -1609(x13) # perform store
   addi x13, x13, -1609 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, I_sd_cg_cp_rs2_b27, I_sd_cg_cp_rs2_b27_str)
-#else
-  sd x27, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x30, x28) # load rs2: x28 = 0xb4bc145b232c0f90
@@ -1299,18 +768,9 @@ I_sd_cg_cp_rs2_b28:
   sd x28, -1349(x11) # perform store
   addi x11, x11, -1349 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x29 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x29, I_sd_cg_cp_rs2_b28, I_sd_cg_cp_rs2_b28_str)
-#else
-  sd x28, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x30, x29) # load rs2: x29 = 0x9867457c5e9bfa25
@@ -1320,18 +780,9 @@ I_sd_cg_cp_rs2_b29:
   sd x29, 586(x16) # perform store
   addi x16, x16, 586 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x22 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x22, I_sd_cg_cp_rs2_b29, I_sd_cg_cp_rs2_b29_str)
-#else
-  sd x29, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x1, x30 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x30)
@@ -1342,18 +793,9 @@ I_sd_cg_cp_rs2_b30:
   sd x30, -1600(x14) # perform store
   addi x14, x14, -1600 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x21 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x21, I_sd_cg_cp_rs2_b30, I_sd_cg_cp_rs2_b30_str)
-#else
-  sd x30, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0xd66e5f58aa8c7665
@@ -1363,18 +805,9 @@ I_sd_cg_cp_rs2_b31:
   sd x31, -92(x12) # perform store
   addi x12, x12, -92 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x20 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x20, I_sd_cg_cp_rs2_b31, I_sd_cg_cp_rs2_b31_str)
-#else
-  sd x31, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -1388,18 +821,9 @@ I_sd_cg_cp_rs2_edges_0x0:
   sd x10, 1785(x17) # perform store
   addi x17, x17, 1785 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x20 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x20, I_sd_cg_cp_rs2_edges_0x0, I_sd_cg_cp_rs2_edges_0x0_str)
-#else
-  sd x10, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x0000000000000001
@@ -1409,18 +833,9 @@ I_sd_cg_cp_rs2_edges_0x1:
   sd x25, -191(x23) # perform store
   addi x23, x23, -191 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x6 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x6, I_sd_cg_cp_rs2_edges_0x1, I_sd_cg_cp_rs2_edges_0x1_str)
-#else
-  sd x25, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x0000000000000002
@@ -1430,18 +845,9 @@ I_sd_cg_cp_rs2_edges_0x2:
   sd x10, -1367(x18) # perform store
   addi x18, x18, -1367 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x3 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x3, I_sd_cg_cp_rs2_edges_0x2, I_sd_cg_cp_rs2_edges_0x2_str)
-#else
-  sd x10, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x8000000000000000
@@ -1451,18 +857,9 @@ I_sd_cg_cp_rs2_edges_0x8000000000000000:
   sd x15, 20(x17) # perform store
   addi x17, x17, 20 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x13 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x13, I_sd_cg_cp_rs2_edges_0x8000000000000000, I_sd_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  sd x15, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x8000000000000001
@@ -1472,18 +869,9 @@ I_sd_cg_cp_rs2_edges_0x8000000000000001:
   sd x23, -1854(x3) # perform store
   addi x3, x3, -1854 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x22 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x22, I_sd_cg_cp_rs2_edges_0x8000000000000001, I_sd_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  sd x23, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0x7fffffffffffffff
@@ -1493,18 +881,9 @@ I_sd_cg_cp_rs2_edges_0x7fffffffffffffff:
   sd x2, -2020(x14) # perform store
   addi x14, x14, -2020 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x6 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x6, I_sd_cg_cp_rs2_edges_0x7fffffffffffffff, I_sd_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  sd x2, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x7ffffffffffffffe
@@ -1514,18 +893,9 @@ I_sd_cg_cp_rs2_edges_0x7ffffffffffffffe:
   sd x10, 670(x17) # perform store
   addi x17, x17, 670 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x30 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x30, I_sd_cg_cp_rs2_edges_0x7ffffffffffffffe, I_sd_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  sd x10, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xffffffffffffffff
@@ -1535,18 +905,9 @@ I_sd_cg_cp_rs2_edges_0xffffffffffffffff:
   sd x2, -929(x31) # perform store
   addi x31, x31, -929 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x25 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x25, I_sd_cg_cp_rs2_edges_0xffffffffffffffff, I_sd_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  sd x2, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0xfffffffffffffffe
@@ -1556,18 +917,9 @@ I_sd_cg_cp_rs2_edges_0xfffffffffffffffe:
   sd x28, -57(x27) # perform store
   addi x27, x27, -57 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x25 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x25, I_sd_cg_cp_rs2_edges_0xfffffffffffffffe, I_sd_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  sd x28, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0x5bbc887763ae86f2
@@ -1577,18 +929,9 @@ I_sd_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   sd x24, 1806(x6) # perform store
   addi x6, x6, 1806 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x25 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x25, I_sd_cg_cp_rs2_edges_0x5bbc887763ae86f2, I_sd_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  sd x24, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xaaaaaaaaaaaaaaaa
@@ -1598,18 +941,9 @@ I_sd_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   sd x12, 8(x13) # perform store
   addi x13, x13, 8 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x22 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x22, I_sd_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, I_sd_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  sd x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x5555555555555555
@@ -1619,18 +953,9 @@ I_sd_cg_cp_rs2_edges_0x5555555555555555:
   sd x15, -1596(x11) # perform store
   addi x11, x11, -1596 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x17 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x17, I_sd_cg_cp_rs2_edges_0x5555555555555555, I_sd_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  sd x15, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x00000000ffffffff
@@ -1640,18 +965,9 @@ I_sd_cg_cp_rs2_edges_0xffffffff:
   sd x29, -1783(x25) # perform store
   addi x25, x25, -1783 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x7 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x7, I_sd_cg_cp_rs2_edges_0xffffffff, I_sd_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  sd x29, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x00000000fffffffe
@@ -1661,18 +977,9 @@ I_sd_cg_cp_rs2_edges_0xfffffffe:
   sd x23, -303(x28) # perform store
   addi x28, x28, -303 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x6 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x6, I_sd_cg_cp_rs2_edges_0xfffffffe, I_sd_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  sd x23, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x0000000100000000
@@ -1682,18 +989,9 @@ I_sd_cg_cp_rs2_edges_0x100000000:
   sd x25, -1142(x2) # perform store
   addi x2, x2, -1142 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, I_sd_cg_cp_rs2_edges_0x100000000, I_sd_cg_cp_rs2_edges_0x100000000_str)
-#else
-  sd x25, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x0000000100000001
@@ -1703,18 +1001,9 @@ I_sd_cg_cp_rs2_edges_0x100000001:
   sd x28, -1988(x24) # perform store
   addi x24, x24, -1988 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x16 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x16, I_sd_cg_cp_rs2_edges_0x100000001, I_sd_cg_cp_rs2_edges_0x100000001_str)
-#else
-  sd x28, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_edges
@@ -1728,18 +1017,9 @@ I_sd_cg_cp_imm_edges_0x0:
   sd x18, 0(x12) # perform store
   addi x12, x12, 0 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x16 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x16, I_sd_cg_cp_imm_edges_0x0, I_sd_cg_cp_imm_edges_0x0_str)
-#else
-  sd x18, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1)
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0xea5545b28886fced
@@ -1749,18 +1029,9 @@ I_sd_cg_cp_imm_edges_0x1:
   sd x9, 1(x14) # perform store
   addi x14, x14, 1 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x26 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x26, I_sd_cg_cp_imm_edges_0x1, I_sd_cg_cp_imm_edges_0x1_str)
-#else
-  sd x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2)
   RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rs2: x18 = 0x02e6cc0ca997274d
@@ -1770,18 +1041,9 @@ I_sd_cg_cp_imm_edges_0x2:
   sd x18, 2(x28) # perform store
   addi x28, x28, 2 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x27 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x27, I_sd_cg_cp_imm_edges_0x2, I_sd_cg_cp_imm_edges_0x2_str)
-#else
-  sd x18, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 3)
   RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0xfa2d7aad7e600774
@@ -1791,18 +1053,9 @@ I_sd_cg_cp_imm_edges_0x3:
   sd x26, 3(x22) # perform store
   addi x22, x22, 3 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x12 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x12, I_sd_cg_cp_imm_edges_0x3, I_sd_cg_cp_imm_edges_0x3_str)
-#else
-  sd x26, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 4)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xcd4b46492b49de54
@@ -1812,18 +1065,9 @@ I_sd_cg_cp_imm_edges_0x4:
   sd x10, 4(x28) # perform store
   addi x28, x28, 4 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x13 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x13, I_sd_cg_cp_imm_edges_0x4, I_sd_cg_cp_imm_edges_0x4_str)
-#else
-  sd x10, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 8)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xaebc757fd9a1608c
@@ -1833,18 +1077,9 @@ I_sd_cg_cp_imm_edges_0x8:
   sd x10, 8(x14) # perform store
   addi x14, x14, 8 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, I_sd_cg_cp_imm_edges_0x8, I_sd_cg_cp_imm_edges_0x8_str)
-#else
-  sd x10, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 16)
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0xcc40c3921afb2bc0
@@ -1854,18 +1089,9 @@ I_sd_cg_cp_imm_edges_0x10:
   sd x19, 16(x10) # perform store
   addi x10, x10, 16 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x25 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x25, I_sd_cg_cp_imm_edges_0x10, I_sd_cg_cp_imm_edges_0x10_str)
-#else
-  sd x19, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 32)
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0xedbd6b2aaed60d1e
@@ -1875,18 +1101,9 @@ I_sd_cg_cp_imm_edges_0x20:
   sd x20, 32(x31) # perform store
   addi x31, x31, 32 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x15 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x15, I_sd_cg_cp_imm_edges_0x20, I_sd_cg_cp_imm_edges_0x20_str)
-#else
-  sd x20, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 64)
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x70c22f4bcd1029c6
@@ -1896,18 +1113,9 @@ I_sd_cg_cp_imm_edges_0x40:
   sd x29, 64(x12) # perform store
   addi x12, x12, 64 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, I_sd_cg_cp_imm_edges_0x40, I_sd_cg_cp_imm_edges_0x40_str)
-#else
-  sd x29, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 128)
   RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rs2: x18 = 0xe86d00164e201015
@@ -1917,18 +1125,9 @@ I_sd_cg_cp_imm_edges_0x80:
   sd x18, 128(x9) # perform store
   addi x9, x9, 128 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x17 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x17, I_sd_cg_cp_imm_edges_0x80, I_sd_cg_cp_imm_edges_0x80_str)
-#else
-  sd x18, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 256)
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x274dacf14165599c
@@ -1938,18 +1137,9 @@ I_sd_cg_cp_imm_edges_0x100:
   sd x21, 256(x24) # perform store
   addi x24, x24, 256 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x22 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x22, I_sd_cg_cp_imm_edges_0x100, I_sd_cg_cp_imm_edges_0x100_str)
-#else
-  sd x21, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 512)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x9884052da0e2118c
@@ -1959,18 +1149,9 @@ I_sd_cg_cp_imm_edges_0x200:
   sd x11, 512(x16) # perform store
   addi x16, x16, 512 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x14 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x14, I_sd_cg_cp_imm_edges_0x200, I_sd_cg_cp_imm_edges_0x200_str)
-#else
-  sd x11, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1023)
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x82e88186b2a4b8a4
@@ -1980,18 +1161,9 @@ I_sd_cg_cp_imm_edges_0x3ff:
   sd x23, 1023(x28) # perform store
   addi x28, x28, 1023 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x31 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x31, I_sd_cg_cp_imm_edges_0x3ff, I_sd_cg_cp_imm_edges_0x3ff_str)
-#else
-  sd x23, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1024)
   RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0x1ec647a7646d3258
@@ -2001,18 +1173,9 @@ I_sd_cg_cp_imm_edges_0x400:
   sd x24, 1024(x6) # perform store
   addi x6, x6, 1024 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x7 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x7, I_sd_cg_cp_imm_edges_0x400, I_sd_cg_cp_imm_edges_0x400_str)
-#else
-  sd x24, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1795)
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0xbaa0c749599213c3
@@ -2022,18 +1185,9 @@ I_sd_cg_cp_imm_edges_0x703:
   sd x25, 1795(x20) # perform store
   addi x20, x20, 1795 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x12 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x12, I_sd_cg_cp_imm_edges_0x703, I_sd_cg_cp_imm_edges_0x703_str)
-#else
-  sd x25, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2047)
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xb6e4d630d7c24c49
@@ -2043,18 +1197,9 @@ I_sd_cg_cp_imm_edges_0x7ff:
   sd x15, 2047(x17) # perform store
   addi x17, x17, 2047 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x21 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x21, I_sd_cg_cp_imm_edges_0x7ff, I_sd_cg_cp_imm_edges_0x7ff_str)
-#else
-  sd x15, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2048)
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x3d7871d8bcf4f964
@@ -2065,18 +1210,9 @@ I_sd_cg_cp_imm_edges_m0x800:
   sd x27, -2048(x29) # perform store
   addi x29, x29, -2048 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x26 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x26, I_sd_cg_cp_imm_edges_m0x800, I_sd_cg_cp_imm_edges_m0x800_str)
-#else
-  sd x27, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2047)
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0x87a61155fe83cf88
@@ -2086,18 +1222,9 @@ I_sd_cg_cp_imm_edges_m0x7ff:
   sd x22, -2047(x13) # perform store
   addi x13, x13, -2047 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, I_sd_cg_cp_imm_edges_m0x7ff, I_sd_cg_cp_imm_edges_m0x7ff_str)
-#else
-  sd x22, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2)
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0x01a0ddf4b689ab49
@@ -2107,18 +1234,9 @@ I_sd_cg_cp_imm_edges_m0x2:
   sd x2, -2(x9) # perform store
   addi x9, x9, -2 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, I_sd_cg_cp_imm_edges_m0x2, I_sd_cg_cp_imm_edges_m0x2_str)
-#else
-  sd x2, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -1)
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xd77957541e271d2b
@@ -2128,18 +1246,9 @@ I_sd_cg_cp_imm_edges_m0x1:
   sd x7, -1(x26) # perform store
   addi x26, x26, -1 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x17 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x17, I_sd_cg_cp_imm_edges_m0x1, I_sd_cg_cp_imm_edges_m0x1_str)
-#else
-  sd x7, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x26 # restore signature pointer to default register for teardown
 

--- a/tests/rv64i/I/I-sh-00.S
+++ b/tests/rv64i/I/I-sh-00.S
@@ -41,18 +41,9 @@ I_sh_cg_cp_rs1_nx0_b1:
   sh x24, 289(x1) # perform store
   addi x1, x1, 289 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x30 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x30, I_sh_cg_cp_rs1_nx0_b1, I_sh_cg_cp_rs1_nx0_b1_str)
-#else
-  sh x24, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0xf294c5c460057e9e
@@ -62,18 +53,9 @@ I_sh_cg_cp_rs1_nx0_b2:
   sh x6, -1077(x2) # perform store
   addi x2, x2, -1077 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x13 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x13, I_sh_cg_cp_rs1_nx0_b2, I_sh_cg_cp_rs1_nx0_b2_str)
-#else
-  sh x6, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x26, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
@@ -84,18 +66,9 @@ I_sh_cg_cp_rs1_nx0_b3:
   sh x0, 1862(x3) # perform store
   addi x3, x3, 1862 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x12 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x12, I_sh_cg_cp_rs1_nx0_b3, I_sh_cg_cp_rs1_nx0_b3_str)
-#else
-  sh x0, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -107,18 +80,9 @@ I_sh_cg_cp_rs1_nx0_b4:
   sh x10, -476(x4) # perform store
   addi x4, x4, -476 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x1 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x1, I_sh_cg_cp_rs1_nx0_b4, I_sh_cg_cp_rs1_nx0_b4_str)
-#else
-  sh x10, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x26, x30) # load rs2: x30 = 0xbbfe28184f14438c
@@ -128,18 +92,9 @@ I_sh_cg_cp_rs1_nx0_b5:
   sh x30, -1689(x5) # perform store
   addi x5, x5, -1689 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x31 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x31, I_sh_cg_cp_rs1_nx0_b5, I_sh_cg_cp_rs1_nx0_b5_str)
-#else
-  sh x30, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x26, x10) # load rs2: x10 = 0xee4438d62873c5ec
@@ -149,18 +104,9 @@ I_sh_cg_cp_rs1_nx0_b6:
   sh x10, 776(x6) # perform store
   addi x6, x6, 776 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x30 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x30, I_sh_cg_cp_rs1_nx0_b6, I_sh_cg_cp_rs1_nx0_b6_str)
-#else
-  sh x10, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x7 # switch temp register to avoid conflict with test
   mv x5, x8 # switch link pointer register to avoid conflict with test
@@ -172,18 +118,9 @@ I_sh_cg_cp_rs1_nx0_b7:
   sh x30, -830(x7) # perform store
   addi x7, x7, -830 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x20 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x20, I_sh_cg_cp_rs1_nx0_b7, I_sh_cg_cp_rs1_nx0_b7_str)
-#else
-  sh x30, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x26, x1) # load rs2: x1 = 0x10746471965f85d8
@@ -193,18 +130,9 @@ I_sh_cg_cp_rs1_nx0_b8:
   sh x1, 1789(x8) # perform store
   addi x8, x8, 1789 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, I_sh_cg_cp_rs1_nx0_b8, I_sh_cg_cp_rs1_nx0_b8_str)
-#else
-  sh x1, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x26, x13) # load rs2: x13 = 0x0e46df56297f36e2
@@ -214,18 +142,9 @@ I_sh_cg_cp_rs1_nx0_b9:
   sh x13, -1754(x9) # perform store
   addi x9, x9, -1754 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x20 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x20, I_sh_cg_cp_rs1_nx0_b9, I_sh_cg_cp_rs1_nx0_b9_str)
-#else
-  sh x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x26, x8) # load rs2: x8 = 0xcc2e17d89ccada61
@@ -235,18 +154,9 @@ I_sh_cg_cp_rs1_nx0_b10:
   sh x8, -2000(x10) # perform store
   addi x10, x10, -2000 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x30 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x30, I_sh_cg_cp_rs1_nx0_b10, I_sh_cg_cp_rs1_nx0_b10_str)
-#else
-  sh x8, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x26, x8) # load rs2: x8 = 0xe372895c3828858c
@@ -256,18 +166,9 @@ I_sh_cg_cp_rs1_nx0_b11:
   sh x8, -961(x11) # perform store
   addi x11, x11, -961 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, I_sh_cg_cp_rs1_nx0_b11, I_sh_cg_cp_rs1_nx0_b11_str)
-#else
-  sh x8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x26, x23) # load rs2: x23 = 0xcfd6b60c8164cbc5
@@ -277,18 +178,9 @@ I_sh_cg_cp_rs1_nx0_b12:
   sh x23, -849(x12) # perform store
   addi x12, x12, -849 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x31 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x31, I_sh_cg_cp_rs1_nx0_b12, I_sh_cg_cp_rs1_nx0_b12_str)
-#else
-  sh x23, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x26, x7) # load rs2: x7 = 0xa0159b3789646f75
@@ -298,18 +190,9 @@ I_sh_cg_cp_rs1_nx0_b13:
   sh x7, -1881(x13) # perform store
   addi x13, x13, -1881 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, I_sh_cg_cp_rs1_nx0_b13, I_sh_cg_cp_rs1_nx0_b13_str)
-#else
-  sh x7, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x26, x21) # load rs2: x21 = 0xa4bea8871e970726
@@ -319,18 +202,9 @@ I_sh_cg_cp_rs1_nx0_b14:
   sh x21, 1354(x14) # perform store
   addi x14, x14, 1354 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x31 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x31, I_sh_cg_cp_rs1_nx0_b14, I_sh_cg_cp_rs1_nx0_b14_str)
-#else
-  sh x21, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x26, x25) # load rs2: x25 = 0xa712d9de382357e8
@@ -340,18 +214,9 @@ I_sh_cg_cp_rs1_nx0_b15:
   sh x25, -1684(x15) # perform store
   addi x15, x15, -1684 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x16 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x16, I_sh_cg_cp_rs1_nx0_b15, I_sh_cg_cp_rs1_nx0_b15_str)
-#else
-  sh x25, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x16)
   RVTEST_TESTDATA_LOAD_INT(x26, x21) # load rs2: x21 = 0x296275146374df87
@@ -361,18 +226,9 @@ I_sh_cg_cp_rs1_nx0_b16:
   sh x21, 1153(x16) # perform store
   addi x16, x16, 1153 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x20 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x20, I_sh_cg_cp_rs1_nx0_b16, I_sh_cg_cp_rs1_nx0_b16_str)
-#else
-  sh x21, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x17)
   RVTEST_TESTDATA_LOAD_INT(x26, x21) # load rs2: x21 = 0x01a73998293f32d0
@@ -382,18 +238,9 @@ I_sh_cg_cp_rs1_nx0_b17:
   sh x21, -1747(x17) # perform store
   addi x17, x17, -1747 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x1 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x1, I_sh_cg_cp_rs1_nx0_b17, I_sh_cg_cp_rs1_nx0_b17_str)
-#else
-  sh x21, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x18)
   RVTEST_TESTDATA_LOAD_INT(x26, x14) # load rs2: x14 = 0x014bc55228c6c87d
@@ -403,18 +250,9 @@ I_sh_cg_cp_rs1_nx0_b18:
   sh x14, -2041(x18) # perform store
   addi x18, x18, -2041 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, I_sh_cg_cp_rs1_nx0_b18, I_sh_cg_cp_rs1_nx0_b18_str)
-#else
-  sh x14, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x19)
   RVTEST_TESTDATA_LOAD_INT(x26, x15) # load rs2: x15 = 0x0ed32e459b0394f2
@@ -424,18 +262,9 @@ I_sh_cg_cp_rs1_nx0_b19:
   sh x15, 947(x19) # perform store
   addi x19, x19, 947 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x28 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x28, I_sh_cg_cp_rs1_nx0_b19, I_sh_cg_cp_rs1_nx0_b19_str)
-#else
-  sh x15, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x20)
   RVTEST_TESTDATA_LOAD_INT(x26, x15) # load rs2: x15 = 0xade0ec7b918b549b
@@ -445,18 +274,9 @@ I_sh_cg_cp_rs1_nx0_b20:
   sh x15, 281(x20) # perform store
   addi x20, x20, 281 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x14 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x14, I_sh_cg_cp_rs1_nx0_b20, I_sh_cg_cp_rs1_nx0_b20_str)
-#else
-  sh x15, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x21)
   RVTEST_TESTDATA_LOAD_INT(x26, x13) # load rs2: x13 = 0x6f8320ba846f38b0
@@ -466,18 +286,9 @@ I_sh_cg_cp_rs1_nx0_b21:
   sh x13, 737(x21) # perform store
   addi x21, x21, 737 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x17 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x17, I_sh_cg_cp_rs1_nx0_b21, I_sh_cg_cp_rs1_nx0_b21_str)
-#else
-  sh x13, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x22)
   RVTEST_TESTDATA_LOAD_INT(x26, x1) # load rs2: x1 = 0xa00a185ebc6598bd
@@ -487,18 +298,9 @@ I_sh_cg_cp_rs1_nx0_b22:
   sh x1, 1489(x22) # perform store
   addi x22, x22, 1489 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x25 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x25, I_sh_cg_cp_rs1_nx0_b22, I_sh_cg_cp_rs1_nx0_b22_str)
-#else
-  sh x1, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x23)
   RVTEST_TESTDATA_LOAD_INT(x26, x10) # load rs2: x10 = 0x8c43e99d25189178
@@ -508,18 +310,9 @@ I_sh_cg_cp_rs1_nx0_b23:
   sh x10, 1812(x23) # perform store
   addi x23, x23, 1812 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x12 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x12, I_sh_cg_cp_rs1_nx0_b23, I_sh_cg_cp_rs1_nx0_b23_str)
-#else
-  sh x10, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x24)
   RVTEST_TESTDATA_LOAD_INT(x26, x6) # load rs2: x6 = 0xfc259537a3cfc6ae
@@ -529,18 +322,9 @@ I_sh_cg_cp_rs1_nx0_b24:
   sh x6, 20(x24) # perform store
   addi x24, x24, 20 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x19 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x19, I_sh_cg_cp_rs1_nx0_b24, I_sh_cg_cp_rs1_nx0_b24_str)
-#else
-  sh x6, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x25)
   RVTEST_TESTDATA_LOAD_INT(x26, x23) # load rs2: x23 = 0x1bbf02a7960dd722
@@ -550,18 +334,9 @@ I_sh_cg_cp_rs1_nx0_b25:
   sh x23, 1406(x25) # perform store
   addi x25, x25, 1406 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x19 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x19, I_sh_cg_cp_rs1_nx0_b25, I_sh_cg_cp_rs1_nx0_b25_str)
-#else
-  sh x23, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x19, x26 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x26)
@@ -572,18 +347,9 @@ I_sh_cg_cp_rs1_nx0_b26:
   sh x28, -1820(x26) # perform store
   addi x26, x26, -1820 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x15 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x15, I_sh_cg_cp_rs1_nx0_b26, I_sh_cg_cp_rs1_nx0_b26_str)
-#else
-  sh x28, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x27)
   RVTEST_TESTDATA_LOAD_INT(x19, x11) # load rs2: x11 = 0x0766e116bf495cbd
@@ -593,18 +359,9 @@ I_sh_cg_cp_rs1_nx0_b27:
   sh x11, 1907(x27) # perform store
   addi x27, x27, 1907 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x20 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x20, I_sh_cg_cp_rs1_nx0_b27, I_sh_cg_cp_rs1_nx0_b27_str)
-#else
-  sh x11, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x28)
   RVTEST_TESTDATA_LOAD_INT(x19, x2) # load rs2: x2 = 0xb2d02b532a8a2239
@@ -614,18 +371,9 @@ I_sh_cg_cp_rs1_nx0_b28:
   sh x2, 1232(x28) # perform store
   addi x28, x28, 1232 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x11 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x11, I_sh_cg_cp_rs1_nx0_b28, I_sh_cg_cp_rs1_nx0_b28_str)
-#else
-  sh x2, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x29)
   RVTEST_TESTDATA_LOAD_INT(x19, x1) # load rs2: x1 = 0x8d63036f74c32f25
@@ -635,18 +383,9 @@ I_sh_cg_cp_rs1_nx0_b29:
   sh x1, -1121(x29) # perform store
   addi x29, x29, -1121 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x31 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x31, I_sh_cg_cp_rs1_nx0_b29, I_sh_cg_cp_rs1_nx0_b29_str)
-#else
-  sh x1, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x30)
   RVTEST_TESTDATA_LOAD_INT(x19, x2) # load rs2: x2 = 0x6527c9912a403bdf
@@ -656,18 +395,9 @@ I_sh_cg_cp_rs1_nx0_b30:
   sh x2, -208(x30) # perform store
   addi x30, x30, -208 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x12 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x12, I_sh_cg_cp_rs1_nx0_b30, I_sh_cg_cp_rs1_nx0_b30_str)
-#else
-  sh x2, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x31)
   RVTEST_TESTDATA_LOAD_INT(x19, x27) # load rs2: x27 = 0x7f07b9e8d040dd47
@@ -677,18 +407,9 @@ I_sh_cg_cp_rs1_nx0_b31:
   sh x27, -1695(x31) # perform store
   addi x31, x31, -1695 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x29 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x29, I_sh_cg_cp_rs1_nx0_b31, I_sh_cg_cp_rs1_nx0_b31_str)
-#else
-  sh x27, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2
@@ -702,18 +423,9 @@ I_sh_cg_cp_rs2_b0:
   sh x0, 1152(x20) # perform store
   addi x20, x20, 1152 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x9 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x9, I_sh_cg_cp_rs2_b0, I_sh_cg_cp_rs2_b0_str)
-#else
-  sh x0, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x19, x1) # load rs2: x1 = 0x210bfbaff78e04c6
@@ -723,18 +435,9 @@ I_sh_cg_cp_rs2_b1:
   sh x1, -1028(x2) # perform store
   addi x2, x2, -1028 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x23 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x23, I_sh_cg_cp_rs2_b1, I_sh_cg_cp_rs2_b1_str)
-#else
-  sh x1, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x20, x2 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x2)
@@ -745,18 +448,9 @@ I_sh_cg_cp_rs2_b2:
   sh x2, -132(x22) # perform store
   addi x22, x22, -132 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x26 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x26, I_sh_cg_cp_rs2_b2, I_sh_cg_cp_rs2_b2_str)
-#else
-  sh x2, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x19, x3) # load rs2: x3 = 0x9fb410146d94ca7e
@@ -766,18 +460,9 @@ I_sh_cg_cp_rs2_b3:
   sh x3, -1431(x14) # perform store
   addi x14, x14, -1431 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x30 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x30, I_sh_cg_cp_rs2_b3, I_sh_cg_cp_rs2_b3_str)
-#else
-  sh x3, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -789,18 +474,9 @@ I_sh_cg_cp_rs2_b4:
   sh x4, 220(x18) # perform store
   addi x18, x18, 220 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x12 contains the expected result. x18 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x18, x8, x7, x12, I_sh_cg_cp_rs2_b4, I_sh_cg_cp_rs2_b4_str)
-#else
-  sh x4, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x19, x5) # load rs2: x5 = 0x8f3ec9dda85d6013
@@ -810,18 +486,9 @@ I_sh_cg_cp_rs2_b5:
   sh x5, -1440(x28) # perform store
   addi x28, x28, -1440 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x3 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x28, x8, x7, x3, I_sh_cg_cp_rs2_b5, I_sh_cg_cp_rs2_b5_str)
-#else
-  sh x5, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x19, x6) # load rs2: x6 = 0xcef71e5da0bda1f4
@@ -831,18 +498,9 @@ I_sh_cg_cp_rs2_b6:
   sh x6, -98(x4) # perform store
   addi x4, x4, -98 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x22 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x22, I_sh_cg_cp_rs2_b6, I_sh_cg_cp_rs2_b6_str)
-#else
-  sh x6, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x7 # switch temp register to avoid conflict with test
   mv x14, x8 # switch link pointer register to avoid conflict with test
@@ -854,18 +512,9 @@ I_sh_cg_cp_rs2_b7:
   sh x7, -221(x28) # perform store
   addi x28, x28, -221 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x10 contains the expected result. x28 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x28, x14, x13, x10, I_sh_cg_cp_rs2_b7, I_sh_cg_cp_rs2_b7_str)
-#else
-  sh x7, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x19, x8) # load rs2: x8 = 0xdd62dfc71c1cd5be
@@ -875,18 +524,9 @@ I_sh_cg_cp_rs2_b8:
   sh x8, -1674(x31) # perform store
   addi x31, x31, -1674 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x17 contains the expected result. x31 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x31, x14, x13, x17, I_sh_cg_cp_rs2_b8, I_sh_cg_cp_rs2_b8_str)
-#else
-  sh x8, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x19, x9) # load rs2: x9 = 0xc945be437a1934d8
@@ -896,18 +536,9 @@ I_sh_cg_cp_rs2_b9:
   sh x9, 279(x12) # perform store
   addi x12, x12, 279 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x4 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x4, I_sh_cg_cp_rs2_b9, I_sh_cg_cp_rs2_b9_str)
-#else
-  sh x9, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x19, x10) # load rs2: x10 = 0x10773afb8e924c7c
@@ -917,18 +548,9 @@ I_sh_cg_cp_rs2_b10:
   sh x10, 1687(x23) # perform store
   addi x23, x23, 1687 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x27 contains the expected result. x23 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x23, x14, x13, x27, I_sh_cg_cp_rs2_b10, I_sh_cg_cp_rs2_b10_str)
-#else
-  sh x10, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x19, x11) # load rs2: x11 = 0x5989a0ca051d76ad
@@ -938,18 +560,9 @@ I_sh_cg_cp_rs2_b11:
   sh x11, 584(x5) # perform store
   addi x5, x5, 584 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x28 contains the expected result. x5 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x5, x14, x13, x28, I_sh_cg_cp_rs2_b11, I_sh_cg_cp_rs2_b11_str)
-#else
-  sh x11, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x19, x12) # load rs2: x12 = 0xe54484fd0d424ad6
@@ -959,18 +572,9 @@ I_sh_cg_cp_rs2_b12:
   sh x12, -1170(x3) # perform store
   addi x3, x3, -1170 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x24 contains the expected result. x3 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x3, x14, x13, x24, I_sh_cg_cp_rs2_b12, I_sh_cg_cp_rs2_b12_str)
-#else
-  sh x12, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -982,18 +586,9 @@ I_sh_cg_cp_rs2_b13:
   sh x13, 1899(x24) # perform store
   addi x24, x24, 1899 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x17 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x17, I_sh_cg_cp_rs2_b13, I_sh_cg_cp_rs2_b13_str)
-#else
-  sh x13, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x19, x14) # load rs2: x14 = 0x123a65e640c2c36a
@@ -1003,18 +598,9 @@ I_sh_cg_cp_rs2_b14:
   sh x14, 1400(x31) # perform store
   addi x31, x31, 1400 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x1 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x1, I_sh_cg_cp_rs2_b14, I_sh_cg_cp_rs2_b14_str)
-#else
-  sh x14, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x19, x15) # load rs2: x15 = 0x17eacd33598b78f6
@@ -1024,18 +610,9 @@ I_sh_cg_cp_rs2_b15:
   sh x15, -1175(x18) # perform store
   addi x18, x18, -1175 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, I_sh_cg_cp_rs2_b15, I_sh_cg_cp_rs2_b15_str)
-#else
-  sh x15, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x19, x16) # load rs2: x16 = 0x48d44a744865ec05
@@ -1045,18 +622,9 @@ I_sh_cg_cp_rs2_b16:
   sh x16, 356(x21) # perform store
   addi x21, x21, 356 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x12 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x12, I_sh_cg_cp_rs2_b16, I_sh_cg_cp_rs2_b16_str)
-#else
-  sh x16, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x19, x17) # load rs2: x17 = 0x7d84ce3a54102fd3
@@ -1066,18 +634,9 @@ I_sh_cg_cp_rs2_b17:
   sh x17, -756(x11) # perform store
   addi x11, x11, -756 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x1 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x1, I_sh_cg_cp_rs2_b17, I_sh_cg_cp_rs2_b17_str)
-#else
-  sh x17, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x19, x18) # load rs2: x18 = 0xe80b356d506c7f99
@@ -1087,18 +646,9 @@ I_sh_cg_cp_rs2_b18:
   sh x18, 764(x8) # perform store
   addi x8, x8, 764 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x15 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x15, I_sh_cg_cp_rs2_b18, I_sh_cg_cp_rs2_b18_str)
-#else
-  sh x18, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x31, x19 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x19)
@@ -1109,18 +659,9 @@ I_sh_cg_cp_rs2_b19:
   sh x19, 890(x26) # perform store
   addi x26, x26, 890 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x30 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x30, I_sh_cg_cp_rs2_b19, I_sh_cg_cp_rs2_b19_str)
-#else
-  sh x19, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x31, x20) # load rs2: x20 = 0x230ad397d1e7b971
@@ -1130,18 +671,9 @@ I_sh_cg_cp_rs2_b20:
   sh x20, -263(x6) # perform store
   addi x6, x6, -263 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x8 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x8, I_sh_cg_cp_rs2_b20, I_sh_cg_cp_rs2_b20_str)
-#else
-  sh x20, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x31, x21) # load rs2: x21 = 0xbf2ebe4c75ca6c81
@@ -1151,18 +683,9 @@ I_sh_cg_cp_rs2_b21:
   sh x21, -109(x2) # perform store
   addi x2, x2, -109 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x10 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x10, I_sh_cg_cp_rs2_b21, I_sh_cg_cp_rs2_b21_str)
-#else
-  sh x21, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x31, x22) # load rs2: x22 = 0x692a94f603ec6e2e
@@ -1172,18 +695,9 @@ I_sh_cg_cp_rs2_b22:
   sh x22, 1423(x29) # perform store
   addi x29, x29, 1423 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x28 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x28, I_sh_cg_cp_rs2_b22, I_sh_cg_cp_rs2_b22_str)
-#else
-  sh x22, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x31, x23) # load rs2: x23 = 0xf5070a88ea00536b
@@ -1193,18 +707,9 @@ I_sh_cg_cp_rs2_b23:
   sh x23, 867(x14) # perform store
   addi x14, x14, 867 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x10 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x10, I_sh_cg_cp_rs2_b23, I_sh_cg_cp_rs2_b23_str)
-#else
-  sh x23, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x31, x24) # load rs2: x24 = 0xa8a917661ceb4d03
@@ -1214,18 +719,9 @@ I_sh_cg_cp_rs2_b24:
   sh x24, 1814(x2) # perform store
   addi x2, x2, 1814 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x22 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x22, I_sh_cg_cp_rs2_b24, I_sh_cg_cp_rs2_b24_str)
-#else
-  sh x24, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x31, x25) # load rs2: x25 = 0x324ef342be2b4289
@@ -1235,18 +731,9 @@ I_sh_cg_cp_rs2_b25:
   sh x25, 1571(x22) # perform store
   addi x22, x22, 1571 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x24 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x24, I_sh_cg_cp_rs2_b25, I_sh_cg_cp_rs2_b25_str)
-#else
-  sh x25, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x31, x26) # load rs2: x26 = 0xb1d17a9c5c0e67eb
@@ -1256,18 +743,9 @@ I_sh_cg_cp_rs2_b26:
   sh x26, 1878(x6) # perform store
   addi x6, x6, 1878 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x17 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x17, I_sh_cg_cp_rs2_b26, I_sh_cg_cp_rs2_b26_str)
-#else
-  sh x26, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x31, x27) # load rs2: x27 = 0xd7bf8e069d4f6759
@@ -1277,18 +755,9 @@ I_sh_cg_cp_rs2_b27:
   sh x27, 985(x20) # perform store
   addi x20, x20, 985 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x9 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x9, I_sh_cg_cp_rs2_b27, I_sh_cg_cp_rs2_b27_str)
-#else
-  sh x27, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x31, x28) # load rs2: x28 = 0x3312faeec1c8ea45
@@ -1298,18 +767,9 @@ I_sh_cg_cp_rs2_b28:
   sh x28, 944(x16) # perform store
   addi x16, x16, 944 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x8 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x8, I_sh_cg_cp_rs2_b28, I_sh_cg_cp_rs2_b28_str)
-#else
-  sh x28, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x31, x29) # load rs2: x29 = 0xbb06fd25ac0f2d12
@@ -1319,18 +779,9 @@ I_sh_cg_cp_rs2_b29:
   sh x29, 741(x8) # perform store
   addi x8, x8, 741 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x30 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x30, I_sh_cg_cp_rs2_b29, I_sh_cg_cp_rs2_b29_str)
-#else
-  sh x29, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x31, x30) # load rs2: x30 = 0x3baf2e52a327e8ad
@@ -1340,18 +791,9 @@ I_sh_cg_cp_rs2_b30:
   sh x30, 1197(x26) # perform store
   addi x26, x26, 1197 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x7 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x7, I_sh_cg_cp_rs2_b30, I_sh_cg_cp_rs2_b30_str)
-#else
-  sh x30, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x28, x31 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x31)
@@ -1362,18 +804,9 @@ I_sh_cg_cp_rs2_b31:
   sh x31, 1874(x30) # perform store
   addi x30, x30, 1874 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x11 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x11, I_sh_cg_cp_rs2_b31, I_sh_cg_cp_rs2_b31_str)
-#else
-  sh x31, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -1387,18 +820,9 @@ I_sh_cg_cp_rs2_edges_0x0:
   sh x20, -560(x3) # perform store
   addi x3, x3, -560 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x16 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x16, I_sh_cg_cp_rs2_edges_0x0, I_sh_cg_cp_rs2_edges_0x0_str)
-#else
-  sh x20, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x28, x18) # load rs2: x18 = 0x0000000000000001
@@ -1408,18 +832,9 @@ I_sh_cg_cp_rs2_edges_0x1:
   sh x18, 1392(x26) # perform store
   addi x26, x26, 1392 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x7 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x7, I_sh_cg_cp_rs2_edges_0x1, I_sh_cg_cp_rs2_edges_0x1_str)
-#else
-  sh x18, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x28, x2) # load rs2: x2 = 0x0000000000000002
@@ -1429,18 +844,9 @@ I_sh_cg_cp_rs2_edges_0x2:
   sh x2, -206(x16) # perform store
   addi x16, x16, -206 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x24 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x24, I_sh_cg_cp_rs2_edges_0x2, I_sh_cg_cp_rs2_edges_0x2_str)
-#else
-  sh x2, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load rs2: x24 = 0x8000000000000000
@@ -1450,18 +856,9 @@ I_sh_cg_cp_rs2_edges_0x8000000000000000:
   sh x24, -261(x2) # perform store
   addi x2, x2, -261 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x29 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x29, I_sh_cg_cp_rs2_edges_0x8000000000000000, I_sh_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  sh x24, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x28, x22) # load rs2: x22 = 0x8000000000000001
@@ -1471,18 +868,9 @@ I_sh_cg_cp_rs2_edges_0x8000000000000001:
   sh x22, 531(x26) # perform store
   addi x26, x26, 531 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x23 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x23, I_sh_cg_cp_rs2_edges_0x8000000000000001, I_sh_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  sh x22, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x28, x17) # load rs2: x17 = 0x7fffffffffffffff
@@ -1492,18 +880,9 @@ I_sh_cg_cp_rs2_edges_0x7fffffffffffffff:
   sh x17, -850(x3) # perform store
   addi x3, x3, -850 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x15 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x15, I_sh_cg_cp_rs2_edges_0x7fffffffffffffff, I_sh_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  sh x17, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x28, x14) # load rs2: x14 = 0x7ffffffffffffffe
@@ -1513,18 +892,9 @@ I_sh_cg_cp_rs2_edges_0x7ffffffffffffffe:
   sh x14, 120(x22) # perform store
   addi x22, x22, 120 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x31 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x31, I_sh_cg_cp_rs2_edges_0x7ffffffffffffffe, I_sh_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  sh x14, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x28, x15) # load rs2: x15 = 0xffffffffffffffff
@@ -1534,18 +904,9 @@ I_sh_cg_cp_rs2_edges_0xffffffffffffffff:
   sh x15, 487(x14) # perform store
   addi x14, x14, 487 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x24 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x24, I_sh_cg_cp_rs2_edges_0xffffffffffffffff, I_sh_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  sh x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x28, x6) # load rs2: x6 = 0xfffffffffffffffe
@@ -1555,18 +916,9 @@ I_sh_cg_cp_rs2_edges_0xfffffffffffffffe:
   sh x6, 709(x25) # perform store
   addi x25, x25, 709 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x13 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x13, I_sh_cg_cp_rs2_edges_0xfffffffffffffffe, I_sh_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  sh x6, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x28, x3) # load rs2: x3 = 0x5bbc887763ae86f2
@@ -1576,18 +928,9 @@ I_sh_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   sh x3, 481(x6) # perform store
   addi x6, x6, 481 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x30 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x30, I_sh_cg_cp_rs2_edges_0x5bbc887763ae86f2, I_sh_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  sh x3, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x28, x7) # load rs2: x7 = 0xaaaaaaaaaaaaaaaa
@@ -1597,18 +940,9 @@ I_sh_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   sh x7, 1110(x8) # perform store
   addi x8, x8, 1110 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x1 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x1, I_sh_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, I_sh_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  sh x7, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x28, x6) # load rs2: x6 = 0x5555555555555555
@@ -1618,18 +952,9 @@ I_sh_cg_cp_rs2_edges_0x5555555555555555:
   sh x6, -269(x7) # perform store
   addi x7, x7, -269 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x12 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x12, I_sh_cg_cp_rs2_edges_0x5555555555555555, I_sh_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  sh x6, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x28, x18) # load rs2: x18 = 0x00000000ffffffff
@@ -1639,18 +964,9 @@ I_sh_cg_cp_rs2_edges_0xffffffff:
   sh x18, -1927(x26) # perform store
   addi x26, x26, -1927 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x24 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x24, I_sh_cg_cp_rs2_edges_0xffffffff, I_sh_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  sh x18, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x28, x12) # load rs2: x12 = 0x00000000fffffffe
@@ -1660,18 +976,9 @@ I_sh_cg_cp_rs2_edges_0xfffffffe:
   sh x12, -1180(x3) # perform store
   addi x3, x3, -1180 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x10 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x10, I_sh_cg_cp_rs2_edges_0xfffffffe, I_sh_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  sh x12, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x28, x23) # load rs2: x23 = 0x0000000100000000
@@ -1681,18 +988,9 @@ I_sh_cg_cp_rs2_edges_0x100000000:
   sh x23, -658(x25) # perform store
   addi x25, x25, -658 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x7 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x7, I_sh_cg_cp_rs2_edges_0x100000000, I_sh_cg_cp_rs2_edges_0x100000000_str)
-#else
-  sh x23, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load rs2: x24 = 0x0000000100000001
@@ -1702,18 +1000,9 @@ I_sh_cg_cp_rs2_edges_0x100000001:
   sh x24, -1644(x20) # perform store
   addi x20, x20, -1644 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x29 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x29, I_sh_cg_cp_rs2_edges_0x100000001, I_sh_cg_cp_rs2_edges_0x100000001_str)
-#else
-  sh x24, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_edges
@@ -1727,18 +1016,9 @@ I_sh_cg_cp_imm_edges_0x0:
   sh x12, 0(x3) # perform store
   addi x3, x3, 0 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x11 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x11, I_sh_cg_cp_imm_edges_0x0, I_sh_cg_cp_imm_edges_0x0_str)
-#else
-  sh x12, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1)
   RVTEST_TESTDATA_LOAD_INT(x28, x14) # load rs2: x14 = 0x9114f3859a59fa2f
@@ -1748,18 +1028,9 @@ I_sh_cg_cp_imm_edges_0x1:
   sh x14, 1(x19) # perform store
   addi x19, x19, 1 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x8 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x8, I_sh_cg_cp_imm_edges_0x1, I_sh_cg_cp_imm_edges_0x1_str)
-#else
-  sh x14, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2)
   RVTEST_TESTDATA_LOAD_INT(x28, x18) # load rs2: x18 = 0x5a20c82a555554fa
@@ -1769,18 +1040,9 @@ I_sh_cg_cp_imm_edges_0x2:
   sh x18, 2(x31) # perform store
   addi x31, x31, 2 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x14 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x14, I_sh_cg_cp_imm_edges_0x2, I_sh_cg_cp_imm_edges_0x2_str)
-#else
-  sh x18, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 3)
   RVTEST_TESTDATA_LOAD_INT(x28, x1) # load rs2: x1 = 0xdbd93942347389b6
@@ -1790,18 +1052,9 @@ I_sh_cg_cp_imm_edges_0x3:
   sh x1, 3(x17) # perform store
   addi x17, x17, 3 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x20 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x20, I_sh_cg_cp_imm_edges_0x3, I_sh_cg_cp_imm_edges_0x3_str)
-#else
-  sh x1, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 4)
   RVTEST_TESTDATA_LOAD_INT(x28, x21) # load rs2: x21 = 0xf60b96af2a43fb79
@@ -1811,18 +1064,9 @@ I_sh_cg_cp_imm_edges_0x4:
   sh x21, 4(x30) # perform store
   addi x30, x30, 4 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x15 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x15, I_sh_cg_cp_imm_edges_0x4, I_sh_cg_cp_imm_edges_0x4_str)
-#else
-  sh x21, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 8)
   RVTEST_TESTDATA_LOAD_INT(x28, x9) # load rs2: x9 = 0x8a77e5eb0a1e5fc0
@@ -1832,18 +1076,9 @@ I_sh_cg_cp_imm_edges_0x8:
   sh x9, 8(x17) # perform store
   addi x17, x17, 8 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x20 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x20, I_sh_cg_cp_imm_edges_0x8, I_sh_cg_cp_imm_edges_0x8_str)
-#else
-  sh x9, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 16)
   RVTEST_TESTDATA_LOAD_INT(x28, x13) # load rs2: x13 = 0x9578f86b23c6d963
@@ -1853,18 +1088,9 @@ I_sh_cg_cp_imm_edges_0x10:
   sh x13, 16(x6) # perform store
   addi x6, x6, 16 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x19 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x19, I_sh_cg_cp_imm_edges_0x10, I_sh_cg_cp_imm_edges_0x10_str)
-#else
-  sh x13, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 32)
   RVTEST_TESTDATA_LOAD_INT(x28, x18) # load rs2: x18 = 0xb6335ee1c541c669
@@ -1874,18 +1100,9 @@ I_sh_cg_cp_imm_edges_0x20:
   sh x18, 32(x2) # perform store
   addi x2, x2, 32 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x30 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x30, I_sh_cg_cp_imm_edges_0x20, I_sh_cg_cp_imm_edges_0x20_str)
-#else
-  sh x18, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 64)
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load rs2: x24 = 0xaf15dc5d963d8c0c
@@ -1895,18 +1112,9 @@ I_sh_cg_cp_imm_edges_0x40:
   sh x24, 64(x26) # perform store
   addi x26, x26, 64 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x8 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x8, I_sh_cg_cp_imm_edges_0x40, I_sh_cg_cp_imm_edges_0x40_str)
-#else
-  sh x24, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 128)
   RVTEST_TESTDATA_LOAD_INT(x28, x10) # load rs2: x10 = 0x6d58c990ee9ae2a6
@@ -1916,18 +1124,9 @@ I_sh_cg_cp_imm_edges_0x80:
   sh x10, 128(x14) # perform store
   addi x14, x14, 128 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x3 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x3, I_sh_cg_cp_imm_edges_0x80, I_sh_cg_cp_imm_edges_0x80_str)
-#else
-  sh x10, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 256)
   RVTEST_TESTDATA_LOAD_INT(x28, x13) # load rs2: x13 = 0xb34de811946b4f7c
@@ -1937,18 +1136,9 @@ I_sh_cg_cp_imm_edges_0x100:
   sh x13, 256(x19) # perform store
   addi x19, x19, 256 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x22 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x22, I_sh_cg_cp_imm_edges_0x100, I_sh_cg_cp_imm_edges_0x100_str)
-#else
-  sh x13, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 512)
   RVTEST_TESTDATA_LOAD_INT(x28, x27) # load rs2: x27 = 0x2b243220e4229615
@@ -1958,18 +1148,9 @@ I_sh_cg_cp_imm_edges_0x200:
   sh x27, 512(x12) # perform store
   addi x12, x12, 512 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x6 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x6, I_sh_cg_cp_imm_edges_0x200, I_sh_cg_cp_imm_edges_0x200_str)
-#else
-  sh x27, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1023)
   RVTEST_TESTDATA_LOAD_INT(x28, x26) # load rs2: x26 = 0x9e7bb89fd5f31744
@@ -1979,18 +1160,9 @@ I_sh_cg_cp_imm_edges_0x3ff:
   sh x26, 1023(x25) # perform store
   addi x25, x25, 1023 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x11 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x11, I_sh_cg_cp_imm_edges_0x3ff, I_sh_cg_cp_imm_edges_0x3ff_str)
-#else
-  sh x26, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1024)
   RVTEST_TESTDATA_LOAD_INT(x28, x18) # load rs2: x18 = 0xdc9632dbaddf1ec3
@@ -2000,18 +1172,9 @@ I_sh_cg_cp_imm_edges_0x400:
   sh x18, 1024(x15) # perform store
   addi x15, x15, 1024 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, I_sh_cg_cp_imm_edges_0x400, I_sh_cg_cp_imm_edges_0x400_str)
-#else
-  sh x18, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1795)
   RVTEST_TESTDATA_LOAD_INT(x28, x16) # load rs2: x16 = 0xacfbf4c227f876f9
@@ -2021,18 +1184,9 @@ I_sh_cg_cp_imm_edges_0x703:
   sh x16, 1795(x19) # perform store
   addi x19, x19, 1795 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x30 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x30, I_sh_cg_cp_imm_edges_0x703, I_sh_cg_cp_imm_edges_0x703_str)
-#else
-  sh x16, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2047)
   RVTEST_TESTDATA_LOAD_INT(x28, x21) # load rs2: x21 = 0xaab19f97f0b04a82
@@ -2042,18 +1196,9 @@ I_sh_cg_cp_imm_edges_0x7ff:
   sh x21, 2047(x26) # perform store
   addi x26, x26, 2047 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x9 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x9, I_sh_cg_cp_imm_edges_0x7ff, I_sh_cg_cp_imm_edges_0x7ff_str)
-#else
-  sh x21, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2048)
   RVTEST_TESTDATA_LOAD_INT(x28, x29) # load rs2: x29 = 0x8d988627caf494b1
@@ -2064,18 +1209,9 @@ I_sh_cg_cp_imm_edges_m0x800:
   sh x29, -2048(x7) # perform store
   addi x7, x7, -2048 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x6 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x6, I_sh_cg_cp_imm_edges_m0x800, I_sh_cg_cp_imm_edges_m0x800_str)
-#else
-  sh x29, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2047)
   RVTEST_TESTDATA_LOAD_INT(x28, x3) # load rs2: x3 = 0x6bcbabbd6f33345c
@@ -2085,18 +1221,9 @@ I_sh_cg_cp_imm_edges_m0x7ff:
   sh x3, -2047(x21) # perform store
   addi x21, x21, -2047 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x17 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x17, I_sh_cg_cp_imm_edges_m0x7ff, I_sh_cg_cp_imm_edges_m0x7ff_str)
-#else
-  sh x3, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2)
   RVTEST_TESTDATA_LOAD_INT(x28, x16) # load rs2: x16 = 0x8ba5c07ef21c37d3
@@ -2106,18 +1233,9 @@ I_sh_cg_cp_imm_edges_m0x2:
   sh x16, -2(x20) # perform store
   addi x20, x20, -2 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x23 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x23, I_sh_cg_cp_imm_edges_m0x2, I_sh_cg_cp_imm_edges_m0x2_str)
-#else
-  sh x16, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -1)
   RVTEST_TESTDATA_LOAD_INT(x28, x6) # load rs2: x6 = 0xa0ee9763816f5b75
@@ -2127,18 +1245,9 @@ I_sh_cg_cp_imm_edges_m0x1:
   sh x6, -1(x9) # perform store
   addi x9, x9, -1 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x18 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x18, I_sh_cg_cp_imm_edges_m0x1, I_sh_cg_cp_imm_edges_m0x1_str)
-#else
-  sh x6, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_align_hword
@@ -2149,72 +1258,36 @@ I_sh_cg_cp_imm_edges_m0x1:
 I_sh_cg_cp_align_hword_b0:
   sh x16, 0(x9) # perform store
   addi x9, x9, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -8(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, I_sh_cg_cp_align_hword_b0, I_sh_cg_cp_align_hword_b0_str)
-#else
-  sh x16, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_hword (imm[2:0] = 010)
   RVTEST_TESTDATA_LOAD_INT(x28, x16) # load rs2: x16 = 0x837f25702ec38ce8
 I_sh_cg_cp_align_hword_b2:
   sh x16, 2(x9) # perform store
   addi x9, x9, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -8(x9) # load stored value for checking
   # Check if x17 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x17, I_sh_cg_cp_align_hword_b2, I_sh_cg_cp_align_hword_b2_str)
-#else
-  sh x16, 2(x9) # repeat store so it is available for checking
-  addi x9, x9, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_hword (imm[2:0] = 100)
   RVTEST_TESTDATA_LOAD_INT(x28, x17) # load rs2: x17 = 0xe1d6e472943e8bf0
 I_sh_cg_cp_align_hword_b4:
   sh x17, 4(x9) # perform store
   addi x9, x9, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -8(x9) # load stored value for checking
   # Check if x23 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x23, I_sh_cg_cp_align_hword_b4, I_sh_cg_cp_align_hword_b4_str)
-#else
-  sh x17, 4(x9) # repeat store so it is available for checking
-  addi x9, x9, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_hword (imm[2:0] = 110)
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load rs2: x24 = 0x2768960cdb5130b0
 I_sh_cg_cp_align_hword_b6:
   sh x24, 6(x9) # perform store
   addi x9, x9, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -8(x9) # load stored value for checking
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x7, I_sh_cg_cp_align_hword_b6, I_sh_cg_cp_align_hword_b6_str)
-#else
-  sh x24, 6(x9) # repeat store so it is available for checking
-  addi x9, x9, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 
   mv x2, x9 # restore signature pointer to default register for teardown

--- a/tests/rv64i/I/I-sw-00.S
+++ b/tests/rv64i/I/I-sw-00.S
@@ -41,18 +41,9 @@ I_sw_cg_cp_rs1_nx0_b1:
   sw x11, 1729(x1) # perform store
   addi x1, x1, 1729 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x29 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x29, I_sw_cg_cp_rs1_nx0_b1, I_sw_cg_cp_rs1_nx0_b1_str)
-#else
-  sw x11, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x17) # load rs2: x17 = 0xdc17b28672942e85
@@ -62,18 +53,9 @@ I_sw_cg_cp_rs1_nx0_b2:
   sw x17, 1047(x2) # perform store
   addi x2, x2, 1047 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x22 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x22, I_sw_cg_cp_rs1_nx0_b2, I_sw_cg_cp_rs1_nx0_b2_str)
-#else
-  sw x17, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x30, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x3)
@@ -84,18 +66,9 @@ I_sw_cg_cp_rs1_nx0_b3:
   sw x0, -343(x3) # perform store
   addi x3, x3, -343 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x16 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x16, I_sw_cg_cp_rs1_nx0_b3, I_sw_cg_cp_rs1_nx0_b3_str)
-#else
-  sw x0, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x13, x4 # switch temp register to avoid conflict with test
   mv x14, x5 # switch link pointer register to avoid conflict with test
@@ -107,18 +80,9 @@ I_sw_cg_cp_rs1_nx0_b4:
   sw x7, -1953(x4) # perform store
   addi x4, x4, -1953 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x15 contains the expected result. x4 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x4, x14, x13, x15, I_sw_cg_cp_rs1_nx0_b4, I_sw_cg_cp_rs1_nx0_b4_str)
-#else
-  sw x7, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x5)
   RVTEST_TESTDATA_LOAD_INT(x30, x27) # load rs2: x27 = 0x48f51cf59bcc028d
@@ -128,18 +92,9 @@ I_sw_cg_cp_rs1_nx0_b5:
   sw x27, 673(x5) # perform store
   addi x5, x5, 673 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x6 contains the expected result. x5 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x5, x14, x13, x6, I_sw_cg_cp_rs1_nx0_b5, I_sw_cg_cp_rs1_nx0_b5_str)
-#else
-  sw x27, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x6)
   RVTEST_TESTDATA_LOAD_INT(x30, x24) # load rs2: x24 = 0x9724069e44374d5e
@@ -149,18 +104,9 @@ I_sw_cg_cp_rs1_nx0_b6:
   sw x24, -1113(x6) # perform store
   addi x6, x6, -1113 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x16 contains the expected result. x6 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x6, x14, x13, x16, I_sw_cg_cp_rs1_nx0_b6, I_sw_cg_cp_rs1_nx0_b6_str)
-#else
-  sw x24, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x7)
   RVTEST_TESTDATA_LOAD_INT(x30, x27) # load rs2: x27 = 0xaf3b9d36f4dc0be9
@@ -170,18 +116,9 @@ I_sw_cg_cp_rs1_nx0_b7:
   sw x27, -823(x7) # perform store
   addi x7, x7, -823 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x20 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x20, I_sw_cg_cp_rs1_nx0_b7, I_sw_cg_cp_rs1_nx0_b7_str)
-#else
-  sw x27, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x8)
   RVTEST_TESTDATA_LOAD_INT(x30, x2) # load rs2: x2 = 0xd34a6317956f308e
@@ -191,18 +128,9 @@ I_sw_cg_cp_rs1_nx0_b8:
   sw x2, 1622(x8) # perform store
   addi x8, x8, 1622 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x1 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x1, I_sw_cg_cp_rs1_nx0_b8, I_sw_cg_cp_rs1_nx0_b8_str)
-#else
-  sw x2, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x30, x17) # load rs2: x17 = 0x65eb89544454b18d
@@ -212,18 +140,9 @@ I_sw_cg_cp_rs1_nx0_b9:
   sw x17, 11(x9) # perform store
   addi x9, x9, 11 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x12, I_sw_cg_cp_rs1_nx0_b9, I_sw_cg_cp_rs1_nx0_b9_str)
-#else
-  sw x17, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x30, x16) # load rs2: x16 = 0x5f53349f016d8b32
@@ -233,18 +152,9 @@ I_sw_cg_cp_rs1_nx0_b10:
   sw x16, 384(x10) # perform store
   addi x10, x10, 384 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x29 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x29, I_sw_cg_cp_rs1_nx0_b10, I_sw_cg_cp_rs1_nx0_b10_str)
-#else
-  sw x16, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x30, x22) # load rs2: x22 = 0x9428534803e2d26b
@@ -254,18 +164,9 @@ I_sw_cg_cp_rs1_nx0_b11:
   sw x22, -1539(x11) # perform store
   addi x11, x11, -1539 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x17 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x17, I_sw_cg_cp_rs1_nx0_b11, I_sw_cg_cp_rs1_nx0_b11_str)
-#else
-  sw x22, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x30, x15) # load rs2: x15 = 0x9cd845402483e6e2
@@ -275,18 +176,9 @@ I_sw_cg_cp_rs1_nx0_b12:
   sw x15, -525(x12) # perform store
   addi x12, x12, -525 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x18 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x18, I_sw_cg_cp_rs1_nx0_b12, I_sw_cg_cp_rs1_nx0_b12_str)
-#else
-  sw x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -298,18 +190,9 @@ I_sw_cg_cp_rs1_nx0_b13:
   sw x6, -1494(x13) # perform store
   addi x13, x13, -1494 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x19 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x19, I_sw_cg_cp_rs1_nx0_b13, I_sw_cg_cp_rs1_nx0_b13_str)
-#else
-  sw x6, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x30, x28) # load rs2: x28 = 0xcdd47bccd4bb39ec
@@ -319,18 +202,9 @@ I_sw_cg_cp_rs1_nx0_b14:
   sw x28, -1207(x14) # perform store
   addi x14, x14, -1207 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x1 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x1, I_sw_cg_cp_rs1_nx0_b14, I_sw_cg_cp_rs1_nx0_b14_str)
-#else
-  sw x28, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x30, x10) # load rs2: x10 = 0x50354a6ae4d923a5
@@ -340,18 +214,9 @@ I_sw_cg_cp_rs1_nx0_b15:
   sw x10, -1726(x15) # perform store
   addi x15, x15, -1726 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x16 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x16, I_sw_cg_cp_rs1_nx0_b15, I_sw_cg_cp_rs1_nx0_b15_str)
-#else
-  sw x10, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x16)
   RVTEST_TESTDATA_LOAD_INT(x30, x31) # load rs2: x31 = 0xbda4d60fe8b518a2
@@ -361,18 +226,9 @@ I_sw_cg_cp_rs1_nx0_b16:
   sw x31, -1269(x16) # perform store
   addi x16, x16, -1269 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x13 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x13, I_sw_cg_cp_rs1_nx0_b16, I_sw_cg_cp_rs1_nx0_b16_str)
-#else
-  sw x31, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x17)
   RVTEST_TESTDATA_LOAD_INT(x30, x25) # load rs2: x25 = 0x42ee3954a898579b
@@ -382,18 +238,9 @@ I_sw_cg_cp_rs1_nx0_b17:
   sw x25, 266(x17) # perform store
   addi x17, x17, 266 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x26 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x26, I_sw_cg_cp_rs1_nx0_b17, I_sw_cg_cp_rs1_nx0_b17_str)
-#else
-  sw x25, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x18)
   RVTEST_TESTDATA_LOAD_INT(x30, x6) # load rs2: x6 = 0x523a5e76671dc0a5
@@ -403,18 +250,9 @@ I_sw_cg_cp_rs1_nx0_b18:
   sw x6, 2024(x18) # perform store
   addi x18, x18, 2024 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, I_sw_cg_cp_rs1_nx0_b18, I_sw_cg_cp_rs1_nx0_b18_str)
-#else
-  sw x6, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x19)
   RVTEST_TESTDATA_LOAD_INT(x30, x3) # load rs2: x3 = 0x189dc6158187c09a
@@ -424,18 +262,9 @@ I_sw_cg_cp_rs1_nx0_b19:
   sw x3, -1944(x19) # perform store
   addi x19, x19, -1944 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x13 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x13, I_sw_cg_cp_rs1_nx0_b19, I_sw_cg_cp_rs1_nx0_b19_str)
-#else
-  sw x3, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x20)
   RVTEST_TESTDATA_LOAD_INT(x30, x7) # load rs2: x7 = 0x942811bea819d0c1
@@ -445,18 +274,9 @@ I_sw_cg_cp_rs1_nx0_b20:
   sw x7, 341(x20) # perform store
   addi x20, x20, 341 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x18 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x18, I_sw_cg_cp_rs1_nx0_b20, I_sw_cg_cp_rs1_nx0_b20_str)
-#else
-  sw x7, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x21)
   RVTEST_TESTDATA_LOAD_INT(x30, x11) # load rs2: x11 = 0xf0377651233805be
@@ -466,18 +286,9 @@ I_sw_cg_cp_rs1_nx0_b21:
   sw x11, 714(x21) # perform store
   addi x21, x21, 714 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x24 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x24, I_sw_cg_cp_rs1_nx0_b21, I_sw_cg_cp_rs1_nx0_b21_str)
-#else
-  sw x11, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x22)
   RVTEST_TESTDATA_LOAD_INT(x30, x20) # load rs2: x20 = 0x422e2704ad3c92b9
@@ -487,18 +298,9 @@ I_sw_cg_cp_rs1_nx0_b22:
   sw x20, -551(x22) # perform store
   addi x22, x22, -551 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x31 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x31, I_sw_cg_cp_rs1_nx0_b22, I_sw_cg_cp_rs1_nx0_b22_str)
-#else
-  sw x20, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x23)
   RVTEST_TESTDATA_LOAD_INT(x30, x1) # load rs2: x1 = 0x6397cf3bbbd405a7
@@ -508,18 +310,9 @@ I_sw_cg_cp_rs1_nx0_b23:
   sw x1, 1288(x23) # perform store
   addi x23, x23, 1288 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x11 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x11, I_sw_cg_cp_rs1_nx0_b23, I_sw_cg_cp_rs1_nx0_b23_str)
-#else
-  sw x1, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x24)
   RVTEST_TESTDATA_LOAD_INT(x30, x26) # load rs2: x26 = 0x611e6b4775566530
@@ -529,18 +322,9 @@ I_sw_cg_cp_rs1_nx0_b24:
   sw x26, 133(x24) # perform store
   addi x24, x24, 133 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x11 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x11, I_sw_cg_cp_rs1_nx0_b24, I_sw_cg_cp_rs1_nx0_b24_str)
-#else
-  sw x26, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x25)
   RVTEST_TESTDATA_LOAD_INT(x30, x28) # load rs2: x28 = 0xa85800b3ff1bb66a
@@ -550,18 +334,9 @@ I_sw_cg_cp_rs1_nx0_b25:
   sw x28, -744(x25) # perform store
   addi x25, x25, -744 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x31 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x31, I_sw_cg_cp_rs1_nx0_b25, I_sw_cg_cp_rs1_nx0_b25_str)
-#else
-  sw x28, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x26)
   RVTEST_TESTDATA_LOAD_INT(x30, x19) # load rs2: x19 = 0xee8b0e84209d9930
@@ -571,18 +346,9 @@ I_sw_cg_cp_rs1_nx0_b26:
   sw x19, 1270(x26) # perform store
   addi x26, x26, 1270 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x17 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x17, I_sw_cg_cp_rs1_nx0_b26, I_sw_cg_cp_rs1_nx0_b26_str)
-#else
-  sw x19, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x27)
   RVTEST_TESTDATA_LOAD_INT(x30, x8) # load rs2: x8 = 0x84356a16522a7e0a
@@ -592,18 +358,9 @@ I_sw_cg_cp_rs1_nx0_b27:
   sw x8, -1488(x27) # perform store
   addi x27, x27, -1488 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x25 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x25, I_sw_cg_cp_rs1_nx0_b27, I_sw_cg_cp_rs1_nx0_b27_str)
-#else
-  sw x8, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x28)
   RVTEST_TESTDATA_LOAD_INT(x30, x16) # load rs2: x16 = 0x6d594dd7d965ac7c
@@ -613,18 +370,9 @@ I_sw_cg_cp_rs1_nx0_b28:
   sw x16, -58(x28) # perform store
   addi x28, x28, -58 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x15 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x15, I_sw_cg_cp_rs1_nx0_b28, I_sw_cg_cp_rs1_nx0_b28_str)
-#else
-  sw x16, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x29)
   RVTEST_TESTDATA_LOAD_INT(x30, x8) # load rs2: x8 = 0x912cf3662d91abde
@@ -634,18 +382,9 @@ I_sw_cg_cp_rs1_nx0_b29:
   sw x8, 675(x29) # perform store
   addi x29, x29, 675 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x10 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x10, I_sw_cg_cp_rs1_nx0_b29, I_sw_cg_cp_rs1_nx0_b29_str)
-#else
-  sw x8, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x12, x30 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs1_nx0 (Test source rs1 = x30)
@@ -656,18 +395,9 @@ I_sw_cg_cp_rs1_nx0_b30:
   sw x31, 1632(x30) # perform store
   addi x30, x30, 1632 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x1 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x1, I_sw_cg_cp_rs1_nx0_b30, I_sw_cg_cp_rs1_nx0_b30_str)
-#else
-  sw x31, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_nx0 (Test source rs1 = x31)
   RVTEST_TESTDATA_LOAD_INT(x12, x23) # load rs2: x23 = 0x9c11c246448fa220
@@ -677,18 +407,9 @@ I_sw_cg_cp_rs1_nx0_b31:
   sw x23, 1128(x31) # perform store
   addi x31, x31, 1128 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x25 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x25, I_sw_cg_cp_rs1_nx0_b31, I_sw_cg_cp_rs1_nx0_b31_str)
-#else
-  sw x23, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2
@@ -702,18 +423,9 @@ I_sw_cg_cp_rs2_b0:
   sw x0, 1417(x22) # perform store
   addi x22, x22, 1417 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x1 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x1, I_sw_cg_cp_rs2_b0, I_sw_cg_cp_rs2_b0_str)
-#else
-  sw x0, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load rs2: x1 = 0x499f7e50dd8db439
@@ -723,18 +435,9 @@ I_sw_cg_cp_rs2_b1:
   sw x1, 2039(x2) # perform store
   addi x2, x2, 2039 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x16 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x16, I_sw_cg_cp_rs2_b1, I_sw_cg_cp_rs2_b1_str)
-#else
-  sw x1, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x31, x2 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x2)
@@ -745,18 +448,9 @@ I_sw_cg_cp_rs2_b2:
   sw x2, 523(x13) # perform store
   addi x13, x13, 523 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x19 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x19, I_sw_cg_cp_rs2_b2, I_sw_cg_cp_rs2_b2_str)
-#else
-  sw x2, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x3)
   RVTEST_TESTDATA_LOAD_INT(x12, x3) # load rs2: x3 = 0x3ba5eea045081a60
@@ -766,18 +460,9 @@ I_sw_cg_cp_rs2_b3:
   sw x3, -1291(x18) # perform store
   addi x18, x18, -1291 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, I_sw_cg_cp_rs2_b3, I_sw_cg_cp_rs2_b3_str)
-#else
-  sw x3, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -789,18 +474,9 @@ I_sw_cg_cp_rs2_b4:
   sw x4, -52(x2) # perform store
   addi x2, x2, -52 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x11 contains the expected result. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x2, x8, x7, x11, I_sw_cg_cp_rs2_b4, I_sw_cg_cp_rs2_b4_str)
-#else
-  sw x4, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x12, x5) # load rs2: x5 = 0xc6667c7affcffe77
@@ -810,18 +486,9 @@ I_sw_cg_cp_rs2_b5:
   sw x5, -1513(x16) # perform store
   addi x16, x16, -1513 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x1 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x16, x8, x7, x1, I_sw_cg_cp_rs2_b5, I_sw_cg_cp_rs2_b5_str)
-#else
-  sw x5, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rs2: x6 = 0xb709c34dc1beb123
@@ -831,18 +498,9 @@ I_sw_cg_cp_rs2_b6:
   sw x6, -380(x26) # perform store
   addi x26, x26, -380 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x18 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x26, x8, x7, x18, I_sw_cg_cp_rs2_b6, I_sw_cg_cp_rs2_b6_str)
-#else
-  sw x6, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x4, x7 # switch temp register to avoid conflict with test
   mv x5, x8 # switch link pointer register to avoid conflict with test
@@ -854,18 +512,9 @@ I_sw_cg_cp_rs2_b7:
   sw x7, -1860(x25) # perform store
   addi x25, x25, -1860 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x17 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x17, I_sw_cg_cp_rs2_b7, I_sw_cg_cp_rs2_b7_str)
-#else
-  sw x7, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x12, x8) # load rs2: x8 = 0xa537101343ee40f9
@@ -875,18 +524,9 @@ I_sw_cg_cp_rs2_b8:
   sw x8, 1392(x3) # perform store
   addi x3, x3, 1392 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x15 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x15, I_sw_cg_cp_rs2_b8, I_sw_cg_cp_rs2_b8_str)
-#else
-  sw x8, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rs2: x9 = 0xea746d2dd19e7111
@@ -896,18 +536,9 @@ I_sw_cg_cp_rs2_b9:
   sw x9, -1064(x18) # perform store
   addi x18, x18, -1064 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x13 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x13, I_sw_cg_cp_rs2_b9, I_sw_cg_cp_rs2_b9_str)
-#else
-  sw x9, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rs2: x10 = 0x0ee8064fd65d6912
@@ -917,18 +548,9 @@ I_sw_cg_cp_rs2_b10:
   sw x10, -755(x2) # perform store
   addi x2, x2, -755 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x16 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x16, I_sw_cg_cp_rs2_b10, I_sw_cg_cp_rs2_b10_str)
-#else
-  sw x10, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x12, x11) # load rs2: x11 = 0xacd3e808e9af0c06
@@ -938,18 +560,9 @@ I_sw_cg_cp_rs2_b11:
   sw x11, 915(x3) # perform store
   addi x3, x3, 915 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x27 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x27, I_sw_cg_cp_rs2_b11, I_sw_cg_cp_rs2_b11_str)
-#else
-  sw x11, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x25, x12 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x12)
@@ -960,18 +573,9 @@ I_sw_cg_cp_rs2_b12:
   sw x12, -1519(x27) # perform store
   addi x27, x27, -1519 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x10 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x10, I_sw_cg_cp_rs2_b12, I_sw_cg_cp_rs2_b12_str)
-#else
-  sw x12, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x25, x13) # load rs2: x13 = 0xaf893931b9a1a647
@@ -981,18 +585,9 @@ I_sw_cg_cp_rs2_b13:
   sw x13, 1211(x18) # perform store
   addi x18, x18, 1211 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x30 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x30, I_sw_cg_cp_rs2_b13, I_sw_cg_cp_rs2_b13_str)
-#else
-  sw x13, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x25, x14) # load rs2: x14 = 0x51fb63b3dcf486f2
@@ -1002,18 +597,9 @@ I_sw_cg_cp_rs2_b14:
   sw x14, 1455(x29) # perform store
   addi x29, x29, 1455 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x30 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x30, I_sw_cg_cp_rs2_b14, I_sw_cg_cp_rs2_b14_str)
-#else
-  sw x14, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x25, x15) # load rs2: x15 = 0x32087164ea963781
@@ -1023,18 +609,9 @@ I_sw_cg_cp_rs2_b15:
   sw x15, 1295(x20) # perform store
   addi x20, x20, 1295 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x13 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x13, I_sw_cg_cp_rs2_b15, I_sw_cg_cp_rs2_b15_str)
-#else
-  sw x15, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x25, x16) # load rs2: x16 = 0x0af2743f60ae233c
@@ -1044,18 +621,9 @@ I_sw_cg_cp_rs2_b16:
   sw x16, -1239(x15) # perform store
   addi x15, x15, -1239 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x28 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x28, I_sw_cg_cp_rs2_b16, I_sw_cg_cp_rs2_b16_str)
-#else
-  sw x16, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x25, x17) # load rs2: x17 = 0x6a86e90469bb647a
@@ -1065,18 +633,9 @@ I_sw_cg_cp_rs2_b17:
   sw x17, 1787(x21) # perform store
   addi x21, x21, 1787 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x22 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x22, I_sw_cg_cp_rs2_b17, I_sw_cg_cp_rs2_b17_str)
-#else
-  sw x17, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x25, x18) # load rs2: x18 = 0xc5e557bba4bfc2f4
@@ -1086,18 +645,9 @@ I_sw_cg_cp_rs2_b18:
   sw x18, -1079(x20) # perform store
   addi x20, x20, -1079 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x7 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x7, I_sw_cg_cp_rs2_b18, I_sw_cg_cp_rs2_b18_str)
-#else
-  sw x18, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x25, x19) # load rs2: x19 = 0x99f718ac7a13f0bb
@@ -1107,18 +657,9 @@ I_sw_cg_cp_rs2_b19:
   sw x19, -534(x13) # perform store
   addi x13, x13, -534 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, I_sw_cg_cp_rs2_b19, I_sw_cg_cp_rs2_b19_str)
-#else
-  sw x19, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x25, x20) # load rs2: x20 = 0xa0616c91ea11f799
@@ -1128,18 +669,9 @@ I_sw_cg_cp_rs2_b20:
   sw x20, -2019(x27) # perform store
   addi x27, x27, -2019 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x31 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x31, I_sw_cg_cp_rs2_b20, I_sw_cg_cp_rs2_b20_str)
-#else
-  sw x20, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x25, x21) # load rs2: x21 = 0xb266b8b7ce35d976
@@ -1149,18 +681,9 @@ I_sw_cg_cp_rs2_b21:
   sw x21, 1946(x28) # perform store
   addi x28, x28, 1946 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x6 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x6, I_sw_cg_cp_rs2_b21, I_sw_cg_cp_rs2_b21_str)
-#else
-  sw x21, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x25, x22) # load rs2: x22 = 0x2f1af4ba06611204
@@ -1170,18 +693,9 @@ I_sw_cg_cp_rs2_b22:
   sw x22, -1123(x24) # perform store
   addi x24, x24, -1123 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x10 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x10, I_sw_cg_cp_rs2_b22, I_sw_cg_cp_rs2_b22_str)
-#else
-  sw x22, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x25, x23) # load rs2: x23 = 0x7f459a32ad82cb9a
@@ -1191,18 +705,9 @@ I_sw_cg_cp_rs2_b23:
   sw x23, -1256(x6) # perform store
   addi x6, x6, -1256 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x17 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x17, I_sw_cg_cp_rs2_b23, I_sw_cg_cp_rs2_b23_str)
-#else
-  sw x23, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x25, x24) # load rs2: x24 = 0xc952eb23d5356823
@@ -1212,18 +717,9 @@ I_sw_cg_cp_rs2_b24:
   sw x24, 58(x13) # perform store
   addi x13, x13, 58 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x18 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x18, I_sw_cg_cp_rs2_b24, I_sw_cg_cp_rs2_b24_str)
-#else
-  sw x24, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x22, x25 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x25)
@@ -1234,18 +730,9 @@ I_sw_cg_cp_rs2_b25:
   sw x25, 659(x1) # perform store
   addi x1, x1, 659 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x30 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x30, I_sw_cg_cp_rs2_b25, I_sw_cg_cp_rs2_b25_str)
-#else
-  sw x25, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x22, x26) # load rs2: x26 = 0xa59b26b95bea13f5
@@ -1255,18 +742,9 @@ I_sw_cg_cp_rs2_b26:
   sw x26, 387(x27) # perform store
   addi x27, x27, 387 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x19 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x19, I_sw_cg_cp_rs2_b26, I_sw_cg_cp_rs2_b26_str)
-#else
-  sw x26, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x6, x27 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x27)
@@ -1277,18 +755,9 @@ I_sw_cg_cp_rs2_b27:
   sw x27, 1664(x18) # perform store
   addi x18, x18, 1664 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x14 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x14, I_sw_cg_cp_rs2_b27, I_sw_cg_cp_rs2_b27_str)
-#else
-  sw x27, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x22, x28) # load rs2: x28 = 0xe68472edf0388e52
@@ -1298,18 +767,9 @@ I_sw_cg_cp_rs2_b28:
   sw x28, 1493(x14) # perform store
   addi x14, x14, 1493 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x3 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x3, I_sw_cg_cp_rs2_b28, I_sw_cg_cp_rs2_b28_str)
-#else
-  sw x28, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x22, x29) # load rs2: x29 = 0x64149a0b36de2e96
@@ -1319,18 +779,9 @@ I_sw_cg_cp_rs2_b29:
   sw x29, 594(x17) # perform store
   addi x17, x17, 594 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x7 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x7, I_sw_cg_cp_rs2_b29, I_sw_cg_cp_rs2_b29_str)
-#else
-  sw x29, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x22, x30) # load rs2: x30 = 0x1b67c899811ec003
@@ -1340,18 +791,9 @@ I_sw_cg_cp_rs2_b30:
   sw x30, 1217(x27) # perform store
   addi x27, x27, 1217 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x11 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x11, I_sw_cg_cp_rs2_b30, I_sw_cg_cp_rs2_b30_str)
-#else
-  sw x30, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x22, x31) # load rs2: x31 = 0xa254a5fe0761fb1c
@@ -1361,18 +803,9 @@ I_sw_cg_cp_rs2_b31:
   sw x31, 1313(x12) # perform store
   addi x12, x12, 1313 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x19 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x19, I_sw_cg_cp_rs2_b31, I_sw_cg_cp_rs2_b31_str)
-#else
-  sw x31, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -1386,18 +819,9 @@ I_sw_cg_cp_rs2_edges_0x0:
   sw x17, -455(x31) # perform store
   addi x31, x31, -455 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x30 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x30, I_sw_cg_cp_rs2_edges_0x0, I_sw_cg_cp_rs2_edges_0x0_str)
-#else
-  sw x17, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x22, x1) # load rs2: x1 = 0x0000000000000001
@@ -1407,18 +831,9 @@ I_sw_cg_cp_rs2_edges_0x1:
   sw x1, 345(x11) # perform store
   addi x11, x11, 345 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x18 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x18, I_sw_cg_cp_rs2_edges_0x1, I_sw_cg_cp_rs2_edges_0x1_str)
-#else
-  sw x1, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x22, x15) # load rs2: x15 = 0x0000000000000002
@@ -1428,18 +843,9 @@ I_sw_cg_cp_rs2_edges_0x2:
   sw x15, -1079(x24) # perform store
   addi x24, x24, -1079 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x26 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x26, I_sw_cg_cp_rs2_edges_0x2, I_sw_cg_cp_rs2_edges_0x2_str)
-#else
-  sw x15, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x22, x6) # load rs2: x6 = 0x8000000000000000
@@ -1449,18 +855,9 @@ I_sw_cg_cp_rs2_edges_0x8000000000000000:
   sw x6, 704(x1) # perform store
   addi x1, x1, 704 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x15, I_sw_cg_cp_rs2_edges_0x8000000000000000, I_sw_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  sw x6, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x22, x25) # load rs2: x25 = 0x8000000000000001
@@ -1470,18 +867,9 @@ I_sw_cg_cp_rs2_edges_0x8000000000000001:
   sw x25, 192(x24) # perform store
   addi x24, x24, 192 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x10 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x10, I_sw_cg_cp_rs2_edges_0x8000000000000001, I_sw_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  sw x25, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x22, x21) # load rs2: x21 = 0x7fffffffffffffff
@@ -1491,18 +879,9 @@ I_sw_cg_cp_rs2_edges_0x7fffffffffffffff:
   sw x21, 35(x28) # perform store
   addi x28, x28, 35 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x8 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x8, I_sw_cg_cp_rs2_edges_0x7fffffffffffffff, I_sw_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  sw x21, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x22, x13) # load rs2: x13 = 0x7ffffffffffffffe
@@ -1512,18 +891,9 @@ I_sw_cg_cp_rs2_edges_0x7ffffffffffffffe:
   sw x13, -1966(x29) # perform store
   addi x29, x29, -1966 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x1 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x1, I_sw_cg_cp_rs2_edges_0x7ffffffffffffffe, I_sw_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  sw x13, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x22, x3) # load rs2: x3 = 0xffffffffffffffff
@@ -1533,18 +903,9 @@ I_sw_cg_cp_rs2_edges_0xffffffffffffffff:
   sw x3, -1008(x7) # perform store
   addi x7, x7, -1008 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x25 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x25, I_sw_cg_cp_rs2_edges_0xffffffffffffffff, I_sw_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  sw x3, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x22, x16) # load rs2: x16 = 0xfffffffffffffffe
@@ -1554,18 +915,9 @@ I_sw_cg_cp_rs2_edges_0xfffffffffffffffe:
   sw x16, 729(x13) # perform store
   addi x13, x13, 729 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, I_sw_cg_cp_rs2_edges_0xfffffffffffffffe, I_sw_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  sw x16, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x22, x26) # load rs2: x26 = 0x5bbc887763ae86f2
@@ -1575,18 +927,9 @@ I_sw_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   sw x26, -1704(x10) # perform store
   addi x10, x10, -1704 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, I_sw_cg_cp_rs2_edges_0x5bbc887763ae86f2, I_sw_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  sw x26, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x22, x13) # load rs2: x13 = 0xaaaaaaaaaaaaaaaa
@@ -1596,18 +939,9 @@ I_sw_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   sw x13, 1655(x9) # perform store
   addi x9, x9, 1655 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x27 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x27, I_sw_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, I_sw_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  sw x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x22, x26) # load rs2: x26 = 0x5555555555555555
@@ -1617,18 +951,9 @@ I_sw_cg_cp_rs2_edges_0x5555555555555555:
   sw x26, 343(x28) # perform store
   addi x28, x28, 343 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x6 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x6, I_sw_cg_cp_rs2_edges_0x5555555555555555, I_sw_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  sw x26, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x22, x18) # load rs2: x18 = 0x00000000ffffffff
@@ -1638,18 +963,9 @@ I_sw_cg_cp_rs2_edges_0xffffffff:
   sw x18, -488(x21) # perform store
   addi x21, x21, -488 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x10 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x10, I_sw_cg_cp_rs2_edges_0xffffffff, I_sw_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  sw x18, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x22, x1) # load rs2: x1 = 0x00000000fffffffe
@@ -1659,18 +975,9 @@ I_sw_cg_cp_rs2_edges_0xfffffffe:
   sw x1, -42(x14) # perform store
   addi x14, x14, -42 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x23 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x23, I_sw_cg_cp_rs2_edges_0xfffffffe, I_sw_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  sw x1, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x22, x1) # load rs2: x1 = 0x0000000100000000
@@ -1680,18 +987,9 @@ I_sw_cg_cp_rs2_edges_0x100000000:
   sw x1, 202(x9) # perform store
   addi x9, x9, 202 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, I_sw_cg_cp_rs2_edges_0x100000000, I_sw_cg_cp_rs2_edges_0x100000000_str)
-#else
-  sw x1, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x22, x15) # load rs2: x15 = 0x0000000100000001
@@ -1701,18 +999,9 @@ I_sw_cg_cp_rs2_edges_0x100000001:
   sw x15, 116(x24) # perform store
   addi x24, x24, 116 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x29 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x29, I_sw_cg_cp_rs2_edges_0x100000001, I_sw_cg_cp_rs2_edges_0x100000001_str)
-#else
-  sw x15, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_edges
@@ -1726,18 +1015,9 @@ I_sw_cg_cp_imm_edges_0x0:
   sw x6, 0(x15) # perform store
   addi x15, x15, 0 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x7 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x7, I_sw_cg_cp_imm_edges_0x0, I_sw_cg_cp_imm_edges_0x0_str)
-#else
-  sw x6, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1)
   RVTEST_TESTDATA_LOAD_INT(x22, x1) # load rs2: x1 = 0x58367654cb95f1a7
@@ -1747,18 +1027,9 @@ I_sw_cg_cp_imm_edges_0x1:
   sw x1, 1(x6) # perform store
   addi x6, x6, 1 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x18 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x18, I_sw_cg_cp_imm_edges_0x1, I_sw_cg_cp_imm_edges_0x1_str)
-#else
-  sw x1, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2)
   RVTEST_TESTDATA_LOAD_INT(x22, x28) # load rs2: x28 = 0x971545546646f919
@@ -1768,18 +1039,9 @@ I_sw_cg_cp_imm_edges_0x2:
   sw x28, 2(x2) # perform store
   addi x2, x2, 2 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x10 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x10, I_sw_cg_cp_imm_edges_0x2, I_sw_cg_cp_imm_edges_0x2_str)
-#else
-  sw x28, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 3)
   RVTEST_TESTDATA_LOAD_INT(x22, x21) # load rs2: x21 = 0x527505d999c0af7f
@@ -1789,18 +1051,9 @@ I_sw_cg_cp_imm_edges_0x3:
   sw x21, 3(x17) # perform store
   addi x17, x17, 3 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x20 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x20, I_sw_cg_cp_imm_edges_0x3, I_sw_cg_cp_imm_edges_0x3_str)
-#else
-  sw x21, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 4)
   RVTEST_TESTDATA_LOAD_INT(x22, x21) # load rs2: x21 = 0xaac6912b43a496fa
@@ -1810,18 +1063,9 @@ I_sw_cg_cp_imm_edges_0x4:
   sw x21, 4(x25) # perform store
   addi x25, x25, 4 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x26 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x26, I_sw_cg_cp_imm_edges_0x4, I_sw_cg_cp_imm_edges_0x4_str)
-#else
-  sw x21, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 8)
   RVTEST_TESTDATA_LOAD_INT(x22, x12) # load rs2: x12 = 0x3c1d5330991813f4
@@ -1831,18 +1075,9 @@ I_sw_cg_cp_imm_edges_0x8:
   sw x12, 8(x3) # perform store
   addi x3, x3, 8 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x23 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x23, I_sw_cg_cp_imm_edges_0x8, I_sw_cg_cp_imm_edges_0x8_str)
-#else
-  sw x12, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 16)
   RVTEST_TESTDATA_LOAD_INT(x22, x12) # load rs2: x12 = 0x70fddd054a09c98a
@@ -1852,18 +1087,9 @@ I_sw_cg_cp_imm_edges_0x10:
   sw x12, 16(x29) # perform store
   addi x29, x29, 16 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x9 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x9, I_sw_cg_cp_imm_edges_0x10, I_sw_cg_cp_imm_edges_0x10_str)
-#else
-  sw x12, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 32)
   RVTEST_TESTDATA_LOAD_INT(x22, x9) # load rs2: x9 = 0x874a85f2ba0ad6f4
@@ -1873,18 +1099,9 @@ I_sw_cg_cp_imm_edges_0x20:
   sw x9, 32(x21) # perform store
   addi x21, x21, 32 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x26 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x26, I_sw_cg_cp_imm_edges_0x20, I_sw_cg_cp_imm_edges_0x20_str)
-#else
-  sw x9, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 64)
   RVTEST_TESTDATA_LOAD_INT(x22, x26) # load rs2: x26 = 0x2d4e622814b367f0
@@ -1894,18 +1111,9 @@ I_sw_cg_cp_imm_edges_0x40:
   sw x26, 64(x12) # perform store
   addi x12, x12, 64 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x10 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x10, I_sw_cg_cp_imm_edges_0x40, I_sw_cg_cp_imm_edges_0x40_str)
-#else
-  sw x26, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 128)
   RVTEST_TESTDATA_LOAD_INT(x22, x19) # load rs2: x19 = 0xfd6a7df939c48ed3
@@ -1915,18 +1123,9 @@ I_sw_cg_cp_imm_edges_0x80:
   sw x19, 128(x30) # perform store
   addi x30, x30, 128 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x21 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x21, I_sw_cg_cp_imm_edges_0x80, I_sw_cg_cp_imm_edges_0x80_str)
-#else
-  sw x19, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 256)
   RVTEST_TESTDATA_LOAD_INT(x22, x1) # load rs2: x1 = 0x932231c452b22622
@@ -1936,18 +1135,9 @@ I_sw_cg_cp_imm_edges_0x100:
   sw x1, 256(x3) # perform store
   addi x3, x3, 256 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x7 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x7, I_sw_cg_cp_imm_edges_0x100, I_sw_cg_cp_imm_edges_0x100_str)
-#else
-  sw x1, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 512)
   RVTEST_TESTDATA_LOAD_INT(x22, x7) # load rs2: x7 = 0xcc7e7c96e9a76242
@@ -1957,18 +1147,9 @@ I_sw_cg_cp_imm_edges_0x200:
   sw x7, 512(x13) # perform store
   addi x13, x13, 512 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x27 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x27, I_sw_cg_cp_imm_edges_0x200, I_sw_cg_cp_imm_edges_0x200_str)
-#else
-  sw x7, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1023)
   RVTEST_TESTDATA_LOAD_INT(x22, x18) # load rs2: x18 = 0x85b1cbfc36145914
@@ -1978,18 +1159,9 @@ I_sw_cg_cp_imm_edges_0x3ff:
   sw x18, 1023(x17) # perform store
   addi x17, x17, 1023 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x29 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x29, I_sw_cg_cp_imm_edges_0x3ff, I_sw_cg_cp_imm_edges_0x3ff_str)
-#else
-  sw x18, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1024)
   RVTEST_TESTDATA_LOAD_INT(x22, x28) # load rs2: x28 = 0x441fd099f2163b04
@@ -1999,18 +1171,9 @@ I_sw_cg_cp_imm_edges_0x400:
   sw x28, 1024(x8) # perform store
   addi x8, x8, 1024 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x30 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x30, I_sw_cg_cp_imm_edges_0x400, I_sw_cg_cp_imm_edges_0x400_str)
-#else
-  sw x28, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 1795)
   RVTEST_TESTDATA_LOAD_INT(x22, x9) # load rs2: x9 = 0x04b003c097b4834f
@@ -2020,18 +1183,9 @@ I_sw_cg_cp_imm_edges_0x703:
   sw x9, 1795(x23) # perform store
   addi x23, x23, 1795 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x13 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x13, I_sw_cg_cp_imm_edges_0x703, I_sw_cg_cp_imm_edges_0x703_str)
-#else
-  sw x9, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = 2047)
   RVTEST_TESTDATA_LOAD_INT(x22, x26) # load rs2: x26 = 0x4b0bc46939e398db
@@ -2041,18 +1195,9 @@ I_sw_cg_cp_imm_edges_0x7ff:
   sw x26, 2047(x2) # perform store
   addi x2, x2, 2047 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x9 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x9, I_sw_cg_cp_imm_edges_0x7ff, I_sw_cg_cp_imm_edges_0x7ff_str)
-#else
-  sw x26, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2048)
   RVTEST_TESTDATA_LOAD_INT(x22, x24) # load rs2: x24 = 0x17133cf817bd2516
@@ -2063,18 +1208,9 @@ I_sw_cg_cp_imm_edges_m0x800:
   sw x24, -2048(x11) # perform store
   addi x11, x11, -2048 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x28, I_sw_cg_cp_imm_edges_m0x800, I_sw_cg_cp_imm_edges_m0x800_str)
-#else
-  sw x24, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2047)
   RVTEST_TESTDATA_LOAD_INT(x22, x12) # load rs2: x12 = 0x97ba2dd2f8751850
@@ -2084,18 +1220,9 @@ I_sw_cg_cp_imm_edges_m0x7ff:
   sw x12, -2047(x25) # perform store
   addi x25, x25, -2047 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x23 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x23, I_sw_cg_cp_imm_edges_m0x7ff, I_sw_cg_cp_imm_edges_m0x7ff_str)
-#else
-  sw x12, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -2)
   RVTEST_TESTDATA_LOAD_INT(x22, x24) # load rs2: x24 = 0xc219295c531542eb
@@ -2105,18 +1232,9 @@ I_sw_cg_cp_imm_edges_m0x2:
   sw x24, -2(x21) # perform store
   addi x21, x21, -2 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x18 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x18, I_sw_cg_cp_imm_edges_m0x2, I_sw_cg_cp_imm_edges_m0x2_str)
-#else
-  sw x24, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_edges (imm = -1)
   RVTEST_TESTDATA_LOAD_INT(x22, x6) # load rs2: x6 = 0x32cb46f4cee69bb1
@@ -2126,18 +1244,9 @@ I_sw_cg_cp_imm_edges_m0x1:
   sw x6, -1(x8) # perform store
   addi x8, x8, -1 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, I_sw_cg_cp_imm_edges_m0x1, I_sw_cg_cp_imm_edges_m0x1_str)
-#else
-  sw x6, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_align_word
@@ -2148,36 +1257,18 @@ I_sw_cg_cp_imm_edges_m0x1:
 I_sw_cg_cp_align_word_b0:
   sw x9, 0(x8) # perform store
   addi x8, x8, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -8(x8) # load stored value for checking
   # Check if x3 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x3, I_sw_cg_cp_align_word_b0, I_sw_cg_cp_align_word_b0_str)
-#else
-  sw x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase: cp_align_word (imm[2:0] = 100)
   RVTEST_TESTDATA_LOAD_INT(x22, x6) # load rs2: x6 = 0xbc1e0991e9b407ee
 I_sw_cg_cp_align_word_b4:
   sw x6, 4(x8) # perform store
   addi x8, x8, 8 # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -8(x8) # load stored value for checking
   # Check if x1 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x1, I_sw_cg_cp_align_word_b4, I_sw_cg_cp_align_word_b4_str)
-#else
-  sw x6, 4(x8) # repeat store so it is available for checking
-  addi x8, x8, 8 # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 
   mv x2, x8 # restore signature pointer to default register for teardown

--- a/tests/rv64i/Zca/Zca-c.sd-00.S
+++ b/tests/rv64i/Zca/Zca-c.sd-00.S
@@ -41,18 +41,9 @@ Zca_c_sd_cg_cp_rs1_p_b8:
   c.sd x11, 40(x8) # perform store
   addi x8, x8, 40 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zca_c_sd_cg_cp_rs1_p_b8, Zca_c_sd_cg_cp_rs1_p_b8_str)
-#else
-  c.sd x11, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x9fb87b460ae752d8
@@ -62,18 +53,9 @@ Zca_c_sd_cg_cp_rs1_p_b9:
   c.sd x13, 24(x9) # perform store
   addi x9, x9, 24 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sd_cg_cp_rs1_p_b9, Zca_c_sd_cg_cp_rs1_p_b9_str)
-#else
-  c.sd x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x8f5927d2632c188e
@@ -83,18 +65,9 @@ Zca_c_sd_cg_cp_rs1_p_b10:
   c.sd x11, 208(x10) # perform store
   addi x10, x10, 208 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, Zca_c_sd_cg_cp_rs1_p_b10, Zca_c_sd_cg_cp_rs1_p_b10_str)
-#else
-  c.sd x11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x912f0e76fc9eb21d
@@ -104,18 +77,9 @@ Zca_c_sd_cg_cp_rs1_p_b11:
   c.sd x15, 240(x11) # perform store
   addi x11, x11, 240 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_sd_cg_cp_rs1_p_b11, Zca_c_sd_cg_cp_rs1_p_b11_str)
-#else
-  c.sd x15, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x2f83f3bcedadc459
@@ -125,18 +89,9 @@ Zca_c_sd_cg_cp_rs1_p_b12:
   c.sd x8, 88(x12) # perform store
   addi x12, x12, 88 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x10 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x10, Zca_c_sd_cg_cp_rs1_p_b12, Zca_c_sd_cg_cp_rs1_p_b12_str)
-#else
-  c.sd x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x0117a431d128fd4c
@@ -146,18 +101,9 @@ Zca_c_sd_cg_cp_rs1_p_b13:
   c.sd x8, 216(x13) # perform store
   addi x13, x13, 216 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, Zca_c_sd_cg_cp_rs1_p_b13, Zca_c_sd_cg_cp_rs1_p_b13_str)
-#else
-  c.sd x8, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x0137b2a2f22b88ca
@@ -167,18 +113,9 @@ Zca_c_sd_cg_cp_rs1_p_b14:
   c.sd x9, 160(x14) # perform store
   addi x14, x14, 160 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x15 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x15, Zca_c_sd_cg_cp_rs1_p_b14, Zca_c_sd_cg_cp_rs1_p_b14_str)
-#else
-  c.sd x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xab0ef85921f8c339
@@ -188,18 +125,9 @@ Zca_c_sd_cg_cp_rs1_p_b15:
   c.sd x13, 136(x15) # perform store
   addi x15, x15, 136 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, Zca_c_sd_cg_cp_rs1_p_b15, Zca_c_sd_cg_cp_rs1_p_b15_str)
-#else
-  c.sd x13, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_p
@@ -213,18 +141,9 @@ Zca_c_sd_cg_cp_rs2_p_b8:
   c.sd x8, 192(x14) # perform store
   addi x14, x14, 192 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zca_c_sd_cg_cp_rs2_p_b8, Zca_c_sd_cg_cp_rs2_p_b8_str)
-#else
-  c.sd x8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xb537c7b1a9d97843
@@ -234,18 +153,9 @@ Zca_c_sd_cg_cp_rs2_p_b9:
   c.sd x9, 136(x8) # perform store
   addi x8, x8, 136 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zca_c_sd_cg_cp_rs2_p_b9, Zca_c_sd_cg_cp_rs2_p_b9_str)
-#else
-  c.sd x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xab38713554dcd8d7
@@ -255,18 +165,9 @@ Zca_c_sd_cg_cp_rs2_p_b10:
   c.sd x10, 144(x13) # perform store
   addi x13, x13, 144 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, Zca_c_sd_cg_cp_rs2_p_b10, Zca_c_sd_cg_cp_rs2_p_b10_str)
-#else
-  c.sd x10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x5b5f45052ecaa215
@@ -276,18 +177,9 @@ Zca_c_sd_cg_cp_rs2_p_b11:
   c.sd x11, 168(x14) # perform store
   addi x14, x14, 168 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zca_c_sd_cg_cp_rs2_p_b11, Zca_c_sd_cg_cp_rs2_p_b11_str)
-#else
-  c.sd x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x20426f8c90a8d37e
@@ -297,18 +189,9 @@ Zca_c_sd_cg_cp_rs2_p_b12:
   c.sd x12, 64(x11) # perform store
   addi x11, x11, 64 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_sd_cg_cp_rs2_p_b12, Zca_c_sd_cg_cp_rs2_p_b12_str)
-#else
-  c.sd x12, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x1ec3c1caa24cb0f8
@@ -318,18 +201,9 @@ Zca_c_sd_cg_cp_rs2_p_b13:
   c.sd x13, 184(x10) # perform store
   addi x10, x10, 184 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, Zca_c_sd_cg_cp_rs2_p_b13, Zca_c_sd_cg_cp_rs2_p_b13_str)
-#else
-  c.sd x13, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x64cff40ad75a8a45
@@ -339,18 +213,9 @@ Zca_c_sd_cg_cp_rs2_p_b14:
   c.sd x14, 0(x12) # perform store
   addi x12, x12, 0 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_sd_cg_cp_rs2_p_b14, Zca_c_sd_cg_cp_rs2_p_b14_str)
-#else
-  c.sd x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xed01605e463760d3
@@ -360,18 +225,9 @@ Zca_c_sd_cg_cp_rs2_p_b15:
   c.sd x15, 232(x9) # perform store
   addi x9, x9, 232 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sd_cg_cp_rs2_p_b15, Zca_c_sd_cg_cp_rs2_p_b15_str)
-#else
-  c.sd x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -385,18 +241,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x0:
   c.sd x13, 8(x11) # perform store
   addi x11, x11, 8 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_sd_cg_cp_rs2_edges_0x0, Zca_c_sd_cg_cp_rs2_edges_0x0_str)
-#else
-  c.sd x13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x0000000000000001
@@ -406,18 +253,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x1:
   c.sd x13, 88(x12) # perform store
   addi x12, x12, 88 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zca_c_sd_cg_cp_rs2_edges_0x1, Zca_c_sd_cg_cp_rs2_edges_0x1_str)
-#else
-  c.sd x13, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x0000000000000002
@@ -427,18 +265,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x2:
   c.sd x15, 128(x13) # perform store
   addi x13, x13, 128 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, Zca_c_sd_cg_cp_rs2_edges_0x2, Zca_c_sd_cg_cp_rs2_edges_0x2_str)
-#else
-  c.sd x15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x8000000000000000
@@ -448,18 +277,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x8000000000000000:
   c.sd x14, 24(x10) # perform store
   addi x10, x10, 24 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x9 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x9, Zca_c_sd_cg_cp_rs2_edges_0x8000000000000000, Zca_c_sd_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  c.sd x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x8000000000000001
@@ -469,18 +289,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x8000000000000001:
   c.sd x14, 112(x15) # perform store
   addi x15, x15, 112 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x9 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x9, Zca_c_sd_cg_cp_rs2_edges_0x8000000000000001, Zca_c_sd_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  c.sd x14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x7fffffffffffffff
@@ -490,18 +301,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x7fffffffffffffff:
   c.sd x12, 40(x8) # perform store
   addi x8, x8, 40 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, Zca_c_sd_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_sd_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  c.sd x12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x7ffffffffffffffe
@@ -511,18 +313,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x7ffffffffffffffe:
   c.sd x14, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sd_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_sd_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  c.sd x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xffffffffffffffff
@@ -532,18 +325,9 @@ Zca_c_sd_cg_cp_rs2_edges_0xffffffffffffffff:
   c.sd x14, 104(x8) # perform store
   addi x8, x8, 104 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zca_c_sd_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_sd_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  c.sd x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xfffffffffffffffe
@@ -553,18 +337,9 @@ Zca_c_sd_cg_cp_rs2_edges_0xfffffffffffffffe:
   c.sd x15, 48(x14) # perform store
   addi x14, x14, 48 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zca_c_sd_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_sd_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  c.sd x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x5bbc887763ae86f2
@@ -574,18 +349,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   c.sd x11, 136(x9) # perform store
   addi x9, x9, 136 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sd_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_sd_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  c.sd x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xaaaaaaaaaaaaaaaa
@@ -595,18 +361,9 @@ Zca_c_sd_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   c.sd x13, 152(x15) # perform store
   addi x15, x15, 152 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zca_c_sd_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_sd_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  c.sd x13, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x5555555555555555
@@ -616,18 +373,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x5555555555555555:
   c.sd x9, 200(x8) # perform store
   addi x8, x8, 200 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zca_c_sd_cg_cp_rs2_edges_0x5555555555555555, Zca_c_sd_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  c.sd x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x00000000ffffffff
@@ -637,18 +385,9 @@ Zca_c_sd_cg_cp_rs2_edges_0xffffffff:
   c.sd x15, 120(x11) # perform store
   addi x11, x11, 120 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_sd_cg_cp_rs2_edges_0xffffffff, Zca_c_sd_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  c.sd x15, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x00000000fffffffe
@@ -658,18 +397,9 @@ Zca_c_sd_cg_cp_rs2_edges_0xfffffffe:
   c.sd x14, 104(x9) # perform store
   addi x9, x9, 104 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sd_cg_cp_rs2_edges_0xfffffffe, Zca_c_sd_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  c.sd x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x0000000100000000
@@ -679,18 +409,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x100000000:
   c.sd x13, 232(x12) # perform store
   addi x12, x12, 232 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zca_c_sd_cg_cp_rs2_edges_0x100000000, Zca_c_sd_cg_cp_rs2_edges_0x100000000_str)
-#else
-  c.sd x13, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x0000000100000001
@@ -700,18 +421,9 @@ Zca_c_sd_cg_cp_rs2_edges_0x100000001:
   c.sd x10, 152(x15) # perform store
   addi x15, x15, 152 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zca_c_sd_cg_cp_rs2_edges_0x100000001, Zca_c_sd_cg_cp_rs2_edges_0x100000001_str)
-#else
-  c.sd x10, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_mul_8
@@ -725,18 +437,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x0:
   c.sd x9, 0(x14) # perform store
   addi x14, x14, 0 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x10 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x10, Zca_c_sd_cg_cp_imm_mul_8_b0x0, Zca_c_sd_cg_cp_imm_mul_8_b0x0_str)
-#else
-  c.sd x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=8
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xc548e12214302b5d
@@ -746,18 +449,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x8:
   c.sd x10, 8(x9) # perform store
   addi x9, x9, 8 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sd_cg_cp_imm_mul_8_b0x8, Zca_c_sd_cg_cp_imm_mul_8_b0x8_str)
-#else
-  c.sd x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=16
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xf348069f6dee3bae
@@ -767,18 +461,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x10:
   c.sd x13, 16(x8) # perform store
   addi x8, x8, 16 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, Zca_c_sd_cg_cp_imm_mul_8_b0x10, Zca_c_sd_cg_cp_imm_mul_8_b0x10_str)
-#else
-  c.sd x13, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=24
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x63d32df923a08b49
@@ -788,18 +473,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x18:
   c.sd x13, 24(x15) # perform store
   addi x15, x15, 24 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zca_c_sd_cg_cp_imm_mul_8_b0x18, Zca_c_sd_cg_cp_imm_mul_8_b0x18_str)
-#else
-  c.sd x13, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=32
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x9906e613cb12f9e6
@@ -809,18 +485,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x20:
   c.sd x13, 32(x8) # perform store
   addi x8, x8, 32 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, Zca_c_sd_cg_cp_imm_mul_8_b0x20, Zca_c_sd_cg_cp_imm_mul_8_b0x20_str)
-#else
-  c.sd x13, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=40
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xce40e27d2a628164
@@ -830,18 +497,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x28:
   c.sd x10, 40(x14) # perform store
   addi x14, x14, 40 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zca_c_sd_cg_cp_imm_mul_8_b0x28, Zca_c_sd_cg_cp_imm_mul_8_b0x28_str)
-#else
-  c.sd x10, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=48
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xf63175840fa39c87
@@ -851,18 +509,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x30:
   c.sd x13, 48(x15) # perform store
   addi x15, x15, 48 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x9 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x9, Zca_c_sd_cg_cp_imm_mul_8_b0x30, Zca_c_sd_cg_cp_imm_mul_8_b0x30_str)
-#else
-  c.sd x13, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=56
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x71204622dc3764e8
@@ -872,18 +521,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x38:
   c.sd x10, 56(x9) # perform store
   addi x9, x9, 56 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sd_cg_cp_imm_mul_8_b0x38, Zca_c_sd_cg_cp_imm_mul_8_b0x38_str)
-#else
-  c.sd x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=64
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xdc95e6a3aeac5b6b
@@ -893,18 +533,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x40:
   c.sd x12, 64(x8) # perform store
   addi x8, x8, 64 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, Zca_c_sd_cg_cp_imm_mul_8_b0x40, Zca_c_sd_cg_cp_imm_mul_8_b0x40_str)
-#else
-  c.sd x12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=72
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x67c31943e237de0d
@@ -914,18 +545,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x48:
   c.sd x13, 72(x9) # perform store
   addi x9, x9, 72 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sd_cg_cp_imm_mul_8_b0x48, Zca_c_sd_cg_cp_imm_mul_8_b0x48_str)
-#else
-  c.sd x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=80
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xb6444b43c0e28766
@@ -935,18 +557,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x50:
   c.sd x15, 80(x8) # perform store
   addi x8, x8, 80 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zca_c_sd_cg_cp_imm_mul_8_b0x50, Zca_c_sd_cg_cp_imm_mul_8_b0x50_str)
-#else
-  c.sd x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=88
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xbb88111e5d506790
@@ -956,18 +569,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x58:
   c.sd x11, 88(x13) # perform store
   addi x13, x13, 88 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, Zca_c_sd_cg_cp_imm_mul_8_b0x58, Zca_c_sd_cg_cp_imm_mul_8_b0x58_str)
-#else
-  c.sd x11, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=96
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x1cc2cbcd2a8dfe71
@@ -977,18 +581,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x60:
   c.sd x9, 96(x11) # perform store
   addi x11, x11, 96 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_sd_cg_cp_imm_mul_8_b0x60, Zca_c_sd_cg_cp_imm_mul_8_b0x60_str)
-#else
-  c.sd x9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=104
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x7d1e9c88dd25f640
@@ -998,18 +593,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x68:
   c.sd x8, 104(x15) # perform store
   addi x15, x15, 104 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x13, Zca_c_sd_cg_cp_imm_mul_8_b0x68, Zca_c_sd_cg_cp_imm_mul_8_b0x68_str)
-#else
-  c.sd x8, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=112
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xa125c69008fd8432
@@ -1019,18 +605,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x70:
   c.sd x12, 112(x11) # perform store
   addi x11, x11, 112 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_sd_cg_cp_imm_mul_8_b0x70, Zca_c_sd_cg_cp_imm_mul_8_b0x70_str)
-#else
-  c.sd x12, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=120
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xa0a98923099fd26d
@@ -1040,18 +617,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x78:
   c.sd x13, 120(x12) # perform store
   addi x12, x12, 120 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x15 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x15, Zca_c_sd_cg_cp_imm_mul_8_b0x78, Zca_c_sd_cg_cp_imm_mul_8_b0x78_str)
-#else
-  c.sd x13, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=128
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x137181878d7759d4
@@ -1061,18 +629,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x80:
   c.sd x15, 128(x9) # perform store
   addi x9, x9, 128 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sd_cg_cp_imm_mul_8_b0x80, Zca_c_sd_cg_cp_imm_mul_8_b0x80_str)
-#else
-  c.sd x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=136
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x3e9232057938f85b
@@ -1082,18 +641,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x88:
   c.sd x13, 136(x11) # perform store
   addi x11, x11, 136 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_sd_cg_cp_imm_mul_8_b0x88, Zca_c_sd_cg_cp_imm_mul_8_b0x88_str)
-#else
-  c.sd x13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=144
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xa6be663cdbd343bd
@@ -1103,18 +653,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x90:
   c.sd x15, 144(x10) # perform store
   addi x10, x10, 144 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zca_c_sd_cg_cp_imm_mul_8_b0x90, Zca_c_sd_cg_cp_imm_mul_8_b0x90_str)
-#else
-  c.sd x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=152
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x21d4e993166ecdf5
@@ -1124,18 +665,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0x98:
   c.sd x15, 152(x9) # perform store
   addi x9, x9, 152 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sd_cg_cp_imm_mul_8_b0x98, Zca_c_sd_cg_cp_imm_mul_8_b0x98_str)
-#else
-  c.sd x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=160
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x5ad4b6ebc6550926
@@ -1145,18 +677,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xa0:
   c.sd x15, 160(x14) # perform store
   addi x14, x14, 160 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zca_c_sd_cg_cp_imm_mul_8_b0xa0, Zca_c_sd_cg_cp_imm_mul_8_b0xa0_str)
-#else
-  c.sd x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=168
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xe6ca12e44af10097
@@ -1166,18 +689,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xa8:
   c.sd x9, 168(x15) # perform store
   addi x15, x15, 168 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, Zca_c_sd_cg_cp_imm_mul_8_b0xa8, Zca_c_sd_cg_cp_imm_mul_8_b0xa8_str)
-#else
-  c.sd x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=176
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x5fad01301a98956c
@@ -1187,18 +701,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xb0:
   c.sd x14, 176(x12) # perform store
   addi x12, x12, 176 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zca_c_sd_cg_cp_imm_mul_8_b0xb0, Zca_c_sd_cg_cp_imm_mul_8_b0xb0_str)
-#else
-  c.sd x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=184
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x75176fafe5291907
@@ -1208,18 +713,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xb8:
   c.sd x13, 184(x14) # perform store
   addi x14, x14, 184 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x10 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x10, Zca_c_sd_cg_cp_imm_mul_8_b0xb8, Zca_c_sd_cg_cp_imm_mul_8_b0xb8_str)
-#else
-  c.sd x13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=192
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xf993f44bf78412a4
@@ -1229,18 +725,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xc0:
   c.sd x15, 192(x10) # perform store
   addi x10, x10, 192 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zca_c_sd_cg_cp_imm_mul_8_b0xc0, Zca_c_sd_cg_cp_imm_mul_8_b0xc0_str)
-#else
-  c.sd x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=200
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x31f9f7e02c0297e2
@@ -1250,18 +737,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xc8:
   c.sd x15, 200(x13) # perform store
   addi x13, x13, 200 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, Zca_c_sd_cg_cp_imm_mul_8_b0xc8, Zca_c_sd_cg_cp_imm_mul_8_b0xc8_str)
-#else
-  c.sd x15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=208
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x3ea33c558959d7e9
@@ -1271,18 +749,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xd0:
   c.sd x14, 208(x12) # perform store
   addi x12, x12, 208 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zca_c_sd_cg_cp_imm_mul_8_b0xd0, Zca_c_sd_cg_cp_imm_mul_8_b0xd0_str)
-#else
-  c.sd x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=216
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xd222b44df7b157ab
@@ -1292,18 +761,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xd8:
   c.sd x10, 216(x8) # perform store
   addi x8, x8, 216 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zca_c_sd_cg_cp_imm_mul_8_b0xd8, Zca_c_sd_cg_cp_imm_mul_8_b0xd8_str)
-#else
-  c.sd x10, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=224
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xbe1706d57ad81ab1
@@ -1313,18 +773,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xe0:
   c.sd x12, 224(x9) # perform store
   addi x9, x9, 224 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sd_cg_cp_imm_mul_8_b0xe0, Zca_c_sd_cg_cp_imm_mul_8_b0xe0_str)
-#else
-  c.sd x12, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=232
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x024e534f03cf1be0
@@ -1334,18 +785,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xe8:
   c.sd x14, 232(x11) # perform store
   addi x11, x11, 232 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_sd_cg_cp_imm_mul_8_b0xe8, Zca_c_sd_cg_cp_imm_mul_8_b0xe8_str)
-#else
-  c.sd x14, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=240
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x63f1adf0a9299293
@@ -1355,18 +797,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xf0:
   c.sd x13, 240(x14) # perform store
   addi x14, x14, 240 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zca_c_sd_cg_cp_imm_mul_8_b0xf0, Zca_c_sd_cg_cp_imm_mul_8_b0xf0_str)
-#else
-  c.sd x13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8: imm=248
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x70fe206ec0da7bc0
@@ -1376,18 +809,9 @@ Zca_c_sd_cg_cp_imm_mul_8_b0xf8:
   c.sd x13, 248(x10) # perform store
   addi x10, x10, 248 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zca_c_sd_cg_cp_imm_mul_8_b0xf8, Zca_c_sd_cg_cp_imm_mul_8_b0xf8_str)
-#else
-  c.sd x13, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x10 # restore signature pointer to default register for teardown
 

--- a/tests/rv64i/Zca/Zca-c.sdsp-00.S
+++ b/tests/rv64i/Zca/Zca-c.sdsp-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 122
+#define SIGUPD_COUNT 234
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -40,6 +40,7 @@ RVTEST_BEGIN
 Zca_c_sdsp_cg_cp_rs2_b0:
   c.sdsp x0, 456(sp) # perform store
   LREG x25, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x25, Zca_c_sdsp_cg_cp_rs2_b0, Zca_c_sdsp_cg_cp_rs2_b0_str)
 
@@ -49,6 +50,7 @@ Zca_c_sdsp_cg_cp_rs2_b0:
 Zca_c_sdsp_cg_cp_rs2_b1:
   c.sdsp x1, 336(sp) # perform store
   LREG x12, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x12, Zca_c_sdsp_cg_cp_rs2_b1, Zca_c_sdsp_cg_cp_rs2_b1_str)
 
@@ -58,6 +60,7 @@ Zca_c_sdsp_cg_cp_rs2_b1:
 Zca_c_sdsp_cg_cp_rs2_b2:
   c.sdsp x2, 184(sp) # perform store
   LREG x22, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x22, Zca_c_sdsp_cg_cp_rs2_b2, Zca_c_sdsp_cg_cp_rs2_b2_str)
 
@@ -68,6 +71,7 @@ Zca_c_sdsp_cg_cp_rs2_b2:
 Zca_c_sdsp_cg_cp_rs2_b3:
   c.sdsp x3, 480(sp) # perform store
   LREG x17, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x17, Zca_c_sdsp_cg_cp_rs2_b3, Zca_c_sdsp_cg_cp_rs2_b3_str)
 
@@ -79,6 +83,7 @@ Zca_c_sdsp_cg_cp_rs2_b3:
 Zca_c_sdsp_cg_cp_rs2_b4:
   c.sdsp x4, 344(sp) # perform store
   LREG x10, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x10, Zca_c_sdsp_cg_cp_rs2_b4, Zca_c_sdsp_cg_cp_rs2_b4_str)
 
@@ -88,6 +93,7 @@ Zca_c_sdsp_cg_cp_rs2_b4:
 Zca_c_sdsp_cg_cp_rs2_b5:
   c.sdsp x5, 432(sp) # perform store
   LREG x4, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x4, Zca_c_sdsp_cg_cp_rs2_b5, Zca_c_sdsp_cg_cp_rs2_b5_str)
 
@@ -97,6 +103,7 @@ Zca_c_sdsp_cg_cp_rs2_b5:
 Zca_c_sdsp_cg_cp_rs2_b6:
   c.sdsp x6, 344(sp) # perform store
   LREG x1, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x1 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x1, Zca_c_sdsp_cg_cp_rs2_b6, Zca_c_sdsp_cg_cp_rs2_b6_str)
 
@@ -108,6 +115,7 @@ Zca_c_sdsp_cg_cp_rs2_b6:
 Zca_c_sdsp_cg_cp_rs2_b7:
   c.sdsp x7, 496(sp) # perform store
   LREG x27, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x23 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x23, x14, x13, x27, Zca_c_sdsp_cg_cp_rs2_b7, Zca_c_sdsp_cg_cp_rs2_b7_str)
 
@@ -117,6 +125,7 @@ Zca_c_sdsp_cg_cp_rs2_b7:
 Zca_c_sdsp_cg_cp_rs2_b8:
   c.sdsp x8, 400(sp) # perform store
   LREG x22, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x23 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x23, x14, x13, x22, Zca_c_sdsp_cg_cp_rs2_b8, Zca_c_sdsp_cg_cp_rs2_b8_str)
 
@@ -126,6 +135,7 @@ Zca_c_sdsp_cg_cp_rs2_b8:
 Zca_c_sdsp_cg_cp_rs2_b9:
   c.sdsp x9, 160(sp) # perform store
   LREG x5, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x23 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x23, x14, x13, x5, Zca_c_sdsp_cg_cp_rs2_b9, Zca_c_sdsp_cg_cp_rs2_b9_str)
 
@@ -135,6 +145,7 @@ Zca_c_sdsp_cg_cp_rs2_b9:
 Zca_c_sdsp_cg_cp_rs2_b10:
   c.sdsp x10, 72(sp) # perform store
   LREG x4, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x23 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x23, x14, x13, x4, Zca_c_sdsp_cg_cp_rs2_b10, Zca_c_sdsp_cg_cp_rs2_b10_str)
 
@@ -144,6 +155,7 @@ Zca_c_sdsp_cg_cp_rs2_b10:
 Zca_c_sdsp_cg_cp_rs2_b11:
   c.sdsp x11, 264(sp) # perform store
   LREG x12, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x23 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x23, x14, x13, x12, Zca_c_sdsp_cg_cp_rs2_b11, Zca_c_sdsp_cg_cp_rs2_b11_str)
 
@@ -153,6 +165,7 @@ Zca_c_sdsp_cg_cp_rs2_b11:
 Zca_c_sdsp_cg_cp_rs2_b12:
   c.sdsp x12, 112(sp) # perform store
   LREG x5, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x23 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x23, x14, x13, x5, Zca_c_sdsp_cg_cp_rs2_b12, Zca_c_sdsp_cg_cp_rs2_b12_str)
 
@@ -164,6 +177,7 @@ Zca_c_sdsp_cg_cp_rs2_b12:
 Zca_c_sdsp_cg_cp_rs2_b13:
   c.sdsp x13, 360(sp) # perform store
   LREG x26, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x26, Zca_c_sdsp_cg_cp_rs2_b13, Zca_c_sdsp_cg_cp_rs2_b13_str)
 
@@ -173,6 +187,7 @@ Zca_c_sdsp_cg_cp_rs2_b13:
 Zca_c_sdsp_cg_cp_rs2_b14:
   c.sdsp x14, 264(sp) # perform store
   LREG x9, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x9, Zca_c_sdsp_cg_cp_rs2_b14, Zca_c_sdsp_cg_cp_rs2_b14_str)
 
@@ -182,6 +197,7 @@ Zca_c_sdsp_cg_cp_rs2_b14:
 Zca_c_sdsp_cg_cp_rs2_b15:
   c.sdsp x15, 312(sp) # perform store
   LREG x4, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x4, Zca_c_sdsp_cg_cp_rs2_b15, Zca_c_sdsp_cg_cp_rs2_b15_str)
 
@@ -191,6 +207,7 @@ Zca_c_sdsp_cg_cp_rs2_b15:
 Zca_c_sdsp_cg_cp_rs2_b16:
   c.sdsp x16, 456(sp) # perform store
   LREG x17, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x17, Zca_c_sdsp_cg_cp_rs2_b16, Zca_c_sdsp_cg_cp_rs2_b16_str)
 
@@ -200,6 +217,7 @@ Zca_c_sdsp_cg_cp_rs2_b16:
 Zca_c_sdsp_cg_cp_rs2_b17:
   c.sdsp x17, 480(sp) # perform store
   LREG x21, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x21, Zca_c_sdsp_cg_cp_rs2_b17, Zca_c_sdsp_cg_cp_rs2_b17_str)
 
@@ -209,6 +227,7 @@ Zca_c_sdsp_cg_cp_rs2_b17:
 Zca_c_sdsp_cg_cp_rs2_b18:
   c.sdsp x18, 472(sp) # perform store
   LREG x29, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x29, Zca_c_sdsp_cg_cp_rs2_b18, Zca_c_sdsp_cg_cp_rs2_b18_str)
 
@@ -218,6 +237,7 @@ Zca_c_sdsp_cg_cp_rs2_b18:
 Zca_c_sdsp_cg_cp_rs2_b19:
   c.sdsp x19, 80(sp) # perform store
   LREG x6, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x6, Zca_c_sdsp_cg_cp_rs2_b19, Zca_c_sdsp_cg_cp_rs2_b19_str)
 
@@ -228,6 +248,7 @@ Zca_c_sdsp_cg_cp_rs2_b19:
 Zca_c_sdsp_cg_cp_rs2_b20:
   c.sdsp x20, 24(sp) # perform store
   LREG x29, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x29, Zca_c_sdsp_cg_cp_rs2_b20, Zca_c_sdsp_cg_cp_rs2_b20_str)
 
@@ -237,6 +258,7 @@ Zca_c_sdsp_cg_cp_rs2_b20:
 Zca_c_sdsp_cg_cp_rs2_b21:
   c.sdsp x21, 16(sp) # perform store
   LREG x14, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x14, Zca_c_sdsp_cg_cp_rs2_b21, Zca_c_sdsp_cg_cp_rs2_b21_str)
 
@@ -246,6 +268,7 @@ Zca_c_sdsp_cg_cp_rs2_b21:
 Zca_c_sdsp_cg_cp_rs2_b22:
   c.sdsp x22, 376(sp) # perform store
   LREG x4, 0(x23) # load stored value for checking
+  addi x23, x23, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x4, Zca_c_sdsp_cg_cp_rs2_b22, Zca_c_sdsp_cg_cp_rs2_b22_str)
 
@@ -256,6 +279,7 @@ Zca_c_sdsp_cg_cp_rs2_b22:
 Zca_c_sdsp_cg_cp_rs2_b23:
   c.sdsp x23, 384(sp) # perform store
   LREG x19, 0(x24) # load stored value for checking
+  addi x24, x24, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x19, Zca_c_sdsp_cg_cp_rs2_b23, Zca_c_sdsp_cg_cp_rs2_b23_str)
 
@@ -266,6 +290,7 @@ Zca_c_sdsp_cg_cp_rs2_b23:
 Zca_c_sdsp_cg_cp_rs2_b24:
   c.sdsp x24, 304(sp) # perform store
   LREG x12, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x12, Zca_c_sdsp_cg_cp_rs2_b24, Zca_c_sdsp_cg_cp_rs2_b24_str)
 
@@ -275,6 +300,7 @@ Zca_c_sdsp_cg_cp_rs2_b24:
 Zca_c_sdsp_cg_cp_rs2_b25:
   c.sdsp x25, 104(sp) # perform store
   LREG x5, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x5, Zca_c_sdsp_cg_cp_rs2_b25, Zca_c_sdsp_cg_cp_rs2_b25_str)
 
@@ -284,6 +310,7 @@ Zca_c_sdsp_cg_cp_rs2_b25:
 Zca_c_sdsp_cg_cp_rs2_b26:
   c.sdsp x26, 88(sp) # perform store
   LREG x14, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x14, Zca_c_sdsp_cg_cp_rs2_b26, Zca_c_sdsp_cg_cp_rs2_b26_str)
 
@@ -293,6 +320,7 @@ Zca_c_sdsp_cg_cp_rs2_b26:
 Zca_c_sdsp_cg_cp_rs2_b27:
   c.sdsp x27, 304(sp) # perform store
   LREG x26, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x26, Zca_c_sdsp_cg_cp_rs2_b27, Zca_c_sdsp_cg_cp_rs2_b27_str)
 
@@ -302,6 +330,7 @@ Zca_c_sdsp_cg_cp_rs2_b27:
 Zca_c_sdsp_cg_cp_rs2_b28:
   c.sdsp x28, 288(sp) # perform store
   LREG x5, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x5, Zca_c_sdsp_cg_cp_rs2_b28, Zca_c_sdsp_cg_cp_rs2_b28_str)
 
@@ -311,6 +340,7 @@ Zca_c_sdsp_cg_cp_rs2_b28:
 Zca_c_sdsp_cg_cp_rs2_b29:
   c.sdsp x29, 344(sp) # perform store
   LREG x22, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x22, Zca_c_sdsp_cg_cp_rs2_b29, Zca_c_sdsp_cg_cp_rs2_b29_str)
 
@@ -320,6 +350,7 @@ Zca_c_sdsp_cg_cp_rs2_b29:
 Zca_c_sdsp_cg_cp_rs2_b30:
   c.sdsp x30, 312(sp) # perform store
   LREG x17, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x17, Zca_c_sdsp_cg_cp_rs2_b30, Zca_c_sdsp_cg_cp_rs2_b30_str)
 
@@ -329,6 +360,7 @@ Zca_c_sdsp_cg_cp_rs2_b30:
 Zca_c_sdsp_cg_cp_rs2_b31:
   c.sdsp x31, 312(sp) # perform store
   LREG x23, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_rs2_b31, Zca_c_sdsp_cg_cp_rs2_b31_str)
 
@@ -342,6 +374,7 @@ Zca_c_sdsp_cg_cp_rs2_b31:
 Zca_c_sdsp_cg_cp_rs2_edges_0x0:
   c.sdsp x31, 312(sp) # perform store
   LREG x23, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_rs2_edges_0x0, Zca_c_sdsp_cg_cp_rs2_edges_0x0_str)
 
@@ -351,6 +384,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x0:
 Zca_c_sdsp_cg_cp_rs2_edges_0x1:
   c.sdsp x16, 40(sp) # perform store
   LREG x20, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x20 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x20, Zca_c_sdsp_cg_cp_rs2_edges_0x1, Zca_c_sdsp_cg_cp_rs2_edges_0x1_str)
 
@@ -360,6 +394,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x1:
 Zca_c_sdsp_cg_cp_rs2_edges_0x2:
   c.sdsp x22, 24(sp) # perform store
   LREG x26, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x26, Zca_c_sdsp_cg_cp_rs2_edges_0x2, Zca_c_sdsp_cg_cp_rs2_edges_0x2_str)
 
@@ -369,6 +404,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x2:
 Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000:
   c.sdsp x18, 392(sp) # perform store
   LREG x22, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x22, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000_str)
 
@@ -378,6 +414,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000:
 Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001:
   c.sdsp x23, 8(sp) # perform store
   LREG x28, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x28, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001_str)
 
@@ -387,6 +424,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001:
 Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff:
   c.sdsp x27, 16(sp) # perform store
   LREG x31, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff_str)
 
@@ -396,6 +434,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff:
 Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
   c.sdsp x5, 240(sp) # perform store
   LREG x22, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x22, Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
 
@@ -405,6 +444,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
 Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff:
   c.sdsp x27, 24(sp) # perform store
   LREG x22, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x22, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff_str)
 
@@ -414,6 +454,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff:
 Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe:
   c.sdsp x14, 48(sp) # perform store
   LREG x29, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe_str)
 
@@ -423,6 +464,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe:
 Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   c.sdsp x25, 336(sp) # perform store
   LREG x31, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
 
@@ -432,6 +474,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
 Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   c.sdsp x16, 232(sp) # perform store
   LREG x10, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x10, Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
 
@@ -441,6 +484,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
 Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555:
   c.sdsp x4, 0(sp) # perform store
   LREG x21, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x21, Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555, Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555_str)
 
@@ -450,6 +494,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555:
 Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff:
   c.sdsp x17, 200(sp) # perform store
   LREG x23, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff_str)
 
@@ -459,6 +504,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff:
 Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe:
   c.sdsp x13, 480(sp) # perform store
   LREG x18, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x18 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x18, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe_str)
 
@@ -468,6 +514,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe:
 Zca_c_sdsp_cg_cp_rs2_edges_0x100000000:
   c.sdsp x14, 240(sp) # perform store
   LREG x23, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_rs2_edges_0x100000000, Zca_c_sdsp_cg_cp_rs2_edges_0x100000000_str)
 
@@ -477,6 +524,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x100000000:
 Zca_c_sdsp_cg_cp_rs2_edges_0x100000001:
   c.sdsp x22, 280(sp) # perform store
   LREG x14, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x14, Zca_c_sdsp_cg_cp_rs2_edges_0x100000001, Zca_c_sdsp_cg_cp_rs2_edges_0x100000001_str)
 
@@ -490,6 +538,7 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x100000001:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0:
   c.sdsp x29, 0(sp) # perform store
   LREG x22, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x22, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0_str)
 
@@ -499,6 +548,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8:
   c.sdsp x0, 8(sp) # perform store
   LREG x26, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x26, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8_str)
 
@@ -508,6 +558,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10:
   c.sdsp x31, 16(sp) # perform store
   LREG x12, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10_str)
 
@@ -517,6 +568,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18:
   c.sdsp x20, 24(sp) # perform store
   LREG x18, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x18 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18_str)
 
@@ -526,6 +578,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20:
   c.sdsp x30, 32(sp) # perform store
   LREG x31, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20_str)
 
@@ -535,6 +588,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28:
   c.sdsp x9, 40(sp) # perform store
   LREG x21, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x21, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28_str)
 
@@ -544,6 +598,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30:
   c.sdsp x25, 48(sp) # perform store
   LREG x12, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30_str)
 
@@ -553,6 +608,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38:
   c.sdsp x13, 56(sp) # perform store
   LREG x29, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38_str)
 
@@ -562,6 +618,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40:
   c.sdsp x13, 64(sp) # perform store
   LREG x24, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x24 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x24, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40_str)
 
@@ -571,6 +628,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48:
   c.sdsp x31, 72(sp) # perform store
   LREG x4, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x4, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48_str)
 
@@ -580,6 +638,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50:
   c.sdsp x13, 80(sp) # perform store
   LREG x18, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x18 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50_str)
 
@@ -589,6 +648,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58:
   c.sdsp x20, 88(sp) # perform store
   LREG x9, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x9, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58_str)
 
@@ -598,6 +658,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60:
   c.sdsp x12, 96(sp) # perform store
   LREG x31, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60_str)
 
@@ -607,6 +668,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68:
   c.sdsp x26, 104(sp) # perform store
   LREG x19, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x19, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68_str)
 
@@ -616,6 +678,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70:
   c.sdsp x28, 112(sp) # perform store
   LREG x23, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70_str)
 
@@ -625,6 +688,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78:
   c.sdsp x0, 120(sp) # perform store
   LREG x1, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x1 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x1, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78_str)
 
@@ -634,6 +698,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80:
   c.sdsp x29, 128(sp) # perform store
   LREG x15, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80_str)
 
@@ -643,6 +708,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88:
   c.sdsp x3, 136(sp) # perform store
   LREG x1, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x1 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x1, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88_str)
 
@@ -652,6 +718,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90:
   c.sdsp x4, 144(sp) # perform store
   LREG x20, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x20 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x20, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90_str)
 
@@ -661,6 +728,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98:
   c.sdsp x1, 152(sp) # perform store
   LREG x22, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x22, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98_str)
 
@@ -670,6 +738,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0:
   c.sdsp x17, 160(sp) # perform store
   LREG x4, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x4, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0_str)
 
@@ -679,6 +748,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8:
   c.sdsp x23, 168(sp) # perform store
   LREG x9, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x9, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8_str)
 
@@ -688,6 +758,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0:
   c.sdsp x4, 176(sp) # perform store
   LREG x18, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x18 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0_str)
 
@@ -697,6 +768,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8:
   c.sdsp x28, 184(sp) # perform store
   LREG x3, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8_str)
 
@@ -706,6 +778,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0:
   c.sdsp x28, 192(sp) # perform store
   LREG x31, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0_str)
 
@@ -715,6 +788,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8:
   c.sdsp x3, 200(sp) # perform store
   LREG x14, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8_str)
 
@@ -724,6 +798,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0:
   c.sdsp x2, 208(sp) # perform store
   LREG x15, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0_str)
 
@@ -733,6 +808,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8:
   c.sdsp x4, 216(sp) # perform store
   LREG x25, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x25, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8_str)
 
@@ -742,6 +818,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0:
   c.sdsp x13, 224(sp) # perform store
   LREG x14, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0_str)
 
@@ -751,6 +828,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8:
   c.sdsp x4, 232(sp) # perform store
   LREG x3, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8_str)
 
@@ -760,6 +838,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0:
   c.sdsp x0, 240(sp) # perform store
   LREG x30, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x30 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0_str)
 
@@ -769,6 +848,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8:
   c.sdsp x3, 248(sp) # perform store
   LREG x10, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8_str)
 
@@ -778,6 +858,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100:
   c.sdsp x14, 256(sp) # perform store
   LREG x1, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x1 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x1, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100_str)
 
@@ -787,6 +868,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108:
   c.sdsp x12, 264(sp) # perform store
   LREG x9, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x9, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108_str)
 
@@ -796,6 +878,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110:
   c.sdsp x21, 272(sp) # perform store
   LREG x16, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x16 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x16, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110_str)
 
@@ -805,6 +888,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118:
   c.sdsp x19, 280(sp) # perform store
   LREG x23, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118_str)
 
@@ -814,6 +898,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120:
   c.sdsp x19, 288(sp) # perform store
   LREG x4, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x4, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120_str)
 
@@ -823,6 +908,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128:
   c.sdsp x30, 296(sp) # perform store
   LREG x23, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128_str)
 
@@ -832,6 +918,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130:
   c.sdsp x23, 304(sp) # perform store
   LREG x25, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x25, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130_str)
 
@@ -841,6 +928,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138:
   c.sdsp x15, 312(sp) # perform store
   LREG x30, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x30 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138_str)
 
@@ -850,6 +938,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140:
   c.sdsp x18, 320(sp) # perform store
   LREG x13, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140_str)
 
@@ -859,6 +948,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148:
   c.sdsp x12, 328(sp) # perform store
   LREG x26, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x26, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148_str)
 
@@ -868,6 +958,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150:
   c.sdsp x18, 336(sp) # perform store
   LREG x12, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150_str)
 
@@ -877,6 +968,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158:
   c.sdsp x5, 344(sp) # perform store
   LREG x17, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x17, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158_str)
 
@@ -886,6 +978,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160:
   c.sdsp x29, 352(sp) # perform store
   LREG x25, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x25, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160_str)
 
@@ -895,6 +988,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168:
   c.sdsp x21, 360(sp) # perform store
   LREG x30, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x30 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168_str)
 
@@ -904,6 +998,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170:
   c.sdsp x16, 368(sp) # perform store
   LREG x9, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x9, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170_str)
 
@@ -913,6 +1008,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178:
   c.sdsp x28, 376(sp) # perform store
   LREG x4, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x4, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178_str)
 
@@ -922,6 +1018,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180:
   c.sdsp x13, 384(sp) # perform store
   LREG x28, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x28, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180_str)
 
@@ -931,6 +1028,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188:
   c.sdsp x9, 392(sp) # perform store
   LREG x21, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x21, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188_str)
 
@@ -940,6 +1038,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190:
   c.sdsp x5, 400(sp) # perform store
   LREG x19, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x19, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190_str)
 
@@ -949,6 +1048,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198:
   c.sdsp x4, 408(sp) # perform store
   LREG x16, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x16 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x16, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198_str)
 
@@ -958,6 +1058,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0:
   c.sdsp x9, 416(sp) # perform store
   LREG x31, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0_str)
 
@@ -967,6 +1068,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8:
   c.sdsp x30, 424(sp) # perform store
   LREG x25, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x25, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8_str)
 
@@ -976,6 +1078,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0:
   c.sdsp x9, 432(sp) # perform store
   LREG x27, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x27, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0_str)
 
@@ -985,6 +1088,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8:
   c.sdsp x16, 440(sp) # perform store
   LREG x29, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8_str)
 
@@ -994,6 +1098,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0:
   c.sdsp x20, 448(sp) # perform store
   LREG x13, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0_str)
 
@@ -1003,6 +1108,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8:
   c.sdsp x31, 456(sp) # perform store
   LREG x27, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x27, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8_str)
 
@@ -1012,6 +1118,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0:
   c.sdsp x21, 464(sp) # perform store
   LREG x19, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x19, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0_str)
 
@@ -1021,6 +1128,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8:
   c.sdsp x20, 472(sp) # perform store
   LREG x27, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x27, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8_str)
 
@@ -1030,6 +1138,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0:
   c.sdsp x27, 480(sp) # perform store
   LREG x15, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0_str)
 
@@ -1039,6 +1148,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8:
   c.sdsp x4, 488(sp) # perform store
   LREG x29, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8_str)
 
@@ -1048,6 +1158,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0:
   c.sdsp x2, 496(sp) # perform store
   LREG x29, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0_str)
 
@@ -1057,6 +1168,7 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0:
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8:
   c.sdsp x31, 504(sp) # perform store
   LREG x25, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x25, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8_str)
 

--- a/tests/rv64i/Zca/Zca-c.sdsp-00.S
+++ b/tests/rv64i/Zca/Zca-c.sdsp-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 234
+#define SIGUPD_COUNT 122
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -39,57 +39,27 @@ RVTEST_BEGIN
   addi sp, x23, -456  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b0:
   c.sdsp x0, 456(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x25, 0(x23) # load stored value for checking
   # Check if x25 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x25, Zca_c_sdsp_cg_cp_rs2_b0, Zca_c_sdsp_cg_cp_rs2_b0_str)
-#else
-  addi sp, sp, 456 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x0, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0x1b1fcbf9782b1154
   addi sp, x23, -336  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b1:
   c.sdsp x1, 336(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x23) # load stored value for checking
   # Check if x12 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x12, Zca_c_sdsp_cg_cp_rs2_b1, Zca_c_sdsp_cg_cp_rs2_b1_str)
-#else
-  addi sp, sp, 336 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x1, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0x0c77aa25a7ebb27e
   addi sp, x23, -184  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b2:
   c.sdsp x2, 184(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x23) # load stored value for checking
   # Check if x22 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x22, Zca_c_sdsp_cg_cp_rs2_b2, Zca_c_sdsp_cg_cp_rs2_b2_str)
-#else
-  addi sp, sp, 184 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x2, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x20, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x3)
@@ -97,19 +67,9 @@ Zca_c_sdsp_cg_cp_rs2_b2:
   addi sp, x23, -480  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b3:
   c.sdsp x3, 480(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x17, 0(x23) # load stored value for checking
   # Check if x17 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x17, Zca_c_sdsp_cg_cp_rs2_b3, Zca_c_sdsp_cg_cp_rs2_b3_str)
-#else
-  addi sp, sp, 480 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x3, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
@@ -118,57 +78,27 @@ Zca_c_sdsp_cg_cp_rs2_b3:
   addi sp, x23, -344  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b4:
   c.sdsp x4, 344(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x23) # load stored value for checking
   # Check if x10 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x10, Zca_c_sdsp_cg_cp_rs2_b4, Zca_c_sdsp_cg_cp_rs2_b4_str)
-#else
-  addi sp, sp, 344 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x4, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x20, x5) # load rs2: x5 = 0x984a9370361b5e33
   addi sp, x23, -432  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b5:
   c.sdsp x5, 432(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x23) # load stored value for checking
   # Check if x4 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x4, Zca_c_sdsp_cg_cp_rs2_b5, Zca_c_sdsp_cg_cp_rs2_b5_str)
-#else
-  addi sp, sp, 432 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x5, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x20, x6) # load rs2: x6 = 0x016624bc4d18b88e
   addi sp, x23, -344  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b6:
   c.sdsp x6, 344(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x1, 0(x23) # load stored value for checking
   # Check if x1 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x1, Zca_c_sdsp_cg_cp_rs2_b6, Zca_c_sdsp_cg_cp_rs2_b6_str)
-#else
-  addi sp, sp, 344 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x6, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x13, x7 # switch temp register to avoid conflict with test
   mv x14, x8 # switch link pointer register to avoid conflict with test
@@ -177,114 +107,54 @@ Zca_c_sdsp_cg_cp_rs2_b6:
   addi sp, x23, -496  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b7:
   c.sdsp x7, 496(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x27, 0(x23) # load stored value for checking
   # Check if x27 contains the expected result. x23 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x23, x14, x13, x27, Zca_c_sdsp_cg_cp_rs2_b7, Zca_c_sdsp_cg_cp_rs2_b7_str)
-#else
-  addi sp, sp, 496 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x7, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x20, x8) # load rs2: x8 = 0xca17196d71aa106d
   addi sp, x23, -400  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b8:
   c.sdsp x8, 400(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x23) # load stored value for checking
   # Check if x22 contains the expected result. x23 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x23, x14, x13, x22, Zca_c_sdsp_cg_cp_rs2_b8, Zca_c_sdsp_cg_cp_rs2_b8_str)
-#else
-  addi sp, sp, 400 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x8, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x20, x9) # load rs2: x9 = 0xb41b04010ffac4d2
   addi sp, x23, -160  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b9:
   c.sdsp x9, 160(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x23) # load stored value for checking
   # Check if x5 contains the expected result. x23 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x23, x14, x13, x5, Zca_c_sdsp_cg_cp_rs2_b9, Zca_c_sdsp_cg_cp_rs2_b9_str)
-#else
-  addi sp, sp, 160 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x9, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x20, x10) # load rs2: x10 = 0xfb8db1dd5fc9c3b3
   addi sp, x23, -72  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b10:
   c.sdsp x10, 72(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x23) # load stored value for checking
   # Check if x4 contains the expected result. x23 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x23, x14, x13, x4, Zca_c_sdsp_cg_cp_rs2_b10, Zca_c_sdsp_cg_cp_rs2_b10_str)
-#else
-  addi sp, sp, 72 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x10, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x20, x11) # load rs2: x11 = 0x29affd80157acf67
   addi sp, x23, -264  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b11:
   c.sdsp x11, 264(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x23) # load stored value for checking
   # Check if x12 contains the expected result. x23 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x23, x14, x13, x12, Zca_c_sdsp_cg_cp_rs2_b11, Zca_c_sdsp_cg_cp_rs2_b11_str)
-#else
-  addi sp, sp, 264 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x11, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x20, x12) # load rs2: x12 = 0xc5aa932981693d06
   addi sp, x23, -112  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b12:
   c.sdsp x12, 112(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x23) # load stored value for checking
   # Check if x5 contains the expected result. x23 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x23, x14, x13, x5, Zca_c_sdsp_cg_cp_rs2_b12, Zca_c_sdsp_cg_cp_rs2_b12_str)
-#else
-  addi sp, sp, 112 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x12, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x7, x13 # switch temp register to avoid conflict with test
   mv x8, x14 # switch link pointer register to avoid conflict with test
@@ -293,133 +163,63 @@ Zca_c_sdsp_cg_cp_rs2_b12:
   addi sp, x23, -360  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b13:
   c.sdsp x13, 360(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x23) # load stored value for checking
   # Check if x26 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x26, Zca_c_sdsp_cg_cp_rs2_b13, Zca_c_sdsp_cg_cp_rs2_b13_str)
-#else
-  addi sp, sp, 360 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x13, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x20, x14) # load rs2: x14 = 0x862894e20f2a322f
   addi sp, x23, -264  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b14:
   c.sdsp x14, 264(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x23) # load stored value for checking
   # Check if x9 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x9, Zca_c_sdsp_cg_cp_rs2_b14, Zca_c_sdsp_cg_cp_rs2_b14_str)
-#else
-  addi sp, sp, 264 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x14, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x20, x15) # load rs2: x15 = 0x0a2612f2958e2010
   addi sp, x23, -312  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b15:
   c.sdsp x15, 312(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x23) # load stored value for checking
   # Check if x4 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x4, Zca_c_sdsp_cg_cp_rs2_b15, Zca_c_sdsp_cg_cp_rs2_b15_str)
-#else
-  addi sp, sp, 312 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x15, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x16)
   RVTEST_TESTDATA_LOAD_INT(x20, x16) # load rs2: x16 = 0xabfe1a72dd44e781
   addi sp, x23, -456  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b16:
   c.sdsp x16, 456(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x17, 0(x23) # load stored value for checking
   # Check if x17 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x17, Zca_c_sdsp_cg_cp_rs2_b16, Zca_c_sdsp_cg_cp_rs2_b16_str)
-#else
-  addi sp, sp, 456 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x16, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x20, x17) # load rs2: x17 = 0xfb1236577ea15321
   addi sp, x23, -480  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b17:
   c.sdsp x17, 480(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x21, 0(x23) # load stored value for checking
   # Check if x21 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x21, Zca_c_sdsp_cg_cp_rs2_b17, Zca_c_sdsp_cg_cp_rs2_b17_str)
-#else
-  addi sp, sp, 480 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x17, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x18)
   RVTEST_TESTDATA_LOAD_INT(x20, x18) # load rs2: x18 = 0x74ae06340dac1e5d
   addi sp, x23, -472  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b18:
   c.sdsp x18, 472(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x29, 0(x23) # load stored value for checking
   # Check if x29 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x29, Zca_c_sdsp_cg_cp_rs2_b18, Zca_c_sdsp_cg_cp_rs2_b18_str)
-#else
-  addi sp, sp, 472 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x18, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x20, x19) # load rs2: x19 = 0x36b430c3003b0571
   addi sp, x23, -80  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b19:
   c.sdsp x19, 80(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x23) # load stored value for checking
   # Check if x6 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x6, Zca_c_sdsp_cg_cp_rs2_b19, Zca_c_sdsp_cg_cp_rs2_b19_str)
-#else
-  addi sp, sp, 80 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x19, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x11, x20 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x20)
@@ -427,57 +227,27 @@ Zca_c_sdsp_cg_cp_rs2_b19:
   addi sp, x23, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b20:
   c.sdsp x20, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x29, 0(x23) # load stored value for checking
   # Check if x29 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x29, Zca_c_sdsp_cg_cp_rs2_b20, Zca_c_sdsp_cg_cp_rs2_b20_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x20, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x11, x21) # load rs2: x21 = 0x1c57ce4e74866b73
   addi sp, x23, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b21:
   c.sdsp x21, 16(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x23) # load stored value for checking
   # Check if x14 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x14, Zca_c_sdsp_cg_cp_rs2_b21, Zca_c_sdsp_cg_cp_rs2_b21_str)
-#else
-  addi sp, sp, 16 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x21, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x11, x22) # load rs2: x22 = 0xcd8f46731f79898e
   addi sp, x23, -376  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b22:
   c.sdsp x22, 376(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x23) # load stored value for checking
   # Check if x4 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x23, x8, x7, x4, Zca_c_sdsp_cg_cp_rs2_b22, Zca_c_sdsp_cg_cp_rs2_b22_str)
-#else
-  addi sp, sp, 376 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x22, 0(sp) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x24, x23 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x23)
@@ -485,19 +255,9 @@ Zca_c_sdsp_cg_cp_rs2_b22:
   addi sp, x24, -384  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b23:
   c.sdsp x23, 384(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x19, 0(x24) # load stored value for checking
   # Check if x19 contains the expected result. x24 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x24, x8, x7, x19, Zca_c_sdsp_cg_cp_rs2_b23, Zca_c_sdsp_cg_cp_rs2_b23_str)
-#else
-  addi sp, sp, 384 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x23, 0(sp) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x6, x24 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x24)
@@ -505,152 +265,72 @@ Zca_c_sdsp_cg_cp_rs2_b23:
   addi sp, x6, -304  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b24:
   c.sdsp x24, 304(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x6) # load stored value for checking
   # Check if x12 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x12, Zca_c_sdsp_cg_cp_rs2_b24, Zca_c_sdsp_cg_cp_rs2_b24_str)
-#else
-  addi sp, sp, 304 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x24, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x11, x25) # load rs2: x25 = 0x92cfce7f9c623a85
   addi sp, x6, -104  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b25:
   c.sdsp x25, 104(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x6) # load stored value for checking
   # Check if x5 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x5, Zca_c_sdsp_cg_cp_rs2_b25, Zca_c_sdsp_cg_cp_rs2_b25_str)
-#else
-  addi sp, sp, 104 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x25, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x11, x26) # load rs2: x26 = 0xb996fd1c609c962e
   addi sp, x6, -88  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b26:
   c.sdsp x26, 88(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x6) # load stored value for checking
   # Check if x14 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x14, Zca_c_sdsp_cg_cp_rs2_b26, Zca_c_sdsp_cg_cp_rs2_b26_str)
-#else
-  addi sp, sp, 88 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x26, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x11, x27) # load rs2: x27 = 0x628fbad1b75e9fb3
   addi sp, x6, -304  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b27:
   c.sdsp x27, 304(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x6) # load stored value for checking
   # Check if x26 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x26, Zca_c_sdsp_cg_cp_rs2_b27, Zca_c_sdsp_cg_cp_rs2_b27_str)
-#else
-  addi sp, sp, 304 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x27, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x11, x28) # load rs2: x28 = 0xa85485c1ab0ff00b
   addi sp, x6, -288  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b28:
   c.sdsp x28, 288(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x5, 0(x6) # load stored value for checking
   # Check if x5 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x5, Zca_c_sdsp_cg_cp_rs2_b28, Zca_c_sdsp_cg_cp_rs2_b28_str)
-#else
-  addi sp, sp, 288 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x28, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x11, x29) # load rs2: x29 = 0x2f12faad85a6a30a
   addi sp, x6, -344  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b29:
   c.sdsp x29, 344(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x6) # load stored value for checking
   # Check if x22 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x22, Zca_c_sdsp_cg_cp_rs2_b29, Zca_c_sdsp_cg_cp_rs2_b29_str)
-#else
-  addi sp, sp, 344 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x29, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x11, x30) # load rs2: x30 = 0x270e175b35698284
   addi sp, x6, -312  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b30:
   c.sdsp x30, 312(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x17, 0(x6) # load stored value for checking
   # Check if x17 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x17, Zca_c_sdsp_cg_cp_rs2_b30, Zca_c_sdsp_cg_cp_rs2_b30_str)
-#else
-  addi sp, sp, 312 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x30, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0xe3a0201ee739f592
   addi sp, x6, -312  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_b31:
   c.sdsp x31, 312(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x6) # load stored value for checking
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_rs2_b31, Zca_c_sdsp_cg_cp_rs2_b31_str)
-#else
-  addi sp, sp, 312 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x31, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -661,304 +341,144 @@ Zca_c_sdsp_cg_cp_rs2_b31:
   addi sp, x6, -312  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x0:
   c.sdsp x31, 312(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x6) # load stored value for checking
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_rs2_edges_0x0, Zca_c_sdsp_cg_cp_rs2_edges_0x0_str)
-#else
-  addi sp, sp, 312 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x31, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x11, x16) # load rs2: x16 = 0x0000000000000001
   addi sp, x6, -40  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x1:
   c.sdsp x16, 40(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x20, 0(x6) # load stored value for checking
   # Check if x20 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x20, Zca_c_sdsp_cg_cp_rs2_edges_0x1, Zca_c_sdsp_cg_cp_rs2_edges_0x1_str)
-#else
-  addi sp, sp, 40 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x16, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x11, x22) # load rs2: x22 = 0x0000000000000002
   addi sp, x6, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x2:
   c.sdsp x22, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x6) # load stored value for checking
   # Check if x26 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x26, Zca_c_sdsp_cg_cp_rs2_edges_0x2, Zca_c_sdsp_cg_cp_rs2_edges_0x2_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x22, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x11, x18) # load rs2: x18 = 0x8000000000000000
   addi sp, x6, -392  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000:
   c.sdsp x18, 392(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x6) # load stored value for checking
   # Check if x22 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x22, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  addi sp, sp, 392 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x18, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x11, x23) # load rs2: x23 = 0x8000000000000001
   addi sp, x6, -8  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001:
   c.sdsp x23, 8(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x28, 0(x6) # load stored value for checking
   # Check if x28 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x28, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  addi sp, sp, 8 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x23, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x11, x27) # load rs2: x27 = 0x7fffffffffffffff
   addi sp, x6, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff:
   c.sdsp x27, 16(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x31, 0(x6) # load stored value for checking
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  addi sp, sp, 16 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x27, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0x7ffffffffffffffe
   addi sp, x6, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
   c.sdsp x5, 240(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x6) # load stored value for checking
   # Check if x22 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x22, Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  addi sp, sp, 240 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x5, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x11, x27) # load rs2: x27 = 0xffffffffffffffff
   addi sp, x6, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff:
   c.sdsp x27, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x6) # load stored value for checking
   # Check if x22 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x22, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x27, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0xfffffffffffffffe
   addi sp, x6, -48  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe:
   c.sdsp x14, 48(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x29, 0(x6) # load stored value for checking
   # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  addi sp, sp, 48 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x14, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x11, x25) # load rs2: x25 = 0x5bbc887763ae86f2
   addi sp, x6, -336  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   c.sdsp x25, 336(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x31, 0(x6) # load stored value for checking
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  addi sp, sp, 336 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x25, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x11, x16) # load rs2: x16 = 0xaaaaaaaaaaaaaaaa
   addi sp, x6, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   c.sdsp x16, 232(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x6) # load stored value for checking
   # Check if x10 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x10, Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  addi sp, sp, 232 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x16, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0x5555555555555555
   addi sp, x6, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555:
   c.sdsp x4, 0(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x21, 0(x6) # load stored value for checking
   # Check if x21 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x21, Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555, Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  addi sp, sp, 0 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x4, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x11, x17) # load rs2: x17 = 0x00000000ffffffff
   addi sp, x6, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff:
   c.sdsp x17, 200(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x6) # load stored value for checking
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  addi sp, sp, 200 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x17, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x11, x13) # load rs2: x13 = 0x00000000fffffffe
   addi sp, x6, -480  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe:
   c.sdsp x13, 480(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x18, 0(x6) # load stored value for checking
   # Check if x18 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x18, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  addi sp, sp, 480 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x13, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0x0000000100000000
   addi sp, x6, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x100000000:
   c.sdsp x14, 240(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x6) # load stored value for checking
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_rs2_edges_0x100000000, Zca_c_sdsp_cg_cp_rs2_edges_0x100000000_str)
-#else
-  addi sp, sp, 240 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x14, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x11, x22) # load rs2: x22 = 0x0000000100000001
   addi sp, x6, -280  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x100000001:
   c.sdsp x22, 280(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x6) # load stored value for checking
   # Check if x14 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x14, Zca_c_sdsp_cg_cp_rs2_edges_0x100000001, Zca_c_sdsp_cg_cp_rs2_edges_0x100000001_str)
-#else
-  addi sp, sp, 280 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x22, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_mul_8sp
@@ -969,1216 +489,576 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x100000001:
   addi sp, x6, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0:
   c.sdsp x29, 0(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x6) # load stored value for checking
   # Check if x22 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x22, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0_str)
-#else
-  addi sp, sp, 0 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x29, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=8
   RVTEST_TESTDATA_LOAD_INT(x11, x0) # load rs2: x0 = 0xe39a83545d97493f
   addi sp, x6, -8  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8:
   c.sdsp x0, 8(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x6) # load stored value for checking
   # Check if x26 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x26, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8_str)
-#else
-  addi sp, sp, 8 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x0, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=16
   RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0xe1b7fc19322c31c2
   addi sp, x6, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10:
   c.sdsp x31, 16(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x6) # load stored value for checking
   # Check if x12 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10_str)
-#else
-  addi sp, sp, 16 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x31, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=24
   RVTEST_TESTDATA_LOAD_INT(x11, x20) # load rs2: x20 = 0x22f38d7a63f41bf5
   addi sp, x6, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18:
   c.sdsp x20, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x18, 0(x6) # load stored value for checking
   # Check if x18 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x20, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=32
   RVTEST_TESTDATA_LOAD_INT(x11, x30) # load rs2: x30 = 0x2e327176756d4ebe
   addi sp, x6, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20:
   c.sdsp x30, 32(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x31, 0(x6) # load stored value for checking
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20_str)
-#else
-  addi sp, sp, 32 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x30, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=40
   RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0xfb0ca41c715a9eb6
   addi sp, x6, -40  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28:
   c.sdsp x9, 40(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x21, 0(x6) # load stored value for checking
   # Check if x21 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x21, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28_str)
-#else
-  addi sp, sp, 40 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x9, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=48
   RVTEST_TESTDATA_LOAD_INT(x11, x25) # load rs2: x25 = 0xe3c5129528f9e5fd
   addi sp, x6, -48  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30:
   c.sdsp x25, 48(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x6) # load stored value for checking
   # Check if x12 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30_str)
-#else
-  addi sp, sp, 48 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x25, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=56
   RVTEST_TESTDATA_LOAD_INT(x11, x13) # load rs2: x13 = 0x1585b3191e4e1db7
   addi sp, x6, -56  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38:
   c.sdsp x13, 56(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x29, 0(x6) # load stored value for checking
   # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38_str)
-#else
-  addi sp, sp, 56 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x13, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=64
   RVTEST_TESTDATA_LOAD_INT(x11, x13) # load rs2: x13 = 0x42a631e63f18b79c
   addi sp, x6, -64  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40:
   c.sdsp x13, 64(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x24, 0(x6) # load stored value for checking
   # Check if x24 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x24, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40_str)
-#else
-  addi sp, sp, 64 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x13, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=72
   RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0x148154ef0ad135b6
   addi sp, x6, -72  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48:
   c.sdsp x31, 72(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x6) # load stored value for checking
   # Check if x4 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x4, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48_str)
-#else
-  addi sp, sp, 72 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x31, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=80
   RVTEST_TESTDATA_LOAD_INT(x11, x13) # load rs2: x13 = 0xbe119d7fa32143be
   addi sp, x6, -80  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50:
   c.sdsp x13, 80(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x18, 0(x6) # load stored value for checking
   # Check if x18 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50_str)
-#else
-  addi sp, sp, 80 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x13, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=88
   RVTEST_TESTDATA_LOAD_INT(x11, x20) # load rs2: x20 = 0x96583c5a4cd19791
   addi sp, x6, -88  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58:
   c.sdsp x20, 88(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x6) # load stored value for checking
   # Check if x9 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x9, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58_str)
-#else
-  addi sp, sp, 88 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x20, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=96
   RVTEST_TESTDATA_LOAD_INT(x11, x12) # load rs2: x12 = 0x5099acee99b9956b
   addi sp, x6, -96  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60:
   c.sdsp x12, 96(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x31, 0(x6) # load stored value for checking
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60_str)
-#else
-  addi sp, sp, 96 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x12, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=104
   RVTEST_TESTDATA_LOAD_INT(x11, x26) # load rs2: x26 = 0xea20320fdd9b0669
   addi sp, x6, -104  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68:
   c.sdsp x26, 104(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x19, 0(x6) # load stored value for checking
   # Check if x19 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x19, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68_str)
-#else
-  addi sp, sp, 104 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x26, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=112
   RVTEST_TESTDATA_LOAD_INT(x11, x28) # load rs2: x28 = 0x04cc8ebd088a04db
   addi sp, x6, -112  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70:
   c.sdsp x28, 112(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x6) # load stored value for checking
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70_str)
-#else
-  addi sp, sp, 112 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x28, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=120
   RVTEST_TESTDATA_LOAD_INT(x11, x0) # load rs2: x0 = 0x2e29e2f2b117c584
   addi sp, x6, -120  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78:
   c.sdsp x0, 120(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x1, 0(x6) # load stored value for checking
   # Check if x1 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x1, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78_str)
-#else
-  addi sp, sp, 120 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x0, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=128
   RVTEST_TESTDATA_LOAD_INT(x11, x29) # load rs2: x29 = 0x9d3c740c0f2e82ea
   addi sp, x6, -128  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80:
   c.sdsp x29, 128(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x6) # load stored value for checking
   # Check if x15 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80_str)
-#else
-  addi sp, sp, 128 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x29, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=136
   RVTEST_TESTDATA_LOAD_INT(x11, x3) # load rs2: x3 = 0x579316aab65ce178
   addi sp, x6, -136  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88:
   c.sdsp x3, 136(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x1, 0(x6) # load stored value for checking
   # Check if x1 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x1, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88_str)
-#else
-  addi sp, sp, 136 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x3, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=144
   RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0x5533b3b8e5199b49
   addi sp, x6, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90:
   c.sdsp x4, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x20, 0(x6) # load stored value for checking
   # Check if x20 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x20, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x4, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=152
   RVTEST_TESTDATA_LOAD_INT(x11, x1) # load rs2: x1 = 0x43e26d557c07ac67
   addi sp, x6, -152  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98:
   c.sdsp x1, 152(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x6) # load stored value for checking
   # Check if x22 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x22, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98_str)
-#else
-  addi sp, sp, 152 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x1, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=160
   RVTEST_TESTDATA_LOAD_INT(x11, x17) # load rs2: x17 = 0x936367ad51b7f0d2
   addi sp, x6, -160  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0:
   c.sdsp x17, 160(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x6) # load stored value for checking
   # Check if x4 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x4, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0_str)
-#else
-  addi sp, sp, 160 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x17, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=168
   RVTEST_TESTDATA_LOAD_INT(x11, x23) # load rs2: x23 = 0x54becd06dfcea75b
   addi sp, x6, -168  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8:
   c.sdsp x23, 168(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x6) # load stored value for checking
   # Check if x9 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x9, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8_str)
-#else
-  addi sp, sp, 168 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x23, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=176
   RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0xc4c3dd45bffa094b
   addi sp, x6, -176  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0:
   c.sdsp x4, 176(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x18, 0(x6) # load stored value for checking
   # Check if x18 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0_str)
-#else
-  addi sp, sp, 176 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x4, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=184
   RVTEST_TESTDATA_LOAD_INT(x11, x28) # load rs2: x28 = 0xaafafa333c526044
   addi sp, x6, -184  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8:
   c.sdsp x28, 184(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x6) # load stored value for checking
   # Check if x3 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8_str)
-#else
-  addi sp, sp, 184 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x28, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=192
   RVTEST_TESTDATA_LOAD_INT(x11, x28) # load rs2: x28 = 0xa2750e708238bbd2
   addi sp, x6, -192  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0:
   c.sdsp x28, 192(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x31, 0(x6) # load stored value for checking
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0_str)
-#else
-  addi sp, sp, 192 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x28, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=200
   RVTEST_TESTDATA_LOAD_INT(x11, x3) # load rs2: x3 = 0x37d886f56ee2044a
   addi sp, x6, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8:
   c.sdsp x3, 200(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x6) # load stored value for checking
   # Check if x14 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8_str)
-#else
-  addi sp, sp, 200 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x3, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=208
   RVTEST_TESTDATA_LOAD_INT(x11, x2) # load rs2: x2 = 0xdbfb793d1da20688
   addi sp, x6, -208  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0:
   c.sdsp x2, 208(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x6) # load stored value for checking
   # Check if x15 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0_str)
-#else
-  addi sp, sp, 208 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x2, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=216
   RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0x65bebc61e949888d
   addi sp, x6, -216  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8:
   c.sdsp x4, 216(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x25, 0(x6) # load stored value for checking
   # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x25, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8_str)
-#else
-  addi sp, sp, 216 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x4, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=224
   RVTEST_TESTDATA_LOAD_INT(x11, x13) # load rs2: x13 = 0xd9fc207d018c7feb
   addi sp, x6, -224  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0:
   c.sdsp x13, 224(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x6) # load stored value for checking
   # Check if x14 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0_str)
-#else
-  addi sp, sp, 224 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x13, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=232
   RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0xd20179d3f7b54a14
   addi sp, x6, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8:
   c.sdsp x4, 232(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x6) # load stored value for checking
   # Check if x3 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8_str)
-#else
-  addi sp, sp, 232 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x4, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=240
   RVTEST_TESTDATA_LOAD_INT(x11, x0) # load rs2: x0 = 0x5773c2c65f0945af
   addi sp, x6, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0:
   c.sdsp x0, 240(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x30, 0(x6) # load stored value for checking
   # Check if x30 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0_str)
-#else
-  addi sp, sp, 240 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x0, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=248
   RVTEST_TESTDATA_LOAD_INT(x11, x3) # load rs2: x3 = 0xa9857e9dc90ae2ab
   addi sp, x6, -248  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8:
   c.sdsp x3, 248(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x10, 0(x6) # load stored value for checking
   # Check if x10 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8_str)
-#else
-  addi sp, sp, 248 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x3, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=256
   RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0x5922a4a7f842cd06
   addi sp, x6, -256  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100:
   c.sdsp x14, 256(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x1, 0(x6) # load stored value for checking
   # Check if x1 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x1, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100_str)
-#else
-  addi sp, sp, 256 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x14, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=264
   RVTEST_TESTDATA_LOAD_INT(x11, x12) # load rs2: x12 = 0x9039b9b4a2c1310d
   addi sp, x6, -264  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108:
   c.sdsp x12, 264(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x6) # load stored value for checking
   # Check if x9 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x9, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108_str)
-#else
-  addi sp, sp, 264 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x12, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=272
   RVTEST_TESTDATA_LOAD_INT(x11, x21) # load rs2: x21 = 0x510ccf70fe1d0e78
   addi sp, x6, -272  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110:
   c.sdsp x21, 272(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x16, 0(x6) # load stored value for checking
   # Check if x16 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x16, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110_str)
-#else
-  addi sp, sp, 272 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x21, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=280
   RVTEST_TESTDATA_LOAD_INT(x11, x19) # load rs2: x19 = 0x3053ebc7a656231f
   addi sp, x6, -280  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118:
   c.sdsp x19, 280(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x6) # load stored value for checking
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118_str)
-#else
-  addi sp, sp, 280 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x19, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=288
   RVTEST_TESTDATA_LOAD_INT(x11, x19) # load rs2: x19 = 0x7c1250bdd773b3b4
   addi sp, x6, -288  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120:
   c.sdsp x19, 288(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x6) # load stored value for checking
   # Check if x4 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x4, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120_str)
-#else
-  addi sp, sp, 288 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x19, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=296
   RVTEST_TESTDATA_LOAD_INT(x11, x30) # load rs2: x30 = 0x6cc39520154c8834
   addi sp, x6, -296  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128:
   c.sdsp x30, 296(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x6) # load stored value for checking
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128_str)
-#else
-  addi sp, sp, 296 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x30, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=304
   RVTEST_TESTDATA_LOAD_INT(x11, x23) # load rs2: x23 = 0xb0c97748314be2d6
   addi sp, x6, -304  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130:
   c.sdsp x23, 304(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x25, 0(x6) # load stored value for checking
   # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x25, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130_str)
-#else
-  addi sp, sp, 304 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x23, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=312
   RVTEST_TESTDATA_LOAD_INT(x11, x15) # load rs2: x15 = 0xde957692bbe7969e
   addi sp, x6, -312  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138:
   c.sdsp x15, 312(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x30, 0(x6) # load stored value for checking
   # Check if x30 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138_str)
-#else
-  addi sp, sp, 312 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x15, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=320
   RVTEST_TESTDATA_LOAD_INT(x11, x18) # load rs2: x18 = 0xd9921c6ddc4c533f
   addi sp, x6, -320  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140:
   c.sdsp x18, 320(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x6) # load stored value for checking
   # Check if x13 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140_str)
-#else
-  addi sp, sp, 320 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x18, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=328
   RVTEST_TESTDATA_LOAD_INT(x11, x12) # load rs2: x12 = 0x569d184d5cb9fdcc
   addi sp, x6, -328  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148:
   c.sdsp x12, 328(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x6) # load stored value for checking
   # Check if x26 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x26, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148_str)
-#else
-  addi sp, sp, 328 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x12, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=336
   RVTEST_TESTDATA_LOAD_INT(x11, x18) # load rs2: x18 = 0x6e9d7a6317eddacb
   addi sp, x6, -336  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150:
   c.sdsp x18, 336(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x6) # load stored value for checking
   # Check if x12 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150_str)
-#else
-  addi sp, sp, 336 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x18, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=344
   RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0xe66b486193f2af0e
   addi sp, x6, -344  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158:
   c.sdsp x5, 344(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x17, 0(x6) # load stored value for checking
   # Check if x17 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x17, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158_str)
-#else
-  addi sp, sp, 344 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x5, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=352
   RVTEST_TESTDATA_LOAD_INT(x11, x29) # load rs2: x29 = 0xbeb9843accce868d
   addi sp, x6, -352  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160:
   c.sdsp x29, 352(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x25, 0(x6) # load stored value for checking
   # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x25, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160_str)
-#else
-  addi sp, sp, 352 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x29, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=360
   RVTEST_TESTDATA_LOAD_INT(x11, x21) # load rs2: x21 = 0x39f2fbe1ae168133
   addi sp, x6, -360  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168:
   c.sdsp x21, 360(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x30, 0(x6) # load stored value for checking
   # Check if x30 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168_str)
-#else
-  addi sp, sp, 360 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x21, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=368
   RVTEST_TESTDATA_LOAD_INT(x11, x16) # load rs2: x16 = 0xb2bf245e6429acbb
   addi sp, x6, -368  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170:
   c.sdsp x16, 368(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x6) # load stored value for checking
   # Check if x9 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x9, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170_str)
-#else
-  addi sp, sp, 368 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x16, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=376
   RVTEST_TESTDATA_LOAD_INT(x11, x28) # load rs2: x28 = 0xefa48ec47be81dda
   addi sp, x6, -376  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178:
   c.sdsp x28, 376(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x4, 0(x6) # load stored value for checking
   # Check if x4 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x4, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178_str)
-#else
-  addi sp, sp, 376 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x28, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=384
   RVTEST_TESTDATA_LOAD_INT(x11, x13) # load rs2: x13 = 0xe4b923143b16ad13
   addi sp, x6, -384  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180:
   c.sdsp x13, 384(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x28, 0(x6) # load stored value for checking
   # Check if x28 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x28, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180_str)
-#else
-  addi sp, sp, 384 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x13, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=392
   RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0x93b38e5decf5e212
   addi sp, x6, -392  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188:
   c.sdsp x9, 392(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x21, 0(x6) # load stored value for checking
   # Check if x21 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x21, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188_str)
-#else
-  addi sp, sp, 392 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x9, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=400
   RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0xc18a2ed77352f88e
   addi sp, x6, -400  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190:
   c.sdsp x5, 400(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x19, 0(x6) # load stored value for checking
   # Check if x19 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x19, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190_str)
-#else
-  addi sp, sp, 400 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x5, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=408
   RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0xfa1a9de47fd6e2dc
   addi sp, x6, -408  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198:
   c.sdsp x4, 408(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x16, 0(x6) # load stored value for checking
   # Check if x16 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x16, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198_str)
-#else
-  addi sp, sp, 408 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x4, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=416
   RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0x2264cb8d638f1709
   addi sp, x6, -416  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0:
   c.sdsp x9, 416(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x31, 0(x6) # load stored value for checking
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0_str)
-#else
-  addi sp, sp, 416 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x9, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=424
   RVTEST_TESTDATA_LOAD_INT(x11, x30) # load rs2: x30 = 0x40ec2a7f005e2c7f
   addi sp, x6, -424  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8:
   c.sdsp x30, 424(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x25, 0(x6) # load stored value for checking
   # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x25, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8_str)
-#else
-  addi sp, sp, 424 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x30, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=432
   RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0xd59fb792e9382239
   addi sp, x6, -432  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0:
   c.sdsp x9, 432(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x27, 0(x6) # load stored value for checking
   # Check if x27 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x27, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0_str)
-#else
-  addi sp, sp, 432 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x9, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=440
   RVTEST_TESTDATA_LOAD_INT(x11, x16) # load rs2: x16 = 0x4b6d5b67caa4c348
   addi sp, x6, -440  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8:
   c.sdsp x16, 440(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x29, 0(x6) # load stored value for checking
   # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8_str)
-#else
-  addi sp, sp, 440 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x16, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=448
   RVTEST_TESTDATA_LOAD_INT(x11, x20) # load rs2: x20 = 0xd9a36e80b18412ee
   addi sp, x6, -448  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0:
   c.sdsp x20, 448(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x6) # load stored value for checking
   # Check if x13 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0_str)
-#else
-  addi sp, sp, 448 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x20, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=456
   RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0xa99b23d29f38afe7
   addi sp, x6, -456  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8:
   c.sdsp x31, 456(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x27, 0(x6) # load stored value for checking
   # Check if x27 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x27, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8_str)
-#else
-  addi sp, sp, 456 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x31, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=464
   RVTEST_TESTDATA_LOAD_INT(x11, x21) # load rs2: x21 = 0xd883a246cd38fb1f
   addi sp, x6, -464  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0:
   c.sdsp x21, 464(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x19, 0(x6) # load stored value for checking
   # Check if x19 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x19, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0_str)
-#else
-  addi sp, sp, 464 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x21, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=472
   RVTEST_TESTDATA_LOAD_INT(x11, x20) # load rs2: x20 = 0x2863ec8f0a9eaf38
   addi sp, x6, -472  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8:
   c.sdsp x20, 472(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x27, 0(x6) # load stored value for checking
   # Check if x27 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x27, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8_str)
-#else
-  addi sp, sp, 472 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x20, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=480
   RVTEST_TESTDATA_LOAD_INT(x11, x27) # load rs2: x27 = 0xbe9f8d619688a066
   addi sp, x6, -480  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0:
   c.sdsp x27, 480(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x6) # load stored value for checking
   # Check if x15 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0_str)
-#else
-  addi sp, sp, 480 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x27, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=488
   RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0xe46fe00895d55ff0
   addi sp, x6, -488  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8:
   c.sdsp x4, 488(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x29, 0(x6) # load stored value for checking
   # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8_str)
-#else
-  addi sp, sp, 488 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x4, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=496
   RVTEST_TESTDATA_LOAD_INT(x11, x2) # load rs2: x2 = 0xf00713851a5400bb
   addi sp, x6, -496  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0:
   c.sdsp x2, 496(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x29, 0(x6) # load stored value for checking
   # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0_str)
-#else
-  addi sp, sp, 496 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x2, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_8sp: imm=504
   RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0x661a0547f97f9aa4
   addi sp, x6, -504  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8:
   c.sdsp x31, 504(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x25, 0(x6) # load stored value for checking
   # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x25, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8_str)
-#else
-  addi sp, sp, 504 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.sdsp x31, 0(sp) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x2, x6 # restore signature pointer to default register for teardown
 

--- a/tests/rv64i/Zca/Zca-c.sw-00.S
+++ b/tests/rv64i/Zca/Zca-c.sw-00.S
@@ -41,18 +41,9 @@ Zca_c_sw_cg_cp_rs1_p_b8:
   c.sw x14, 80(x8) # perform store
   addi x8, x8, 80 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, Zca_c_sw_cg_cp_rs1_p_b8, Zca_c_sw_cg_cp_rs1_p_b8_str)
-#else
-  c.sw x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x7a898f641840338b
@@ -62,18 +53,9 @@ Zca_c_sw_cg_cp_rs1_p_b9:
   c.sw x15, 64(x9) # perform store
   addi x9, x9, 64 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sw_cg_cp_rs1_p_b9, Zca_c_sw_cg_cp_rs1_p_b9_str)
-#else
-  c.sw x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xa19584f5702212fd
@@ -83,18 +65,9 @@ Zca_c_sw_cg_cp_rs1_p_b10:
   c.sw x15, 96(x10) # perform store
   addi x10, x10, 96 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zca_c_sw_cg_cp_rs1_p_b10, Zca_c_sw_cg_cp_rs1_p_b10_str)
-#else
-  c.sw x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x4239ab23d928d8af
@@ -104,18 +77,9 @@ Zca_c_sw_cg_cp_rs1_p_b11:
   c.sw x14, 104(x11) # perform store
   addi x11, x11, 104 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_sw_cg_cp_rs1_p_b11, Zca_c_sw_cg_cp_rs1_p_b11_str)
-#else
-  c.sw x14, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xcd8d6d729c27445c
@@ -125,18 +89,9 @@ Zca_c_sw_cg_cp_rs1_p_b12:
   c.sw x10, 100(x12) # perform store
   addi x12, x12, 100 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zca_c_sw_cg_cp_rs1_p_b12, Zca_c_sw_cg_cp_rs1_p_b12_str)
-#else
-  c.sw x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x9f3fb1ec7231ea2f
@@ -146,18 +101,9 @@ Zca_c_sw_cg_cp_rs1_p_b13:
   c.sw x8, 100(x13) # perform store
   addi x13, x13, 100 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, Zca_c_sw_cg_cp_rs1_p_b13, Zca_c_sw_cg_cp_rs1_p_b13_str)
-#else
-  c.sw x8, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x92eb3e81c8c29810
@@ -167,18 +113,9 @@ Zca_c_sw_cg_cp_rs1_p_b14:
   c.sw x15, 32(x14) # perform store
   addi x14, x14, 32 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x11 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x11, Zca_c_sw_cg_cp_rs1_p_b14, Zca_c_sw_cg_cp_rs1_p_b14_str)
-#else
-  c.sw x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xa5ed539b1ec7d405
@@ -188,18 +125,9 @@ Zca_c_sw_cg_cp_rs1_p_b15:
   c.sw x9, 92(x15) # perform store
   addi x15, x15, 92 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x8 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x8, Zca_c_sw_cg_cp_rs1_p_b15, Zca_c_sw_cg_cp_rs1_p_b15_str)
-#else
-  c.sw x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_p
@@ -213,18 +141,9 @@ Zca_c_sw_cg_cp_rs2_p_b8:
   c.sw x8, 124(x12) # perform store
   addi x12, x12, 124 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zca_c_sw_cg_cp_rs2_p_b8, Zca_c_sw_cg_cp_rs2_p_b8_str)
-#else
-  c.sw x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x65cdd6a07bf89343
@@ -234,18 +153,9 @@ Zca_c_sw_cg_cp_rs2_p_b9:
   c.sw x9, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_sw_cg_cp_rs2_p_b9, Zca_c_sw_cg_cp_rs2_p_b9_str)
-#else
-  c.sw x9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xd17be87d5b60e7ff
@@ -255,18 +165,9 @@ Zca_c_sw_cg_cp_rs2_p_b10:
   c.sw x10, 88(x12) # perform store
   addi x12, x12, 88 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_sw_cg_cp_rs2_p_b10, Zca_c_sw_cg_cp_rs2_p_b10_str)
-#else
-  c.sw x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x7ea2a510614c03a4
@@ -276,18 +177,9 @@ Zca_c_sw_cg_cp_rs2_p_b11:
   c.sw x11, 120(x15) # perform store
   addi x15, x15, 120 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zca_c_sw_cg_cp_rs2_p_b11, Zca_c_sw_cg_cp_rs2_p_b11_str)
-#else
-  c.sw x11, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x4da605c36878612f
@@ -297,18 +189,9 @@ Zca_c_sw_cg_cp_rs2_p_b12:
   c.sw x12, 92(x10) # perform store
   addi x10, x10, 92 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zca_c_sw_cg_cp_rs2_p_b12, Zca_c_sw_cg_cp_rs2_p_b12_str)
-#else
-  c.sw x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x9ac406dd5fa2ab75
@@ -318,18 +201,9 @@ Zca_c_sw_cg_cp_rs2_p_b13:
   c.sw x13, 120(x8) # perform store
   addi x8, x8, 120 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zca_c_sw_cg_cp_rs2_p_b13, Zca_c_sw_cg_cp_rs2_p_b13_str)
-#else
-  c.sw x13, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x07249ef9fbb93992
@@ -339,18 +213,9 @@ Zca_c_sw_cg_cp_rs2_p_b14:
   c.sw x14, 92(x15) # perform store
   addi x15, x15, 92 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x9 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x9, Zca_c_sw_cg_cp_rs2_p_b14, Zca_c_sw_cg_cp_rs2_p_b14_str)
-#else
-  c.sw x14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x26, x15 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2_p (Test source rs2 = x15)
@@ -361,18 +226,9 @@ Zca_c_sw_cg_cp_rs2_p_b15:
   c.sw x15, 40(x13) # perform store
   addi x13, x13, 40 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, Zca_c_sw_cg_cp_rs2_p_b15, Zca_c_sw_cg_cp_rs2_p_b15_str)
-#else
-  c.sw x15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -386,18 +242,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x0:
   c.sw x8, 92(x9) # perform store
   addi x9, x9, 92 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sw_cg_cp_rs2_edges_0x0, Zca_c_sw_cg_cp_rs2_edges_0x0_str)
-#else
-  c.sw x8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x0000000000000001
@@ -407,18 +254,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x1:
   c.sw x14, 60(x8) # perform store
   addi x8, x8, 60 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0x1, Zca_c_sw_cg_cp_rs2_edges_0x1_str)
-#else
-  c.sw x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x0000000000000002
@@ -428,18 +266,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x2:
   c.sw x14, 4(x10) # perform store
   addi x10, x10, 4 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x11 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x11, Zca_c_sw_cg_cp_rs2_edges_0x2, Zca_c_sw_cg_cp_rs2_edges_0x2_str)
-#else
-  c.sw x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x8000000000000000
@@ -449,18 +278,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x8000000000000000:
   c.sw x14, 84(x11) # perform store
   addi x11, x11, 84 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0x8000000000000000, Zca_c_sw_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  c.sw x14, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x8000000000000001
@@ -470,18 +290,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x8000000000000001:
   c.sw x9, 48(x8) # perform store
   addi x8, x8, 48 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, Zca_c_sw_cg_cp_rs2_edges_0x8000000000000001, Zca_c_sw_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  c.sw x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x7fffffffffffffff
@@ -491,18 +302,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x7fffffffffffffff:
   c.sw x14, 104(x13) # perform store
   addi x13, x13, 104 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_sw_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  c.sw x14, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x7ffffffffffffffe
@@ -512,18 +314,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x7ffffffffffffffe:
   c.sw x8, 20(x15) # perform store
   addi x15, x15, 20 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zca_c_sw_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_sw_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  c.sw x8, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xffffffffffffffff
@@ -533,18 +326,9 @@ Zca_c_sw_cg_cp_rs2_edges_0xffffffffffffffff:
   c.sw x8, 28(x9) # perform store
   addi x9, x9, 28 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sw_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_sw_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  c.sw x8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xfffffffffffffffe
@@ -554,18 +338,9 @@ Zca_c_sw_cg_cp_rs2_edges_0xfffffffffffffffe:
   c.sw x8, 28(x13) # perform store
   addi x13, x13, 28 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, Zca_c_sw_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_sw_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  c.sw x8, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x5bbc887763ae86f2
@@ -575,18 +350,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   c.sw x9, 12(x15) # perform store
   addi x15, x15, 12 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_sw_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  c.sw x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xaaaaaaaaaaaaaaaa
@@ -596,18 +362,9 @@ Zca_c_sw_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   c.sw x14, 92(x9) # perform store
   addi x9, x9, 92 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_sw_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  c.sw x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x5555555555555555
@@ -617,18 +374,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x5555555555555555:
   c.sw x8, 0(x12) # perform store
   addi x12, x12, 0 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x13 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x13, Zca_c_sw_cg_cp_rs2_edges_0x5555555555555555, Zca_c_sw_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  c.sw x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x00000000ffffffff
@@ -638,18 +386,9 @@ Zca_c_sw_cg_cp_rs2_edges_0xffffffff:
   c.sw x11, 4(x9) # perform store
   addi x9, x9, 4 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sw_cg_cp_rs2_edges_0xffffffff, Zca_c_sw_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  c.sw x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x00000000fffffffe
@@ -659,18 +398,9 @@ Zca_c_sw_cg_cp_rs2_edges_0xfffffffe:
   c.sw x11, 72(x14) # perform store
   addi x14, x14, 72 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zca_c_sw_cg_cp_rs2_edges_0xfffffffe, Zca_c_sw_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  c.sw x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x0000000100000000
@@ -680,18 +410,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x100000000:
   c.sw x9, 72(x8) # perform store
   addi x8, x8, 72 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zca_c_sw_cg_cp_rs2_edges_0x100000000, Zca_c_sw_cg_cp_rs2_edges_0x100000000_str)
-#else
-  c.sw x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x0000000100000001
@@ -701,18 +422,9 @@ Zca_c_sw_cg_cp_rs2_edges_0x100000001:
   c.sw x14, 124(x15) # perform store
   addi x15, x15, 124 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, Zca_c_sw_cg_cp_rs2_edges_0x100000001, Zca_c_sw_cg_cp_rs2_edges_0x100000001_str)
-#else
-  c.sw x14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_mul
@@ -726,18 +438,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x0:
   c.sw x11, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x0, Zca_c_sw_cg_cp_imm_mul_b0x0_str)
-#else
-  c.sw x11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=4
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x54c5a6dfabf15ee5
@@ -747,18 +450,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x4:
   c.sw x15, 4(x8) # perform store
   addi x8, x8, 4 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zca_c_sw_cg_cp_imm_mul_b0x4, Zca_c_sw_cg_cp_imm_mul_b0x4_str)
-#else
-  c.sw x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=8
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x0c23901808487427
@@ -768,18 +462,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x8:
   c.sw x11, 8(x13) # perform store
   addi x13, x13, 8 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x8, Zca_c_sw_cg_cp_imm_mul_b0x8_str)
-#else
-  c.sw x11, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=12
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x6dd9e2ac2d9955c1
@@ -789,18 +474,9 @@ Zca_c_sw_cg_cp_imm_mul_b0xc:
   c.sw x14, 12(x9) # perform store
   addi x9, x9, 12 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sw_cg_cp_imm_mul_b0xc, Zca_c_sw_cg_cp_imm_mul_b0xc_str)
-#else
-  c.sw x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=16
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xa8e36e5419294280
@@ -810,18 +486,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x10:
   c.sw x13, 16(x11) # perform store
   addi x11, x11, 16 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x10, Zca_c_sw_cg_cp_imm_mul_b0x10_str)
-#else
-  c.sw x13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=20
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x2dc2b862168fbc82
@@ -831,18 +498,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x14:
   c.sw x14, 20(x9) # perform store
   addi x9, x9, 20 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x14, Zca_c_sw_cg_cp_imm_mul_b0x14_str)
-#else
-  c.sw x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=24
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x84785848451f04ac
@@ -852,18 +510,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x18:
   c.sw x15, 24(x12) # perform store
   addi x12, x12, 24 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zca_c_sw_cg_cp_imm_mul_b0x18, Zca_c_sw_cg_cp_imm_mul_b0x18_str)
-#else
-  c.sw x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=28
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x5207bd35e8d13401
@@ -873,18 +522,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x1c:
   c.sw x9, 28(x10) # perform store
   addi x10, x10, 28 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x1c, Zca_c_sw_cg_cp_imm_mul_b0x1c_str)
-#else
-  c.sw x9, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=32
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x41d1cf0ab126467c
@@ -894,18 +534,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x20:
   c.sw x15, 32(x12) # perform store
   addi x12, x12, 32 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x9 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x9, Zca_c_sw_cg_cp_imm_mul_b0x20, Zca_c_sw_cg_cp_imm_mul_b0x20_str)
-#else
-  c.sw x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=36
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x3d0911516de183d2
@@ -915,18 +546,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x24:
   c.sw x11, 36(x9) # perform store
   addi x9, x9, 36 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sw_cg_cp_imm_mul_b0x24, Zca_c_sw_cg_cp_imm_mul_b0x24_str)
-#else
-  c.sw x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=40
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xe1c5cf355a7d8f95
@@ -936,18 +558,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x28:
   c.sw x11, 40(x14) # perform store
   addi x14, x14, 40 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zca_c_sw_cg_cp_imm_mul_b0x28, Zca_c_sw_cg_cp_imm_mul_b0x28_str)
-#else
-  c.sw x11, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=44
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xada111f0e31e1d6e
@@ -957,18 +570,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x2c:
   c.sw x9, 44(x8) # perform store
   addi x8, x8, 44 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, Zca_c_sw_cg_cp_imm_mul_b0x2c, Zca_c_sw_cg_cp_imm_mul_b0x2c_str)
-#else
-  c.sw x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=48
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xc8bd824660f8c8dd
@@ -978,18 +582,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x30:
   c.sw x12, 48(x14) # perform store
   addi x14, x14, 48 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x15 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x15, Zca_c_sw_cg_cp_imm_mul_b0x30, Zca_c_sw_cg_cp_imm_mul_b0x30_str)
-#else
-  c.sw x12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=52
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x7eac658f4936a854
@@ -999,18 +594,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x34:
   c.sw x15, 52(x8) # perform store
   addi x8, x8, 52 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zca_c_sw_cg_cp_imm_mul_b0x34, Zca_c_sw_cg_cp_imm_mul_b0x34_str)
-#else
-  c.sw x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=56
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x7fb4aec408748137
@@ -1020,18 +606,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x38:
   c.sw x13, 56(x9) # perform store
   addi x9, x9, 56 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x38, Zca_c_sw_cg_cp_imm_mul_b0x38_str)
-#else
-  c.sw x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=60
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xa7779ac9fffa1c37
@@ -1041,18 +618,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x3c:
   c.sw x8, 60(x14) # perform store
   addi x14, x14, 60 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x10 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x10, Zca_c_sw_cg_cp_imm_mul_b0x3c, Zca_c_sw_cg_cp_imm_mul_b0x3c_str)
-#else
-  c.sw x8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=64
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xbb410b8c32b83326
@@ -1062,18 +630,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x40:
   c.sw x8, 64(x9) # perform store
   addi x9, x9, 64 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sw_cg_cp_imm_mul_b0x40, Zca_c_sw_cg_cp_imm_mul_b0x40_str)
-#else
-  c.sw x8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=68
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xd44784fd11b68aab
@@ -1083,18 +642,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x44:
   c.sw x11, 68(x12) # perform store
   addi x12, x12, 68 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x44, Zca_c_sw_cg_cp_imm_mul_b0x44_str)
-#else
-  c.sw x11, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=72
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xd01a226027faf4a2
@@ -1104,18 +654,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x48:
   c.sw x14, 72(x10) # perform store
   addi x10, x10, 72 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x9 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x9, Zca_c_sw_cg_cp_imm_mul_b0x48, Zca_c_sw_cg_cp_imm_mul_b0x48_str)
-#else
-  c.sw x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=76
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x10c065317ea175d4
@@ -1125,18 +666,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x4c:
   c.sw x14, 76(x15) # perform store
   addi x15, x15, 76 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x4c, Zca_c_sw_cg_cp_imm_mul_b0x4c_str)
-#else
-  c.sw x14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=80
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xad1a8c94cc1bad8f
@@ -1146,18 +678,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x50:
   c.sw x13, 80(x11) # perform store
   addi x11, x11, 80 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_sw_cg_cp_imm_mul_b0x50, Zca_c_sw_cg_cp_imm_mul_b0x50_str)
-#else
-  c.sw x13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=84
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xe433e05adc03cb9f
@@ -1167,18 +690,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x54:
   c.sw x10, 84(x9) # perform store
   addi x9, x9, 84 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x54, Zca_c_sw_cg_cp_imm_mul_b0x54_str)
-#else
-  c.sw x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=88
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x2f450c693dd059c1
@@ -1188,18 +702,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x58:
   c.sw x13, 88(x12) # perform store
   addi x12, x12, 88 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x58, Zca_c_sw_cg_cp_imm_mul_b0x58_str)
-#else
-  c.sw x13, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=92
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x7db92205ca7c00be
@@ -1209,18 +714,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x5c:
   c.sw x11, 92(x8) # perform store
   addi x8, x8, 92 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x5c, Zca_c_sw_cg_cp_imm_mul_b0x5c_str)
-#else
-  c.sw x11, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=96
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xadae6b9f73aef449
@@ -1230,18 +726,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x60:
   c.sw x9, 96(x14) # perform store
   addi x14, x14, 96 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x12 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x12, Zca_c_sw_cg_cp_imm_mul_b0x60, Zca_c_sw_cg_cp_imm_mul_b0x60_str)
-#else
-  c.sw x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=100
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x4b9c87aaee0afe7f
@@ -1251,18 +738,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x64:
   c.sw x15, 100(x11) # perform store
   addi x11, x11, 100 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_sw_cg_cp_imm_mul_b0x64, Zca_c_sw_cg_cp_imm_mul_b0x64_str)
-#else
-  c.sw x15, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=104
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xc7a891a2b80538d3
@@ -1272,18 +750,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x68:
   c.sw x13, 104(x10) # perform store
   addi x10, x10, 104 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x68, Zca_c_sw_cg_cp_imm_mul_b0x68_str)
-#else
-  c.sw x13, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=108
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x6db54a469e3cc4d0
@@ -1293,18 +762,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x6c:
   c.sw x9, 108(x11) # perform store
   addi x11, x11, 108 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x6c, Zca_c_sw_cg_cp_imm_mul_b0x6c_str)
-#else
-  c.sw x9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=112
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0xab71333c1c7b9c84
@@ -1314,18 +774,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x70:
   c.sw x8, 112(x10) # perform store
   addi x10, x10, 112 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, Zca_c_sw_cg_cp_imm_mul_b0x70, Zca_c_sw_cg_cp_imm_mul_b0x70_str)
-#else
-  c.sw x8, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=116
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x4ae8e5192b9ae9ac
@@ -1335,18 +786,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x74:
   c.sw x8, 116(x11) # perform store
   addi x11, x11, 116 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, Zca_c_sw_cg_cp_imm_mul_b0x74, Zca_c_sw_cg_cp_imm_mul_b0x74_str)
-#else
-  c.sw x8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=120
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x3fb3480d3aa2f131
@@ -1356,18 +798,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x78:
   c.sw x12, 120(x13) # perform store
   addi x13, x13, 120 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zca_c_sw_cg_cp_imm_mul_b0x78, Zca_c_sw_cg_cp_imm_mul_b0x78_str)
-#else
-  c.sw x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul: imm=124
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x230332169b6831ac
@@ -1377,18 +810,9 @@ Zca_c_sw_cg_cp_imm_mul_b0x7c:
   c.sw x11, 124(x12) # perform store
   addi x12, x12, 124 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_sw_cg_cp_imm_mul_b0x7c, Zca_c_sw_cg_cp_imm_mul_b0x7c_str)
-#else
-  c.sw x11, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x12 # restore signature pointer to default register for teardown
 

--- a/tests/rv64i/Zca/Zca-c.swsp-00.S
+++ b/tests/rv64i/Zca/Zca-c.swsp-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 122
+#define SIGUPD_COUNT 234
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -40,6 +40,7 @@ RVTEST_BEGIN
 Zca_c_swsp_cg_cp_rs2_b0:
   c.swsp x0, 32(sp) # perform store
   LREG x24, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x24 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x24, Zca_c_swsp_cg_cp_rs2_b0, Zca_c_swsp_cg_cp_rs2_b0_str)
 
@@ -49,6 +50,7 @@ Zca_c_swsp_cg_cp_rs2_b0:
 Zca_c_swsp_cg_cp_rs2_b1:
   c.swsp x1, 64(sp) # perform store
   LREG x9, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x9, Zca_c_swsp_cg_cp_rs2_b1, Zca_c_swsp_cg_cp_rs2_b1_str)
 
@@ -58,6 +60,7 @@ Zca_c_swsp_cg_cp_rs2_b1:
 Zca_c_swsp_cg_cp_rs2_b2:
   c.swsp x2, 132(sp) # perform store
   LREG x8, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zca_c_swsp_cg_cp_rs2_b2, Zca_c_swsp_cg_cp_rs2_b2_str)
 
@@ -68,6 +71,7 @@ Zca_c_swsp_cg_cp_rs2_b2:
 Zca_c_swsp_cg_cp_rs2_b3:
   c.swsp x3, 120(sp) # perform store
   LREG x17, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zca_c_swsp_cg_cp_rs2_b3, Zca_c_swsp_cg_cp_rs2_b3_str)
 
@@ -79,6 +83,7 @@ Zca_c_swsp_cg_cp_rs2_b3:
 Zca_c_swsp_cg_cp_rs2_b4:
   c.swsp x4, 12(sp) # perform store
   LREG x7, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x7, Zca_c_swsp_cg_cp_rs2_b4, Zca_c_swsp_cg_cp_rs2_b4_str)
 
@@ -88,6 +93,7 @@ Zca_c_swsp_cg_cp_rs2_b4:
 Zca_c_swsp_cg_cp_rs2_b5:
   c.swsp x5, 212(sp) # perform store
   LREG x31, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x31, Zca_c_swsp_cg_cp_rs2_b5, Zca_c_swsp_cg_cp_rs2_b5_str)
 
@@ -97,6 +103,7 @@ Zca_c_swsp_cg_cp_rs2_b5:
 Zca_c_swsp_cg_cp_rs2_b6:
   c.swsp x6, 228(sp) # perform store
   LREG x21, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x21, Zca_c_swsp_cg_cp_rs2_b6, Zca_c_swsp_cg_cp_rs2_b6_str)
 
@@ -106,6 +113,7 @@ Zca_c_swsp_cg_cp_rs2_b6:
 Zca_c_swsp_cg_cp_rs2_b7:
   c.swsp x7, 152(sp) # perform store
   LREG x1, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x1 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x1, Zca_c_swsp_cg_cp_rs2_b7, Zca_c_swsp_cg_cp_rs2_b7_str)
 
@@ -115,6 +123,7 @@ Zca_c_swsp_cg_cp_rs2_b7:
 Zca_c_swsp_cg_cp_rs2_b8:
   c.swsp x8, 200(sp) # perform store
   LREG x1, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x1 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x1, Zca_c_swsp_cg_cp_rs2_b8, Zca_c_swsp_cg_cp_rs2_b8_str)
 
@@ -124,6 +133,7 @@ Zca_c_swsp_cg_cp_rs2_b8:
 Zca_c_swsp_cg_cp_rs2_b9:
   c.swsp x9, 0(sp) # perform store
   LREG x30, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x30 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x30, Zca_c_swsp_cg_cp_rs2_b9, Zca_c_swsp_cg_cp_rs2_b9_str)
 
@@ -133,6 +143,7 @@ Zca_c_swsp_cg_cp_rs2_b9:
 Zca_c_swsp_cg_cp_rs2_b10:
   c.swsp x10, 96(sp) # perform store
   LREG x11, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x11, Zca_c_swsp_cg_cp_rs2_b10, Zca_c_swsp_cg_cp_rs2_b10_str)
 
@@ -142,6 +153,7 @@ Zca_c_swsp_cg_cp_rs2_b10:
 Zca_c_swsp_cg_cp_rs2_b11:
   c.swsp x11, 36(sp) # perform store
   LREG x15, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x15, Zca_c_swsp_cg_cp_rs2_b11, Zca_c_swsp_cg_cp_rs2_b11_str)
 
@@ -151,6 +163,7 @@ Zca_c_swsp_cg_cp_rs2_b11:
 Zca_c_swsp_cg_cp_rs2_b12:
   c.swsp x12, 136(sp) # perform store
   LREG x27, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x27, Zca_c_swsp_cg_cp_rs2_b12, Zca_c_swsp_cg_cp_rs2_b12_str)
 
@@ -162,6 +175,7 @@ Zca_c_swsp_cg_cp_rs2_b12:
 Zca_c_swsp_cg_cp_rs2_b13:
   c.swsp x13, 8(sp) # perform store
   LREG x19, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_b13, Zca_c_swsp_cg_cp_rs2_b13_str)
 
@@ -171,6 +185,7 @@ Zca_c_swsp_cg_cp_rs2_b13:
 Zca_c_swsp_cg_cp_rs2_b14:
   c.swsp x14, 52(sp) # perform store
   LREG x11, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x11, Zca_c_swsp_cg_cp_rs2_b14, Zca_c_swsp_cg_cp_rs2_b14_str)
 
@@ -180,6 +195,7 @@ Zca_c_swsp_cg_cp_rs2_b14:
 Zca_c_swsp_cg_cp_rs2_b15:
   c.swsp x15, 60(sp) # perform store
   LREG x25, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x25, Zca_c_swsp_cg_cp_rs2_b15, Zca_c_swsp_cg_cp_rs2_b15_str)
 
@@ -190,6 +206,7 @@ Zca_c_swsp_cg_cp_rs2_b15:
 Zca_c_swsp_cg_cp_rs2_b16:
   c.swsp x16, 172(sp) # perform store
   LREG x13, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x13, Zca_c_swsp_cg_cp_rs2_b16, Zca_c_swsp_cg_cp_rs2_b16_str)
 
@@ -199,6 +216,7 @@ Zca_c_swsp_cg_cp_rs2_b16:
 Zca_c_swsp_cg_cp_rs2_b17:
   c.swsp x17, 12(sp) # perform store
   LREG x7, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x7, Zca_c_swsp_cg_cp_rs2_b17, Zca_c_swsp_cg_cp_rs2_b17_str)
 
@@ -209,6 +227,7 @@ Zca_c_swsp_cg_cp_rs2_b17:
 Zca_c_swsp_cg_cp_rs2_b18:
   c.swsp x18, 184(sp) # perform store
   LREG x16, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_swsp_cg_cp_rs2_b18, Zca_c_swsp_cg_cp_rs2_b18_str)
 
@@ -218,6 +237,7 @@ Zca_c_swsp_cg_cp_rs2_b18:
 Zca_c_swsp_cg_cp_rs2_b19:
   c.swsp x19, 40(sp) # perform store
   LREG x28, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_swsp_cg_cp_rs2_b19, Zca_c_swsp_cg_cp_rs2_b19_str)
 
@@ -227,6 +247,7 @@ Zca_c_swsp_cg_cp_rs2_b19:
 Zca_c_swsp_cg_cp_rs2_b20:
   c.swsp x20, 48(sp) # perform store
   LREG x7, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_rs2_b20, Zca_c_swsp_cg_cp_rs2_b20_str)
 
@@ -236,6 +257,7 @@ Zca_c_swsp_cg_cp_rs2_b20:
 Zca_c_swsp_cg_cp_rs2_b21:
   c.swsp x21, 148(sp) # perform store
   LREG x14, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_swsp_cg_cp_rs2_b21, Zca_c_swsp_cg_cp_rs2_b21_str)
 
@@ -245,6 +267,7 @@ Zca_c_swsp_cg_cp_rs2_b21:
 Zca_c_swsp_cg_cp_rs2_b22:
   c.swsp x22, 184(sp) # perform store
   LREG x24, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_rs2_b22, Zca_c_swsp_cg_cp_rs2_b22_str)
 
@@ -254,6 +277,7 @@ Zca_c_swsp_cg_cp_rs2_b22:
 Zca_c_swsp_cg_cp_rs2_b23:
   c.swsp x23, 152(sp) # perform store
   LREG x16, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_swsp_cg_cp_rs2_b23, Zca_c_swsp_cg_cp_rs2_b23_str)
 
@@ -263,6 +287,7 @@ Zca_c_swsp_cg_cp_rs2_b23:
 Zca_c_swsp_cg_cp_rs2_b24:
   c.swsp x24, 180(sp) # perform store
   LREG x15, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_rs2_b24, Zca_c_swsp_cg_cp_rs2_b24_str)
 
@@ -272,6 +297,7 @@ Zca_c_swsp_cg_cp_rs2_b24:
 Zca_c_swsp_cg_cp_rs2_b25:
   c.swsp x25, 228(sp) # perform store
   LREG x26, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_rs2_b25, Zca_c_swsp_cg_cp_rs2_b25_str)
 
@@ -281,6 +307,7 @@ Zca_c_swsp_cg_cp_rs2_b25:
 Zca_c_swsp_cg_cp_rs2_b26:
   c.swsp x26, 92(sp) # perform store
   LREG x18, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x18 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x18, Zca_c_swsp_cg_cp_rs2_b26, Zca_c_swsp_cg_cp_rs2_b26_str)
 
@@ -290,6 +317,7 @@ Zca_c_swsp_cg_cp_rs2_b26:
 Zca_c_swsp_cg_cp_rs2_b27:
   c.swsp x27, 152(sp) # perform store
   LREG x13, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, Zca_c_swsp_cg_cp_rs2_b27, Zca_c_swsp_cg_cp_rs2_b27_str)
 
@@ -299,6 +327,7 @@ Zca_c_swsp_cg_cp_rs2_b27:
 Zca_c_swsp_cg_cp_rs2_b28:
   c.swsp x28, 24(sp) # perform store
   LREG x12, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, Zca_c_swsp_cg_cp_rs2_b28, Zca_c_swsp_cg_cp_rs2_b28_str)
 
@@ -308,6 +337,7 @@ Zca_c_swsp_cg_cp_rs2_b28:
 Zca_c_swsp_cg_cp_rs2_b29:
   c.swsp x29, 44(sp) # perform store
   LREG x22, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_rs2_b29, Zca_c_swsp_cg_cp_rs2_b29_str)
 
@@ -317,6 +347,7 @@ Zca_c_swsp_cg_cp_rs2_b29:
 Zca_c_swsp_cg_cp_rs2_b30:
   c.swsp x30, 28(sp) # perform store
   LREG x6, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_swsp_cg_cp_rs2_b30, Zca_c_swsp_cg_cp_rs2_b30_str)
 
@@ -326,6 +357,7 @@ Zca_c_swsp_cg_cp_rs2_b30:
 Zca_c_swsp_cg_cp_rs2_b31:
   c.swsp x31, 168(sp) # perform store
   LREG x12, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, Zca_c_swsp_cg_cp_rs2_b31, Zca_c_swsp_cg_cp_rs2_b31_str)
 
@@ -339,6 +371,7 @@ Zca_c_swsp_cg_cp_rs2_b31:
 Zca_c_swsp_cg_cp_rs2_edges_0x0:
   c.swsp x9, 16(sp) # perform store
   LREG x6, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_swsp_cg_cp_rs2_edges_0x0, Zca_c_swsp_cg_cp_rs2_edges_0x0_str)
 
@@ -348,6 +381,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x0:
 Zca_c_swsp_cg_cp_rs2_edges_0x1:
   c.swsp x23, 144(sp) # perform store
   LREG x19, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_edges_0x1, Zca_c_swsp_cg_cp_rs2_edges_0x1_str)
 
@@ -357,6 +391,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x1:
 Zca_c_swsp_cg_cp_rs2_edges_0x2:
   c.swsp x12, 44(sp) # perform store
   LREG x20, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x20 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x20, Zca_c_swsp_cg_cp_rs2_edges_0x2, Zca_c_swsp_cg_cp_rs2_edges_0x2_str)
 
@@ -366,6 +401,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x2:
 Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000:
   c.swsp x25, 112(sp) # perform store
   LREG x27, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000_str)
 
@@ -375,6 +411,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000:
 Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001:
   c.swsp x12, 212(sp) # perform store
   LREG x26, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001_str)
 
@@ -384,6 +421,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001:
 Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff:
   c.swsp x13, 28(sp) # perform store
   LREG x16, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff_str)
 
@@ -393,6 +431,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff:
 Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
   c.swsp x23, 240(sp) # perform store
   LREG x6, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
 
@@ -402,6 +441,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
 Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff:
   c.swsp x12, 128(sp) # perform store
   LREG x21, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x21, Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff_str)
 
@@ -411,6 +451,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff:
 Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe:
   c.swsp x20, 144(sp) # perform store
   LREG x28, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe_str)
 
@@ -420,6 +461,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe:
 Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   c.swsp x29, 196(sp) # perform store
   LREG x26, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
 
@@ -429,6 +471,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
 Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   c.swsp x20, 172(sp) # perform store
   LREG x23, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x23, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
 
@@ -438,6 +481,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
 Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555:
   c.swsp x17, 32(sp) # perform store
   LREG x19, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555, Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555_str)
 
@@ -447,6 +491,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555:
 Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
   c.swsp x12, 196(sp) # perform store
   LREG x7, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff_str)
 
@@ -456,6 +501,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
 Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
   c.swsp x21, 228(sp) # perform store
   LREG x24, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe_str)
 
@@ -465,6 +511,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
 Zca_c_swsp_cg_cp_rs2_edges_0x100000000:
   c.swsp x16, 12(sp) # perform store
   LREG x27, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_swsp_cg_cp_rs2_edges_0x100000000, Zca_c_swsp_cg_cp_rs2_edges_0x100000000_str)
 
@@ -474,6 +521,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x100000000:
 Zca_c_swsp_cg_cp_rs2_edges_0x100000001:
   c.swsp x19, 32(sp) # perform store
   LREG x9, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_swsp_cg_cp_rs2_edges_0x100000001, Zca_c_swsp_cg_cp_rs2_edges_0x100000001_str)
 
@@ -487,6 +535,7 @@ Zca_c_swsp_cg_cp_rs2_edges_0x100000001:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0:
   c.swsp x15, 0(sp) # perform store
   LREG x18, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x18 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0_str)
 
@@ -496,6 +545,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4:
   c.swsp x8, 4(sp) # perform store
   LREG x26, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4_str)
 
@@ -505,6 +555,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8:
   c.swsp x7, 8(sp) # perform store
   LREG x30, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x30 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8_str)
 
@@ -514,6 +565,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc:
   c.swsp x29, 12(sp) # perform store
   LREG x20, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x20 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc_str)
 
@@ -523,6 +575,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10:
   c.swsp x16, 16(sp) # perform store
   LREG x3, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10_str)
 
@@ -532,6 +585,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14:
   c.swsp x25, 20(sp) # perform store
   LREG x7, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14_str)
 
@@ -541,6 +595,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18:
   c.swsp x3, 24(sp) # perform store
   LREG x22, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18_str)
 
@@ -550,6 +605,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c:
   c.swsp x12, 28(sp) # perform store
   LREG x8, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c_str)
 
@@ -559,6 +615,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20:
   c.swsp x16, 32(sp) # perform store
   LREG x26, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20_str)
 
@@ -568,6 +625,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24:
   c.swsp x27, 36(sp) # perform store
   LREG x15, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24_str)
 
@@ -577,6 +635,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28:
   c.swsp x14, 40(sp) # perform store
   LREG x28, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28_str)
 
@@ -586,6 +645,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
   c.swsp x9, 44(sp) # perform store
   LREG x23, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c_str)
 
@@ -595,6 +655,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
   c.swsp x28, 48(sp) # perform store
   LREG x6, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30_str)
 
@@ -604,6 +665,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
   c.swsp x26, 52(sp) # perform store
   LREG x14, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34_str)
 
@@ -613,6 +675,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
   c.swsp x21, 56(sp) # perform store
   LREG x8, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38_str)
 
@@ -622,6 +685,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
   c.swsp x27, 60(sp) # perform store
   LREG x30, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x30 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c_str)
 
@@ -631,6 +695,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
   c.swsp x2, 64(sp) # perform store
   LREG x21, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40_str)
 
@@ -640,6 +705,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
   c.swsp x31, 68(sp) # perform store
   LREG x23, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44_str)
 
@@ -649,6 +715,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
   c.swsp x20, 72(sp) # perform store
   LREG x7, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48_str)
 
@@ -658,6 +725,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
   c.swsp x2, 76(sp) # perform store
   LREG x16, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c_str)
 
@@ -667,6 +735,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
   c.swsp x0, 80(sp) # perform store
   LREG x21, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50_str)
 
@@ -676,6 +745,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
   c.swsp x10, 84(sp) # perform store
   LREG x28, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54_str)
 
@@ -685,6 +755,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
   c.swsp x12, 88(sp) # perform store
   LREG x26, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58_str)
 
@@ -694,6 +765,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
   c.swsp x9, 92(sp) # perform store
   LREG x15, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c_str)
 
@@ -703,6 +775,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
   c.swsp x24, 96(sp) # perform store
   LREG x25, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x25, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60_str)
 
@@ -712,6 +785,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
   c.swsp x13, 100(sp) # perform store
   LREG x14, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64_str)
 
@@ -721,6 +795,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
   c.swsp x3, 104(sp) # perform store
   LREG x28, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68_str)
 
@@ -730,6 +805,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
   c.swsp x3, 108(sp) # perform store
   LREG x9, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c_str)
 
@@ -739,6 +815,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
   c.swsp x20, 112(sp) # perform store
   LREG x15, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70_str)
 
@@ -748,6 +825,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
   c.swsp x26, 116(sp) # perform store
   LREG x7, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74_str)
 
@@ -757,6 +835,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
   c.swsp x13, 120(sp) # perform store
   LREG x8, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78_str)
 
@@ -766,6 +845,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
   c.swsp x25, 124(sp) # perform store
   LREG x17, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x17, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c_str)
 
@@ -775,6 +855,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
   c.swsp x10, 128(sp) # perform store
   LREG x22, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80_str)
 
@@ -784,6 +865,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
   c.swsp x3, 132(sp) # perform store
   LREG x31, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84_str)
 
@@ -793,6 +875,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
   c.swsp x29, 136(sp) # perform store
   LREG x31, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88_str)
 
@@ -802,6 +885,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
   c.swsp x23, 140(sp) # perform store
   LREG x26, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c_str)
 
@@ -811,6 +895,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
   c.swsp x27, 144(sp) # perform store
   LREG x29, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90_str)
 
@@ -820,6 +905,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
   c.swsp x8, 148(sp) # perform store
   LREG x25, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x25, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94_str)
 
@@ -829,6 +915,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
   c.swsp x25, 152(sp) # perform store
   LREG x15, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98_str)
 
@@ -838,6 +925,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
   c.swsp x0, 156(sp) # perform store
   LREG x15, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c_str)
 
@@ -847,6 +935,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
   c.swsp x20, 160(sp) # perform store
   LREG x15, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0_str)
 
@@ -856,6 +945,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
   c.swsp x30, 164(sp) # perform store
   LREG x22, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4_str)
 
@@ -865,6 +955,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
   c.swsp x9, 168(sp) # perform store
   LREG x24, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8_str)
 
@@ -874,6 +965,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
   c.swsp x23, 172(sp) # perform store
   LREG x27, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac_str)
 
@@ -883,6 +975,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
   c.swsp x7, 176(sp) # perform store
   LREG x30, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x30 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0_str)
 
@@ -892,6 +985,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
   c.swsp x22, 180(sp) # perform store
   LREG x7, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4_str)
 
@@ -901,6 +995,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
   c.swsp x15, 184(sp) # perform store
   LREG x6, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8_str)
 
@@ -910,6 +1005,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
   c.swsp x14, 188(sp) # perform store
   LREG x31, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc_str)
 
@@ -919,6 +1015,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
   c.swsp x14, 192(sp) # perform store
   LREG x7, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0_str)
 
@@ -928,6 +1025,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
   c.swsp x18, 196(sp) # perform store
   LREG x14, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4_str)
 
@@ -937,6 +1035,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
   c.swsp x12, 200(sp) # perform store
   LREG x27, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8_str)
 
@@ -946,6 +1045,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
   c.swsp x21, 204(sp) # perform store
   LREG x9, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc_str)
 
@@ -955,6 +1055,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
   c.swsp x25, 208(sp) # perform store
   LREG x20, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x20 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0_str)
 
@@ -964,6 +1065,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
   c.swsp x31, 212(sp) # perform store
   LREG x16, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4_str)
 
@@ -973,6 +1075,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
   c.swsp x16, 216(sp) # perform store
   LREG x29, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8_str)
 
@@ -982,6 +1085,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
   c.swsp x15, 220(sp) # perform store
   LREG x26, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc_str)
 
@@ -991,6 +1095,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
   c.swsp x12, 224(sp) # perform store
   LREG x3, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0_str)
 
@@ -1000,6 +1105,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
   c.swsp x30, 228(sp) # perform store
   LREG x22, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4_str)
 
@@ -1009,6 +1115,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
   c.swsp x18, 232(sp) # perform store
   LREG x24, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8_str)
 
@@ -1018,6 +1125,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
   c.swsp x24, 236(sp) # perform store
   LREG x23, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec_str)
 
@@ -1027,6 +1135,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
   c.swsp x7, 240(sp) # perform store
   LREG x18, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x18 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0_str)
 
@@ -1036,6 +1145,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
   c.swsp x31, 244(sp) # perform store
   LREG x16, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4_str)
 
@@ -1045,6 +1155,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
   c.swsp x19, 248(sp) # perform store
   LREG x29, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8_str)
 
@@ -1054,6 +1165,7 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc:
   c.swsp x13, 252(sp) # perform store
   LREG x24, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc_str)
 

--- a/tests/rv64i/Zca/Zca-c.swsp-00.S
+++ b/tests/rv64i/Zca/Zca-c.swsp-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 234
+#define SIGUPD_COUNT 122
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -39,57 +39,27 @@ RVTEST_BEGIN
   addi sp, x18, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b0:
   c.swsp x0, 32(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x24, 0(x18) # load stored value for checking
   # Check if x24 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x24, Zca_c_swsp_cg_cp_rs2_b0, Zca_c_swsp_cg_cp_rs2_b0_str)
-#else
-  addi sp, sp, 32 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x1)
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0x1ebc841f2300173d
   addi sp, x18, -64  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b1:
   c.swsp x1, 64(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x18) # load stored value for checking
   # Check if x9 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x9, Zca_c_swsp_cg_cp_rs2_b1, Zca_c_swsp_cg_cp_rs2_b1_str)
-#else
-  addi sp, sp, 64 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x1, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x2)
   RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0xc6079cbd44cb18e0
   addi sp, x18, -132  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b2:
   c.swsp x2, 132(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x8, 0(x18) # load stored value for checking
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zca_c_swsp_cg_cp_rs2_b2, Zca_c_swsp_cg_cp_rs2_b2_str)
-#else
-  addi sp, sp, 132 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x2, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x16, x3 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x3)
@@ -97,19 +67,9 @@ Zca_c_swsp_cg_cp_rs2_b2:
   addi sp, x18, -120  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b3:
   c.swsp x3, 120(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x17, 0(x18) # load stored value for checking
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zca_c_swsp_cg_cp_rs2_b3, Zca_c_swsp_cg_cp_rs2_b3_str)
-#else
-  addi sp, sp, 120 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x13, x4 # switch temp register to avoid conflict with test
   mv x14, x5 # switch link pointer register to avoid conflict with test
@@ -118,171 +78,81 @@ Zca_c_swsp_cg_cp_rs2_b3:
   addi sp, x18, -12  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b4:
   c.swsp x4, 12(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x18) # load stored value for checking
   # Check if x7 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x7, Zca_c_swsp_cg_cp_rs2_b4, Zca_c_swsp_cg_cp_rs2_b4_str)
-#else
-  addi sp, sp, 12 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x4, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x5)
   RVTEST_TESTDATA_LOAD_INT(x16, x5) # load rs2: x5 = 0x555a5752982b4163
   addi sp, x18, -212  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b5:
   c.swsp x5, 212(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x31, 0(x18) # load stored value for checking
   # Check if x31 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x31, Zca_c_swsp_cg_cp_rs2_b5, Zca_c_swsp_cg_cp_rs2_b5_str)
-#else
-  addi sp, sp, 212 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x5, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x6)
   RVTEST_TESTDATA_LOAD_INT(x16, x6) # load rs2: x6 = 0xb3c13b3584ceeabd
   addi sp, x18, -228  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b6:
   c.swsp x6, 228(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x21, 0(x18) # load stored value for checking
   # Check if x21 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x21, Zca_c_swsp_cg_cp_rs2_b6, Zca_c_swsp_cg_cp_rs2_b6_str)
-#else
-  addi sp, sp, 228 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x6, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x7)
   RVTEST_TESTDATA_LOAD_INT(x16, x7) # load rs2: x7 = 0xff6f63c33b4c81c3
   addi sp, x18, -152  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b7:
   c.swsp x7, 152(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x1, 0(x18) # load stored value for checking
   # Check if x1 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x1, Zca_c_swsp_cg_cp_rs2_b7, Zca_c_swsp_cg_cp_rs2_b7_str)
-#else
-  addi sp, sp, 152 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x7, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x8)
   RVTEST_TESTDATA_LOAD_INT(x16, x8) # load rs2: x8 = 0x01755c471a4efd34
   addi sp, x18, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b8:
   c.swsp x8, 200(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x1, 0(x18) # load stored value for checking
   # Check if x1 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x1, Zca_c_swsp_cg_cp_rs2_b8, Zca_c_swsp_cg_cp_rs2_b8_str)
-#else
-  addi sp, sp, 200 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x8, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x16, x9) # load rs2: x9 = 0x92232868eb470d4c
   addi sp, x18, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b9:
   c.swsp x9, 0(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x30, 0(x18) # load stored value for checking
   # Check if x30 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x30, Zca_c_swsp_cg_cp_rs2_b9, Zca_c_swsp_cg_cp_rs2_b9_str)
-#else
-  addi sp, sp, 0 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x16, x10) # load rs2: x10 = 0xb252930bf5a5e894
   addi sp, x18, -96  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b10:
   c.swsp x10, 96(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x18) # load stored value for checking
   # Check if x11 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x11, Zca_c_swsp_cg_cp_rs2_b10, Zca_c_swsp_cg_cp_rs2_b10_str)
-#else
-  addi sp, sp, 96 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x16, x11) # load rs2: x11 = 0xe2422f126dd0fa77
   addi sp, x18, -36  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b11:
   c.swsp x11, 36(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x18) # load stored value for checking
   # Check if x15 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x15, Zca_c_swsp_cg_cp_rs2_b11, Zca_c_swsp_cg_cp_rs2_b11_str)
-#else
-  addi sp, sp, 36 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x11, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x16, x12) # load rs2: x12 = 0x112f99af5ec67929
   addi sp, x18, -136  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b12:
   c.swsp x12, 136(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x27, 0(x18) # load stored value for checking
   # Check if x27 contains the expected result. x18 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x18, x14, x13, x27, Zca_c_swsp_cg_cp_rs2_b12, Zca_c_swsp_cg_cp_rs2_b12_str)
-#else
-  addi sp, sp, 136 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
@@ -291,57 +161,27 @@ Zca_c_swsp_cg_cp_rs2_b12:
   addi sp, x18, -8  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b13:
   c.swsp x13, 8(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x19, 0(x18) # load stored value for checking
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_b13, Zca_c_swsp_cg_cp_rs2_b13_str)
-#else
-  addi sp, sp, 8 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x16, x14) # load rs2: x14 = 0x25a31ba85fd69ccd
   addi sp, x18, -52  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b14:
   c.swsp x14, 52(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x11, 0(x18) # load stored value for checking
   # Check if x11 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x11, Zca_c_swsp_cg_cp_rs2_b14, Zca_c_swsp_cg_cp_rs2_b14_str)
-#else
-  addi sp, sp, 52 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x16, x15) # load rs2: x15 = 0x0842add314d502d3
   addi sp, x18, -60  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b15:
   c.swsp x15, 60(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x25, 0(x18) # load stored value for checking
   # Check if x25 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x25, Zca_c_swsp_cg_cp_rs2_b15, Zca_c_swsp_cg_cp_rs2_b15_str)
-#else
-  addi sp, sp, 60 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x1, x16 # switch data pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x16)
@@ -349,38 +189,18 @@ Zca_c_swsp_cg_cp_rs2_b15:
   addi sp, x18, -172  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b16:
   c.swsp x16, 172(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x18) # load stored value for checking
   # Check if x13 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x13, Zca_c_swsp_cg_cp_rs2_b16, Zca_c_swsp_cg_cp_rs2_b16_str)
-#else
-  addi sp, sp, 172 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x16, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x17)
   RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0x79f020f1491e9820
   addi sp, x18, -12  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b17:
   c.swsp x17, 12(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x18) # load stored value for checking
   # Check if x7 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x7, Zca_c_swsp_cg_cp_rs2_b17, Zca_c_swsp_cg_cp_rs2_b17_str)
-#else
-  addi sp, sp, 12 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x17, 0(sp) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x11, x18 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2 (Test source rs2 = x18)
@@ -388,266 +208,126 @@ Zca_c_swsp_cg_cp_rs2_b17:
   addi sp, x11, -184  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b18:
   c.swsp x18, 184(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x16, 0(x11) # load stored value for checking
   # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_swsp_cg_cp_rs2_b18, Zca_c_swsp_cg_cp_rs2_b18_str)
-#else
-  addi sp, sp, 184 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x18, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x19)
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0x651aede44b177094
   addi sp, x11, -40  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b19:
   c.swsp x19, 40(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x28, 0(x11) # load stored value for checking
   # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_swsp_cg_cp_rs2_b19, Zca_c_swsp_cg_cp_rs2_b19_str)
-#else
-  addi sp, sp, 40 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x19, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x20)
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x0b484ee68c51c7dd
   addi sp, x11, -48  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b20:
   c.swsp x20, 48(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x11) # load stored value for checking
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_rs2_b20, Zca_c_swsp_cg_cp_rs2_b20_str)
-#else
-  addi sp, sp, 48 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x20, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x21)
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0xe2c219e33c264024
   addi sp, x11, -148  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b21:
   c.swsp x21, 148(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_swsp_cg_cp_rs2_b21, Zca_c_swsp_cg_cp_rs2_b21_str)
-#else
-  addi sp, sp, 148 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x21, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x22)
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0x3b1c7fa46a2358c2
   addi sp, x11, -184  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b22:
   c.swsp x22, 184(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x24, 0(x11) # load stored value for checking
   # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_rs2_b22, Zca_c_swsp_cg_cp_rs2_b22_str)
-#else
-  addi sp, sp, 184 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x22, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x23)
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0xff67d63cf033dd13
   addi sp, x11, -152  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b23:
   c.swsp x23, 152(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x16, 0(x11) # load stored value for checking
   # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_swsp_cg_cp_rs2_b23, Zca_c_swsp_cg_cp_rs2_b23_str)
-#else
-  addi sp, sp, 152 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x23, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x24)
   RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0x5132b87bf2218bbc
   addi sp, x11, -180  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b24:
   c.swsp x24, 180(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_rs2_b24, Zca_c_swsp_cg_cp_rs2_b24_str)
-#else
-  addi sp, sp, 180 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x24, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x25)
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x6aa77a2d910ebdbb
   addi sp, x11, -228  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b25:
   c.swsp x25, 228(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x11) # load stored value for checking
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_rs2_b25, Zca_c_swsp_cg_cp_rs2_b25_str)
-#else
-  addi sp, sp, 228 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x25, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x26)
   RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0xbb87065e9b8437c3
   addi sp, x11, -92  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b26:
   c.swsp x26, 92(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x18, 0(x11) # load stored value for checking
   # Check if x18 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x18, Zca_c_swsp_cg_cp_rs2_b26, Zca_c_swsp_cg_cp_rs2_b26_str)
-#else
-  addi sp, sp, 92 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x26, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x27)
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x15ea6b3aa7180ec5
   addi sp, x11, -152  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b27:
   c.swsp x27, 152(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x13, 0(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, Zca_c_swsp_cg_cp_rs2_b27, Zca_c_swsp_cg_cp_rs2_b27_str)
-#else
-  addi sp, sp, 152 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x27, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x28)
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x964c703bae418f11
   addi sp, x11, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b28:
   c.swsp x28, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, Zca_c_swsp_cg_cp_rs2_b28, Zca_c_swsp_cg_cp_rs2_b28_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x28, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x29)
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0xd290f41e9aa71bfc
   addi sp, x11, -44  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b29:
   c.swsp x29, 44(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x11) # load stored value for checking
   # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_rs2_b29, Zca_c_swsp_cg_cp_rs2_b29_str)
-#else
-  addi sp, sp, 44 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x29, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x30)
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0xdc824e1958247f65
   addi sp, x11, -28  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b30:
   c.swsp x30, 28(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x11) # load stored value for checking
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_swsp_cg_cp_rs2_b30, Zca_c_swsp_cg_cp_rs2_b30_str)
-#else
-  addi sp, sp, 28 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x30, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2 (Test source rs2 = x31)
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x315ceb3a30169fff
   addi sp, x11, -168  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_b31:
   c.swsp x31, 168(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x12, 0(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, Zca_c_swsp_cg_cp_rs2_b31, Zca_c_swsp_cg_cp_rs2_b31_str)
-#else
-  addi sp, sp, 168 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x31, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -658,304 +338,144 @@ Zca_c_swsp_cg_cp_rs2_b31:
   addi sp, x11, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x0:
   c.swsp x9, 16(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x11) # load stored value for checking
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_swsp_cg_cp_rs2_edges_0x0, Zca_c_swsp_cg_cp_rs2_edges_0x0_str)
-#else
-  addi sp, sp, 16 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x0000000000000001
   addi sp, x11, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x1:
   c.swsp x23, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x19, 0(x11) # load stored value for checking
   # Check if x19 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_edges_0x1, Zca_c_swsp_cg_cp_rs2_edges_0x1_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x23, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x0000000000000002
   addi sp, x11, -44  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x2:
   c.swsp x12, 44(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x20, 0(x11) # load stored value for checking
   # Check if x20 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x20, Zca_c_swsp_cg_cp_rs2_edges_0x2, Zca_c_swsp_cg_cp_rs2_edges_0x2_str)
-#else
-  addi sp, sp, 44 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x8000000000000000
   addi sp, x11, -112  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000:
   c.swsp x25, 112(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x27, 0(x11) # load stored value for checking
   # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  addi sp, sp, 112 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x25, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x8000000000000001
   addi sp, x11, -212  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001:
   c.swsp x12, 212(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x11) # load stored value for checking
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  addi sp, sp, 212 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x7fffffffffffffff
   addi sp, x11, -28  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff:
   c.swsp x13, 28(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x16, 0(x11) # load stored value for checking
   # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  addi sp, sp, 28 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x7ffffffffffffffe
   addi sp, x11, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
   c.swsp x23, 240(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x11) # load stored value for checking
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  addi sp, sp, 240 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x23, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xffffffffffffffff
   addi sp, x11, -128  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff:
   c.swsp x12, 128(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x21, 0(x11) # load stored value for checking
   # Check if x21 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x21, Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  addi sp, sp, 128 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0xfffffffffffffffe
   addi sp, x11, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe:
   c.swsp x20, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x28, 0(x11) # load stored value for checking
   # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x20, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x5bbc887763ae86f2
   addi sp, x11, -196  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   c.swsp x29, 196(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x11) # load stored value for checking
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  addi sp, sp, 196 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x29, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0xaaaaaaaaaaaaaaaa
   addi sp, x11, -172  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   c.swsp x20, 172(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x11) # load stored value for checking
   # Check if x23 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x23, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  addi sp, sp, 172 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x20, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0x5555555555555555
   addi sp, x11, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555:
   c.swsp x17, 32(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x19, 0(x11) # load stored value for checking
   # Check if x19 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555, Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  addi sp, sp, 32 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x17, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x00000000ffffffff
   addi sp, x11, -196  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
   c.swsp x12, 196(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x11) # load stored value for checking
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  addi sp, sp, 196 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x00000000fffffffe
   addi sp, x11, -228  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
   c.swsp x21, 228(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x24, 0(x11) # load stored value for checking
   # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  addi sp, sp, 228 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x21, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x0000000100000000
   addi sp, x11, -12  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x100000000:
   c.swsp x16, 12(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x27, 0(x11) # load stored value for checking
   # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_swsp_cg_cp_rs2_edges_0x100000000, Zca_c_swsp_cg_cp_rs2_edges_0x100000000_str)
-#else
-  addi sp, sp, 12 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x16, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0x0000000100000001
   addi sp, x11, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x100000001:
   c.swsp x19, 32(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_swsp_cg_cp_rs2_edges_0x100000001, Zca_c_swsp_cg_cp_rs2_edges_0x100000001_str)
-#else
-  addi sp, sp, 32 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x19, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_imm_mul_4sp
@@ -966,1216 +486,576 @@ Zca_c_swsp_cg_cp_rs2_edges_0x100000001:
   addi sp, x11, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0:
   c.swsp x15, 0(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x18, 0(x11) # load stored value for checking
   # Check if x18 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0_str)
-#else
-  addi sp, sp, 0 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=4
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xce44699c438312ff
   addi sp, x11, -4  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4:
   c.swsp x8, 4(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x11) # load stored value for checking
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4_str)
-#else
-  addi sp, sp, 4 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x8, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=8
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xbe081e73ad1eb060
   addi sp, x11, -8  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8:
   c.swsp x7, 8(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x30, 0(x11) # load stored value for checking
   # Check if x30 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8_str)
-#else
-  addi sp, sp, 8 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x7, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=12
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x6b21e26621cd47bd
   addi sp, x11, -12  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc:
   c.swsp x29, 12(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x20, 0(x11) # load stored value for checking
   # Check if x20 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc_str)
-#else
-  addi sp, sp, 12 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x29, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=16
   RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x68bd767c1ef803ee
   addi sp, x11, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10:
   c.swsp x16, 16(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x11) # load stored value for checking
   # Check if x3 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10_str)
-#else
-  addi sp, sp, 16 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x16, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=20
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x09a836698e0b9668
   addi sp, x11, -20  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14:
   c.swsp x25, 20(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x11) # load stored value for checking
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14_str)
-#else
-  addi sp, sp, 20 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x25, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=24
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xf7c9a3078d2115c3
   addi sp, x11, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18:
   c.swsp x3, 24(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x11) # load stored value for checking
   # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18_str)
-#else
-  addi sp, sp, 24 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=28
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x2dc2d097d9b73684
   addi sp, x11, -28  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c:
   c.swsp x12, 28(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x8, 0(x11) # load stored value for checking
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c_str)
-#else
-  addi sp, sp, 28 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=32
   RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x45c79713e475d3b4
   addi sp, x11, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20:
   c.swsp x16, 32(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x11) # load stored value for checking
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20_str)
-#else
-  addi sp, sp, 32 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x16, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=36
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x926d86de825588f2
   addi sp, x11, -36  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24:
   c.swsp x27, 36(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24_str)
-#else
-  addi sp, sp, 36 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x27, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=40
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xbcc0102f318ad02d
   addi sp, x11, -40  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28:
   c.swsp x14, 40(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x28, 0(x11) # load stored value for checking
   # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28_str)
-#else
-  addi sp, sp, 40 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=44
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x419d87b97e3eb16c
   addi sp, x11, -44  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
   c.swsp x9, 44(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x11) # load stored value for checking
   # Check if x23 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c_str)
-#else
-  addi sp, sp, 44 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=48
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0xdf3eea06bccafcad
   addi sp, x11, -48  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
   c.swsp x28, 48(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x11) # load stored value for checking
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30_str)
-#else
-  addi sp, sp, 48 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x28, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=52
   RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x2db624b0b45b2c8b
   addi sp, x11, -52  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
   c.swsp x26, 52(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34_str)
-#else
-  addi sp, sp, 52 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x26, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=56
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x688d523781f6d56d
   addi sp, x11, -56  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
   c.swsp x21, 56(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x8, 0(x11) # load stored value for checking
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38_str)
-#else
-  addi sp, sp, 56 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x21, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=60
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x80dc5f589b13aa7d
   addi sp, x11, -60  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
   c.swsp x27, 60(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x30, 0(x11) # load stored value for checking
   # Check if x30 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c_str)
-#else
-  addi sp, sp, 60 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x27, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=64
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xb7a2726dc175b476
   addi sp, x11, -64  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
   c.swsp x2, 64(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x21, 0(x11) # load stored value for checking
   # Check if x21 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40_str)
-#else
-  addi sp, sp, 64 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x2, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=68
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x007aeb44a84065b0
   addi sp, x11, -68  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
   c.swsp x31, 68(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x11) # load stored value for checking
   # Check if x23 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44_str)
-#else
-  addi sp, sp, 68 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x31, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=72
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0xbfcd51149a9509f6
   addi sp, x11, -72  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
   c.swsp x20, 72(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x11) # load stored value for checking
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48_str)
-#else
-  addi sp, sp, 72 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x20, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=76
   RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xfc4e095f418c3264
   addi sp, x11, -76  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
   c.swsp x2, 76(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x16, 0(x11) # load stored value for checking
   # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c_str)
-#else
-  addi sp, sp, 76 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x2, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=80
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x823bf5eb1f15dcb8
   addi sp, x11, -80  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
   c.swsp x0, 80(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x21, 0(x11) # load stored value for checking
   # Check if x21 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50_str)
-#else
-  addi sp, sp, 80 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=84
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xb5b23d03a5bff6fb
   addi sp, x11, -84  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
   c.swsp x10, 84(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x28, 0(x11) # load stored value for checking
   # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54_str)
-#else
-  addi sp, sp, 84 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=88
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x12be5c00004a3fed
   addi sp, x11, -88  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
   c.swsp x12, 88(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x11) # load stored value for checking
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58_str)
-#else
-  addi sp, sp, 88 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=92
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x408148003ab1aa06
   addi sp, x11, -92  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
   c.swsp x9, 92(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c_str)
-#else
-  addi sp, sp, 92 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=96
   RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0xfd7e6a452e04c112
   addi sp, x11, -96  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
   c.swsp x24, 96(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x25, 0(x11) # load stored value for checking
   # Check if x25 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x25, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60_str)
-#else
-  addi sp, sp, 96 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x24, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=100
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xaf6fdcc0de38ff0e
   addi sp, x11, -100  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
   c.swsp x13, 100(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64_str)
-#else
-  addi sp, sp, 100 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=104
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x81c761661b99e043
   addi sp, x11, -104  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
   c.swsp x3, 104(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x28, 0(x11) # load stored value for checking
   # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68_str)
-#else
-  addi sp, sp, 104 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=108
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x0c1f86852445601b
   addi sp, x11, -108  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
   c.swsp x3, 108(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c_str)
-#else
-  addi sp, sp, 108 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=112
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x9f2e744b3e6fd0d3
   addi sp, x11, -112  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
   c.swsp x20, 112(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70_str)
-#else
-  addi sp, sp, 112 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x20, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=116
   RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0xc76e4eac8b5a9947
   addi sp, x11, -116  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
   c.swsp x26, 116(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x11) # load stored value for checking
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74_str)
-#else
-  addi sp, sp, 116 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x26, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=120
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xa5fdc85bc94a6e3a
   addi sp, x11, -120  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
   c.swsp x13, 120(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x8, 0(x11) # load stored value for checking
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78_str)
-#else
-  addi sp, sp, 120 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=124
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0xec4e4dbb72f89694
   addi sp, x11, -124  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
   c.swsp x25, 124(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x17, 0(x11) # load stored value for checking
   # Check if x17 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x17, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c_str)
-#else
-  addi sp, sp, 124 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x25, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=128
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xfe63f0d7c5845e44
   addi sp, x11, -128  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
   c.swsp x10, 128(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x11) # load stored value for checking
   # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80_str)
-#else
-  addi sp, sp, 128 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x10, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=132
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x350cf49aa81afa8d
   addi sp, x11, -132  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
   c.swsp x3, 132(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x31, 0(x11) # load stored value for checking
   # Check if x31 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84_str)
-#else
-  addi sp, sp, 132 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x3, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=136
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x3dd4f2173af5f404
   addi sp, x11, -136  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
   c.swsp x29, 136(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x31, 0(x11) # load stored value for checking
   # Check if x31 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88_str)
-#else
-  addi sp, sp, 136 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x29, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=140
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x1403baf187eef96a
   addi sp, x11, -140  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
   c.swsp x23, 140(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x11) # load stored value for checking
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c_str)
-#else
-  addi sp, sp, 140 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x23, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=144
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x1a38a42b877ef27e
   addi sp, x11, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
   c.swsp x27, 144(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x29, 0(x11) # load stored value for checking
   # Check if x29 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90_str)
-#else
-  addi sp, sp, 144 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x27, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=148
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xf4ac6d36d084e406
   addi sp, x11, -148  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
   c.swsp x8, 148(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x25, 0(x11) # load stored value for checking
   # Check if x25 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x25, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94_str)
-#else
-  addi sp, sp, 148 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x8, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=152
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x7bc268c2a7be4141
   addi sp, x11, -152  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
   c.swsp x25, 152(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98_str)
-#else
-  addi sp, sp, 152 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x25, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=156
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x4c5429651a4f0a20
   addi sp, x11, -156  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
   c.swsp x0, 156(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c_str)
-#else
-  addi sp, sp, 156 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x0, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=160
   RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x1e17df6a3a92f564
   addi sp, x11, -160  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
   c.swsp x20, 160(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x15, 0(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0_str)
-#else
-  addi sp, sp, 160 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x20, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=164
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0xdbdc8cbc4611b086
   addi sp, x11, -164  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
   c.swsp x30, 164(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x11) # load stored value for checking
   # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4_str)
-#else
-  addi sp, sp, 164 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x30, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=168
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x14f57c1e7730ae14
   addi sp, x11, -168  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
   c.swsp x9, 168(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x24, 0(x11) # load stored value for checking
   # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8_str)
-#else
-  addi sp, sp, 168 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x9, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=172
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x95b90a8d4ccf5ac6
   addi sp, x11, -172  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
   c.swsp x23, 172(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x27, 0(x11) # load stored value for checking
   # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac_str)
-#else
-  addi sp, sp, 172 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x23, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=176
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x0a25908fa6593dcc
   addi sp, x11, -176  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
   c.swsp x7, 176(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x30, 0(x11) # load stored value for checking
   # Check if x30 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0_str)
-#else
-  addi sp, sp, 176 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x7, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=180
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0xb80c8b139f02dfca
   addi sp, x11, -180  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
   c.swsp x22, 180(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x11) # load stored value for checking
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4_str)
-#else
-  addi sp, sp, 180 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x22, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=184
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x96b5673af5cd4ac4
   addi sp, x11, -184  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
   c.swsp x15, 184(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x6, 0(x11) # load stored value for checking
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8_str)
-#else
-  addi sp, sp, 184 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=188
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xb44a4f10b81f94c9
   addi sp, x11, -188  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
   c.swsp x14, 188(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x31, 0(x11) # load stored value for checking
   # Check if x31 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc_str)
-#else
-  addi sp, sp, 188 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=192
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x6e70fb89a7f55807
   addi sp, x11, -192  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
   c.swsp x14, 192(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x7, 0(x11) # load stored value for checking
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0_str)
-#else
-  addi sp, sp, 192 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x14, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=196
   RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rs2: x18 = 0x0668109ea5789853
   addi sp, x11, -196  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
   c.swsp x18, 196(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x14, 0(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4_str)
-#else
-  addi sp, sp, 196 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x18, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=200
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x52bdd3617f8b6d8c
   addi sp, x11, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
   c.swsp x12, 200(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x27, 0(x11) # load stored value for checking
   # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8_str)
-#else
-  addi sp, sp, 200 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=204
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0xf1bc5dd064d42cac
   addi sp, x11, -204  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
   c.swsp x21, 204(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x9, 0(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc_str)
-#else
-  addi sp, sp, 204 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x21, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=208
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0xf578d9a8accea683
   addi sp, x11, -208  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
   c.swsp x25, 208(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x20, 0(x11) # load stored value for checking
   # Check if x20 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0_str)
-#else
-  addi sp, sp, 208 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x25, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=212
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x4d5bde9a9003b69b
   addi sp, x11, -212  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
   c.swsp x31, 212(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x16, 0(x11) # load stored value for checking
   # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4_str)
-#else
-  addi sp, sp, 212 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x31, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=216
   RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x127ee9b1f2aeccd0
   addi sp, x11, -216  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
   c.swsp x16, 216(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x29, 0(x11) # load stored value for checking
   # Check if x29 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8_str)
-#else
-  addi sp, sp, 216 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x16, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=220
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x90a91e295406c510
   addi sp, x11, -220  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
   c.swsp x15, 220(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x26, 0(x11) # load stored value for checking
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc_str)
-#else
-  addi sp, sp, 220 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x15, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=224
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xea87f67205d085b3
   addi sp, x11, -224  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
   c.swsp x12, 224(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x3, 0(x11) # load stored value for checking
   # Check if x3 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0_str)
-#else
-  addi sp, sp, 224 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x12, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=228
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x427582f2bcc6b099
   addi sp, x11, -228  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
   c.swsp x30, 228(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x22, 0(x11) # load stored value for checking
   # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4_str)
-#else
-  addi sp, sp, 228 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x30, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=232
   RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rs2: x18 = 0xfef588226e40e4d3
   addi sp, x11, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
   c.swsp x18, 232(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x24, 0(x11) # load stored value for checking
   # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8_str)
-#else
-  addi sp, sp, 232 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x18, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=236
   RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0xbd789a4d5f9c0192
   addi sp, x11, -236  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
   c.swsp x24, 236(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x23, 0(x11) # load stored value for checking
   # Check if x23 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec_str)
-#else
-  addi sp, sp, 236 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x24, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=240
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xf5322a13b5cf94f1
   addi sp, x11, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
   c.swsp x7, 240(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x18, 0(x11) # load stored value for checking
   # Check if x18 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0_str)
-#else
-  addi sp, sp, 240 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x7, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=244
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0xf707262c7db9241d
   addi sp, x11, -244  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
   c.swsp x31, 244(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x16, 0(x11) # load stored value for checking
   # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4_str)
-#else
-  addi sp, sp, 244 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x31, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=248
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0x320353d8e46ad67b
   addi sp, x11, -248  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
   c.swsp x19, 248(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x29, 0(x11) # load stored value for checking
   # Check if x29 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8_str)
-#else
-  addi sp, sp, 248 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x19, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
 # Testcase cp_imm_mul_4sp: imm=252
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xe219fe6f1b4d49e8
   addi sp, x11, -252  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc:
   c.swsp x13, 252(sp) # perform store
-#ifdef RVTEST_SELFCHECK
   LREG x24, 0(x11) # load stored value for checking
   # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc_str)
-#else
-  addi sp, sp, 252 # remove offset from sp
-  addi sp, sp, SIG_STRIDE # increment signature pointer in sp
-  c.swsp x13, 0(sp) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-#endif
 
   mv x2, x11 # restore signature pointer to default register for teardown
 

--- a/tests/rv64i/Zcb/Zcb-c.sb-00.S
+++ b/tests/rv64i/Zcb/Zcb-c.sb-00.S
@@ -41,18 +41,9 @@ Zcb_c_sb_cg_cp_rs1_p_b8:
   c.sb x15, 2(x8) # perform store
   addi x8, x8, 2 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, Zcb_c_sb_cg_cp_rs1_p_b8, Zcb_c_sb_cg_cp_rs1_p_b8_str)
-#else
-  c.sb x15, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x8499bc36dea9bad4
@@ -62,18 +53,9 @@ Zcb_c_sb_cg_cp_rs1_p_b9:
   c.sb x15, 3(x9) # perform store
   addi x9, x9, 3 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x13, Zcb_c_sb_cg_cp_rs1_p_b9, Zcb_c_sb_cg_cp_rs1_p_b9_str)
-#else
-  c.sb x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xd4354735d218636e
@@ -83,18 +65,9 @@ Zcb_c_sb_cg_cp_rs1_p_b10:
   c.sb x12, 2(x10) # perform store
   addi x10, x10, 2 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zcb_c_sb_cg_cp_rs1_p_b10, Zcb_c_sb_cg_cp_rs1_p_b10_str)
-#else
-  c.sb x12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x316dd682503c9e93
@@ -104,18 +77,9 @@ Zcb_c_sb_cg_cp_rs1_p_b11:
   c.sb x14, 3(x11) # perform store
   addi x11, x11, 3 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zcb_c_sb_cg_cp_rs1_p_b11, Zcb_c_sb_cg_cp_rs1_p_b11_str)
-#else
-  c.sb x14, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xdee894b0537c556a
@@ -125,18 +89,9 @@ Zcb_c_sb_cg_cp_rs1_p_b12:
   c.sb x14, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x10 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x10, Zcb_c_sb_cg_cp_rs1_p_b12, Zcb_c_sb_cg_cp_rs1_p_b12_str)
-#else
-  c.sb x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x2bcb4b03d1c0b210
@@ -146,18 +101,9 @@ Zcb_c_sb_cg_cp_rs1_p_b13:
   c.sb x10, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, Zcb_c_sb_cg_cp_rs1_p_b13, Zcb_c_sb_cg_cp_rs1_p_b13_str)
-#else
-  c.sb x10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x8c59029c66a703fd
@@ -167,18 +113,9 @@ Zcb_c_sb_cg_cp_rs1_p_b14:
   c.sb x9, 3(x14) # perform store
   addi x14, x14, 3 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x11 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x11, Zcb_c_sb_cg_cp_rs1_p_b14, Zcb_c_sb_cg_cp_rs1_p_b14_str)
-#else
-  c.sb x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xb2f5b56884f01891
@@ -188,18 +125,9 @@ Zcb_c_sb_cg_cp_rs1_p_b15:
   c.sb x12, 2(x15) # perform store
   addi x15, x15, 2 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x8 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x8, Zcb_c_sb_cg_cp_rs1_p_b15, Zcb_c_sb_cg_cp_rs1_p_b15_str)
-#else
-  c.sb x12, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_p
@@ -213,18 +141,9 @@ Zcb_c_sb_cg_cp_rs2_p_b8:
   c.sb x8, 0(x12) # perform store
   addi x12, x12, 0 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zcb_c_sb_cg_cp_rs2_p_b8, Zcb_c_sb_cg_cp_rs2_p_b8_str)
-#else
-  c.sb x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x428801d9d52ee987
@@ -234,18 +153,9 @@ Zcb_c_sb_cg_cp_rs2_p_b9:
   c.sb x9, 2(x14) # perform store
   addi x14, x14, 2 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x8 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x8, Zcb_c_sb_cg_cp_rs2_p_b9, Zcb_c_sb_cg_cp_rs2_p_b9_str)
-#else
-  c.sb x9, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x814794f6e365f1e3
@@ -255,18 +165,9 @@ Zcb_c_sb_cg_cp_rs2_p_b10:
   c.sb x10, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zcb_c_sb_cg_cp_rs2_p_b10, Zcb_c_sb_cg_cp_rs2_p_b10_str)
-#else
-  c.sb x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x39e732759de3960a
@@ -276,18 +177,9 @@ Zcb_c_sb_cg_cp_rs2_p_b11:
   c.sb x11, 2(x13) # perform store
   addi x13, x13, 2 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x8 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x8, Zcb_c_sb_cg_cp_rs2_p_b11, Zcb_c_sb_cg_cp_rs2_p_b11_str)
-#else
-  c.sb x11, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x9631085ada15a429
@@ -297,18 +189,9 @@ Zcb_c_sb_cg_cp_rs2_p_b12:
   c.sb x12, 1(x8) # perform store
   addi x8, x8, 1 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x14 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x14, Zcb_c_sb_cg_cp_rs2_p_b12, Zcb_c_sb_cg_cp_rs2_p_b12_str)
-#else
-  c.sb x12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x79fceef222dd47ca
@@ -318,18 +201,9 @@ Zcb_c_sb_cg_cp_rs2_p_b13:
   c.sb x13, 2(x15) # perform store
   addi x15, x15, 2 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x11 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x11, Zcb_c_sb_cg_cp_rs2_p_b13, Zcb_c_sb_cg_cp_rs2_p_b13_str)
-#else
-  c.sb x13, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xc8fb752d9d863298
@@ -339,18 +213,9 @@ Zcb_c_sb_cg_cp_rs2_p_b14:
   c.sb x14, 1(x10) # perform store
   addi x10, x10, 1 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_p_b14, Zcb_c_sb_cg_cp_rs2_p_b14_str)
-#else
-  c.sb x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x17b893ad1d006e82
@@ -360,18 +225,9 @@ Zcb_c_sb_cg_cp_rs2_p_b15:
   c.sb x15, 1(x9) # perform store
   addi x9, x9, 1 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zcb_c_sb_cg_cp_rs2_p_b15, Zcb_c_sb_cg_cp_rs2_p_b15_str)
-#else
-  c.sb x15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -385,18 +241,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x0:
   c.sb x8, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_edges_0x0, Zcb_c_sb_cg_cp_rs2_edges_0x0_str)
-#else
-  c.sb x8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x0000000000000001
@@ -406,18 +253,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x1:
   c.sb x15, 2(x10) # perform store
   addi x10, x10, 2 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zcb_c_sb_cg_cp_rs2_edges_0x1, Zcb_c_sb_cg_cp_rs2_edges_0x1_str)
-#else
-  c.sb x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x0000000000000002
@@ -427,18 +265,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x2:
   c.sb x14, 0(x8) # perform store
   addi x8, x8, 0 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x12 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x12, Zcb_c_sb_cg_cp_rs2_edges_0x2, Zcb_c_sb_cg_cp_rs2_edges_0x2_str)
-#else
-  c.sb x14, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x8000000000000000
@@ -448,18 +277,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x8000000000000000:
   c.sb x11, 3(x9) # perform store
   addi x9, x9, 3 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zcb_c_sb_cg_cp_rs2_edges_0x8000000000000000, Zcb_c_sb_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  c.sb x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x8000000000000001
@@ -469,18 +289,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x8000000000000001:
   c.sb x8, 1(x12) # perform store
   addi x12, x12, 1 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zcb_c_sb_cg_cp_rs2_edges_0x8000000000000001, Zcb_c_sb_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  c.sb x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x7fffffffffffffff
@@ -490,18 +301,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x7fffffffffffffff:
   c.sb x14, 1(x9) # perform store
   addi x9, x9, 1 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zcb_c_sb_cg_cp_rs2_edges_0x7fffffffffffffff, Zcb_c_sb_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  c.sb x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x7ffffffffffffffe
@@ -511,18 +313,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x7ffffffffffffffe:
   c.sb x10, 0(x8) # perform store
   addi x8, x8, 0 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_edges_0x7ffffffffffffffe, Zcb_c_sb_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  c.sb x10, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xffffffffffffffff
@@ -532,18 +325,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0xffffffffffffffff:
   c.sb x14, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zcb_c_sb_cg_cp_rs2_edges_0xffffffffffffffff, Zcb_c_sb_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  c.sb x14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xfffffffffffffffe
@@ -553,18 +337,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0xfffffffffffffffe:
   c.sb x12, 1(x13) # perform store
   addi x13, x13, 1 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zcb_c_sb_cg_cp_rs2_edges_0xfffffffffffffffe, Zcb_c_sb_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  c.sb x12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x5bbc887763ae86f2
@@ -574,18 +349,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   c.sb x15, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zcb_c_sb_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zcb_c_sb_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  c.sb x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xaaaaaaaaaaaaaaaa
@@ -595,18 +361,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   c.sb x9, 1(x8) # perform store
   addi x8, x8, 1 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zcb_c_sb_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zcb_c_sb_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  c.sb x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x5555555555555555
@@ -616,18 +373,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x5555555555555555:
   c.sb x10, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, Zcb_c_sb_cg_cp_rs2_edges_0x5555555555555555, Zcb_c_sb_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  c.sb x10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x00000000ffffffff
@@ -637,18 +385,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0xffffffff:
   c.sb x14, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x9 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x9, Zcb_c_sb_cg_cp_rs2_edges_0xffffffff, Zcb_c_sb_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  c.sb x14, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x00000000fffffffe
@@ -658,18 +397,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0xfffffffe:
   c.sb x15, 3(x11) # perform store
   addi x11, x11, 3 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zcb_c_sb_cg_cp_rs2_edges_0xfffffffe, Zcb_c_sb_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  c.sb x15, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x0000000100000000
@@ -679,18 +409,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x100000000:
   c.sb x9, 1(x8) # perform store
   addi x8, x8, 1 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x13 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x13, Zcb_c_sb_cg_cp_rs2_edges_0x100000000, Zcb_c_sb_cg_cp_rs2_edges_0x100000000_str)
-#else
-  c.sb x9, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x0000000100000001
@@ -700,18 +421,9 @@ Zcb_c_sb_cg_cp_rs2_edges_0x100000001:
   c.sb x15, 1(x13) # perform store
   addi x13, x13, 1 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x10 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x10, Zcb_c_sb_cg_cp_rs2_edges_0x100000001, Zcb_c_sb_cg_cp_rs2_edges_0x100000001_str)
-#else
-  c.sb x15, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x13 # restore signature pointer to default register for teardown
 

--- a/tests/rv64i/Zcb/Zcb-c.sh-00.S
+++ b/tests/rv64i/Zcb/Zcb-c.sh-00.S
@@ -41,18 +41,9 @@ Zcb_c_sh_cg_cp_rs1_p_b8:
   c.sh x13, 2(x8) # perform store
   addi x8, x8, 2 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zcb_c_sh_cg_cp_rs1_p_b8, Zcb_c_sh_cg_cp_rs1_p_b8_str)
-#else
-  c.sh x13, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xf3676ccfd39a867e
@@ -62,18 +53,9 @@ Zcb_c_sh_cg_cp_rs1_p_b9:
   c.sh x14, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zcb_c_sh_cg_cp_rs1_p_b9, Zcb_c_sh_cg_cp_rs1_p_b9_str)
-#else
-  c.sh x14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x112b1c6395c7a112
@@ -83,18 +65,9 @@ Zcb_c_sh_cg_cp_rs1_p_b10:
   c.sh x8, 2(x10) # perform store
   addi x10, x10, 2 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zcb_c_sh_cg_cp_rs1_p_b10, Zcb_c_sh_cg_cp_rs1_p_b10_str)
-#else
-  c.sh x8, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xd8bbf0d74259286d
@@ -104,18 +77,9 @@ Zcb_c_sh_cg_cp_rs1_p_b11:
   c.sh x13, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x12, Zcb_c_sh_cg_cp_rs1_p_b11, Zcb_c_sh_cg_cp_rs1_p_b11_str)
-#else
-  c.sh x13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x7df6acc5b6917598
@@ -125,18 +89,9 @@ Zcb_c_sh_cg_cp_rs1_p_b12:
   c.sh x9, 0(x12) # perform store
   addi x12, x12, 0 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zcb_c_sh_cg_cp_rs1_p_b12, Zcb_c_sh_cg_cp_rs1_p_b12_str)
-#else
-  c.sh x9, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xd67330968f41e2db
@@ -146,18 +101,9 @@ Zcb_c_sh_cg_cp_rs1_p_b13:
   c.sh x9, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zcb_c_sh_cg_cp_rs1_p_b13, Zcb_c_sh_cg_cp_rs1_p_b13_str)
-#else
-  c.sh x9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x14)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xaf65f4d88abeb76c
@@ -167,18 +113,9 @@ Zcb_c_sh_cg_cp_rs1_p_b14:
   c.sh x12, 2(x14) # perform store
   addi x14, x14, 2 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x15 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x15, Zcb_c_sh_cg_cp_rs1_p_b14, Zcb_c_sh_cg_cp_rs1_p_b14_str)
-#else
-  c.sh x12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs1_p (Test source rs1 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xb5f18ed9dc8f00fc
@@ -188,18 +125,9 @@ Zcb_c_sh_cg_cp_rs1_p_b15:
   c.sh x11, 0(x15) # perform store
   addi x15, x15, 0 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, Zcb_c_sh_cg_cp_rs1_p_b15, Zcb_c_sh_cg_cp_rs1_p_b15_str)
-#else
-  c.sh x11, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_p
@@ -213,18 +141,9 @@ Zcb_c_sh_cg_cp_rs2_p_b8:
   c.sh x8, 0(x12) # perform store
   addi x12, x12, 0 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zcb_c_sh_cg_cp_rs2_p_b8, Zcb_c_sh_cg_cp_rs2_p_b8_str)
-#else
-  c.sh x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x9)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x3ed656cc12900675
@@ -234,18 +153,9 @@ Zcb_c_sh_cg_cp_rs2_p_b9:
   c.sh x9, 2(x13) # perform store
   addi x13, x13, 2 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_p_b9, Zcb_c_sh_cg_cp_rs2_p_b9_str)
-#else
-  c.sh x9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x10)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xaaa77ada0cea1e27
@@ -255,18 +165,9 @@ Zcb_c_sh_cg_cp_rs2_p_b10:
   c.sh x10, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zcb_c_sh_cg_cp_rs2_p_b10, Zcb_c_sh_cg_cp_rs2_p_b10_str)
-#else
-  c.sh x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x11)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x9f08f76c1bc8f8c8
@@ -276,18 +177,9 @@ Zcb_c_sh_cg_cp_rs2_p_b11:
   c.sh x11, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zcb_c_sh_cg_cp_rs2_p_b11, Zcb_c_sh_cg_cp_rs2_p_b11_str)
-#else
-  c.sh x11, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x12)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xa8095977d9d3a876
@@ -297,18 +189,9 @@ Zcb_c_sh_cg_cp_rs2_p_b12:
   c.sh x12, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zcb_c_sh_cg_cp_rs2_p_b12, Zcb_c_sh_cg_cp_rs2_p_b12_str)
-#else
-  c.sh x12, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x13)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xa81a03d8effb4b03
@@ -318,18 +201,9 @@ Zcb_c_sh_cg_cp_rs2_p_b13:
   c.sh x13, 2(x14) # perform store
   addi x14, x14, 2 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x15 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_p_b13, Zcb_c_sh_cg_cp_rs2_p_b13_str)
-#else
-  c.sh x13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x16, x14 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rs2_p (Test source rs2 = x14)
@@ -340,18 +214,9 @@ Zcb_c_sh_cg_cp_rs2_p_b14:
   c.sh x14, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zcb_c_sh_cg_cp_rs2_p_b14, Zcb_c_sh_cg_cp_rs2_p_b14_str)
-#else
-  c.sh x14, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_p (Test source rs2 = x15)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x434150b61f904267
@@ -361,18 +226,9 @@ Zcb_c_sh_cg_cp_rs2_p_b15:
   c.sh x15, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x13 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x13, Zcb_c_sh_cg_cp_rs2_p_b15, Zcb_c_sh_cg_cp_rs2_p_b15_str)
-#else
-  c.sh x15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 /////////////////////////////////
 // cp_rs2_edges
@@ -386,18 +242,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x0:
   c.sh x15, 0(x14) # perform store
   addi x14, x14, 0 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x11 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x11, Zcb_c_sh_cg_cp_rs2_edges_0x0, Zcb_c_sh_cg_cp_rs2_edges_0x0_str)
-#else
-  c.sh x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x0000000000000001
@@ -407,18 +254,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x1:
   c.sh x10, 0(x13) # perform store
   addi x13, x13, 0 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x15 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_edges_0x1, Zcb_c_sh_cg_cp_rs2_edges_0x1_str)
-#else
-  c.sh x10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x0000000000000002
@@ -428,18 +266,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x2:
   c.sh x12, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, Zcb_c_sh_cg_cp_rs2_edges_0x2, Zcb_c_sh_cg_cp_rs2_edges_0x2_str)
-#else
-  c.sh x12, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x8000000000000000
@@ -449,18 +278,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x8000000000000000:
   c.sh x10, 2(x9) # perform store
   addi x9, x9, 2 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zcb_c_sh_cg_cp_rs2_edges_0x8000000000000000, Zcb_c_sh_cg_cp_rs2_edges_0x8000000000000000_str)
-#else
-  c.sh x10, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x8000000000000001
@@ -470,18 +290,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x8000000000000001:
   c.sh x8, 2(x10) # perform store
   addi x10, x10, 2 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zcb_c_sh_cg_cp_rs2_edges_0x8000000000000001, Zcb_c_sh_cg_cp_rs2_edges_0x8000000000000001_str)
-#else
-  c.sh x8, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x7fffffffffffffff
@@ -491,18 +302,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x7fffffffffffffff:
   c.sh x11, 2(x15) # perform store
   addi x15, x15, 2 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zcb_c_sh_cg_cp_rs2_edges_0x7fffffffffffffff, Zcb_c_sh_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-#else
-  c.sh x11, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x7ffffffffffffffe
@@ -512,18 +314,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x7ffffffffffffffe:
   c.sh x10, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x13 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x13, Zcb_c_sh_cg_cp_rs2_edges_0x7ffffffffffffffe, Zcb_c_sh_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-#else
-  c.sh x10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xffffffffffffffff
@@ -533,18 +326,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0xffffffffffffffff:
   c.sh x9, 0(x15) # perform store
   addi x15, x15, 0 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x10, Zcb_c_sh_cg_cp_rs2_edges_0xffffffffffffffff, Zcb_c_sh_cg_cp_rs2_edges_0xffffffffffffffff_str)
-#else
-  c.sh x9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xfffffffffffffffe
@@ -554,18 +338,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0xfffffffffffffffe:
   c.sh x14, 0(x11) # perform store
   addi x11, x11, 0 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zcb_c_sh_cg_cp_rs2_edges_0xfffffffffffffffe, Zcb_c_sh_cg_cp_rs2_edges_0xfffffffffffffffe_str)
-#else
-  c.sh x14, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x5bbc887763ae86f2
@@ -575,18 +350,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x5bbc887763ae86f2:
   c.sh x13, 2(x9) # perform store
   addi x9, x9, 2 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zcb_c_sh_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
-#else
-  c.sh x13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xaaaaaaaaaaaaaaaa
@@ -596,18 +362,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
   c.sh x15, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x11, Zcb_c_sh_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zcb_c_sh_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
-#else
-  c.sh x15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x5555555555555555
@@ -617,18 +374,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x5555555555555555:
   c.sh x9, 0(x10) # perform store
   addi x10, x10, 0 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x8, Zcb_c_sh_cg_cp_rs2_edges_0x5555555555555555, Zcb_c_sh_cg_cp_rs2_edges_0x5555555555555555_str)
-#else
-  c.sh x9, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x00000000ffffffff
@@ -638,18 +386,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0xffffffff:
   c.sh x8, 2(x11) # perform store
   addi x11, x11, 2 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zcb_c_sh_cg_cp_rs2_edges_0xffffffff, Zcb_c_sh_cg_cp_rs2_edges_0xffffffff_str)
-#else
-  c.sh x8, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x00000000fffffffe
@@ -659,18 +398,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0xfffffffe:
   c.sh x8, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x15 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_edges_0xfffffffe, Zcb_c_sh_cg_cp_rs2_edges_0xfffffffe_str)
-#else
-  c.sh x8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x0000000100000000
@@ -680,18 +410,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x100000000:
   c.sh x8, 0(x9) # perform store
   addi x9, x9, 0 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zcb_c_sh_cg_cp_rs2_edges_0x100000000, Zcb_c_sh_cg_cp_rs2_edges_0x100000000_str)
-#else
-  c.sh x8, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x0000000100000001
@@ -701,18 +422,9 @@ Zcb_c_sh_cg_cp_rs2_edges_0x100000001:
   c.sh x15, 2(x14) # perform store
   addi x14, x14, 2 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x13 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x13, Zcb_c_sh_cg_cp_rs2_edges_0x100000001, Zcb_c_sh_cg_cp_rs2_edges_0x100000001_str)
-#else
-  c.sh x15, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
 
   mv x2, x14 # restore signature pointer to default register for teardown
 

--- a/tests/rv64i/Zcd/Zcd-c.fsd-00.S
+++ b/tests/rv64i/Zcd/Zcd-c.fsd-00.S
@@ -42,18 +42,9 @@ Zcd_c_fsd_cg_cp_rs1_p_b8:
   c.fsd f11, 64(x8) # perform store
   addi x8, x8, 64 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zcd_c_fsd_cg_cp_rs1_p_b8, Zcd_c_fsd_cg_cp_rs1_p_b8_str)
-#else
-  c.fsd f11, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zcd_c_fsd_cg_cp_rs1_p_b8, Zcd_c_fsd_cg_cp_rs1_p_b8_str)
 
@@ -66,18 +57,9 @@ Zcd_c_fsd_cg_cp_rs1_p_b9:
   c.fsd f13, 168(x9) # perform store
   addi x9, x9, 168 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zcd_c_fsd_cg_cp_rs1_p_b9, Zcd_c_fsd_cg_cp_rs1_p_b9_str)
-#else
-  c.fsd f13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcd_c_fsd_cg_cp_rs1_p_b9, Zcd_c_fsd_cg_cp_rs1_p_b9_str)
 
@@ -90,18 +72,9 @@ Zcd_c_fsd_cg_cp_rs1_p_b10:
   c.fsd f14, 208(x10) # perform store
   addi x10, x10, 208 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x11 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x11, Zcd_c_fsd_cg_cp_rs1_p_b10, Zcd_c_fsd_cg_cp_rs1_p_b10_str)
-#else
-  c.fsd f14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcd_c_fsd_cg_cp_rs1_p_b10, Zcd_c_fsd_cg_cp_rs1_p_b10_str)
 
@@ -114,18 +87,9 @@ Zcd_c_fsd_cg_cp_rs1_p_b11:
   c.fsd f10, 248(x11) # perform store
   addi x11, x11, 248 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zcd_c_fsd_cg_cp_rs1_p_b11, Zcd_c_fsd_cg_cp_rs1_p_b11_str)
-#else
-  c.fsd f10, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zcd_c_fsd_cg_cp_rs1_p_b11, Zcd_c_fsd_cg_cp_rs1_p_b11_str)
 
@@ -138,18 +102,9 @@ Zcd_c_fsd_cg_cp_rs1_p_b12:
   c.fsd f11, 248(x12) # perform store
   addi x12, x12, 248 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x9 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x9, Zcd_c_fsd_cg_cp_rs1_p_b12, Zcd_c_fsd_cg_cp_rs1_p_b12_str)
-#else
-  c.fsd f11, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcd_c_fsd_cg_cp_rs1_p_b12, Zcd_c_fsd_cg_cp_rs1_p_b12_str)
 
@@ -162,18 +117,9 @@ Zcd_c_fsd_cg_cp_rs1_p_b13:
   c.fsd f11, 232(x13) # perform store
   addi x13, x13, 232 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, Zcd_c_fsd_cg_cp_rs1_p_b13, Zcd_c_fsd_cg_cp_rs1_p_b13_str)
-#else
-  c.fsd f11, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zcd_c_fsd_cg_cp_rs1_p_b13, Zcd_c_fsd_cg_cp_rs1_p_b13_str)
 
@@ -186,18 +132,9 @@ Zcd_c_fsd_cg_cp_rs1_p_b14:
   c.fsd f14, 232(x14) # perform store
   addi x14, x14, 232 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x11 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x11, Zcd_c_fsd_cg_cp_rs1_p_b14, Zcd_c_fsd_cg_cp_rs1_p_b14_str)
-#else
-  c.fsd f14, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcd_c_fsd_cg_cp_rs1_p_b14, Zcd_c_fsd_cg_cp_rs1_p_b14_str)
 
@@ -210,18 +147,9 @@ Zcd_c_fsd_cg_cp_rs1_p_b15:
   c.fsd f13, 216(x15) # perform store
   addi x15, x15, 216 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x13, Zcd_c_fsd_cg_cp_rs1_p_b15, Zcd_c_fsd_cg_cp_rs1_p_b15_str)
-#else
-  c.fsd f13, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcd_c_fsd_cg_cp_rs1_p_b15, Zcd_c_fsd_cg_cp_rs1_p_b15_str)
 
@@ -238,18 +166,9 @@ Zcd_c_fsd_cg_cp_fs2_p_b8:
   c.fsd f8, 72(x12) # perform store
   addi x12, x12, 72 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, Zcd_c_fsd_cg_cp_fs2_p_b8, Zcd_c_fsd_cg_cp_fs2_p_b8_str)
-#else
-  c.fsd f8, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcd_c_fsd_cg_cp_fs2_p_b8, Zcd_c_fsd_cg_cp_fs2_p_b8_str)
 
@@ -262,18 +181,9 @@ Zcd_c_fsd_cg_cp_fs2_p_b9:
   c.fsd f9, 16(x15) # perform store
   addi x15, x15, 16 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x13, Zcd_c_fsd_cg_cp_fs2_p_b9, Zcd_c_fsd_cg_cp_fs2_p_b9_str)
-#else
-  c.fsd f9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcd_c_fsd_cg_cp_fs2_p_b9, Zcd_c_fsd_cg_cp_fs2_p_b9_str)
 
@@ -286,18 +196,9 @@ Zcd_c_fsd_cg_cp_fs2_p_b10:
   c.fsd f10, 88(x10) # perform store
   addi x10, x10, 88 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x9 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x9, Zcd_c_fsd_cg_cp_fs2_p_b10, Zcd_c_fsd_cg_cp_fs2_p_b10_str)
-#else
-  c.fsd f10, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcd_c_fsd_cg_cp_fs2_p_b10, Zcd_c_fsd_cg_cp_fs2_p_b10_str)
 
@@ -310,18 +211,9 @@ Zcd_c_fsd_cg_cp_fs2_p_b11:
   c.fsd f11, 136(x8) # perform store
   addi x8, x8, 136 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zcd_c_fsd_cg_cp_fs2_p_b11, Zcd_c_fsd_cg_cp_fs2_p_b11_str)
-#else
-  c.fsd f11, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zcd_c_fsd_cg_cp_fs2_p_b11, Zcd_c_fsd_cg_cp_fs2_p_b11_str)
 
@@ -334,18 +226,9 @@ Zcd_c_fsd_cg_cp_fs2_p_b12:
   c.fsd f12, 208(x14) # perform store
   addi x14, x14, 208 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zcd_c_fsd_cg_cp_fs2_p_b12, Zcd_c_fsd_cg_cp_fs2_p_b12_str)
-#else
-  c.fsd f12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcd_c_fsd_cg_cp_fs2_p_b12, Zcd_c_fsd_cg_cp_fs2_p_b12_str)
 
@@ -358,18 +241,9 @@ Zcd_c_fsd_cg_cp_fs2_p_b13:
   c.fsd f13, 16(x11) # perform store
   addi x11, x11, 16 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zcd_c_fsd_cg_cp_fs2_p_b13, Zcd_c_fsd_cg_cp_fs2_p_b13_str)
-#else
-  c.fsd f13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zcd_c_fsd_cg_cp_fs2_p_b13, Zcd_c_fsd_cg_cp_fs2_p_b13_str)
 
@@ -382,18 +256,9 @@ Zcd_c_fsd_cg_cp_fs2_p_b14:
   c.fsd f14, 184(x15) # perform store
   addi x15, x15, 184 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x9 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x9, Zcd_c_fsd_cg_cp_fs2_p_b14, Zcd_c_fsd_cg_cp_fs2_p_b14_str)
-#else
-  c.fsd f14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcd_c_fsd_cg_cp_fs2_p_b14, Zcd_c_fsd_cg_cp_fs2_p_b14_str)
 
@@ -406,18 +271,9 @@ Zcd_c_fsd_cg_cp_fs2_p_b15:
   c.fsd f15, 104(x10) # perform store
   addi x10, x10, 104 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x9 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x9, Zcd_c_fsd_cg_cp_fs2_p_b15, Zcd_c_fsd_cg_cp_fs2_p_b15_str)
-#else
-  c.fsd f15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcd_c_fsd_cg_cp_fs2_p_b15, Zcd_c_fsd_cg_cp_fs2_p_b15_str)
 
@@ -434,18 +290,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x0:
   c.fsd f13, 0(x14) # perform store
   addi x14, x14, 0 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x11 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x11, Zcd_c_fsd_cg_cp_imm_mul_8_b0x0, Zcd_c_fsd_cg_cp_imm_mul_8_b0x0_str)
-#else
-  c.fsd f13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x0, Zcd_c_fsd_cg_cp_imm_mul_8_b0x0_str)
 
@@ -458,18 +305,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x8:
   c.fsd f9, 8(x13) # perform store
   addi x13, x13, 8 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x10 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x10, Zcd_c_fsd_cg_cp_imm_mul_8_b0x8, Zcd_c_fsd_cg_cp_imm_mul_8_b0x8_str)
-#else
-  c.fsd f9, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x8, Zcd_c_fsd_cg_cp_imm_mul_8_b0x8_str)
 
@@ -482,18 +320,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x10:
   c.fsd f14, 16(x10) # perform store
   addi x10, x10, 16 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x11 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x11, Zcd_c_fsd_cg_cp_imm_mul_8_b0x10, Zcd_c_fsd_cg_cp_imm_mul_8_b0x10_str)
-#else
-  c.fsd f14, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x10, Zcd_c_fsd_cg_cp_imm_mul_8_b0x10_str)
 
@@ -506,18 +335,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x18:
   c.fsd f10, 24(x12) # perform store
   addi x12, x12, 24 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x13 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x13, Zcd_c_fsd_cg_cp_imm_mul_8_b0x18, Zcd_c_fsd_cg_cp_imm_mul_8_b0x18_str)
-#else
-  c.fsd f10, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x18, Zcd_c_fsd_cg_cp_imm_mul_8_b0x18_str)
 
@@ -530,18 +350,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x20:
   c.fsd f8, 32(x8) # perform store
   addi x8, x8, 32 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zcd_c_fsd_cg_cp_imm_mul_8_b0x20, Zcd_c_fsd_cg_cp_imm_mul_8_b0x20_str)
-#else
-  c.fsd f8, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x20, Zcd_c_fsd_cg_cp_imm_mul_8_b0x20_str)
 
@@ -554,18 +365,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x28:
   c.fsd f8, 40(x10) # perform store
   addi x10, x10, 40 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x12 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x12, Zcd_c_fsd_cg_cp_imm_mul_8_b0x28, Zcd_c_fsd_cg_cp_imm_mul_8_b0x28_str)
-#else
-  c.fsd f8, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x28, Zcd_c_fsd_cg_cp_imm_mul_8_b0x28_str)
 
@@ -578,18 +380,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x30:
   c.fsd f10, 48(x15) # perform store
   addi x15, x15, 48 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x13, Zcd_c_fsd_cg_cp_imm_mul_8_b0x30, Zcd_c_fsd_cg_cp_imm_mul_8_b0x30_str)
-#else
-  c.fsd f10, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x30, Zcd_c_fsd_cg_cp_imm_mul_8_b0x30_str)
 
@@ -602,18 +395,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x38:
   c.fsd f12, 56(x13) # perform store
   addi x13, x13, 56 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zcd_c_fsd_cg_cp_imm_mul_8_b0x38, Zcd_c_fsd_cg_cp_imm_mul_8_b0x38_str)
-#else
-  c.fsd f12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x38, Zcd_c_fsd_cg_cp_imm_mul_8_b0x38_str)
 
@@ -626,18 +410,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x40:
   c.fsd f13, 64(x10) # perform store
   addi x10, x10, 64 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x14 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x14, Zcd_c_fsd_cg_cp_imm_mul_8_b0x40, Zcd_c_fsd_cg_cp_imm_mul_8_b0x40_str)
-#else
-  c.fsd f13, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x40, Zcd_c_fsd_cg_cp_imm_mul_8_b0x40_str)
 
@@ -650,18 +425,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x48:
   c.fsd f14, 72(x15) # perform store
   addi x15, x15, 72 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x13, Zcd_c_fsd_cg_cp_imm_mul_8_b0x48, Zcd_c_fsd_cg_cp_imm_mul_8_b0x48_str)
-#else
-  c.fsd f14, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x48, Zcd_c_fsd_cg_cp_imm_mul_8_b0x48_str)
 
@@ -674,18 +440,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x50:
   c.fsd f11, 80(x8) # perform store
   addi x8, x8, 80 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zcd_c_fsd_cg_cp_imm_mul_8_b0x50, Zcd_c_fsd_cg_cp_imm_mul_8_b0x50_str)
-#else
-  c.fsd f11, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x50, Zcd_c_fsd_cg_cp_imm_mul_8_b0x50_str)
 
@@ -698,18 +455,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x58:
   c.fsd f12, 88(x14) # perform store
   addi x14, x14, 88 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x11 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x11, Zcd_c_fsd_cg_cp_imm_mul_8_b0x58, Zcd_c_fsd_cg_cp_imm_mul_8_b0x58_str)
-#else
-  c.fsd f12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x58, Zcd_c_fsd_cg_cp_imm_mul_8_b0x58_str)
 
@@ -722,18 +470,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x60:
   c.fsd f12, 96(x8) # perform store
   addi x8, x8, 96 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x11 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x11, Zcd_c_fsd_cg_cp_imm_mul_8_b0x60, Zcd_c_fsd_cg_cp_imm_mul_8_b0x60_str)
-#else
-  c.fsd f12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x60, Zcd_c_fsd_cg_cp_imm_mul_8_b0x60_str)
 
@@ -746,18 +485,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x68:
   c.fsd f8, 104(x15) # perform store
   addi x15, x15, 104 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x11 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x11, Zcd_c_fsd_cg_cp_imm_mul_8_b0x68, Zcd_c_fsd_cg_cp_imm_mul_8_b0x68_str)
-#else
-  c.fsd f8, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x68, Zcd_c_fsd_cg_cp_imm_mul_8_b0x68_str)
 
@@ -770,18 +500,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x70:
   c.fsd f15, 112(x9) # perform store
   addi x9, x9, 112 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zcd_c_fsd_cg_cp_imm_mul_8_b0x70, Zcd_c_fsd_cg_cp_imm_mul_8_b0x70_str)
-#else
-  c.fsd f15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x70, Zcd_c_fsd_cg_cp_imm_mul_8_b0x70_str)
 
@@ -794,18 +515,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x78:
   c.fsd f11, 120(x10) # perform store
   addi x10, x10, 120 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x15 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x15, Zcd_c_fsd_cg_cp_imm_mul_8_b0x78, Zcd_c_fsd_cg_cp_imm_mul_8_b0x78_str)
-#else
-  c.fsd f11, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x78, Zcd_c_fsd_cg_cp_imm_mul_8_b0x78_str)
 
@@ -818,18 +530,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x80:
   c.fsd f10, 128(x15) # perform store
   addi x15, x15, 128 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x11 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x11, Zcd_c_fsd_cg_cp_imm_mul_8_b0x80, Zcd_c_fsd_cg_cp_imm_mul_8_b0x80_str)
-#else
-  c.fsd f10, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x80, Zcd_c_fsd_cg_cp_imm_mul_8_b0x80_str)
 
@@ -842,18 +545,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x88:
   c.fsd f14, 136(x14) # perform store
   addi x14, x14, 136 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x9 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x9, Zcd_c_fsd_cg_cp_imm_mul_8_b0x88, Zcd_c_fsd_cg_cp_imm_mul_8_b0x88_str)
-#else
-  c.fsd f14, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x88, Zcd_c_fsd_cg_cp_imm_mul_8_b0x88_str)
 
@@ -866,18 +560,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x90:
   c.fsd f10, 144(x8) # perform store
   addi x8, x8, 144 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zcd_c_fsd_cg_cp_imm_mul_8_b0x90, Zcd_c_fsd_cg_cp_imm_mul_8_b0x90_str)
-#else
-  c.fsd f10, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x90, Zcd_c_fsd_cg_cp_imm_mul_8_b0x90_str)
 
@@ -890,18 +575,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0x98:
   c.fsd f13, 152(x11) # perform store
   addi x11, x11, 152 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x9, Zcd_c_fsd_cg_cp_imm_mul_8_b0x98, Zcd_c_fsd_cg_cp_imm_mul_8_b0x98_str)
-#else
-  c.fsd f13, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0x98, Zcd_c_fsd_cg_cp_imm_mul_8_b0x98_str)
 
@@ -914,18 +590,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xa0:
   c.fsd f11, 160(x13) # perform store
   addi x13, x13, 160 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, Zcd_c_fsd_cg_cp_imm_mul_8_b0xa0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xa0_str)
-#else
-  c.fsd f11, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xa0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xa0_str)
 
@@ -938,18 +605,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xa8:
   c.fsd f11, 168(x12) # perform store
   addi x12, x12, 168 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x15 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x15, Zcd_c_fsd_cg_cp_imm_mul_8_b0xa8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xa8_str)
-#else
-  c.fsd f11, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xa8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xa8_str)
 
@@ -962,18 +620,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xb0:
   c.fsd f15, 176(x9) # perform store
   addi x9, x9, 176 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zcd_c_fsd_cg_cp_imm_mul_8_b0xb0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xb0_str)
-#else
-  c.fsd f15, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xb0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xb0_str)
 
@@ -986,18 +635,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xb8:
   c.fsd f15, 184(x12) # perform store
   addi x12, x12, 184 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xb8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xb8_str)
-#else
-  c.fsd f15, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xb8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xb8_str)
 
@@ -1010,18 +650,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xc0:
   c.fsd f12, 192(x8) # perform store
   addi x8, x8, 192 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x10 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x10, Zcd_c_fsd_cg_cp_imm_mul_8_b0xc0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xc0_str)
-#else
-  c.fsd f12, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xc0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xc0_str)
 
@@ -1034,18 +665,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xc8:
   c.fsd f11, 200(x12) # perform store
   addi x12, x12, 200 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x9 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x9, Zcd_c_fsd_cg_cp_imm_mul_8_b0xc8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xc8_str)
-#else
-  c.fsd f11, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xc8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xc8_str)
 
@@ -1058,18 +680,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xd0:
   c.fsd f12, 208(x10) # perform store
   addi x10, x10, 208 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x9 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x9, Zcd_c_fsd_cg_cp_imm_mul_8_b0xd0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xd0_str)
-#else
-  c.fsd f12, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xd0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xd0_str)
 
@@ -1082,18 +695,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xd8:
   c.fsd f14, 216(x13) # perform store
   addi x13, x13, 216 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x12 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x12, Zcd_c_fsd_cg_cp_imm_mul_8_b0xd8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xd8_str)
-#else
-  c.fsd f14, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xd8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xd8_str)
 
@@ -1106,18 +710,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xe0:
   c.fsd f13, 224(x9) # perform store
   addi x9, x9, 224 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xe0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xe0_str)
-#else
-  c.fsd f13, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xe0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xe0_str)
 
@@ -1130,18 +725,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xe8:
   c.fsd f9, 232(x11) # perform store
   addi x11, x11, 232 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xe8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xe8_str)
-#else
-  c.fsd f9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xe8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xe8_str)
 
@@ -1154,18 +740,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xf0:
   c.fsd f12, 240(x15) # perform store
   addi x15, x15, 240 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x8 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xf0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xf0_str)
-#else
-  c.fsd f12, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xf0, Zcd_c_fsd_cg_cp_imm_mul_8_b0xf0_str)
 
@@ -1178,18 +755,9 @@ Zcd_c_fsd_cg_cp_imm_mul_8_b0xf8:
   c.fsd f11, 248(x8) # perform store
   addi x8, x8, 248 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x9 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x9, Zcd_c_fsd_cg_cp_imm_mul_8_b0xf8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xf8_str)
-#else
-  c.fsd f11, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zcd_c_fsd_cg_cp_imm_mul_8_b0xf8, Zcd_c_fsd_cg_cp_imm_mul_8_b0xf8_str)
 

--- a/tests/rv64i/Zfbfmin/Zfbfmin-fsh-00.S
+++ b/tests/rv64i/Zfbfmin/Zfbfmin-fsh-00.S
@@ -42,18 +42,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b1:
   fsh f26, -120(x1) # perform store
   addi x1, x1, -120 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x26 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x26, Zfbfmin_fsh_cg_cp_rs1_nx0_b1, Zfbfmin_fsh_cg_cp_rs1_nx0_b1_str)
-#else
-  fsh f26, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b1, Zfbfmin_fsh_cg_cp_rs1_nx0_b1_str)
 
@@ -66,18 +57,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b2:
   fsh f3, 1312(x2) # perform store
   addi x2, x2, 1312 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x6 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x6, Zfbfmin_fsh_cg_cp_rs1_nx0_b2, Zfbfmin_fsh_cg_cp_rs1_nx0_b2_str)
-#else
-  fsh f3, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b2, Zfbfmin_fsh_cg_cp_rs1_nx0_b2_str)
 
@@ -91,18 +73,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b3:
   fsh f17, -268(x3) # perform store
   addi x3, x3, -268 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x12 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x12, Zfbfmin_fsh_cg_cp_rs1_nx0_b3, Zfbfmin_fsh_cg_cp_rs1_nx0_b3_str)
-#else
-  fsh f17, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b3, Zfbfmin_fsh_cg_cp_rs1_nx0_b3_str)
 
@@ -117,18 +90,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b4:
   fsh f15, -1082(x4) # perform store
   addi x4, x4, -1082 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x25 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x25, Zfbfmin_fsh_cg_cp_rs1_nx0_b4, Zfbfmin_fsh_cg_cp_rs1_nx0_b4_str)
-#else
-  fsh f15, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x4, x8, x7, Zfbfmin_fsh_cg_cp_rs1_nx0_b4, Zfbfmin_fsh_cg_cp_rs1_nx0_b4_str)
 
@@ -141,18 +105,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b5:
   fsh f25, 1943(x5) # perform store
   addi x5, x5, 1943 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x9 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x9, Zfbfmin_fsh_cg_cp_rs1_nx0_b5, Zfbfmin_fsh_cg_cp_rs1_nx0_b5_str)
-#else
-  fsh f25, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x5, x8, x7, Zfbfmin_fsh_cg_cp_rs1_nx0_b5, Zfbfmin_fsh_cg_cp_rs1_nx0_b5_str)
 
@@ -165,18 +120,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b6:
   fsh f6, 968(x6) # perform store
   addi x6, x6, 968 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x27 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x27, Zfbfmin_fsh_cg_cp_rs1_nx0_b6, Zfbfmin_fsh_cg_cp_rs1_nx0_b6_str)
-#else
-  fsh f6, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x8, x7, Zfbfmin_fsh_cg_cp_rs1_nx0_b6, Zfbfmin_fsh_cg_cp_rs1_nx0_b6_str)
 
@@ -191,18 +137,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b7:
   fsh f31, -1761(x7) # perform store
   addi x7, x7, -1761 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x4 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b7, Zfbfmin_fsh_cg_cp_rs1_nx0_b7_str)
-#else
-  fsh f31, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x14, x13, Zfbfmin_fsh_cg_cp_rs1_nx0_b7, Zfbfmin_fsh_cg_cp_rs1_nx0_b7_str)
 
@@ -215,18 +152,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b8:
   fsh f27, -1102(x8) # perform store
   addi x8, x8, -1102 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x4 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b8, Zfbfmin_fsh_cg_cp_rs1_nx0_b8_str)
-#else
-  fsh f27, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x14, x13, Zfbfmin_fsh_cg_cp_rs1_nx0_b8, Zfbfmin_fsh_cg_cp_rs1_nx0_b8_str)
 
@@ -239,18 +167,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b9:
   fsh f2, 361(x9) # perform store
   addi x9, x9, 361 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x23 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x23, Zfbfmin_fsh_cg_cp_rs1_nx0_b9, Zfbfmin_fsh_cg_cp_rs1_nx0_b9_str)
-#else
-  fsh f2, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x14, x13, Zfbfmin_fsh_cg_cp_rs1_nx0_b9, Zfbfmin_fsh_cg_cp_rs1_nx0_b9_str)
 
@@ -263,18 +182,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b10:
   fsh f6, -1868(x10) # perform store
   addi x10, x10, -1868 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x8, Zfbfmin_fsh_cg_cp_rs1_nx0_b10, Zfbfmin_fsh_cg_cp_rs1_nx0_b10_str)
-#else
-  fsh f6, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x14, x13, Zfbfmin_fsh_cg_cp_rs1_nx0_b10, Zfbfmin_fsh_cg_cp_rs1_nx0_b10_str)
 
@@ -287,18 +197,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b11:
   fsh f5, -1623(x11) # perform store
   addi x11, x11, -1623 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x5 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x5, Zfbfmin_fsh_cg_cp_rs1_nx0_b11, Zfbfmin_fsh_cg_cp_rs1_nx0_b11_str)
-#else
-  fsh f5, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x14, x13, Zfbfmin_fsh_cg_cp_rs1_nx0_b11, Zfbfmin_fsh_cg_cp_rs1_nx0_b11_str)
 
@@ -311,18 +212,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b12:
   fsh f9, -1461(x12) # perform store
   addi x12, x12, -1461 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x24 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x24, Zfbfmin_fsh_cg_cp_rs1_nx0_b12, Zfbfmin_fsh_cg_cp_rs1_nx0_b12_str)
-#else
-  fsh f9, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x14, x13, Zfbfmin_fsh_cg_cp_rs1_nx0_b12, Zfbfmin_fsh_cg_cp_rs1_nx0_b12_str)
 
@@ -337,18 +229,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b13:
   fsh f14, 58(x13) # perform store
   addi x13, x13, 58 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zfbfmin_fsh_cg_cp_rs1_nx0_b13, Zfbfmin_fsh_cg_cp_rs1_nx0_b13_str)
-#else
-  fsh f14, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b13, Zfbfmin_fsh_cg_cp_rs1_nx0_b13_str)
 
@@ -361,18 +244,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b14:
   fsh f13, -1360(x14) # perform store
   addi x14, x14, -1360 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x7 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x7, Zfbfmin_fsh_cg_cp_rs1_nx0_b14, Zfbfmin_fsh_cg_cp_rs1_nx0_b14_str)
-#else
-  fsh f13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b14, Zfbfmin_fsh_cg_cp_rs1_nx0_b14_str)
 
@@ -385,18 +259,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b15:
   fsh f30, 725(x15) # perform store
   addi x15, x15, 725 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x16 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x16, Zfbfmin_fsh_cg_cp_rs1_nx0_b15, Zfbfmin_fsh_cg_cp_rs1_nx0_b15_str)
-#else
-  fsh f30, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b15, Zfbfmin_fsh_cg_cp_rs1_nx0_b15_str)
 
@@ -409,18 +274,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b16:
   fsh f27, -512(x16) # perform store
   addi x16, x16, -512 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x17 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x17, Zfbfmin_fsh_cg_cp_rs1_nx0_b16, Zfbfmin_fsh_cg_cp_rs1_nx0_b16_str)
-#else
-  fsh f27, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b16, Zfbfmin_fsh_cg_cp_rs1_nx0_b16_str)
 
@@ -433,18 +289,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b17:
   fsh f23, -955(x17) # perform store
   addi x17, x17, -955 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x31 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x31, Zfbfmin_fsh_cg_cp_rs1_nx0_b17, Zfbfmin_fsh_cg_cp_rs1_nx0_b17_str)
-#else
-  fsh f23, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b17, Zfbfmin_fsh_cg_cp_rs1_nx0_b17_str)
 
@@ -457,18 +304,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b18:
   fsh f25, 1326(x18) # perform store
   addi x18, x18, 1326 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x13 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x13, Zfbfmin_fsh_cg_cp_rs1_nx0_b18, Zfbfmin_fsh_cg_cp_rs1_nx0_b18_str)
-#else
-  fsh f25, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b18, Zfbfmin_fsh_cg_cp_rs1_nx0_b18_str)
 
@@ -481,18 +319,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b19:
   fsh f17, 1913(x19) # perform store
   addi x19, x19, 1913 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x20 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x20, Zfbfmin_fsh_cg_cp_rs1_nx0_b19, Zfbfmin_fsh_cg_cp_rs1_nx0_b19_str)
-#else
-  fsh f17, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b19, Zfbfmin_fsh_cg_cp_rs1_nx0_b19_str)
 
@@ -505,18 +334,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b20:
   fsh f10, -1757(x20) # perform store
   addi x20, x20, -1757 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x17 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x17, Zfbfmin_fsh_cg_cp_rs1_nx0_b20, Zfbfmin_fsh_cg_cp_rs1_nx0_b20_str)
-#else
-  fsh f10, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b20, Zfbfmin_fsh_cg_cp_rs1_nx0_b20_str)
 
@@ -529,18 +349,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b21:
   fsh f8, 2043(x21) # perform store
   addi x21, x21, 2043 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x14 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x14, Zfbfmin_fsh_cg_cp_rs1_nx0_b21, Zfbfmin_fsh_cg_cp_rs1_nx0_b21_str)
-#else
-  fsh f8, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b21, Zfbfmin_fsh_cg_cp_rs1_nx0_b21_str)
 
@@ -553,18 +364,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b22:
   fsh f17, -266(x22) # perform store
   addi x22, x22, -266 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x7 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x7, Zfbfmin_fsh_cg_cp_rs1_nx0_b22, Zfbfmin_fsh_cg_cp_rs1_nx0_b22_str)
-#else
-  fsh f17, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b22, Zfbfmin_fsh_cg_cp_rs1_nx0_b22_str)
 
@@ -577,18 +379,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b23:
   fsh f22, 1721(x23) # perform store
   addi x23, x23, 1721 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x16 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x16, Zfbfmin_fsh_cg_cp_rs1_nx0_b23, Zfbfmin_fsh_cg_cp_rs1_nx0_b23_str)
-#else
-  fsh f22, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b23, Zfbfmin_fsh_cg_cp_rs1_nx0_b23_str)
 
@@ -601,18 +394,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b24:
   fsh f16, 803(x24) # perform store
   addi x24, x24, 803 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x14 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x14, Zfbfmin_fsh_cg_cp_rs1_nx0_b24, Zfbfmin_fsh_cg_cp_rs1_nx0_b24_str)
-#else
-  fsh f16, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b24, Zfbfmin_fsh_cg_cp_rs1_nx0_b24_str)
 
@@ -625,18 +409,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b25:
   fsh f24, 1777(x25) # perform store
   addi x25, x25, 1777 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x3 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x3, Zfbfmin_fsh_cg_cp_rs1_nx0_b25, Zfbfmin_fsh_cg_cp_rs1_nx0_b25_str)
-#else
-  fsh f24, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b25, Zfbfmin_fsh_cg_cp_rs1_nx0_b25_str)
 
@@ -650,18 +425,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b26:
   fsh f2, -1388(x26) # perform store
   addi x26, x26, -1388 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x17 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x17, Zfbfmin_fsh_cg_cp_rs1_nx0_b26, Zfbfmin_fsh_cg_cp_rs1_nx0_b26_str)
-#else
-  fsh f2, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b26, Zfbfmin_fsh_cg_cp_rs1_nx0_b26_str)
 
@@ -674,18 +440,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b27:
   fsh f20, -1468(x27) # perform store
   addi x27, x27, -1468 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x22 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x22, Zfbfmin_fsh_cg_cp_rs1_nx0_b27, Zfbfmin_fsh_cg_cp_rs1_nx0_b27_str)
-#else
-  fsh f20, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b27, Zfbfmin_fsh_cg_cp_rs1_nx0_b27_str)
 
@@ -698,18 +455,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b28:
   fsh f14, -95(x28) # perform store
   addi x28, x28, -95 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x17 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x17, Zfbfmin_fsh_cg_cp_rs1_nx0_b28, Zfbfmin_fsh_cg_cp_rs1_nx0_b28_str)
-#else
-  fsh f14, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b28, Zfbfmin_fsh_cg_cp_rs1_nx0_b28_str)
 
@@ -722,18 +470,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b29:
   fsh f30, -1210(x29) # perform store
   addi x29, x29, -1210 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x27 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x27, Zfbfmin_fsh_cg_cp_rs1_nx0_b29, Zfbfmin_fsh_cg_cp_rs1_nx0_b29_str)
-#else
-  fsh f30, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b29, Zfbfmin_fsh_cg_cp_rs1_nx0_b29_str)
 
@@ -746,18 +485,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b30:
   fsh f9, -1756(x30) # perform store
   addi x30, x30, -1756 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x31 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x31, Zfbfmin_fsh_cg_cp_rs1_nx0_b30, Zfbfmin_fsh_cg_cp_rs1_nx0_b30_str)
-#else
-  fsh f9, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b30, Zfbfmin_fsh_cg_cp_rs1_nx0_b30_str)
 
@@ -770,18 +500,9 @@ Zfbfmin_fsh_cg_cp_rs1_nx0_b31:
   fsh f8, -1890(x31) # perform store
   addi x31, x31, -1890 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x23 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x23, Zfbfmin_fsh_cg_cp_rs1_nx0_b31, Zfbfmin_fsh_cg_cp_rs1_nx0_b31_str)
-#else
-  fsh f8, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfbfmin_fsh_cg_cp_rs1_nx0_b31, Zfbfmin_fsh_cg_cp_rs1_nx0_b31_str)
 
@@ -798,18 +519,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x0:
   fsh f16, 0(x21) # perform store
   addi x21, x21, 0 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x13 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x13, Zfbfmin_fsh_cg_cp_imm_edges_0x0, Zfbfmin_fsh_cg_cp_imm_edges_0x0_str)
-#else
-  fsh f16, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x0, Zfbfmin_fsh_cg_cp_imm_edges_0x0_str)
 
@@ -822,18 +534,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x1:
   fsh f7, 1(x26) # perform store
   addi x26, x26, 1 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x3 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x3, Zfbfmin_fsh_cg_cp_imm_edges_0x1, Zfbfmin_fsh_cg_cp_imm_edges_0x1_str)
-#else
-  fsh f7, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x1, Zfbfmin_fsh_cg_cp_imm_edges_0x1_str)
 
@@ -846,18 +549,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x2:
   fsh f30, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x31 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x31, Zfbfmin_fsh_cg_cp_imm_edges_0x2, Zfbfmin_fsh_cg_cp_imm_edges_0x2_str)
-#else
-  fsh f30, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x2, Zfbfmin_fsh_cg_cp_imm_edges_0x2_str)
 
@@ -870,18 +564,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x3:
   fsh f13, 3(x31) # perform store
   addi x31, x31, 3 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x21 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x21, Zfbfmin_fsh_cg_cp_imm_edges_0x3, Zfbfmin_fsh_cg_cp_imm_edges_0x3_str)
-#else
-  fsh f13, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x3, Zfbfmin_fsh_cg_cp_imm_edges_0x3_str)
 
@@ -894,18 +579,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x4:
   fsh f23, 4(x2) # perform store
   addi x2, x2, 4 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x22 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x22, Zfbfmin_fsh_cg_cp_imm_edges_0x4, Zfbfmin_fsh_cg_cp_imm_edges_0x4_str)
-#else
-  fsh f23, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x4, Zfbfmin_fsh_cg_cp_imm_edges_0x4_str)
 
@@ -918,18 +594,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x8:
   fsh f21, 8(x21) # perform store
   addi x21, x21, 8 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x15 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x15, Zfbfmin_fsh_cg_cp_imm_edges_0x8, Zfbfmin_fsh_cg_cp_imm_edges_0x8_str)
-#else
-  fsh f21, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x8, Zfbfmin_fsh_cg_cp_imm_edges_0x8_str)
 
@@ -942,18 +609,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x10:
   fsh f12, 16(x16) # perform store
   addi x16, x16, 16 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x30 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x30, Zfbfmin_fsh_cg_cp_imm_edges_0x10, Zfbfmin_fsh_cg_cp_imm_edges_0x10_str)
-#else
-  fsh f12, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x10, Zfbfmin_fsh_cg_cp_imm_edges_0x10_str)
 
@@ -966,18 +624,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x20:
   fsh f13, 32(x24) # perform store
   addi x24, x24, 32 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x14 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x14, Zfbfmin_fsh_cg_cp_imm_edges_0x20, Zfbfmin_fsh_cg_cp_imm_edges_0x20_str)
-#else
-  fsh f13, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x20, Zfbfmin_fsh_cg_cp_imm_edges_0x20_str)
 
@@ -990,18 +639,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x40:
   fsh f13, 64(x27) # perform store
   addi x27, x27, 64 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x21 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x21, Zfbfmin_fsh_cg_cp_imm_edges_0x40, Zfbfmin_fsh_cg_cp_imm_edges_0x40_str)
-#else
-  fsh f13, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x40, Zfbfmin_fsh_cg_cp_imm_edges_0x40_str)
 
@@ -1014,18 +654,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x80:
   fsh f23, 128(x10) # perform store
   addi x10, x10, 128 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x7 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x7, Zfbfmin_fsh_cg_cp_imm_edges_0x80, Zfbfmin_fsh_cg_cp_imm_edges_0x80_str)
-#else
-  fsh f23, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x80, Zfbfmin_fsh_cg_cp_imm_edges_0x80_str)
 
@@ -1038,18 +669,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x100:
   fsh f10, 256(x27) # perform store
   addi x27, x27, 256 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x23 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x23, Zfbfmin_fsh_cg_cp_imm_edges_0x100, Zfbfmin_fsh_cg_cp_imm_edges_0x100_str)
-#else
-  fsh f10, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x100, Zfbfmin_fsh_cg_cp_imm_edges_0x100_str)
 
@@ -1062,18 +684,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x200:
   fsh f9, 512(x15) # perform store
   addi x15, x15, 512 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x28 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x28, Zfbfmin_fsh_cg_cp_imm_edges_0x200, Zfbfmin_fsh_cg_cp_imm_edges_0x200_str)
-#else
-  fsh f9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x200, Zfbfmin_fsh_cg_cp_imm_edges_0x200_str)
 
@@ -1086,18 +699,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x3ff:
   fsh f26, 1023(x14) # perform store
   addi x14, x14, 1023 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x18 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x18, Zfbfmin_fsh_cg_cp_imm_edges_0x3ff, Zfbfmin_fsh_cg_cp_imm_edges_0x3ff_str)
-#else
-  fsh f26, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x3ff, Zfbfmin_fsh_cg_cp_imm_edges_0x3ff_str)
 
@@ -1110,18 +714,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x400:
   fsh f18, 1024(x15) # perform store
   addi x15, x15, 1024 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, Zfbfmin_fsh_cg_cp_imm_edges_0x400, Zfbfmin_fsh_cg_cp_imm_edges_0x400_str)
-#else
-  fsh f18, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x400, Zfbfmin_fsh_cg_cp_imm_edges_0x400_str)
 
@@ -1134,18 +729,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x703:
   fsh f24, 1795(x13) # perform store
   addi x13, x13, 1795 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x27 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x27, Zfbfmin_fsh_cg_cp_imm_edges_0x703, Zfbfmin_fsh_cg_cp_imm_edges_0x703_str)
-#else
-  fsh f24, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x703, Zfbfmin_fsh_cg_cp_imm_edges_0x703_str)
 
@@ -1158,18 +744,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_0x7ff:
   fsh f15, 2047(x17) # perform store
   addi x17, x17, 2047 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x23 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x23, Zfbfmin_fsh_cg_cp_imm_edges_0x7ff, Zfbfmin_fsh_cg_cp_imm_edges_0x7ff_str)
-#else
-  fsh f15, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_0x7ff, Zfbfmin_fsh_cg_cp_imm_edges_0x7ff_str)
 
@@ -1183,18 +760,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_m0x800:
   fsh f11, -2048(x22) # perform store
   addi x22, x22, -2048 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x25 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x25, Zfbfmin_fsh_cg_cp_imm_edges_m0x800, Zfbfmin_fsh_cg_cp_imm_edges_m0x800_str)
-#else
-  fsh f11, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_m0x800, Zfbfmin_fsh_cg_cp_imm_edges_m0x800_str)
 
@@ -1207,18 +775,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_m0x7ff:
   fsh f26, -2047(x31) # perform store
   addi x31, x31, -2047 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x17 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x17, Zfbfmin_fsh_cg_cp_imm_edges_m0x7ff, Zfbfmin_fsh_cg_cp_imm_edges_m0x7ff_str)
-#else
-  fsh f26, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_m0x7ff, Zfbfmin_fsh_cg_cp_imm_edges_m0x7ff_str)
 
@@ -1231,18 +790,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_m0x2:
   fsh f25, -2(x25) # perform store
   addi x25, x25, -2 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x16 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x16, Zfbfmin_fsh_cg_cp_imm_edges_m0x2, Zfbfmin_fsh_cg_cp_imm_edges_m0x2_str)
-#else
-  fsh f25, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_m0x2, Zfbfmin_fsh_cg_cp_imm_edges_m0x2_str)
 
@@ -1255,18 +805,9 @@ Zfbfmin_fsh_cg_cp_imm_edges_m0x1:
   fsh f31, -1(x10) # perform store
   addi x10, x10, -1 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x23 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x23, Zfbfmin_fsh_cg_cp_imm_edges_m0x1, Zfbfmin_fsh_cg_cp_imm_edges_m0x1_str)
-#else
-  fsh f31, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfbfmin_fsh_cg_cp_imm_edges_m0x1, Zfbfmin_fsh_cg_cp_imm_edges_m0x1_str)
 
@@ -1283,18 +824,9 @@ Zfbfmin_fsh_cg_cp_fs2_b0:
   fsh f0, -163(x17) # perform store
   addi x17, x17, -163 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x13 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x13, Zfbfmin_fsh_cg_cp_fs2_b0, Zfbfmin_fsh_cg_cp_fs2_b0_str)
-#else
-  fsh f0, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b0, Zfbfmin_fsh_cg_cp_fs2_b0_str)
 
@@ -1307,18 +839,9 @@ Zfbfmin_fsh_cg_cp_fs2_b1:
   fsh f1, 1761(x30) # perform store
   addi x30, x30, 1761 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x12 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x12, Zfbfmin_fsh_cg_cp_fs2_b1, Zfbfmin_fsh_cg_cp_fs2_b1_str)
-#else
-  fsh f1, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b1, Zfbfmin_fsh_cg_cp_fs2_b1_str)
 
@@ -1331,18 +854,9 @@ Zfbfmin_fsh_cg_cp_fs2_b2:
   fsh f2, 1029(x23) # perform store
   addi x23, x23, 1029 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x24 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x24, Zfbfmin_fsh_cg_cp_fs2_b2, Zfbfmin_fsh_cg_cp_fs2_b2_str)
-#else
-  fsh f2, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b2, Zfbfmin_fsh_cg_cp_fs2_b2_str)
 
@@ -1355,18 +869,9 @@ Zfbfmin_fsh_cg_cp_fs2_b3:
   fsh f3, -1663(x11) # perform store
   addi x11, x11, -1663 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zfbfmin_fsh_cg_cp_fs2_b3, Zfbfmin_fsh_cg_cp_fs2_b3_str)
-#else
-  fsh f3, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b3, Zfbfmin_fsh_cg_cp_fs2_b3_str)
 
@@ -1379,18 +884,9 @@ Zfbfmin_fsh_cg_cp_fs2_b4:
   fsh f4, 166(x7) # perform store
   addi x7, x7, 166 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x16 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x16, Zfbfmin_fsh_cg_cp_fs2_b4, Zfbfmin_fsh_cg_cp_fs2_b4_str)
-#else
-  fsh f4, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b4, Zfbfmin_fsh_cg_cp_fs2_b4_str)
 
@@ -1403,18 +899,9 @@ Zfbfmin_fsh_cg_cp_fs2_b5:
   fsh f5, 221(x23) # perform store
   addi x23, x23, 221 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x25 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x25, Zfbfmin_fsh_cg_cp_fs2_b5, Zfbfmin_fsh_cg_cp_fs2_b5_str)
-#else
-  fsh f5, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b5, Zfbfmin_fsh_cg_cp_fs2_b5_str)
 
@@ -1427,18 +914,9 @@ Zfbfmin_fsh_cg_cp_fs2_b6:
   fsh f6, -1072(x13) # perform store
   addi x13, x13, -1072 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zfbfmin_fsh_cg_cp_fs2_b6, Zfbfmin_fsh_cg_cp_fs2_b6_str)
-#else
-  fsh f6, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b6, Zfbfmin_fsh_cg_cp_fs2_b6_str)
 
@@ -1451,18 +929,9 @@ Zfbfmin_fsh_cg_cp_fs2_b7:
   fsh f7, -347(x1) # perform store
   addi x1, x1, -347 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x30 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x30, Zfbfmin_fsh_cg_cp_fs2_b7, Zfbfmin_fsh_cg_cp_fs2_b7_str)
-#else
-  fsh f7, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b7, Zfbfmin_fsh_cg_cp_fs2_b7_str)
 
@@ -1475,18 +944,9 @@ Zfbfmin_fsh_cg_cp_fs2_b8:
   fsh f8, 1059(x21) # perform store
   addi x21, x21, 1059 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x26 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x26, Zfbfmin_fsh_cg_cp_fs2_b8, Zfbfmin_fsh_cg_cp_fs2_b8_str)
-#else
-  fsh f8, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b8, Zfbfmin_fsh_cg_cp_fs2_b8_str)
 
@@ -1499,18 +959,9 @@ Zfbfmin_fsh_cg_cp_fs2_b9:
   fsh f9, -838(x22) # perform store
   addi x22, x22, -838 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x15 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x15, Zfbfmin_fsh_cg_cp_fs2_b9, Zfbfmin_fsh_cg_cp_fs2_b9_str)
-#else
-  fsh f9, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b9, Zfbfmin_fsh_cg_cp_fs2_b9_str)
 
@@ -1523,18 +974,9 @@ Zfbfmin_fsh_cg_cp_fs2_b10:
   fsh f10, 1172(x23) # perform store
   addi x23, x23, 1172 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x31 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x31, Zfbfmin_fsh_cg_cp_fs2_b10, Zfbfmin_fsh_cg_cp_fs2_b10_str)
-#else
-  fsh f10, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b10, Zfbfmin_fsh_cg_cp_fs2_b10_str)
 
@@ -1547,18 +989,9 @@ Zfbfmin_fsh_cg_cp_fs2_b11:
   fsh f11, 1741(x2) # perform store
   addi x2, x2, 1741 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x3 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x3, Zfbfmin_fsh_cg_cp_fs2_b11, Zfbfmin_fsh_cg_cp_fs2_b11_str)
-#else
-  fsh f11, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b11, Zfbfmin_fsh_cg_cp_fs2_b11_str)
 
@@ -1571,18 +1004,9 @@ Zfbfmin_fsh_cg_cp_fs2_b12:
   fsh f12, 547(x16) # perform store
   addi x16, x16, 547 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x13 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x13, Zfbfmin_fsh_cg_cp_fs2_b12, Zfbfmin_fsh_cg_cp_fs2_b12_str)
-#else
-  fsh f12, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b12, Zfbfmin_fsh_cg_cp_fs2_b12_str)
 
@@ -1595,18 +1019,9 @@ Zfbfmin_fsh_cg_cp_fs2_b13:
   fsh f13, 985(x15) # perform store
   addi x15, x15, 985 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x6 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x6, Zfbfmin_fsh_cg_cp_fs2_b13, Zfbfmin_fsh_cg_cp_fs2_b13_str)
-#else
-  fsh f13, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b13, Zfbfmin_fsh_cg_cp_fs2_b13_str)
 
@@ -1619,18 +1034,9 @@ Zfbfmin_fsh_cg_cp_fs2_b14:
   fsh f14, 632(x24) # perform store
   addi x24, x24, 632 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x23 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x23, Zfbfmin_fsh_cg_cp_fs2_b14, Zfbfmin_fsh_cg_cp_fs2_b14_str)
-#else
-  fsh f14, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b14, Zfbfmin_fsh_cg_cp_fs2_b14_str)
 
@@ -1643,18 +1049,9 @@ Zfbfmin_fsh_cg_cp_fs2_b15:
   fsh f15, 1967(x19) # perform store
   addi x19, x19, 1967 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x18 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x18, Zfbfmin_fsh_cg_cp_fs2_b15, Zfbfmin_fsh_cg_cp_fs2_b15_str)
-#else
-  fsh f15, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b15, Zfbfmin_fsh_cg_cp_fs2_b15_str)
 
@@ -1667,18 +1064,9 @@ Zfbfmin_fsh_cg_cp_fs2_b16:
   fsh f16, 1223(x3) # perform store
   addi x3, x3, 1223 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x14 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x14, Zfbfmin_fsh_cg_cp_fs2_b16, Zfbfmin_fsh_cg_cp_fs2_b16_str)
-#else
-  fsh f16, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b16, Zfbfmin_fsh_cg_cp_fs2_b16_str)
 
@@ -1691,18 +1079,9 @@ Zfbfmin_fsh_cg_cp_fs2_b17:
   fsh f17, 1853(x10) # perform store
   addi x10, x10, 1853 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x25 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x25, Zfbfmin_fsh_cg_cp_fs2_b17, Zfbfmin_fsh_cg_cp_fs2_b17_str)
-#else
-  fsh f17, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b17, Zfbfmin_fsh_cg_cp_fs2_b17_str)
 
@@ -1715,18 +1094,9 @@ Zfbfmin_fsh_cg_cp_fs2_b18:
   fsh f18, -1804(x31) # perform store
   addi x31, x31, -1804 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x11 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x11, Zfbfmin_fsh_cg_cp_fs2_b18, Zfbfmin_fsh_cg_cp_fs2_b18_str)
-#else
-  fsh f18, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b18, Zfbfmin_fsh_cg_cp_fs2_b18_str)
 
@@ -1739,18 +1109,9 @@ Zfbfmin_fsh_cg_cp_fs2_b19:
   fsh f19, 2013(x3) # perform store
   addi x3, x3, 2013 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x13 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x13, Zfbfmin_fsh_cg_cp_fs2_b19, Zfbfmin_fsh_cg_cp_fs2_b19_str)
-#else
-  fsh f19, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b19, Zfbfmin_fsh_cg_cp_fs2_b19_str)
 
@@ -1763,18 +1124,9 @@ Zfbfmin_fsh_cg_cp_fs2_b20:
   fsh f20, 2011(x29) # perform store
   addi x29, x29, 2011 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x11 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x11, Zfbfmin_fsh_cg_cp_fs2_b20, Zfbfmin_fsh_cg_cp_fs2_b20_str)
-#else
-  fsh f20, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b20, Zfbfmin_fsh_cg_cp_fs2_b20_str)
 
@@ -1787,18 +1139,9 @@ Zfbfmin_fsh_cg_cp_fs2_b21:
   fsh f21, 593(x12) # perform store
   addi x12, x12, 593 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x18 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x18, Zfbfmin_fsh_cg_cp_fs2_b21, Zfbfmin_fsh_cg_cp_fs2_b21_str)
-#else
-  fsh f21, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b21, Zfbfmin_fsh_cg_cp_fs2_b21_str)
 
@@ -1811,18 +1154,9 @@ Zfbfmin_fsh_cg_cp_fs2_b22:
   fsh f22, -306(x6) # perform store
   addi x6, x6, -306 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x8 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x8, Zfbfmin_fsh_cg_cp_fs2_b22, Zfbfmin_fsh_cg_cp_fs2_b22_str)
-#else
-  fsh f22, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b22, Zfbfmin_fsh_cg_cp_fs2_b22_str)
 
@@ -1835,18 +1169,9 @@ Zfbfmin_fsh_cg_cp_fs2_b23:
   fsh f23, -1834(x26) # perform store
   addi x26, x26, -1834 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x21 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x21, Zfbfmin_fsh_cg_cp_fs2_b23, Zfbfmin_fsh_cg_cp_fs2_b23_str)
-#else
-  fsh f23, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b23, Zfbfmin_fsh_cg_cp_fs2_b23_str)
 
@@ -1859,18 +1184,9 @@ Zfbfmin_fsh_cg_cp_fs2_b24:
   fsh f24, 221(x23) # perform store
   addi x23, x23, 221 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x13 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x13, Zfbfmin_fsh_cg_cp_fs2_b24, Zfbfmin_fsh_cg_cp_fs2_b24_str)
-#else
-  fsh f24, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b24, Zfbfmin_fsh_cg_cp_fs2_b24_str)
 
@@ -1883,18 +1199,9 @@ Zfbfmin_fsh_cg_cp_fs2_b25:
   fsh f25, -276(x17) # perform store
   addi x17, x17, -276 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x24 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x24, Zfbfmin_fsh_cg_cp_fs2_b25, Zfbfmin_fsh_cg_cp_fs2_b25_str)
-#else
-  fsh f25, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b25, Zfbfmin_fsh_cg_cp_fs2_b25_str)
 
@@ -1907,18 +1214,9 @@ Zfbfmin_fsh_cg_cp_fs2_b26:
   fsh f26, -1953(x12) # perform store
   addi x12, x12, -1953 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x21 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x21, Zfbfmin_fsh_cg_cp_fs2_b26, Zfbfmin_fsh_cg_cp_fs2_b26_str)
-#else
-  fsh f26, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b26, Zfbfmin_fsh_cg_cp_fs2_b26_str)
 
@@ -1931,18 +1229,9 @@ Zfbfmin_fsh_cg_cp_fs2_b27:
   fsh f27, -982(x19) # perform store
   addi x19, x19, -982 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x21 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x21, Zfbfmin_fsh_cg_cp_fs2_b27, Zfbfmin_fsh_cg_cp_fs2_b27_str)
-#else
-  fsh f27, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b27, Zfbfmin_fsh_cg_cp_fs2_b27_str)
 
@@ -1955,18 +1244,9 @@ Zfbfmin_fsh_cg_cp_fs2_b28:
   fsh f28, 405(x9) # perform store
   addi x9, x9, 405 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x17 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x17, Zfbfmin_fsh_cg_cp_fs2_b28, Zfbfmin_fsh_cg_cp_fs2_b28_str)
-#else
-  fsh f28, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b28, Zfbfmin_fsh_cg_cp_fs2_b28_str)
 
@@ -1979,18 +1259,9 @@ Zfbfmin_fsh_cg_cp_fs2_b29:
   fsh f29, -1644(x26) # perform store
   addi x26, x26, -1644 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x14 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x14, Zfbfmin_fsh_cg_cp_fs2_b29, Zfbfmin_fsh_cg_cp_fs2_b29_str)
-#else
-  fsh f29, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b29, Zfbfmin_fsh_cg_cp_fs2_b29_str)
 
@@ -2003,18 +1274,9 @@ Zfbfmin_fsh_cg_cp_fs2_b30:
   fsh f30, -1587(x28) # perform store
   addi x28, x28, -1587 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x18 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x18, Zfbfmin_fsh_cg_cp_fs2_b30, Zfbfmin_fsh_cg_cp_fs2_b30_str)
-#else
-  fsh f30, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b30, Zfbfmin_fsh_cg_cp_fs2_b30_str)
 
@@ -2027,18 +1289,9 @@ Zfbfmin_fsh_cg_cp_fs2_b31:
   fsh f31, 146(x23) # perform store
   addi x23, x23, 146 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x9 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x9, Zfbfmin_fsh_cg_cp_fs2_b31, Zfbfmin_fsh_cg_cp_fs2_b31_str)
-#else
-  fsh f31, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfbfmin_fsh_cg_cp_fs2_b31, Zfbfmin_fsh_cg_cp_fs2_b31_str)
 
@@ -2055,18 +1308,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x0:
   fsh f27, 334(x16) # perform store
   addi x16, x16, 334 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x18 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x18, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x0, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x0_str)
-#else
-  fsh f27, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x0, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x0_str)
 
@@ -2079,18 +1323,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8000:
   fsh f9, -1370(x7) # perform store
   addi x7, x7, -1370 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x17 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x17, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8000, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8000_str)
-#else
-  fsh f9, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8000, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8000_str)
 
@@ -2103,18 +1338,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3c00:
   fsh f6, -380(x28) # perform store
   addi x28, x28, -380 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x12 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x12, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3c00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3c00_str)
-#else
-  fsh f6, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3c00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3c00_str)
 
@@ -2127,18 +1353,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbc00:
   fsh f31, 1592(x29) # perform store
   addi x29, x29, 1592 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x27 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x27, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbc00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbc00_str)
-#else
-  fsh f31, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbc00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbc00_str)
 
@@ -2151,18 +1368,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3e00:
   fsh f19, 1663(x15) # perform store
   addi x15, x15, 1663 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x18 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x18, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3e00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3e00_str)
-#else
-  fsh f19, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3e00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3e00_str)
 
@@ -2175,18 +1383,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbe00:
   fsh f20, -2013(x8) # perform store
   addi x8, x8, -2013 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x28 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x28, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbe00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbe00_str)
-#else
-  fsh f20, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbe00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xbe00_str)
 
@@ -2199,18 +1398,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x4000:
   fsh f12, 1772(x14) # perform store
   addi x14, x14, 1772 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x17 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x17, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x4000, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x4000_str)
-#else
-  fsh f12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x4000, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x4000_str)
 
@@ -2223,18 +1413,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc000:
   fsh f17, -1411(x13) # perform store
   addi x13, x13, -1411 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x30 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x30, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc000, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc000_str)
-#else
-  fsh f17, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc000, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc000_str)
 
@@ -2247,18 +1428,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x400:
   fsh f21, 202(x15) # perform store
   addi x15, x15, 202 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x16 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x16, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x400, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x400_str)
-#else
-  fsh f21, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x400, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x400_str)
 
@@ -2271,18 +1443,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8400:
   fsh f2, 1405(x25) # perform store
   addi x25, x25, 1405 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x16 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x16, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8400, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8400_str)
-#else
-  fsh f2, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8400, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8400_str)
 
@@ -2295,18 +1458,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7bff:
   fsh f8, -1191(x14) # perform store
   addi x14, x14, -1191 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x27 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x27, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7bff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7bff_str)
-#else
-  fsh f8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7bff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7bff_str)
 
@@ -2319,18 +1473,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfbff:
   fsh f9, 1218(x27) # perform store
   addi x27, x27, 1218 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x19 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x19, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfbff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfbff_str)
-#else
-  fsh f9, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfbff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfbff_str)
 
@@ -2343,18 +1488,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3ff:
   fsh f29, -379(x19) # perform store
   addi x19, x19, -379 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x10 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x10, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3ff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3ff_str)
-#else
-  fsh f29, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3ff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x3ff_str)
 
@@ -2367,18 +1503,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x83ff:
   fsh f3, -847(x14) # perform store
   addi x14, x14, -847 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x18 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x18, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x83ff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x83ff_str)
-#else
-  fsh f3, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x83ff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x83ff_str)
 
@@ -2391,18 +1518,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x200:
   fsh f18, -1102(x25) # perform store
   addi x25, x25, -1102 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x30 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x30, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x200, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x200_str)
-#else
-  fsh f18, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x200, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x200_str)
 
@@ -2415,18 +1533,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8200:
   fsh f16, 1701(x30) # perform store
   addi x30, x30, 1701 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x23 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x23, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8200, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8200_str)
-#else
-  fsh f16, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8200, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8200_str)
 
@@ -2439,18 +1548,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x1:
   fsh f21, 466(x31) # perform store
   addi x31, x31, 466 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x16 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x16, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x1, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x1_str)
-#else
-  fsh f21, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x1, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x1_str)
 
@@ -2463,18 +1563,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8001:
   fsh f5, -1061(x27) # perform store
   addi x27, x27, -1061 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x10 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x10, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8001, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8001_str)
-#else
-  fsh f5, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8001, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x8001_str)
 
@@ -2487,18 +1578,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c00:
   fsh f31, -509(x21) # perform store
   addi x21, x21, -509 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x25 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x25, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c00_str)
-#else
-  fsh f31, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c00_str)
 
@@ -2511,18 +1593,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc00:
   fsh f14, -1974(x9) # perform store
   addi x9, x9, -1974 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x17 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x17, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc00_str)
-#else
-  fsh f14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc00_str)
 
@@ -2535,18 +1608,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7e00:
   fsh f27, 1090(x1) # perform store
   addi x1, x1, 1090 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x11, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7e00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7e00_str)
-#else
-  fsh f27, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7e00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7e00_str)
 
@@ -2559,18 +1623,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7fff:
   fsh f22, 448(x30) # perform store
   addi x30, x30, 448 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x26 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x26, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7fff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7fff_str)
-#else
-  fsh f22, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7fff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7fff_str)
 
@@ -2583,18 +1638,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfe00:
   fsh f12, -153(x13) # perform store
   addi x13, x13, -153 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfe00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfe00_str)
-#else
-  fsh f12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfe00, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfe00_str)
 
@@ -2607,18 +1653,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c01:
   fsh f12, -649(x19) # perform store
   addi x19, x19, -649 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x25 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x25, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c01, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c01_str)
-#else
-  fsh f12, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c01, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7c01_str)
 
@@ -2631,18 +1668,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7dff:
   fsh f22, 1959(x14) # perform store
   addi x14, x14, 1959 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x31 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x31, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7dff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7dff_str)
-#else
-  fsh f22, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7dff, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x7dff_str)
 
@@ -2655,18 +1683,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc01:
   fsh f22, -735(x1) # perform store
   addi x1, x1, -735 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x6 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x6, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc01, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc01_str)
-#else
-  fsh f22, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc01, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xfc01_str)
 
@@ -2679,18 +1698,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x58b4:
   fsh f17, 664(x10) # perform store
   addi x10, x10, 664 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x22 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x22, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x58b4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x58b4_str)
-#else
-  fsh f17, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x58b4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0x58b4_str)
 
@@ -2703,18 +1713,9 @@ Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc93a:
   fsh f4, 1199(x24) # perform store
   addi x24, x24, 1199 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x19 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x19, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc93a, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc93a_str)
-#else
-  fsh f4, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc93a, Zfbfmin_fsh_cg_cp_fs2_edges_H_b0xc93a_str)
 
@@ -2731,18 +1732,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x0:
   fsh f15, -691(x10) # perform store
   addi x10, x10, -691 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x28 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x28, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x0, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x0_str)
-#else
-  fsh f15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x0, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x0_str)
 
@@ -2755,18 +1747,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000:
   fsh f8, 1467(x1) # perform store
   addi x1, x1, 1467 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x26 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x26, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000_str)
-#else
-  fsh f8, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000_str)
 
@@ -2779,18 +1762,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00:
   fsh f28, 1925(x16) # perform store
   addi x16, x16, 1925 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x13 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x13, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00_str)
-#else
-  fsh f28, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00_str)
 
@@ -2803,18 +1777,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00:
   fsh f19, 179(x27) # perform store
   addi x27, x27, 179 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x12 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x12, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00_str)
-#else
-  fsh f19, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00_str)
 
@@ -2827,18 +1792,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400:
   fsh f21, 344(x21) # perform store
   addi x21, x21, 344 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x18 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x18, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400_str)
-#else
-  fsh f21, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400_str)
 
@@ -2851,18 +1807,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400:
   fsh f9, 164(x15) # perform store
   addi x15, x15, 164 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400_str)
-#else
-  fsh f9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400_str)
 
@@ -2875,18 +1822,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff:
   fsh f24, 1839(x9) # perform store
   addi x9, x9, 1839 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x21 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x21, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff_str)
-#else
-  fsh f24, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff_str)
 
@@ -2899,18 +1837,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff:
   fsh f13, 381(x14) # perform store
   addi x14, x14, 381 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x16 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x16, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff_str)
-#else
-  fsh f13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff_str)
 
@@ -2923,18 +1852,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00:
   fsh f20, 1600(x12) # perform store
   addi x12, x12, 1600 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x23 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x23, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00_str)
-#else
-  fsh f20, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00_str)
 
@@ -2947,18 +1867,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00:
   fsh f27, 922(x27) # perform store
   addi x27, x27, 922 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x21 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x21, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00_str)
-#else
-  fsh f27, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00_str)
 
@@ -2971,18 +1882,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00:
   fsh f13, 1939(x22) # perform store
   addi x22, x22, 1939 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x14 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x14, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00_str)
-#else
-  fsh f13, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00_str)
 
@@ -2995,18 +1897,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff:
   fsh f9, 1058(x11) # perform store
   addi x11, x11, 1058 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x17 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x17, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff_str)
-#else
-  fsh f9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff_str)
 
@@ -3019,18 +1912,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01:
   fsh f21, 27(x2) # perform store
   addi x2, x2, 27 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x1 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x1, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01_str)
-#else
-  fsh f21, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01_str)
 
@@ -3043,18 +1927,9 @@ Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff:
   fsh f17, -327(x1) # perform store
   addi x1, x1, -327 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x15, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff_str)
-#else
-  fsh f17, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff, Zfbfmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff_str)
 

--- a/tests/rv64i/Zfh/Zfh-fsh-00.S
+++ b/tests/rv64i/Zfh/Zfh-fsh-00.S
@@ -42,18 +42,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b1:
   fsh f26, -120(x1) # perform store
   addi x1, x1, -120 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x26 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x26, Zfh_fsh_cg_cp_rs1_nx0_b1, Zfh_fsh_cg_cp_rs1_nx0_b1_str)
-#else
-  fsh f26, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b1, Zfh_fsh_cg_cp_rs1_nx0_b1_str)
 
@@ -66,18 +57,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b2:
   fsh f3, 1312(x2) # perform store
   addi x2, x2, 1312 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x6 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x6, Zfh_fsh_cg_cp_rs1_nx0_b2, Zfh_fsh_cg_cp_rs1_nx0_b2_str)
-#else
-  fsh f3, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b2, Zfh_fsh_cg_cp_rs1_nx0_b2_str)
 
@@ -91,18 +73,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b3:
   fsh f17, -268(x3) # perform store
   addi x3, x3, -268 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x12 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x12, Zfh_fsh_cg_cp_rs1_nx0_b3, Zfh_fsh_cg_cp_rs1_nx0_b3_str)
-#else
-  fsh f17, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b3, Zfh_fsh_cg_cp_rs1_nx0_b3_str)
 
@@ -117,18 +90,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b4:
   fsh f15, -1082(x4) # perform store
   addi x4, x4, -1082 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x25 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x25, Zfh_fsh_cg_cp_rs1_nx0_b4, Zfh_fsh_cg_cp_rs1_nx0_b4_str)
-#else
-  fsh f15, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x4, x8, x7, Zfh_fsh_cg_cp_rs1_nx0_b4, Zfh_fsh_cg_cp_rs1_nx0_b4_str)
 
@@ -141,18 +105,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b5:
   fsh f25, 1943(x5) # perform store
   addi x5, x5, 1943 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x9 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x9, Zfh_fsh_cg_cp_rs1_nx0_b5, Zfh_fsh_cg_cp_rs1_nx0_b5_str)
-#else
-  fsh f25, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x5, x8, x7, Zfh_fsh_cg_cp_rs1_nx0_b5, Zfh_fsh_cg_cp_rs1_nx0_b5_str)
 
@@ -165,18 +120,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b6:
   fsh f6, 968(x6) # perform store
   addi x6, x6, 968 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x27 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x27, Zfh_fsh_cg_cp_rs1_nx0_b6, Zfh_fsh_cg_cp_rs1_nx0_b6_str)
-#else
-  fsh f6, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x8, x7, Zfh_fsh_cg_cp_rs1_nx0_b6, Zfh_fsh_cg_cp_rs1_nx0_b6_str)
 
@@ -191,18 +137,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b7:
   fsh f31, -1761(x7) # perform store
   addi x7, x7, -1761 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x4 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x4, Zfh_fsh_cg_cp_rs1_nx0_b7, Zfh_fsh_cg_cp_rs1_nx0_b7_str)
-#else
-  fsh f31, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x14, x13, Zfh_fsh_cg_cp_rs1_nx0_b7, Zfh_fsh_cg_cp_rs1_nx0_b7_str)
 
@@ -215,18 +152,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b8:
   fsh f27, -1102(x8) # perform store
   addi x8, x8, -1102 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x4 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x4, Zfh_fsh_cg_cp_rs1_nx0_b8, Zfh_fsh_cg_cp_rs1_nx0_b8_str)
-#else
-  fsh f27, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x14, x13, Zfh_fsh_cg_cp_rs1_nx0_b8, Zfh_fsh_cg_cp_rs1_nx0_b8_str)
 
@@ -239,18 +167,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b9:
   fsh f2, 361(x9) # perform store
   addi x9, x9, 361 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x23 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x23, Zfh_fsh_cg_cp_rs1_nx0_b9, Zfh_fsh_cg_cp_rs1_nx0_b9_str)
-#else
-  fsh f2, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x14, x13, Zfh_fsh_cg_cp_rs1_nx0_b9, Zfh_fsh_cg_cp_rs1_nx0_b9_str)
 
@@ -263,18 +182,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b10:
   fsh f6, -1868(x10) # perform store
   addi x10, x10, -1868 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x8, Zfh_fsh_cg_cp_rs1_nx0_b10, Zfh_fsh_cg_cp_rs1_nx0_b10_str)
-#else
-  fsh f6, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x14, x13, Zfh_fsh_cg_cp_rs1_nx0_b10, Zfh_fsh_cg_cp_rs1_nx0_b10_str)
 
@@ -287,18 +197,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b11:
   fsh f5, -1623(x11) # perform store
   addi x11, x11, -1623 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x5 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x5, Zfh_fsh_cg_cp_rs1_nx0_b11, Zfh_fsh_cg_cp_rs1_nx0_b11_str)
-#else
-  fsh f5, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x14, x13, Zfh_fsh_cg_cp_rs1_nx0_b11, Zfh_fsh_cg_cp_rs1_nx0_b11_str)
 
@@ -311,18 +212,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b12:
   fsh f9, -1461(x12) # perform store
   addi x12, x12, -1461 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x24 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x24, Zfh_fsh_cg_cp_rs1_nx0_b12, Zfh_fsh_cg_cp_rs1_nx0_b12_str)
-#else
-  fsh f9, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x14, x13, Zfh_fsh_cg_cp_rs1_nx0_b12, Zfh_fsh_cg_cp_rs1_nx0_b12_str)
 
@@ -337,18 +229,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b13:
   fsh f14, 58(x13) # perform store
   addi x13, x13, 58 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zfh_fsh_cg_cp_rs1_nx0_b13, Zfh_fsh_cg_cp_rs1_nx0_b13_str)
-#else
-  fsh f14, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b13, Zfh_fsh_cg_cp_rs1_nx0_b13_str)
 
@@ -361,18 +244,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b14:
   fsh f13, -1360(x14) # perform store
   addi x14, x14, -1360 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x7 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x7, Zfh_fsh_cg_cp_rs1_nx0_b14, Zfh_fsh_cg_cp_rs1_nx0_b14_str)
-#else
-  fsh f13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b14, Zfh_fsh_cg_cp_rs1_nx0_b14_str)
 
@@ -385,18 +259,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b15:
   fsh f30, 725(x15) # perform store
   addi x15, x15, 725 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x16 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x16, Zfh_fsh_cg_cp_rs1_nx0_b15, Zfh_fsh_cg_cp_rs1_nx0_b15_str)
-#else
-  fsh f30, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b15, Zfh_fsh_cg_cp_rs1_nx0_b15_str)
 
@@ -409,18 +274,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b16:
   fsh f27, -512(x16) # perform store
   addi x16, x16, -512 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x17 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x17, Zfh_fsh_cg_cp_rs1_nx0_b16, Zfh_fsh_cg_cp_rs1_nx0_b16_str)
-#else
-  fsh f27, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b16, Zfh_fsh_cg_cp_rs1_nx0_b16_str)
 
@@ -433,18 +289,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b17:
   fsh f23, -955(x17) # perform store
   addi x17, x17, -955 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x31 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x31, Zfh_fsh_cg_cp_rs1_nx0_b17, Zfh_fsh_cg_cp_rs1_nx0_b17_str)
-#else
-  fsh f23, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b17, Zfh_fsh_cg_cp_rs1_nx0_b17_str)
 
@@ -457,18 +304,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b18:
   fsh f25, 1326(x18) # perform store
   addi x18, x18, 1326 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x13 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x13, Zfh_fsh_cg_cp_rs1_nx0_b18, Zfh_fsh_cg_cp_rs1_nx0_b18_str)
-#else
-  fsh f25, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b18, Zfh_fsh_cg_cp_rs1_nx0_b18_str)
 
@@ -481,18 +319,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b19:
   fsh f17, 1913(x19) # perform store
   addi x19, x19, 1913 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x20 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x20, Zfh_fsh_cg_cp_rs1_nx0_b19, Zfh_fsh_cg_cp_rs1_nx0_b19_str)
-#else
-  fsh f17, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b19, Zfh_fsh_cg_cp_rs1_nx0_b19_str)
 
@@ -505,18 +334,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b20:
   fsh f10, -1757(x20) # perform store
   addi x20, x20, -1757 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x17 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x17, Zfh_fsh_cg_cp_rs1_nx0_b20, Zfh_fsh_cg_cp_rs1_nx0_b20_str)
-#else
-  fsh f10, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b20, Zfh_fsh_cg_cp_rs1_nx0_b20_str)
 
@@ -529,18 +349,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b21:
   fsh f8, 2043(x21) # perform store
   addi x21, x21, 2043 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x14 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x14, Zfh_fsh_cg_cp_rs1_nx0_b21, Zfh_fsh_cg_cp_rs1_nx0_b21_str)
-#else
-  fsh f8, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b21, Zfh_fsh_cg_cp_rs1_nx0_b21_str)
 
@@ -553,18 +364,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b22:
   fsh f17, -266(x22) # perform store
   addi x22, x22, -266 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x7 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x7, Zfh_fsh_cg_cp_rs1_nx0_b22, Zfh_fsh_cg_cp_rs1_nx0_b22_str)
-#else
-  fsh f17, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b22, Zfh_fsh_cg_cp_rs1_nx0_b22_str)
 
@@ -577,18 +379,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b23:
   fsh f22, 1721(x23) # perform store
   addi x23, x23, 1721 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x16 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x16, Zfh_fsh_cg_cp_rs1_nx0_b23, Zfh_fsh_cg_cp_rs1_nx0_b23_str)
-#else
-  fsh f22, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b23, Zfh_fsh_cg_cp_rs1_nx0_b23_str)
 
@@ -601,18 +394,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b24:
   fsh f16, 803(x24) # perform store
   addi x24, x24, 803 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x14 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x14, Zfh_fsh_cg_cp_rs1_nx0_b24, Zfh_fsh_cg_cp_rs1_nx0_b24_str)
-#else
-  fsh f16, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b24, Zfh_fsh_cg_cp_rs1_nx0_b24_str)
 
@@ -625,18 +409,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b25:
   fsh f24, 1777(x25) # perform store
   addi x25, x25, 1777 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x3 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x3, Zfh_fsh_cg_cp_rs1_nx0_b25, Zfh_fsh_cg_cp_rs1_nx0_b25_str)
-#else
-  fsh f24, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b25, Zfh_fsh_cg_cp_rs1_nx0_b25_str)
 
@@ -650,18 +425,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b26:
   fsh f2, -1388(x26) # perform store
   addi x26, x26, -1388 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x17 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x17, Zfh_fsh_cg_cp_rs1_nx0_b26, Zfh_fsh_cg_cp_rs1_nx0_b26_str)
-#else
-  fsh f2, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b26, Zfh_fsh_cg_cp_rs1_nx0_b26_str)
 
@@ -674,18 +440,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b27:
   fsh f20, -1468(x27) # perform store
   addi x27, x27, -1468 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x22 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x22, Zfh_fsh_cg_cp_rs1_nx0_b27, Zfh_fsh_cg_cp_rs1_nx0_b27_str)
-#else
-  fsh f20, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b27, Zfh_fsh_cg_cp_rs1_nx0_b27_str)
 
@@ -698,18 +455,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b28:
   fsh f14, -95(x28) # perform store
   addi x28, x28, -95 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x17 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x17, Zfh_fsh_cg_cp_rs1_nx0_b28, Zfh_fsh_cg_cp_rs1_nx0_b28_str)
-#else
-  fsh f14, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b28, Zfh_fsh_cg_cp_rs1_nx0_b28_str)
 
@@ -722,18 +470,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b29:
   fsh f30, -1210(x29) # perform store
   addi x29, x29, -1210 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x27 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x27, Zfh_fsh_cg_cp_rs1_nx0_b29, Zfh_fsh_cg_cp_rs1_nx0_b29_str)
-#else
-  fsh f30, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b29, Zfh_fsh_cg_cp_rs1_nx0_b29_str)
 
@@ -746,18 +485,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b30:
   fsh f9, -1756(x30) # perform store
   addi x30, x30, -1756 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x31 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x31, Zfh_fsh_cg_cp_rs1_nx0_b30, Zfh_fsh_cg_cp_rs1_nx0_b30_str)
-#else
-  fsh f9, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b30, Zfh_fsh_cg_cp_rs1_nx0_b30_str)
 
@@ -770,18 +500,9 @@ Zfh_fsh_cg_cp_rs1_nx0_b31:
   fsh f8, -1890(x31) # perform store
   addi x31, x31, -1890 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x23 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x23, Zfh_fsh_cg_cp_rs1_nx0_b31, Zfh_fsh_cg_cp_rs1_nx0_b31_str)
-#else
-  fsh f8, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfh_fsh_cg_cp_rs1_nx0_b31, Zfh_fsh_cg_cp_rs1_nx0_b31_str)
 
@@ -798,18 +519,9 @@ Zfh_fsh_cg_cp_imm_edges_0x0:
   fsh f16, 0(x21) # perform store
   addi x21, x21, 0 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x13 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x13, Zfh_fsh_cg_cp_imm_edges_0x0, Zfh_fsh_cg_cp_imm_edges_0x0_str)
-#else
-  fsh f16, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x0, Zfh_fsh_cg_cp_imm_edges_0x0_str)
 
@@ -822,18 +534,9 @@ Zfh_fsh_cg_cp_imm_edges_0x1:
   fsh f7, 1(x26) # perform store
   addi x26, x26, 1 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x3 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x3, Zfh_fsh_cg_cp_imm_edges_0x1, Zfh_fsh_cg_cp_imm_edges_0x1_str)
-#else
-  fsh f7, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x1, Zfh_fsh_cg_cp_imm_edges_0x1_str)
 
@@ -846,18 +549,9 @@ Zfh_fsh_cg_cp_imm_edges_0x2:
   fsh f30, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x31 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x31, Zfh_fsh_cg_cp_imm_edges_0x2, Zfh_fsh_cg_cp_imm_edges_0x2_str)
-#else
-  fsh f30, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x2, Zfh_fsh_cg_cp_imm_edges_0x2_str)
 
@@ -870,18 +564,9 @@ Zfh_fsh_cg_cp_imm_edges_0x3:
   fsh f13, 3(x31) # perform store
   addi x31, x31, 3 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x21 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x21, Zfh_fsh_cg_cp_imm_edges_0x3, Zfh_fsh_cg_cp_imm_edges_0x3_str)
-#else
-  fsh f13, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x3, Zfh_fsh_cg_cp_imm_edges_0x3_str)
 
@@ -894,18 +579,9 @@ Zfh_fsh_cg_cp_imm_edges_0x4:
   fsh f23, 4(x2) # perform store
   addi x2, x2, 4 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x22 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x22, Zfh_fsh_cg_cp_imm_edges_0x4, Zfh_fsh_cg_cp_imm_edges_0x4_str)
-#else
-  fsh f23, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x4, Zfh_fsh_cg_cp_imm_edges_0x4_str)
 
@@ -918,18 +594,9 @@ Zfh_fsh_cg_cp_imm_edges_0x8:
   fsh f21, 8(x21) # perform store
   addi x21, x21, 8 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x15 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x15, Zfh_fsh_cg_cp_imm_edges_0x8, Zfh_fsh_cg_cp_imm_edges_0x8_str)
-#else
-  fsh f21, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x8, Zfh_fsh_cg_cp_imm_edges_0x8_str)
 
@@ -942,18 +609,9 @@ Zfh_fsh_cg_cp_imm_edges_0x10:
   fsh f12, 16(x16) # perform store
   addi x16, x16, 16 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x30 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x30, Zfh_fsh_cg_cp_imm_edges_0x10, Zfh_fsh_cg_cp_imm_edges_0x10_str)
-#else
-  fsh f12, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x10, Zfh_fsh_cg_cp_imm_edges_0x10_str)
 
@@ -966,18 +624,9 @@ Zfh_fsh_cg_cp_imm_edges_0x20:
   fsh f13, 32(x24) # perform store
   addi x24, x24, 32 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x14 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x14, Zfh_fsh_cg_cp_imm_edges_0x20, Zfh_fsh_cg_cp_imm_edges_0x20_str)
-#else
-  fsh f13, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x20, Zfh_fsh_cg_cp_imm_edges_0x20_str)
 
@@ -990,18 +639,9 @@ Zfh_fsh_cg_cp_imm_edges_0x40:
   fsh f13, 64(x27) # perform store
   addi x27, x27, 64 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x21 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x21, Zfh_fsh_cg_cp_imm_edges_0x40, Zfh_fsh_cg_cp_imm_edges_0x40_str)
-#else
-  fsh f13, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x40, Zfh_fsh_cg_cp_imm_edges_0x40_str)
 
@@ -1014,18 +654,9 @@ Zfh_fsh_cg_cp_imm_edges_0x80:
   fsh f23, 128(x10) # perform store
   addi x10, x10, 128 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x7 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x7, Zfh_fsh_cg_cp_imm_edges_0x80, Zfh_fsh_cg_cp_imm_edges_0x80_str)
-#else
-  fsh f23, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x80, Zfh_fsh_cg_cp_imm_edges_0x80_str)
 
@@ -1038,18 +669,9 @@ Zfh_fsh_cg_cp_imm_edges_0x100:
   fsh f10, 256(x27) # perform store
   addi x27, x27, 256 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x23 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x23, Zfh_fsh_cg_cp_imm_edges_0x100, Zfh_fsh_cg_cp_imm_edges_0x100_str)
-#else
-  fsh f10, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x100, Zfh_fsh_cg_cp_imm_edges_0x100_str)
 
@@ -1062,18 +684,9 @@ Zfh_fsh_cg_cp_imm_edges_0x200:
   fsh f9, 512(x15) # perform store
   addi x15, x15, 512 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x28 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x28, Zfh_fsh_cg_cp_imm_edges_0x200, Zfh_fsh_cg_cp_imm_edges_0x200_str)
-#else
-  fsh f9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x200, Zfh_fsh_cg_cp_imm_edges_0x200_str)
 
@@ -1086,18 +699,9 @@ Zfh_fsh_cg_cp_imm_edges_0x3ff:
   fsh f26, 1023(x14) # perform store
   addi x14, x14, 1023 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x18 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x18, Zfh_fsh_cg_cp_imm_edges_0x3ff, Zfh_fsh_cg_cp_imm_edges_0x3ff_str)
-#else
-  fsh f26, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x3ff, Zfh_fsh_cg_cp_imm_edges_0x3ff_str)
 
@@ -1110,18 +714,9 @@ Zfh_fsh_cg_cp_imm_edges_0x400:
   fsh f18, 1024(x15) # perform store
   addi x15, x15, 1024 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, Zfh_fsh_cg_cp_imm_edges_0x400, Zfh_fsh_cg_cp_imm_edges_0x400_str)
-#else
-  fsh f18, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x400, Zfh_fsh_cg_cp_imm_edges_0x400_str)
 
@@ -1134,18 +729,9 @@ Zfh_fsh_cg_cp_imm_edges_0x703:
   fsh f24, 1795(x13) # perform store
   addi x13, x13, 1795 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x27 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x27, Zfh_fsh_cg_cp_imm_edges_0x703, Zfh_fsh_cg_cp_imm_edges_0x703_str)
-#else
-  fsh f24, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x703, Zfh_fsh_cg_cp_imm_edges_0x703_str)
 
@@ -1158,18 +744,9 @@ Zfh_fsh_cg_cp_imm_edges_0x7ff:
   fsh f15, 2047(x17) # perform store
   addi x17, x17, 2047 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x23 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x23, Zfh_fsh_cg_cp_imm_edges_0x7ff, Zfh_fsh_cg_cp_imm_edges_0x7ff_str)
-#else
-  fsh f15, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfh_fsh_cg_cp_imm_edges_0x7ff, Zfh_fsh_cg_cp_imm_edges_0x7ff_str)
 
@@ -1183,18 +760,9 @@ Zfh_fsh_cg_cp_imm_edges_m0x800:
   fsh f11, -2048(x22) # perform store
   addi x22, x22, -2048 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x25 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x25, Zfh_fsh_cg_cp_imm_edges_m0x800, Zfh_fsh_cg_cp_imm_edges_m0x800_str)
-#else
-  fsh f11, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfh_fsh_cg_cp_imm_edges_m0x800, Zfh_fsh_cg_cp_imm_edges_m0x800_str)
 
@@ -1207,18 +775,9 @@ Zfh_fsh_cg_cp_imm_edges_m0x7ff:
   fsh f26, -2047(x31) # perform store
   addi x31, x31, -2047 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x17 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x17, Zfh_fsh_cg_cp_imm_edges_m0x7ff, Zfh_fsh_cg_cp_imm_edges_m0x7ff_str)
-#else
-  fsh f26, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfh_fsh_cg_cp_imm_edges_m0x7ff, Zfh_fsh_cg_cp_imm_edges_m0x7ff_str)
 
@@ -1231,18 +790,9 @@ Zfh_fsh_cg_cp_imm_edges_m0x2:
   fsh f25, -2(x25) # perform store
   addi x25, x25, -2 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x16 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x16, Zfh_fsh_cg_cp_imm_edges_m0x2, Zfh_fsh_cg_cp_imm_edges_m0x2_str)
-#else
-  fsh f25, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfh_fsh_cg_cp_imm_edges_m0x2, Zfh_fsh_cg_cp_imm_edges_m0x2_str)
 
@@ -1255,18 +805,9 @@ Zfh_fsh_cg_cp_imm_edges_m0x1:
   fsh f31, -1(x10) # perform store
   addi x10, x10, -1 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x23 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x23, Zfh_fsh_cg_cp_imm_edges_m0x1, Zfh_fsh_cg_cp_imm_edges_m0x1_str)
-#else
-  fsh f31, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfh_fsh_cg_cp_imm_edges_m0x1, Zfh_fsh_cg_cp_imm_edges_m0x1_str)
 
@@ -1283,18 +824,9 @@ Zfh_fsh_cg_cp_fs2_b0:
   fsh f0, -163(x17) # perform store
   addi x17, x17, -163 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x13 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x13, Zfh_fsh_cg_cp_fs2_b0, Zfh_fsh_cg_cp_fs2_b0_str)
-#else
-  fsh f0, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfh_fsh_cg_cp_fs2_b0, Zfh_fsh_cg_cp_fs2_b0_str)
 
@@ -1307,18 +839,9 @@ Zfh_fsh_cg_cp_fs2_b1:
   fsh f1, 1761(x30) # perform store
   addi x30, x30, 1761 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x12 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x12, Zfh_fsh_cg_cp_fs2_b1, Zfh_fsh_cg_cp_fs2_b1_str)
-#else
-  fsh f1, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfh_fsh_cg_cp_fs2_b1, Zfh_fsh_cg_cp_fs2_b1_str)
 
@@ -1331,18 +854,9 @@ Zfh_fsh_cg_cp_fs2_b2:
   fsh f2, 1029(x23) # perform store
   addi x23, x23, 1029 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x24 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x24, Zfh_fsh_cg_cp_fs2_b2, Zfh_fsh_cg_cp_fs2_b2_str)
-#else
-  fsh f2, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfh_fsh_cg_cp_fs2_b2, Zfh_fsh_cg_cp_fs2_b2_str)
 
@@ -1355,18 +869,9 @@ Zfh_fsh_cg_cp_fs2_b3:
   fsh f3, -1663(x11) # perform store
   addi x11, x11, -1663 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zfh_fsh_cg_cp_fs2_b3, Zfh_fsh_cg_cp_fs2_b3_str)
-#else
-  fsh f3, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfh_fsh_cg_cp_fs2_b3, Zfh_fsh_cg_cp_fs2_b3_str)
 
@@ -1379,18 +884,9 @@ Zfh_fsh_cg_cp_fs2_b4:
   fsh f4, 166(x7) # perform store
   addi x7, x7, 166 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x16 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x16, Zfh_fsh_cg_cp_fs2_b4, Zfh_fsh_cg_cp_fs2_b4_str)
-#else
-  fsh f4, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, Zfh_fsh_cg_cp_fs2_b4, Zfh_fsh_cg_cp_fs2_b4_str)
 
@@ -1403,18 +899,9 @@ Zfh_fsh_cg_cp_fs2_b5:
   fsh f5, 221(x23) # perform store
   addi x23, x23, 221 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x25 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x25, Zfh_fsh_cg_cp_fs2_b5, Zfh_fsh_cg_cp_fs2_b5_str)
-#else
-  fsh f5, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfh_fsh_cg_cp_fs2_b5, Zfh_fsh_cg_cp_fs2_b5_str)
 
@@ -1427,18 +914,9 @@ Zfh_fsh_cg_cp_fs2_b6:
   fsh f6, -1072(x13) # perform store
   addi x13, x13, -1072 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zfh_fsh_cg_cp_fs2_b6, Zfh_fsh_cg_cp_fs2_b6_str)
-#else
-  fsh f6, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfh_fsh_cg_cp_fs2_b6, Zfh_fsh_cg_cp_fs2_b6_str)
 
@@ -1451,18 +929,9 @@ Zfh_fsh_cg_cp_fs2_b7:
   fsh f7, -347(x1) # perform store
   addi x1, x1, -347 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x30 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x30, Zfh_fsh_cg_cp_fs2_b7, Zfh_fsh_cg_cp_fs2_b7_str)
-#else
-  fsh f7, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfh_fsh_cg_cp_fs2_b7, Zfh_fsh_cg_cp_fs2_b7_str)
 
@@ -1475,18 +944,9 @@ Zfh_fsh_cg_cp_fs2_b8:
   fsh f8, 1059(x21) # perform store
   addi x21, x21, 1059 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x26 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x26, Zfh_fsh_cg_cp_fs2_b8, Zfh_fsh_cg_cp_fs2_b8_str)
-#else
-  fsh f8, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfh_fsh_cg_cp_fs2_b8, Zfh_fsh_cg_cp_fs2_b8_str)
 
@@ -1499,18 +959,9 @@ Zfh_fsh_cg_cp_fs2_b9:
   fsh f9, -838(x22) # perform store
   addi x22, x22, -838 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x15 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x15, Zfh_fsh_cg_cp_fs2_b9, Zfh_fsh_cg_cp_fs2_b9_str)
-#else
-  fsh f9, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfh_fsh_cg_cp_fs2_b9, Zfh_fsh_cg_cp_fs2_b9_str)
 
@@ -1523,18 +974,9 @@ Zfh_fsh_cg_cp_fs2_b10:
   fsh f10, 1172(x23) # perform store
   addi x23, x23, 1172 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x31 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x31, Zfh_fsh_cg_cp_fs2_b10, Zfh_fsh_cg_cp_fs2_b10_str)
-#else
-  fsh f10, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfh_fsh_cg_cp_fs2_b10, Zfh_fsh_cg_cp_fs2_b10_str)
 
@@ -1547,18 +989,9 @@ Zfh_fsh_cg_cp_fs2_b11:
   fsh f11, 1741(x2) # perform store
   addi x2, x2, 1741 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x3 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x3, Zfh_fsh_cg_cp_fs2_b11, Zfh_fsh_cg_cp_fs2_b11_str)
-#else
-  fsh f11, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfh_fsh_cg_cp_fs2_b11, Zfh_fsh_cg_cp_fs2_b11_str)
 
@@ -1571,18 +1004,9 @@ Zfh_fsh_cg_cp_fs2_b12:
   fsh f12, 547(x16) # perform store
   addi x16, x16, 547 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x13 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x13, Zfh_fsh_cg_cp_fs2_b12, Zfh_fsh_cg_cp_fs2_b12_str)
-#else
-  fsh f12, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfh_fsh_cg_cp_fs2_b12, Zfh_fsh_cg_cp_fs2_b12_str)
 
@@ -1595,18 +1019,9 @@ Zfh_fsh_cg_cp_fs2_b13:
   fsh f13, 985(x15) # perform store
   addi x15, x15, 985 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x6 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x6, Zfh_fsh_cg_cp_fs2_b13, Zfh_fsh_cg_cp_fs2_b13_str)
-#else
-  fsh f13, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfh_fsh_cg_cp_fs2_b13, Zfh_fsh_cg_cp_fs2_b13_str)
 
@@ -1619,18 +1034,9 @@ Zfh_fsh_cg_cp_fs2_b14:
   fsh f14, 632(x24) # perform store
   addi x24, x24, 632 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x23 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x23, Zfh_fsh_cg_cp_fs2_b14, Zfh_fsh_cg_cp_fs2_b14_str)
-#else
-  fsh f14, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfh_fsh_cg_cp_fs2_b14, Zfh_fsh_cg_cp_fs2_b14_str)
 
@@ -1643,18 +1049,9 @@ Zfh_fsh_cg_cp_fs2_b15:
   fsh f15, 1967(x19) # perform store
   addi x19, x19, 1967 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x18 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x18, Zfh_fsh_cg_cp_fs2_b15, Zfh_fsh_cg_cp_fs2_b15_str)
-#else
-  fsh f15, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfh_fsh_cg_cp_fs2_b15, Zfh_fsh_cg_cp_fs2_b15_str)
 
@@ -1667,18 +1064,9 @@ Zfh_fsh_cg_cp_fs2_b16:
   fsh f16, 1223(x3) # perform store
   addi x3, x3, 1223 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x14 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x14, Zfh_fsh_cg_cp_fs2_b16, Zfh_fsh_cg_cp_fs2_b16_str)
-#else
-  fsh f16, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfh_fsh_cg_cp_fs2_b16, Zfh_fsh_cg_cp_fs2_b16_str)
 
@@ -1691,18 +1079,9 @@ Zfh_fsh_cg_cp_fs2_b17:
   fsh f17, 1853(x10) # perform store
   addi x10, x10, 1853 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x25 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x25, Zfh_fsh_cg_cp_fs2_b17, Zfh_fsh_cg_cp_fs2_b17_str)
-#else
-  fsh f17, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfh_fsh_cg_cp_fs2_b17, Zfh_fsh_cg_cp_fs2_b17_str)
 
@@ -1715,18 +1094,9 @@ Zfh_fsh_cg_cp_fs2_b18:
   fsh f18, -1804(x31) # perform store
   addi x31, x31, -1804 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x11 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x11, Zfh_fsh_cg_cp_fs2_b18, Zfh_fsh_cg_cp_fs2_b18_str)
-#else
-  fsh f18, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfh_fsh_cg_cp_fs2_b18, Zfh_fsh_cg_cp_fs2_b18_str)
 
@@ -1739,18 +1109,9 @@ Zfh_fsh_cg_cp_fs2_b19:
   fsh f19, 2013(x3) # perform store
   addi x3, x3, 2013 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x13 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x13, Zfh_fsh_cg_cp_fs2_b19, Zfh_fsh_cg_cp_fs2_b19_str)
-#else
-  fsh f19, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfh_fsh_cg_cp_fs2_b19, Zfh_fsh_cg_cp_fs2_b19_str)
 
@@ -1763,18 +1124,9 @@ Zfh_fsh_cg_cp_fs2_b20:
   fsh f20, 2011(x29) # perform store
   addi x29, x29, 2011 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x11 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x11, Zfh_fsh_cg_cp_fs2_b20, Zfh_fsh_cg_cp_fs2_b20_str)
-#else
-  fsh f20, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfh_fsh_cg_cp_fs2_b20, Zfh_fsh_cg_cp_fs2_b20_str)
 
@@ -1787,18 +1139,9 @@ Zfh_fsh_cg_cp_fs2_b21:
   fsh f21, 593(x12) # perform store
   addi x12, x12, 593 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x18 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x18, Zfh_fsh_cg_cp_fs2_b21, Zfh_fsh_cg_cp_fs2_b21_str)
-#else
-  fsh f21, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfh_fsh_cg_cp_fs2_b21, Zfh_fsh_cg_cp_fs2_b21_str)
 
@@ -1811,18 +1154,9 @@ Zfh_fsh_cg_cp_fs2_b22:
   fsh f22, -306(x6) # perform store
   addi x6, x6, -306 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x8 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x8, Zfh_fsh_cg_cp_fs2_b22, Zfh_fsh_cg_cp_fs2_b22_str)
-#else
-  fsh f22, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfh_fsh_cg_cp_fs2_b22, Zfh_fsh_cg_cp_fs2_b22_str)
 
@@ -1835,18 +1169,9 @@ Zfh_fsh_cg_cp_fs2_b23:
   fsh f23, -1834(x26) # perform store
   addi x26, x26, -1834 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x21 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x21, Zfh_fsh_cg_cp_fs2_b23, Zfh_fsh_cg_cp_fs2_b23_str)
-#else
-  fsh f23, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfh_fsh_cg_cp_fs2_b23, Zfh_fsh_cg_cp_fs2_b23_str)
 
@@ -1859,18 +1184,9 @@ Zfh_fsh_cg_cp_fs2_b24:
   fsh f24, 221(x23) # perform store
   addi x23, x23, 221 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x13 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x13, Zfh_fsh_cg_cp_fs2_b24, Zfh_fsh_cg_cp_fs2_b24_str)
-#else
-  fsh f24, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfh_fsh_cg_cp_fs2_b24, Zfh_fsh_cg_cp_fs2_b24_str)
 
@@ -1883,18 +1199,9 @@ Zfh_fsh_cg_cp_fs2_b25:
   fsh f25, -276(x17) # perform store
   addi x17, x17, -276 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x24 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x24, Zfh_fsh_cg_cp_fs2_b25, Zfh_fsh_cg_cp_fs2_b25_str)
-#else
-  fsh f25, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfh_fsh_cg_cp_fs2_b25, Zfh_fsh_cg_cp_fs2_b25_str)
 
@@ -1907,18 +1214,9 @@ Zfh_fsh_cg_cp_fs2_b26:
   fsh f26, -1953(x12) # perform store
   addi x12, x12, -1953 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x21 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x21, Zfh_fsh_cg_cp_fs2_b26, Zfh_fsh_cg_cp_fs2_b26_str)
-#else
-  fsh f26, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfh_fsh_cg_cp_fs2_b26, Zfh_fsh_cg_cp_fs2_b26_str)
 
@@ -1931,18 +1229,9 @@ Zfh_fsh_cg_cp_fs2_b27:
   fsh f27, -982(x19) # perform store
   addi x19, x19, -982 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x21 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x21, Zfh_fsh_cg_cp_fs2_b27, Zfh_fsh_cg_cp_fs2_b27_str)
-#else
-  fsh f27, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfh_fsh_cg_cp_fs2_b27, Zfh_fsh_cg_cp_fs2_b27_str)
 
@@ -1955,18 +1244,9 @@ Zfh_fsh_cg_cp_fs2_b28:
   fsh f28, 405(x9) # perform store
   addi x9, x9, 405 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x17 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x17, Zfh_fsh_cg_cp_fs2_b28, Zfh_fsh_cg_cp_fs2_b28_str)
-#else
-  fsh f28, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfh_fsh_cg_cp_fs2_b28, Zfh_fsh_cg_cp_fs2_b28_str)
 
@@ -1979,18 +1259,9 @@ Zfh_fsh_cg_cp_fs2_b29:
   fsh f29, -1644(x26) # perform store
   addi x26, x26, -1644 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x14 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x14, Zfh_fsh_cg_cp_fs2_b29, Zfh_fsh_cg_cp_fs2_b29_str)
-#else
-  fsh f29, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfh_fsh_cg_cp_fs2_b29, Zfh_fsh_cg_cp_fs2_b29_str)
 
@@ -2003,18 +1274,9 @@ Zfh_fsh_cg_cp_fs2_b30:
   fsh f30, -1587(x28) # perform store
   addi x28, x28, -1587 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x18 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x18, Zfh_fsh_cg_cp_fs2_b30, Zfh_fsh_cg_cp_fs2_b30_str)
-#else
-  fsh f30, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, Zfh_fsh_cg_cp_fs2_b30, Zfh_fsh_cg_cp_fs2_b30_str)
 
@@ -2027,18 +1289,9 @@ Zfh_fsh_cg_cp_fs2_b31:
   fsh f31, 146(x23) # perform store
   addi x23, x23, 146 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x9 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x9, Zfh_fsh_cg_cp_fs2_b31, Zfh_fsh_cg_cp_fs2_b31_str)
-#else
-  fsh f31, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfh_fsh_cg_cp_fs2_b31, Zfh_fsh_cg_cp_fs2_b31_str)
 
@@ -2055,18 +1308,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x0:
   fsh f27, 334(x16) # perform store
   addi x16, x16, 334 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x18 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x18, Zfh_fsh_cg_cp_fs2_edges_H_b0x0, Zfh_fsh_cg_cp_fs2_edges_H_b0x0_str)
-#else
-  fsh f27, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x0, Zfh_fsh_cg_cp_fs2_edges_H_b0x0_str)
 
@@ -2079,18 +1323,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x8000:
   fsh f9, -1370(x7) # perform store
   addi x7, x7, -1370 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x17 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x17, Zfh_fsh_cg_cp_fs2_edges_H_b0x8000, Zfh_fsh_cg_cp_fs2_edges_H_b0x8000_str)
-#else
-  fsh f9, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x8000, Zfh_fsh_cg_cp_fs2_edges_H_b0x8000_str)
 
@@ -2103,18 +1338,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x3c00:
   fsh f6, -380(x28) # perform store
   addi x28, x28, -380 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x12 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x12, Zfh_fsh_cg_cp_fs2_edges_H_b0x3c00, Zfh_fsh_cg_cp_fs2_edges_H_b0x3c00_str)
-#else
-  fsh f6, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x3c00, Zfh_fsh_cg_cp_fs2_edges_H_b0x3c00_str)
 
@@ -2127,18 +1353,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0xbc00:
   fsh f31, 1592(x29) # perform store
   addi x29, x29, 1592 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x27 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x27, Zfh_fsh_cg_cp_fs2_edges_H_b0xbc00, Zfh_fsh_cg_cp_fs2_edges_H_b0xbc00_str)
-#else
-  fsh f31, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0xbc00, Zfh_fsh_cg_cp_fs2_edges_H_b0xbc00_str)
 
@@ -2151,18 +1368,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x3e00:
   fsh f19, 1663(x15) # perform store
   addi x15, x15, 1663 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x18 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x18, Zfh_fsh_cg_cp_fs2_edges_H_b0x3e00, Zfh_fsh_cg_cp_fs2_edges_H_b0x3e00_str)
-#else
-  fsh f19, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x3e00, Zfh_fsh_cg_cp_fs2_edges_H_b0x3e00_str)
 
@@ -2175,18 +1383,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0xbe00:
   fsh f20, -2013(x8) # perform store
   addi x8, x8, -2013 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x28 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x28, Zfh_fsh_cg_cp_fs2_edges_H_b0xbe00, Zfh_fsh_cg_cp_fs2_edges_H_b0xbe00_str)
-#else
-  fsh f20, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0xbe00, Zfh_fsh_cg_cp_fs2_edges_H_b0xbe00_str)
 
@@ -2199,18 +1398,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x4000:
   fsh f12, 1772(x14) # perform store
   addi x14, x14, 1772 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x17 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x17, Zfh_fsh_cg_cp_fs2_edges_H_b0x4000, Zfh_fsh_cg_cp_fs2_edges_H_b0x4000_str)
-#else
-  fsh f12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x4000, Zfh_fsh_cg_cp_fs2_edges_H_b0x4000_str)
 
@@ -2223,18 +1413,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0xc000:
   fsh f17, -1411(x13) # perform store
   addi x13, x13, -1411 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x30 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x30, Zfh_fsh_cg_cp_fs2_edges_H_b0xc000, Zfh_fsh_cg_cp_fs2_edges_H_b0xc000_str)
-#else
-  fsh f17, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0xc000, Zfh_fsh_cg_cp_fs2_edges_H_b0xc000_str)
 
@@ -2247,18 +1428,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x400:
   fsh f21, 202(x15) # perform store
   addi x15, x15, 202 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x16 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x16, Zfh_fsh_cg_cp_fs2_edges_H_b0x400, Zfh_fsh_cg_cp_fs2_edges_H_b0x400_str)
-#else
-  fsh f21, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x400, Zfh_fsh_cg_cp_fs2_edges_H_b0x400_str)
 
@@ -2271,18 +1443,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x8400:
   fsh f2, 1405(x25) # perform store
   addi x25, x25, 1405 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x16 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x16, Zfh_fsh_cg_cp_fs2_edges_H_b0x8400, Zfh_fsh_cg_cp_fs2_edges_H_b0x8400_str)
-#else
-  fsh f2, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x8400, Zfh_fsh_cg_cp_fs2_edges_H_b0x8400_str)
 
@@ -2295,18 +1458,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x7bff:
   fsh f8, -1191(x14) # perform store
   addi x14, x14, -1191 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x27 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x27, Zfh_fsh_cg_cp_fs2_edges_H_b0x7bff, Zfh_fsh_cg_cp_fs2_edges_H_b0x7bff_str)
-#else
-  fsh f8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x7bff, Zfh_fsh_cg_cp_fs2_edges_H_b0x7bff_str)
 
@@ -2319,18 +1473,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0xfbff:
   fsh f9, 1218(x27) # perform store
   addi x27, x27, 1218 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x19 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x19, Zfh_fsh_cg_cp_fs2_edges_H_b0xfbff, Zfh_fsh_cg_cp_fs2_edges_H_b0xfbff_str)
-#else
-  fsh f9, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0xfbff, Zfh_fsh_cg_cp_fs2_edges_H_b0xfbff_str)
 
@@ -2343,18 +1488,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x3ff:
   fsh f29, -379(x19) # perform store
   addi x19, x19, -379 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x10 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x10, Zfh_fsh_cg_cp_fs2_edges_H_b0x3ff, Zfh_fsh_cg_cp_fs2_edges_H_b0x3ff_str)
-#else
-  fsh f29, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x3ff, Zfh_fsh_cg_cp_fs2_edges_H_b0x3ff_str)
 
@@ -2367,18 +1503,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x83ff:
   fsh f3, -847(x14) # perform store
   addi x14, x14, -847 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x18 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x18, Zfh_fsh_cg_cp_fs2_edges_H_b0x83ff, Zfh_fsh_cg_cp_fs2_edges_H_b0x83ff_str)
-#else
-  fsh f3, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x83ff, Zfh_fsh_cg_cp_fs2_edges_H_b0x83ff_str)
 
@@ -2391,18 +1518,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x200:
   fsh f18, -1102(x25) # perform store
   addi x25, x25, -1102 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x30 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x30, Zfh_fsh_cg_cp_fs2_edges_H_b0x200, Zfh_fsh_cg_cp_fs2_edges_H_b0x200_str)
-#else
-  fsh f18, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x200, Zfh_fsh_cg_cp_fs2_edges_H_b0x200_str)
 
@@ -2415,18 +1533,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x8200:
   fsh f16, 1701(x30) # perform store
   addi x30, x30, 1701 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x23 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x23, Zfh_fsh_cg_cp_fs2_edges_H_b0x8200, Zfh_fsh_cg_cp_fs2_edges_H_b0x8200_str)
-#else
-  fsh f16, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x8200, Zfh_fsh_cg_cp_fs2_edges_H_b0x8200_str)
 
@@ -2439,18 +1548,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x1:
   fsh f21, 466(x31) # perform store
   addi x31, x31, 466 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x16 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x16, Zfh_fsh_cg_cp_fs2_edges_H_b0x1, Zfh_fsh_cg_cp_fs2_edges_H_b0x1_str)
-#else
-  fsh f21, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x1, Zfh_fsh_cg_cp_fs2_edges_H_b0x1_str)
 
@@ -2463,18 +1563,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x8001:
   fsh f5, -1061(x27) # perform store
   addi x27, x27, -1061 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x10 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x10, Zfh_fsh_cg_cp_fs2_edges_H_b0x8001, Zfh_fsh_cg_cp_fs2_edges_H_b0x8001_str)
-#else
-  fsh f5, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x8001, Zfh_fsh_cg_cp_fs2_edges_H_b0x8001_str)
 
@@ -2487,18 +1578,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x7c00:
   fsh f31, -509(x21) # perform store
   addi x21, x21, -509 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x25 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x25, Zfh_fsh_cg_cp_fs2_edges_H_b0x7c00, Zfh_fsh_cg_cp_fs2_edges_H_b0x7c00_str)
-#else
-  fsh f31, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x7c00, Zfh_fsh_cg_cp_fs2_edges_H_b0x7c00_str)
 
@@ -2511,18 +1593,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0xfc00:
   fsh f14, -1974(x9) # perform store
   addi x9, x9, -1974 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x17 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x17, Zfh_fsh_cg_cp_fs2_edges_H_b0xfc00, Zfh_fsh_cg_cp_fs2_edges_H_b0xfc00_str)
-#else
-  fsh f14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0xfc00, Zfh_fsh_cg_cp_fs2_edges_H_b0xfc00_str)
 
@@ -2535,18 +1608,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x7e00:
   fsh f27, 1090(x1) # perform store
   addi x1, x1, 1090 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x11, Zfh_fsh_cg_cp_fs2_edges_H_b0x7e00, Zfh_fsh_cg_cp_fs2_edges_H_b0x7e00_str)
-#else
-  fsh f27, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x7e00, Zfh_fsh_cg_cp_fs2_edges_H_b0x7e00_str)
 
@@ -2559,18 +1623,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x7fff:
   fsh f22, 448(x30) # perform store
   addi x30, x30, 448 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x26 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x26, Zfh_fsh_cg_cp_fs2_edges_H_b0x7fff, Zfh_fsh_cg_cp_fs2_edges_H_b0x7fff_str)
-#else
-  fsh f22, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x7fff, Zfh_fsh_cg_cp_fs2_edges_H_b0x7fff_str)
 
@@ -2583,18 +1638,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0xfe00:
   fsh f12, -153(x13) # perform store
   addi x13, x13, -153 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, Zfh_fsh_cg_cp_fs2_edges_H_b0xfe00, Zfh_fsh_cg_cp_fs2_edges_H_b0xfe00_str)
-#else
-  fsh f12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0xfe00, Zfh_fsh_cg_cp_fs2_edges_H_b0xfe00_str)
 
@@ -2607,18 +1653,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x7c01:
   fsh f12, -649(x19) # perform store
   addi x19, x19, -649 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x25 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x25, Zfh_fsh_cg_cp_fs2_edges_H_b0x7c01, Zfh_fsh_cg_cp_fs2_edges_H_b0x7c01_str)
-#else
-  fsh f12, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x7c01, Zfh_fsh_cg_cp_fs2_edges_H_b0x7c01_str)
 
@@ -2631,18 +1668,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x7dff:
   fsh f22, 1959(x14) # perform store
   addi x14, x14, 1959 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x31 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x31, Zfh_fsh_cg_cp_fs2_edges_H_b0x7dff, Zfh_fsh_cg_cp_fs2_edges_H_b0x7dff_str)
-#else
-  fsh f22, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x7dff, Zfh_fsh_cg_cp_fs2_edges_H_b0x7dff_str)
 
@@ -2655,18 +1683,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0xfc01:
   fsh f22, -735(x1) # perform store
   addi x1, x1, -735 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x6 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x6, Zfh_fsh_cg_cp_fs2_edges_H_b0xfc01, Zfh_fsh_cg_cp_fs2_edges_H_b0xfc01_str)
-#else
-  fsh f22, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0xfc01, Zfh_fsh_cg_cp_fs2_edges_H_b0xfc01_str)
 
@@ -2679,18 +1698,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0x58b4:
   fsh f17, 664(x10) # perform store
   addi x10, x10, 664 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x22 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x22, Zfh_fsh_cg_cp_fs2_edges_H_b0x58b4, Zfh_fsh_cg_cp_fs2_edges_H_b0x58b4_str)
-#else
-  fsh f17, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0x58b4, Zfh_fsh_cg_cp_fs2_edges_H_b0x58b4_str)
 
@@ -2703,18 +1713,9 @@ Zfh_fsh_cg_cp_fs2_edges_H_b0xc93a:
   fsh f4, 1199(x24) # perform store
   addi x24, x24, 1199 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x19 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x19, Zfh_fsh_cg_cp_fs2_edges_H_b0xc93a, Zfh_fsh_cg_cp_fs2_edges_H_b0xc93a_str)
-#else
-  fsh f4, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfh_fsh_cg_cp_fs2_edges_H_b0xc93a, Zfh_fsh_cg_cp_fs2_edges_H_b0xc93a_str)
 
@@ -2731,18 +1732,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x0:
   fsh f15, -691(x10) # perform store
   addi x10, x10, -691 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x28 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x28, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x0, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x0_str)
-#else
-  fsh f15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x0, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x0_str)
 
@@ -2755,18 +1747,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000:
   fsh f8, 1467(x1) # perform store
   addi x1, x1, 1467 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x26 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x26, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000_str)
-#else
-  fsh f8, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000_str)
 
@@ -2779,18 +1762,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00:
   fsh f28, 1925(x16) # perform store
   addi x16, x16, 1925 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x13 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x13, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00_str)
-#else
-  fsh f28, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00_str)
 
@@ -2803,18 +1777,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00:
   fsh f19, 179(x27) # perform store
   addi x27, x27, 179 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x12 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x12, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00_str)
-#else
-  fsh f19, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00_str)
 
@@ -2827,18 +1792,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400:
   fsh f21, 344(x21) # perform store
   addi x21, x21, 344 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x18 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x18, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400_str)
-#else
-  fsh f21, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400_str)
 
@@ -2851,18 +1807,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400:
   fsh f9, 164(x15) # perform store
   addi x15, x15, 164 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400_str)
-#else
-  fsh f9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400_str)
 
@@ -2875,18 +1822,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff:
   fsh f24, 1839(x9) # perform store
   addi x9, x9, 1839 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x21 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x21, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff_str)
-#else
-  fsh f24, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff_str)
 
@@ -2899,18 +1837,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff:
   fsh f13, 381(x14) # perform store
   addi x14, x14, 381 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x16 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x16, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff_str)
-#else
-  fsh f13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff_str)
 
@@ -2923,18 +1852,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00:
   fsh f20, 1600(x12) # perform store
   addi x12, x12, 1600 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x23 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x23, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00_str)
-#else
-  fsh f20, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00_str)
 
@@ -2947,18 +1867,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00:
   fsh f27, 922(x27) # perform store
   addi x27, x27, 922 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x21 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x21, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00_str)
-#else
-  fsh f27, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00_str)
 
@@ -2971,18 +1882,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00:
   fsh f13, 1939(x22) # perform store
   addi x22, x22, 1939 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x14 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x14, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00_str)
-#else
-  fsh f13, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00_str)
 
@@ -2995,18 +1897,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff:
   fsh f9, 1058(x11) # perform store
   addi x11, x11, 1058 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x17 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x17, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff_str)
-#else
-  fsh f9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff_str)
 
@@ -3019,18 +1912,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01:
   fsh f21, 27(x2) # perform store
   addi x2, x2, 27 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x1 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x1, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01_str)
-#else
-  fsh f21, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01_str)
 
@@ -3043,18 +1927,9 @@ Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff:
   fsh f17, -327(x1) # perform store
   addi x1, x1, -327 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x15, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff_str)
-#else
-  fsh f17, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff, Zfh_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff_str)
 

--- a/tests/rv64i/ZfhD/ZfhD-fsh-00.S
+++ b/tests/rv64i/ZfhD/ZfhD-fsh-00.S
@@ -42,18 +42,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000:
   fsh f3, 289(x25) # perform store
   addi x25, x25, 289 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x9 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x9, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000_str)
-#else
-  fsh f3, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000_str)
 
@@ -66,18 +57,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000:
   fsh f9, 449(x16) # perform store
   addi x16, x16, 449 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x11 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x11, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000_str)
-#else
-  fsh f9, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000_str)
 
@@ -90,18 +72,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00:
   fsh f10, -1605(x24) # perform store
   addi x24, x24, -1605 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x30 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x30, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00_str)
-#else
-  fsh f10, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00_str)
 
@@ -114,18 +87,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00:
   fsh f10, -555(x13) # perform store
   addi x13, x13, -555 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00_str)
-#else
-  fsh f10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00_str)
 
@@ -138,18 +102,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400:
   fsh f25, 372(x17) # perform store
   addi x17, x17, 372 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x18 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x18, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400_str)
-#else
-  fsh f25, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400_str)
 
@@ -162,18 +117,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400:
   fsh f7, 158(x10) # perform store
   addi x10, x10, 158 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x30 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x30, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400_str)
-#else
-  fsh f7, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400_str)
 
@@ -186,18 +132,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff:
   fsh f5, 737(x1) # perform store
   addi x1, x1, 737 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x26 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x26, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff_str)
-#else
-  fsh f5, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff_str)
 
@@ -210,18 +147,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff:
   fsh f16, -174(x23) # perform store
   addi x23, x23, -174 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x29 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x29, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff_str)
-#else
-  fsh f16, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff_str)
 
@@ -234,18 +162,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00:
   fsh f16, 779(x19) # perform store
   addi x19, x19, 779 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x7 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x7, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00_str)
-#else
-  fsh f16, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00_str)
 
@@ -258,18 +177,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00:
   fsh f6, -824(x2) # perform store
   addi x2, x2, -824 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00_str)
-#else
-  fsh f6, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00_str)
 
@@ -282,18 +192,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00:
   fsh f1, -1991(x9) # perform store
   addi x9, x9, -1991 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00_str)
-#else
-  fsh f1, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00_str)
 
@@ -306,18 +207,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff:
   fsh f30, 1358(x12) # perform store
   addi x12, x12, 1358 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff_str)
-#else
-  fsh f30, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff_str)
 
@@ -330,18 +222,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01:
   fsh f17, 1468(x7) # perform store
   addi x7, x7, 1468 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x15 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x15, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01_str)
-#else
-  fsh f17, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01_str)
 
@@ -354,18 +237,9 @@ ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff:
   fsh f7, 472(x19) # perform store
   addi x19, x19, 472 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x26 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x26, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff_str)
-#else
-  fsh f7, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff, ZfhD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff_str)
 

--- a/tests/rv64i/Zfhmin/Zfhmin-fsh-00.S
+++ b/tests/rv64i/Zfhmin/Zfhmin-fsh-00.S
@@ -42,18 +42,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b1:
   fsh f26, -120(x1) # perform store
   addi x1, x1, -120 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x26 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x26, Zfhmin_fsh_cg_cp_rs1_nx0_b1, Zfhmin_fsh_cg_cp_rs1_nx0_b1_str)
-#else
-  fsh f26, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b1, Zfhmin_fsh_cg_cp_rs1_nx0_b1_str)
 
@@ -66,18 +57,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b2:
   fsh f3, 1312(x2) # perform store
   addi x2, x2, 1312 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x6 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x6, Zfhmin_fsh_cg_cp_rs1_nx0_b2, Zfhmin_fsh_cg_cp_rs1_nx0_b2_str)
-#else
-  fsh f3, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b2, Zfhmin_fsh_cg_cp_rs1_nx0_b2_str)
 
@@ -91,18 +73,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b3:
   fsh f17, -268(x3) # perform store
   addi x3, x3, -268 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x12 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x12, Zfhmin_fsh_cg_cp_rs1_nx0_b3, Zfhmin_fsh_cg_cp_rs1_nx0_b3_str)
-#else
-  fsh f17, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b3, Zfhmin_fsh_cg_cp_rs1_nx0_b3_str)
 
@@ -117,18 +90,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b4:
   fsh f15, -1082(x4) # perform store
   addi x4, x4, -1082 # restore base address
   addi x4, x4, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x4) # load stored value for checking
   # Check if x25 contains the expected result. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x4, x8, x7, x25, Zfhmin_fsh_cg_cp_rs1_nx0_b4, Zfhmin_fsh_cg_cp_rs1_nx0_b4_str)
-#else
-  fsh f15, 0(x4) # repeat store so it is available for checking
-  addi x4, x4, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x4 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x4, x8, x7, Zfhmin_fsh_cg_cp_rs1_nx0_b4, Zfhmin_fsh_cg_cp_rs1_nx0_b4_str)
 
@@ -141,18 +105,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b5:
   fsh f25, 1943(x5) # perform store
   addi x5, x5, 1943 # restore base address
   addi x5, x5, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x5) # load stored value for checking
   # Check if x9 contains the expected result. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x5, x8, x7, x9, Zfhmin_fsh_cg_cp_rs1_nx0_b5, Zfhmin_fsh_cg_cp_rs1_nx0_b5_str)
-#else
-  fsh f25, 0(x5) # repeat store so it is available for checking
-  addi x5, x5, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x5 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x5, x8, x7, Zfhmin_fsh_cg_cp_rs1_nx0_b5, Zfhmin_fsh_cg_cp_rs1_nx0_b5_str)
 
@@ -165,18 +120,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b6:
   fsh f6, 968(x6) # perform store
   addi x6, x6, 968 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x27 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x27, Zfhmin_fsh_cg_cp_rs1_nx0_b6, Zfhmin_fsh_cg_cp_rs1_nx0_b6_str)
-#else
-  fsh f6, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x8, x7, Zfhmin_fsh_cg_cp_rs1_nx0_b6, Zfhmin_fsh_cg_cp_rs1_nx0_b6_str)
 
@@ -191,18 +137,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b7:
   fsh f31, -1761(x7) # perform store
   addi x7, x7, -1761 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x4 contains the expected result. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x7, x14, x13, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b7, Zfhmin_fsh_cg_cp_rs1_nx0_b7_str)
-#else
-  fsh f31, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x14, x13, Zfhmin_fsh_cg_cp_rs1_nx0_b7, Zfhmin_fsh_cg_cp_rs1_nx0_b7_str)
 
@@ -215,18 +152,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b8:
   fsh f27, -1102(x8) # perform store
   addi x8, x8, -1102 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x4, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x4 contains the expected result. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x8, x14, x13, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b8, Zfhmin_fsh_cg_cp_rs1_nx0_b8_str)
-#else
-  fsh f27, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x14, x13, Zfhmin_fsh_cg_cp_rs1_nx0_b8, Zfhmin_fsh_cg_cp_rs1_nx0_b8_str)
 
@@ -239,18 +167,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b9:
   fsh f2, 361(x9) # perform store
   addi x9, x9, 361 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x23 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x9, x14, x13, x23, Zfhmin_fsh_cg_cp_rs1_nx0_b9, Zfhmin_fsh_cg_cp_rs1_nx0_b9_str)
-#else
-  fsh f2, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x14, x13, Zfhmin_fsh_cg_cp_rs1_nx0_b9, Zfhmin_fsh_cg_cp_rs1_nx0_b9_str)
 
@@ -263,18 +182,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b10:
   fsh f6, -1868(x10) # perform store
   addi x10, x10, -1868 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x8 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x10, x14, x13, x8, Zfhmin_fsh_cg_cp_rs1_nx0_b10, Zfhmin_fsh_cg_cp_rs1_nx0_b10_str)
-#else
-  fsh f6, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x14, x13, Zfhmin_fsh_cg_cp_rs1_nx0_b10, Zfhmin_fsh_cg_cp_rs1_nx0_b10_str)
 
@@ -287,18 +197,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b11:
   fsh f5, -1623(x11) # perform store
   addi x11, x11, -1623 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x5, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x5 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x11, x14, x13, x5, Zfhmin_fsh_cg_cp_rs1_nx0_b11, Zfhmin_fsh_cg_cp_rs1_nx0_b11_str)
-#else
-  fsh f5, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x14, x13, Zfhmin_fsh_cg_cp_rs1_nx0_b11, Zfhmin_fsh_cg_cp_rs1_nx0_b11_str)
 
@@ -311,18 +212,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b12:
   fsh f9, -1461(x12) # perform store
   addi x12, x12, -1461 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x24 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD(x12, x14, x13, x24, Zfhmin_fsh_cg_cp_rs1_nx0_b12, Zfhmin_fsh_cg_cp_rs1_nx0_b12_str)
-#else
-  fsh f9, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x14, x13, Zfhmin_fsh_cg_cp_rs1_nx0_b12, Zfhmin_fsh_cg_cp_rs1_nx0_b12_str)
 
@@ -337,18 +229,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b13:
   fsh f14, 58(x13) # perform store
   addi x13, x13, 58 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zfhmin_fsh_cg_cp_rs1_nx0_b13, Zfhmin_fsh_cg_cp_rs1_nx0_b13_str)
-#else
-  fsh f14, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b13, Zfhmin_fsh_cg_cp_rs1_nx0_b13_str)
 
@@ -361,18 +244,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b14:
   fsh f13, -1360(x14) # perform store
   addi x14, x14, -1360 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x7 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x7, Zfhmin_fsh_cg_cp_rs1_nx0_b14, Zfhmin_fsh_cg_cp_rs1_nx0_b14_str)
-#else
-  fsh f13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b14, Zfhmin_fsh_cg_cp_rs1_nx0_b14_str)
 
@@ -385,18 +259,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b15:
   fsh f30, 725(x15) # perform store
   addi x15, x15, 725 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x16 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x16, Zfhmin_fsh_cg_cp_rs1_nx0_b15, Zfhmin_fsh_cg_cp_rs1_nx0_b15_str)
-#else
-  fsh f30, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b15, Zfhmin_fsh_cg_cp_rs1_nx0_b15_str)
 
@@ -409,18 +274,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b16:
   fsh f27, -512(x16) # perform store
   addi x16, x16, -512 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x17 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x17, Zfhmin_fsh_cg_cp_rs1_nx0_b16, Zfhmin_fsh_cg_cp_rs1_nx0_b16_str)
-#else
-  fsh f27, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b16, Zfhmin_fsh_cg_cp_rs1_nx0_b16_str)
 
@@ -433,18 +289,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b17:
   fsh f23, -955(x17) # perform store
   addi x17, x17, -955 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x31 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x31, Zfhmin_fsh_cg_cp_rs1_nx0_b17, Zfhmin_fsh_cg_cp_rs1_nx0_b17_str)
-#else
-  fsh f23, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b17, Zfhmin_fsh_cg_cp_rs1_nx0_b17_str)
 
@@ -457,18 +304,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b18:
   fsh f25, 1326(x18) # perform store
   addi x18, x18, 1326 # restore base address
   addi x18, x18, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x18) # load stored value for checking
   # Check if x13 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x13, Zfhmin_fsh_cg_cp_rs1_nx0_b18, Zfhmin_fsh_cg_cp_rs1_nx0_b18_str)
-#else
-  fsh f25, 0(x18) # repeat store so it is available for checking
-  addi x18, x18, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x18, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b18, Zfhmin_fsh_cg_cp_rs1_nx0_b18_str)
 
@@ -481,18 +319,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b19:
   fsh f17, 1913(x19) # perform store
   addi x19, x19, 1913 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x20, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x20 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x20, Zfhmin_fsh_cg_cp_rs1_nx0_b19, Zfhmin_fsh_cg_cp_rs1_nx0_b19_str)
-#else
-  fsh f17, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b19, Zfhmin_fsh_cg_cp_rs1_nx0_b19_str)
 
@@ -505,18 +334,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b20:
   fsh f10, -1757(x20) # perform store
   addi x20, x20, -1757 # restore base address
   addi x20, x20, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x20) # load stored value for checking
   # Check if x17 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x20, x5, x4, x17, Zfhmin_fsh_cg_cp_rs1_nx0_b20, Zfhmin_fsh_cg_cp_rs1_nx0_b20_str)
-#else
-  fsh f10, 0(x20) # repeat store so it is available for checking
-  addi x20, x20, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x20, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b20, Zfhmin_fsh_cg_cp_rs1_nx0_b20_str)
 
@@ -529,18 +349,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b21:
   fsh f8, 2043(x21) # perform store
   addi x21, x21, 2043 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x14 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x14, Zfhmin_fsh_cg_cp_rs1_nx0_b21, Zfhmin_fsh_cg_cp_rs1_nx0_b21_str)
-#else
-  fsh f8, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b21, Zfhmin_fsh_cg_cp_rs1_nx0_b21_str)
 
@@ -553,18 +364,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b22:
   fsh f17, -266(x22) # perform store
   addi x22, x22, -266 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x7 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x7, Zfhmin_fsh_cg_cp_rs1_nx0_b22, Zfhmin_fsh_cg_cp_rs1_nx0_b22_str)
-#else
-  fsh f17, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b22, Zfhmin_fsh_cg_cp_rs1_nx0_b22_str)
 
@@ -577,18 +379,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b23:
   fsh f22, 1721(x23) # perform store
   addi x23, x23, 1721 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x16 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x16, Zfhmin_fsh_cg_cp_rs1_nx0_b23, Zfhmin_fsh_cg_cp_rs1_nx0_b23_str)
-#else
-  fsh f22, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b23, Zfhmin_fsh_cg_cp_rs1_nx0_b23_str)
 
@@ -601,18 +394,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b24:
   fsh f16, 803(x24) # perform store
   addi x24, x24, 803 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x14 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x14, Zfhmin_fsh_cg_cp_rs1_nx0_b24, Zfhmin_fsh_cg_cp_rs1_nx0_b24_str)
-#else
-  fsh f16, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b24, Zfhmin_fsh_cg_cp_rs1_nx0_b24_str)
 
@@ -625,18 +409,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b25:
   fsh f24, 1777(x25) # perform store
   addi x25, x25, 1777 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x3 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x3, Zfhmin_fsh_cg_cp_rs1_nx0_b25, Zfhmin_fsh_cg_cp_rs1_nx0_b25_str)
-#else
-  fsh f24, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b25, Zfhmin_fsh_cg_cp_rs1_nx0_b25_str)
 
@@ -650,18 +425,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b26:
   fsh f2, -1388(x26) # perform store
   addi x26, x26, -1388 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x17 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x17, Zfhmin_fsh_cg_cp_rs1_nx0_b26, Zfhmin_fsh_cg_cp_rs1_nx0_b26_str)
-#else
-  fsh f2, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b26, Zfhmin_fsh_cg_cp_rs1_nx0_b26_str)
 
@@ -674,18 +440,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b27:
   fsh f20, -1468(x27) # perform store
   addi x27, x27, -1468 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x22 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x22, Zfhmin_fsh_cg_cp_rs1_nx0_b27, Zfhmin_fsh_cg_cp_rs1_nx0_b27_str)
-#else
-  fsh f20, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b27, Zfhmin_fsh_cg_cp_rs1_nx0_b27_str)
 
@@ -698,18 +455,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b28:
   fsh f14, -95(x28) # perform store
   addi x28, x28, -95 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x17 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x17, Zfhmin_fsh_cg_cp_rs1_nx0_b28, Zfhmin_fsh_cg_cp_rs1_nx0_b28_str)
-#else
-  fsh f14, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b28, Zfhmin_fsh_cg_cp_rs1_nx0_b28_str)
 
@@ -722,18 +470,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b29:
   fsh f30, -1210(x29) # perform store
   addi x29, x29, -1210 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x27 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x27, Zfhmin_fsh_cg_cp_rs1_nx0_b29, Zfhmin_fsh_cg_cp_rs1_nx0_b29_str)
-#else
-  fsh f30, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b29, Zfhmin_fsh_cg_cp_rs1_nx0_b29_str)
 
@@ -746,18 +485,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b30:
   fsh f9, -1756(x30) # perform store
   addi x30, x30, -1756 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x31 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x31, Zfhmin_fsh_cg_cp_rs1_nx0_b30, Zfhmin_fsh_cg_cp_rs1_nx0_b30_str)
-#else
-  fsh f9, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b30, Zfhmin_fsh_cg_cp_rs1_nx0_b30_str)
 
@@ -770,18 +500,9 @@ Zfhmin_fsh_cg_cp_rs1_nx0_b31:
   fsh f8, -1890(x31) # perform store
   addi x31, x31, -1890 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x23 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x23, Zfhmin_fsh_cg_cp_rs1_nx0_b31, Zfhmin_fsh_cg_cp_rs1_nx0_b31_str)
-#else
-  fsh f8, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfhmin_fsh_cg_cp_rs1_nx0_b31, Zfhmin_fsh_cg_cp_rs1_nx0_b31_str)
 
@@ -798,18 +519,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x0:
   fsh f16, 0(x21) # perform store
   addi x21, x21, 0 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x13 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x13, Zfhmin_fsh_cg_cp_imm_edges_0x0, Zfhmin_fsh_cg_cp_imm_edges_0x0_str)
-#else
-  fsh f16, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x0, Zfhmin_fsh_cg_cp_imm_edges_0x0_str)
 
@@ -822,18 +534,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x1:
   fsh f7, 1(x26) # perform store
   addi x26, x26, 1 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x3 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x3, Zfhmin_fsh_cg_cp_imm_edges_0x1, Zfhmin_fsh_cg_cp_imm_edges_0x1_str)
-#else
-  fsh f7, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x1, Zfhmin_fsh_cg_cp_imm_edges_0x1_str)
 
@@ -846,18 +549,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x2:
   fsh f30, 2(x12) # perform store
   addi x12, x12, 2 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x31 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x31, Zfhmin_fsh_cg_cp_imm_edges_0x2, Zfhmin_fsh_cg_cp_imm_edges_0x2_str)
-#else
-  fsh f30, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x2, Zfhmin_fsh_cg_cp_imm_edges_0x2_str)
 
@@ -870,18 +564,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x3:
   fsh f13, 3(x31) # perform store
   addi x31, x31, 3 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x21 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x21, Zfhmin_fsh_cg_cp_imm_edges_0x3, Zfhmin_fsh_cg_cp_imm_edges_0x3_str)
-#else
-  fsh f13, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x3, Zfhmin_fsh_cg_cp_imm_edges_0x3_str)
 
@@ -894,18 +579,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x4:
   fsh f23, 4(x2) # perform store
   addi x2, x2, 4 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x22 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x22, Zfhmin_fsh_cg_cp_imm_edges_0x4, Zfhmin_fsh_cg_cp_imm_edges_0x4_str)
-#else
-  fsh f23, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x4, Zfhmin_fsh_cg_cp_imm_edges_0x4_str)
 
@@ -918,18 +594,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x8:
   fsh f21, 8(x21) # perform store
   addi x21, x21, 8 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x15 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x15, Zfhmin_fsh_cg_cp_imm_edges_0x8, Zfhmin_fsh_cg_cp_imm_edges_0x8_str)
-#else
-  fsh f21, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x8, Zfhmin_fsh_cg_cp_imm_edges_0x8_str)
 
@@ -942,18 +609,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x10:
   fsh f12, 16(x16) # perform store
   addi x16, x16, 16 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x30 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x30, Zfhmin_fsh_cg_cp_imm_edges_0x10, Zfhmin_fsh_cg_cp_imm_edges_0x10_str)
-#else
-  fsh f12, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x10, Zfhmin_fsh_cg_cp_imm_edges_0x10_str)
 
@@ -966,18 +624,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x20:
   fsh f13, 32(x24) # perform store
   addi x24, x24, 32 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x14 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x14, Zfhmin_fsh_cg_cp_imm_edges_0x20, Zfhmin_fsh_cg_cp_imm_edges_0x20_str)
-#else
-  fsh f13, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x20, Zfhmin_fsh_cg_cp_imm_edges_0x20_str)
 
@@ -990,18 +639,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x40:
   fsh f13, 64(x27) # perform store
   addi x27, x27, 64 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x21 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x21, Zfhmin_fsh_cg_cp_imm_edges_0x40, Zfhmin_fsh_cg_cp_imm_edges_0x40_str)
-#else
-  fsh f13, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x40, Zfhmin_fsh_cg_cp_imm_edges_0x40_str)
 
@@ -1014,18 +654,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x80:
   fsh f23, 128(x10) # perform store
   addi x10, x10, 128 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x7 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x7, Zfhmin_fsh_cg_cp_imm_edges_0x80, Zfhmin_fsh_cg_cp_imm_edges_0x80_str)
-#else
-  fsh f23, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x80, Zfhmin_fsh_cg_cp_imm_edges_0x80_str)
 
@@ -1038,18 +669,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x100:
   fsh f10, 256(x27) # perform store
   addi x27, x27, 256 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x23 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x23, Zfhmin_fsh_cg_cp_imm_edges_0x100, Zfhmin_fsh_cg_cp_imm_edges_0x100_str)
-#else
-  fsh f10, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x100, Zfhmin_fsh_cg_cp_imm_edges_0x100_str)
 
@@ -1062,18 +684,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x200:
   fsh f9, 512(x15) # perform store
   addi x15, x15, 512 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x28 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x28, Zfhmin_fsh_cg_cp_imm_edges_0x200, Zfhmin_fsh_cg_cp_imm_edges_0x200_str)
-#else
-  fsh f9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x200, Zfhmin_fsh_cg_cp_imm_edges_0x200_str)
 
@@ -1086,18 +699,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x3ff:
   fsh f26, 1023(x14) # perform store
   addi x14, x14, 1023 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x18 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x18, Zfhmin_fsh_cg_cp_imm_edges_0x3ff, Zfhmin_fsh_cg_cp_imm_edges_0x3ff_str)
-#else
-  fsh f26, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x3ff, Zfhmin_fsh_cg_cp_imm_edges_0x3ff_str)
 
@@ -1110,18 +714,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x400:
   fsh f18, 1024(x15) # perform store
   addi x15, x15, 1024 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x12, Zfhmin_fsh_cg_cp_imm_edges_0x400, Zfhmin_fsh_cg_cp_imm_edges_0x400_str)
-#else
-  fsh f18, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x400, Zfhmin_fsh_cg_cp_imm_edges_0x400_str)
 
@@ -1134,18 +729,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x703:
   fsh f24, 1795(x13) # perform store
   addi x13, x13, 1795 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x27 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x27, Zfhmin_fsh_cg_cp_imm_edges_0x703, Zfhmin_fsh_cg_cp_imm_edges_0x703_str)
-#else
-  fsh f24, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x703, Zfhmin_fsh_cg_cp_imm_edges_0x703_str)
 
@@ -1158,18 +744,9 @@ Zfhmin_fsh_cg_cp_imm_edges_0x7ff:
   fsh f15, 2047(x17) # perform store
   addi x17, x17, 2047 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x23 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x23, Zfhmin_fsh_cg_cp_imm_edges_0x7ff, Zfhmin_fsh_cg_cp_imm_edges_0x7ff_str)
-#else
-  fsh f15, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_0x7ff, Zfhmin_fsh_cg_cp_imm_edges_0x7ff_str)
 
@@ -1183,18 +760,9 @@ Zfhmin_fsh_cg_cp_imm_edges_m0x800:
   fsh f11, -2048(x22) # perform store
   addi x22, x22, -2048 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x25 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x25, Zfhmin_fsh_cg_cp_imm_edges_m0x800, Zfhmin_fsh_cg_cp_imm_edges_m0x800_str)
-#else
-  fsh f11, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_m0x800, Zfhmin_fsh_cg_cp_imm_edges_m0x800_str)
 
@@ -1207,18 +775,9 @@ Zfhmin_fsh_cg_cp_imm_edges_m0x7ff:
   fsh f26, -2047(x31) # perform store
   addi x31, x31, -2047 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x17 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x17, Zfhmin_fsh_cg_cp_imm_edges_m0x7ff, Zfhmin_fsh_cg_cp_imm_edges_m0x7ff_str)
-#else
-  fsh f26, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_m0x7ff, Zfhmin_fsh_cg_cp_imm_edges_m0x7ff_str)
 
@@ -1231,18 +790,9 @@ Zfhmin_fsh_cg_cp_imm_edges_m0x2:
   fsh f25, -2(x25) # perform store
   addi x25, x25, -2 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x16 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x16, Zfhmin_fsh_cg_cp_imm_edges_m0x2, Zfhmin_fsh_cg_cp_imm_edges_m0x2_str)
-#else
-  fsh f25, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_m0x2, Zfhmin_fsh_cg_cp_imm_edges_m0x2_str)
 
@@ -1255,18 +805,9 @@ Zfhmin_fsh_cg_cp_imm_edges_m0x1:
   fsh f31, -1(x10) # perform store
   addi x10, x10, -1 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x23 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x23, Zfhmin_fsh_cg_cp_imm_edges_m0x1, Zfhmin_fsh_cg_cp_imm_edges_m0x1_str)
-#else
-  fsh f31, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfhmin_fsh_cg_cp_imm_edges_m0x1, Zfhmin_fsh_cg_cp_imm_edges_m0x1_str)
 
@@ -1283,18 +824,9 @@ Zfhmin_fsh_cg_cp_fs2_b0:
   fsh f0, -163(x17) # perform store
   addi x17, x17, -163 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x13 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x13, Zfhmin_fsh_cg_cp_fs2_b0, Zfhmin_fsh_cg_cp_fs2_b0_str)
-#else
-  fsh f0, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfhmin_fsh_cg_cp_fs2_b0, Zfhmin_fsh_cg_cp_fs2_b0_str)
 
@@ -1307,18 +839,9 @@ Zfhmin_fsh_cg_cp_fs2_b1:
   fsh f1, 1761(x30) # perform store
   addi x30, x30, 1761 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x12 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x12, Zfhmin_fsh_cg_cp_fs2_b1, Zfhmin_fsh_cg_cp_fs2_b1_str)
-#else
-  fsh f1, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfhmin_fsh_cg_cp_fs2_b1, Zfhmin_fsh_cg_cp_fs2_b1_str)
 
@@ -1331,18 +854,9 @@ Zfhmin_fsh_cg_cp_fs2_b2:
   fsh f2, 1029(x23) # perform store
   addi x23, x23, 1029 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x24 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x24, Zfhmin_fsh_cg_cp_fs2_b2, Zfhmin_fsh_cg_cp_fs2_b2_str)
-#else
-  fsh f2, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfhmin_fsh_cg_cp_fs2_b2, Zfhmin_fsh_cg_cp_fs2_b2_str)
 
@@ -1355,18 +869,9 @@ Zfhmin_fsh_cg_cp_fs2_b3:
   fsh f3, -1663(x11) # perform store
   addi x11, x11, -1663 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x10, Zfhmin_fsh_cg_cp_fs2_b3, Zfhmin_fsh_cg_cp_fs2_b3_str)
-#else
-  fsh f3, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfhmin_fsh_cg_cp_fs2_b3, Zfhmin_fsh_cg_cp_fs2_b3_str)
 
@@ -1379,18 +884,9 @@ Zfhmin_fsh_cg_cp_fs2_b4:
   fsh f4, 166(x7) # perform store
   addi x7, x7, 166 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x16 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x16, Zfhmin_fsh_cg_cp_fs2_b4, Zfhmin_fsh_cg_cp_fs2_b4_str)
-#else
-  fsh f4, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, Zfhmin_fsh_cg_cp_fs2_b4, Zfhmin_fsh_cg_cp_fs2_b4_str)
 
@@ -1403,18 +899,9 @@ Zfhmin_fsh_cg_cp_fs2_b5:
   fsh f5, 221(x23) # perform store
   addi x23, x23, 221 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x25 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x25, Zfhmin_fsh_cg_cp_fs2_b5, Zfhmin_fsh_cg_cp_fs2_b5_str)
-#else
-  fsh f5, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfhmin_fsh_cg_cp_fs2_b5, Zfhmin_fsh_cg_cp_fs2_b5_str)
 
@@ -1427,18 +914,9 @@ Zfhmin_fsh_cg_cp_fs2_b6:
   fsh f6, -1072(x13) # perform store
   addi x13, x13, -1072 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x14 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x14, Zfhmin_fsh_cg_cp_fs2_b6, Zfhmin_fsh_cg_cp_fs2_b6_str)
-#else
-  fsh f6, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfhmin_fsh_cg_cp_fs2_b6, Zfhmin_fsh_cg_cp_fs2_b6_str)
 
@@ -1451,18 +929,9 @@ Zfhmin_fsh_cg_cp_fs2_b7:
   fsh f7, -347(x1) # perform store
   addi x1, x1, -347 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x30 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x30, Zfhmin_fsh_cg_cp_fs2_b7, Zfhmin_fsh_cg_cp_fs2_b7_str)
-#else
-  fsh f7, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfhmin_fsh_cg_cp_fs2_b7, Zfhmin_fsh_cg_cp_fs2_b7_str)
 
@@ -1475,18 +944,9 @@ Zfhmin_fsh_cg_cp_fs2_b8:
   fsh f8, 1059(x21) # perform store
   addi x21, x21, 1059 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x26 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x26, Zfhmin_fsh_cg_cp_fs2_b8, Zfhmin_fsh_cg_cp_fs2_b8_str)
-#else
-  fsh f8, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfhmin_fsh_cg_cp_fs2_b8, Zfhmin_fsh_cg_cp_fs2_b8_str)
 
@@ -1499,18 +959,9 @@ Zfhmin_fsh_cg_cp_fs2_b9:
   fsh f9, -838(x22) # perform store
   addi x22, x22, -838 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x15 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x15, Zfhmin_fsh_cg_cp_fs2_b9, Zfhmin_fsh_cg_cp_fs2_b9_str)
-#else
-  fsh f9, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfhmin_fsh_cg_cp_fs2_b9, Zfhmin_fsh_cg_cp_fs2_b9_str)
 
@@ -1523,18 +974,9 @@ Zfhmin_fsh_cg_cp_fs2_b10:
   fsh f10, 1172(x23) # perform store
   addi x23, x23, 1172 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x31 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x31, Zfhmin_fsh_cg_cp_fs2_b10, Zfhmin_fsh_cg_cp_fs2_b10_str)
-#else
-  fsh f10, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfhmin_fsh_cg_cp_fs2_b10, Zfhmin_fsh_cg_cp_fs2_b10_str)
 
@@ -1547,18 +989,9 @@ Zfhmin_fsh_cg_cp_fs2_b11:
   fsh f11, 1741(x2) # perform store
   addi x2, x2, 1741 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x3, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x3 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x3, Zfhmin_fsh_cg_cp_fs2_b11, Zfhmin_fsh_cg_cp_fs2_b11_str)
-#else
-  fsh f11, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfhmin_fsh_cg_cp_fs2_b11, Zfhmin_fsh_cg_cp_fs2_b11_str)
 
@@ -1571,18 +1004,9 @@ Zfhmin_fsh_cg_cp_fs2_b12:
   fsh f12, 547(x16) # perform store
   addi x16, x16, 547 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x13 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x13, Zfhmin_fsh_cg_cp_fs2_b12, Zfhmin_fsh_cg_cp_fs2_b12_str)
-#else
-  fsh f12, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfhmin_fsh_cg_cp_fs2_b12, Zfhmin_fsh_cg_cp_fs2_b12_str)
 
@@ -1595,18 +1019,9 @@ Zfhmin_fsh_cg_cp_fs2_b13:
   fsh f13, 985(x15) # perform store
   addi x15, x15, 985 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x6 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x6, Zfhmin_fsh_cg_cp_fs2_b13, Zfhmin_fsh_cg_cp_fs2_b13_str)
-#else
-  fsh f13, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfhmin_fsh_cg_cp_fs2_b13, Zfhmin_fsh_cg_cp_fs2_b13_str)
 
@@ -1619,18 +1034,9 @@ Zfhmin_fsh_cg_cp_fs2_b14:
   fsh f14, 632(x24) # perform store
   addi x24, x24, 632 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x23 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x23, Zfhmin_fsh_cg_cp_fs2_b14, Zfhmin_fsh_cg_cp_fs2_b14_str)
-#else
-  fsh f14, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfhmin_fsh_cg_cp_fs2_b14, Zfhmin_fsh_cg_cp_fs2_b14_str)
 
@@ -1643,18 +1049,9 @@ Zfhmin_fsh_cg_cp_fs2_b15:
   fsh f15, 1967(x19) # perform store
   addi x19, x19, 1967 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x18 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x18, Zfhmin_fsh_cg_cp_fs2_b15, Zfhmin_fsh_cg_cp_fs2_b15_str)
-#else
-  fsh f15, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfhmin_fsh_cg_cp_fs2_b15, Zfhmin_fsh_cg_cp_fs2_b15_str)
 
@@ -1667,18 +1064,9 @@ Zfhmin_fsh_cg_cp_fs2_b16:
   fsh f16, 1223(x3) # perform store
   addi x3, x3, 1223 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x14 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x14, Zfhmin_fsh_cg_cp_fs2_b16, Zfhmin_fsh_cg_cp_fs2_b16_str)
-#else
-  fsh f16, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfhmin_fsh_cg_cp_fs2_b16, Zfhmin_fsh_cg_cp_fs2_b16_str)
 
@@ -1691,18 +1079,9 @@ Zfhmin_fsh_cg_cp_fs2_b17:
   fsh f17, 1853(x10) # perform store
   addi x10, x10, 1853 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x25 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x25, Zfhmin_fsh_cg_cp_fs2_b17, Zfhmin_fsh_cg_cp_fs2_b17_str)
-#else
-  fsh f17, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfhmin_fsh_cg_cp_fs2_b17, Zfhmin_fsh_cg_cp_fs2_b17_str)
 
@@ -1715,18 +1094,9 @@ Zfhmin_fsh_cg_cp_fs2_b18:
   fsh f18, -1804(x31) # perform store
   addi x31, x31, -1804 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x11 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x11, Zfhmin_fsh_cg_cp_fs2_b18, Zfhmin_fsh_cg_cp_fs2_b18_str)
-#else
-  fsh f18, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfhmin_fsh_cg_cp_fs2_b18, Zfhmin_fsh_cg_cp_fs2_b18_str)
 
@@ -1739,18 +1109,9 @@ Zfhmin_fsh_cg_cp_fs2_b19:
   fsh f19, 2013(x3) # perform store
   addi x3, x3, 2013 # restore base address
   addi x3, x3, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x3) # load stored value for checking
   # Check if x13 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x13, Zfhmin_fsh_cg_cp_fs2_b19, Zfhmin_fsh_cg_cp_fs2_b19_str)
-#else
-  fsh f19, 0(x3) # repeat store so it is available for checking
-  addi x3, x3, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x3, x5, x4, Zfhmin_fsh_cg_cp_fs2_b19, Zfhmin_fsh_cg_cp_fs2_b19_str)
 
@@ -1763,18 +1124,9 @@ Zfhmin_fsh_cg_cp_fs2_b20:
   fsh f20, 2011(x29) # perform store
   addi x29, x29, 2011 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x11 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x11, Zfhmin_fsh_cg_cp_fs2_b20, Zfhmin_fsh_cg_cp_fs2_b20_str)
-#else
-  fsh f20, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfhmin_fsh_cg_cp_fs2_b20, Zfhmin_fsh_cg_cp_fs2_b20_str)
 
@@ -1787,18 +1139,9 @@ Zfhmin_fsh_cg_cp_fs2_b21:
   fsh f21, 593(x12) # perform store
   addi x12, x12, 593 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x18 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x18, Zfhmin_fsh_cg_cp_fs2_b21, Zfhmin_fsh_cg_cp_fs2_b21_str)
-#else
-  fsh f21, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfhmin_fsh_cg_cp_fs2_b21, Zfhmin_fsh_cg_cp_fs2_b21_str)
 
@@ -1811,18 +1154,9 @@ Zfhmin_fsh_cg_cp_fs2_b22:
   fsh f22, -306(x6) # perform store
   addi x6, x6, -306 # restore base address
   addi x6, x6, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x8, -SIG_STRIDE(x6) # load stored value for checking
   # Check if x8 contains the expected result. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x6, x5, x4, x8, Zfhmin_fsh_cg_cp_fs2_b22, Zfhmin_fsh_cg_cp_fs2_b22_str)
-#else
-  fsh f22, 0(x6) # repeat store so it is available for checking
-  addi x6, x6, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x6 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x6, x5, x4, Zfhmin_fsh_cg_cp_fs2_b22, Zfhmin_fsh_cg_cp_fs2_b22_str)
 
@@ -1835,18 +1169,9 @@ Zfhmin_fsh_cg_cp_fs2_b23:
   fsh f23, -1834(x26) # perform store
   addi x26, x26, -1834 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x21 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x21, Zfhmin_fsh_cg_cp_fs2_b23, Zfhmin_fsh_cg_cp_fs2_b23_str)
-#else
-  fsh f23, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfhmin_fsh_cg_cp_fs2_b23, Zfhmin_fsh_cg_cp_fs2_b23_str)
 
@@ -1859,18 +1184,9 @@ Zfhmin_fsh_cg_cp_fs2_b24:
   fsh f24, 221(x23) # perform store
   addi x23, x23, 221 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x13 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x13, Zfhmin_fsh_cg_cp_fs2_b24, Zfhmin_fsh_cg_cp_fs2_b24_str)
-#else
-  fsh f24, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfhmin_fsh_cg_cp_fs2_b24, Zfhmin_fsh_cg_cp_fs2_b24_str)
 
@@ -1883,18 +1199,9 @@ Zfhmin_fsh_cg_cp_fs2_b25:
   fsh f25, -276(x17) # perform store
   addi x17, x17, -276 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x24 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x24, Zfhmin_fsh_cg_cp_fs2_b25, Zfhmin_fsh_cg_cp_fs2_b25_str)
-#else
-  fsh f25, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, Zfhmin_fsh_cg_cp_fs2_b25, Zfhmin_fsh_cg_cp_fs2_b25_str)
 
@@ -1907,18 +1214,9 @@ Zfhmin_fsh_cg_cp_fs2_b26:
   fsh f26, -1953(x12) # perform store
   addi x12, x12, -1953 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x21 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x21, Zfhmin_fsh_cg_cp_fs2_b26, Zfhmin_fsh_cg_cp_fs2_b26_str)
-#else
-  fsh f26, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfhmin_fsh_cg_cp_fs2_b26, Zfhmin_fsh_cg_cp_fs2_b26_str)
 
@@ -1931,18 +1229,9 @@ Zfhmin_fsh_cg_cp_fs2_b27:
   fsh f27, -982(x19) # perform store
   addi x19, x19, -982 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x21 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x21, Zfhmin_fsh_cg_cp_fs2_b27, Zfhmin_fsh_cg_cp_fs2_b27_str)
-#else
-  fsh f27, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfhmin_fsh_cg_cp_fs2_b27, Zfhmin_fsh_cg_cp_fs2_b27_str)
 
@@ -1955,18 +1244,9 @@ Zfhmin_fsh_cg_cp_fs2_b28:
   fsh f28, 405(x9) # perform store
   addi x9, x9, 405 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x17 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x17, Zfhmin_fsh_cg_cp_fs2_b28, Zfhmin_fsh_cg_cp_fs2_b28_str)
-#else
-  fsh f28, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfhmin_fsh_cg_cp_fs2_b28, Zfhmin_fsh_cg_cp_fs2_b28_str)
 
@@ -1979,18 +1259,9 @@ Zfhmin_fsh_cg_cp_fs2_b29:
   fsh f29, -1644(x26) # perform store
   addi x26, x26, -1644 # restore base address
   addi x26, x26, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x26) # load stored value for checking
   # Check if x14 contains the expected result. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x26, x5, x4, x14, Zfhmin_fsh_cg_cp_fs2_b29, Zfhmin_fsh_cg_cp_fs2_b29_str)
-#else
-  fsh f29, 0(x26) # repeat store so it is available for checking
-  addi x26, x26, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x26, x5, x4, Zfhmin_fsh_cg_cp_fs2_b29, Zfhmin_fsh_cg_cp_fs2_b29_str)
 
@@ -2003,18 +1274,9 @@ Zfhmin_fsh_cg_cp_fs2_b30:
   fsh f30, -1587(x28) # perform store
   addi x28, x28, -1587 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x18 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x18, Zfhmin_fsh_cg_cp_fs2_b30, Zfhmin_fsh_cg_cp_fs2_b30_str)
-#else
-  fsh f30, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, Zfhmin_fsh_cg_cp_fs2_b30, Zfhmin_fsh_cg_cp_fs2_b30_str)
 
@@ -2027,18 +1289,9 @@ Zfhmin_fsh_cg_cp_fs2_b31:
   fsh f31, 146(x23) # perform store
   addi x23, x23, 146 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x9 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x9, Zfhmin_fsh_cg_cp_fs2_b31, Zfhmin_fsh_cg_cp_fs2_b31_str)
-#else
-  fsh f31, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, Zfhmin_fsh_cg_cp_fs2_b31, Zfhmin_fsh_cg_cp_fs2_b31_str)
 
@@ -2055,18 +1308,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x0:
   fsh f27, 334(x16) # perform store
   addi x16, x16, 334 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x18 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x18, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x0, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x0_str)
-#else
-  fsh f27, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x0, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x0_str)
 
@@ -2079,18 +1323,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8000:
   fsh f9, -1370(x7) # perform store
   addi x7, x7, -1370 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x17 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x17, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8000, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8000_str)
-#else
-  fsh f9, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8000, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8000_str)
 
@@ -2103,18 +1338,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3c00:
   fsh f6, -380(x28) # perform store
   addi x28, x28, -380 # restore base address
   addi x28, x28, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x28) # load stored value for checking
   # Check if x12 contains the expected result. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x28, x5, x4, x12, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3c00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3c00_str)
-#else
-  fsh f6, 0(x28) # repeat store so it is available for checking
-  addi x28, x28, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x28, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3c00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3c00_str)
 
@@ -2127,18 +1353,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbc00:
   fsh f31, 1592(x29) # perform store
   addi x29, x29, 1592 # restore base address
   addi x29, x29, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x29) # load stored value for checking
   # Check if x27 contains the expected result. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x29, x5, x4, x27, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbc00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbc00_str)
-#else
-  fsh f31, 0(x29) # repeat store so it is available for checking
-  addi x29, x29, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x29 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x29, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbc00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbc00_str)
 
@@ -2151,18 +1368,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3e00:
   fsh f19, 1663(x15) # perform store
   addi x15, x15, 1663 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x18 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x18, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3e00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3e00_str)
-#else
-  fsh f19, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3e00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3e00_str)
 
@@ -2175,18 +1383,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbe00:
   fsh f20, -2013(x8) # perform store
   addi x8, x8, -2013 # restore base address
   addi x8, x8, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x8) # load stored value for checking
   # Check if x28 contains the expected result. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x8, x5, x4, x28, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbe00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbe00_str)
-#else
-  fsh f20, 0(x8) # repeat store so it is available for checking
-  addi x8, x8, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x8 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x8, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbe00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xbe00_str)
 
@@ -2199,18 +1398,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x4000:
   fsh f12, 1772(x14) # perform store
   addi x14, x14, 1772 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x17 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x17, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x4000, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x4000_str)
-#else
-  fsh f12, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x4000, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x4000_str)
 
@@ -2223,18 +1413,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc000:
   fsh f17, -1411(x13) # perform store
   addi x13, x13, -1411 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x30 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x30, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc000, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc000_str)
-#else
-  fsh f17, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc000, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc000_str)
 
@@ -2247,18 +1428,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x400:
   fsh f21, 202(x15) # perform store
   addi x15, x15, 202 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x16 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x16, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x400, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x400_str)
-#else
-  fsh f21, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x400, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x400_str)
 
@@ -2271,18 +1443,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8400:
   fsh f2, 1405(x25) # perform store
   addi x25, x25, 1405 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x16 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x16, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8400, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8400_str)
-#else
-  fsh f2, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8400, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8400_str)
 
@@ -2295,18 +1458,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7bff:
   fsh f8, -1191(x14) # perform store
   addi x14, x14, -1191 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x27, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x27 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x27, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7bff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7bff_str)
-#else
-  fsh f8, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7bff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7bff_str)
 
@@ -2319,18 +1473,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfbff:
   fsh f9, 1218(x27) # perform store
   addi x27, x27, 1218 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x19 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x19, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfbff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfbff_str)
-#else
-  fsh f9, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfbff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfbff_str)
 
@@ -2343,18 +1488,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3ff:
   fsh f29, -379(x19) # perform store
   addi x19, x19, -379 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x10 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x10, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3ff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3ff_str)
-#else
-  fsh f29, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3ff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x3ff_str)
 
@@ -2367,18 +1503,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x83ff:
   fsh f3, -847(x14) # perform store
   addi x14, x14, -847 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x18 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x18, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x83ff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x83ff_str)
-#else
-  fsh f3, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x83ff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x83ff_str)
 
@@ -2391,18 +1518,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x200:
   fsh f18, -1102(x25) # perform store
   addi x25, x25, -1102 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x30 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x30, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x200, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x200_str)
-#else
-  fsh f18, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x200, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x200_str)
 
@@ -2415,18 +1533,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8200:
   fsh f16, 1701(x30) # perform store
   addi x30, x30, 1701 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x23 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x23, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8200, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8200_str)
-#else
-  fsh f16, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8200, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8200_str)
 
@@ -2439,18 +1548,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x1:
   fsh f21, 466(x31) # perform store
   addi x31, x31, 466 # restore base address
   addi x31, x31, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x31) # load stored value for checking
   # Check if x16 contains the expected result. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x31, x5, x4, x16, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x1, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x1_str)
-#else
-  fsh f21, 0(x31) # repeat store so it is available for checking
-  addi x31, x31, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x31 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x31, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x1, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x1_str)
 
@@ -2463,18 +1563,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8001:
   fsh f5, -1061(x27) # perform store
   addi x27, x27, -1061 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x10 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x10, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8001, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8001_str)
-#else
-  fsh f5, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8001, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x8001_str)
 
@@ -2487,18 +1578,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c00:
   fsh f31, -509(x21) # perform store
   addi x21, x21, -509 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x25 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x25, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c00_str)
-#else
-  fsh f31, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c00_str)
 
@@ -2511,18 +1593,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc00:
   fsh f14, -1974(x9) # perform store
   addi x9, x9, -1974 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x17 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x17, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc00_str)
-#else
-  fsh f14, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc00_str)
 
@@ -2535,18 +1608,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7e00:
   fsh f27, 1090(x1) # perform store
   addi x1, x1, 1090 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x11 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x11, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7e00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7e00_str)
-#else
-  fsh f27, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7e00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7e00_str)
 
@@ -2559,18 +1623,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7fff:
   fsh f22, 448(x30) # perform store
   addi x30, x30, 448 # restore base address
   addi x30, x30, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x30) # load stored value for checking
   # Check if x26 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x26, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7fff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7fff_str)
-#else
-  fsh f22, 0(x30) # repeat store so it is available for checking
-  addi x30, x30, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x30, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7fff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7fff_str)
 
@@ -2583,18 +1638,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfe00:
   fsh f12, -153(x13) # perform store
   addi x13, x13, -153 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x9 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x9, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfe00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfe00_str)
-#else
-  fsh f12, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfe00, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfe00_str)
 
@@ -2607,18 +1653,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c01:
   fsh f12, -649(x19) # perform store
   addi x19, x19, -649 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x25, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x25 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x25, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c01, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c01_str)
-#else
-  fsh f12, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c01, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7c01_str)
 
@@ -2631,18 +1668,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7dff:
   fsh f22, 1959(x14) # perform store
   addi x14, x14, 1959 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x31, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x31 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x31, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7dff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7dff_str)
-#else
-  fsh f22, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7dff, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x7dff_str)
 
@@ -2655,18 +1683,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc01:
   fsh f22, -735(x1) # perform store
   addi x1, x1, -735 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x6, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x6 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x6, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc01, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc01_str)
-#else
-  fsh f22, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc01, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xfc01_str)
 
@@ -2679,18 +1698,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0x58b4:
   fsh f17, 664(x10) # perform store
   addi x10, x10, 664 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x22, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x22 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x22, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x58b4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x58b4_str)
-#else
-  fsh f17, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x58b4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0x58b4_str)
 
@@ -2703,18 +1713,9 @@ Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc93a:
   fsh f4, 1199(x24) # perform store
   addi x24, x24, 1199 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x19, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x19 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x19, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc93a, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc93a_str)
-#else
-  fsh f4, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc93a, Zfhmin_fsh_cg_cp_fs2_edges_H_b0xc93a_str)
 
@@ -2731,18 +1732,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x0:
   fsh f15, -691(x10) # perform store
   addi x10, x10, -691 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x28, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x28 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x28, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x0, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x0_str)
-#else
-  fsh f15, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x0, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x0_str)
 
@@ -2755,18 +1747,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000:
   fsh f8, 1467(x1) # perform store
   addi x1, x1, 1467 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x26 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x26, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000_str)
-#else
-  fsh f8, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfffe8000_str)
 
@@ -2779,18 +1762,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00:
   fsh f28, 1925(x16) # perform store
   addi x16, x16, 1925 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x13, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x13 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x13, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00_str)
-#else
-  fsh f28, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x7fff3c00_str)
 
@@ -2803,18 +1777,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00:
   fsh f19, 179(x27) # perform store
   addi x27, x27, 179 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x12, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x12 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x12, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00_str)
-#else
-  fsh f19, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xbeefbc00_str)
 
@@ -2827,18 +1792,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400:
   fsh f21, 344(x21) # perform store
   addi x21, x21, 344 # restore base address
   addi x21, x21, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x21) # load stored value for checking
   # Check if x18 contains the expected result. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x21, x5, x4, x18, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400_str)
-#else
-  fsh f21, 0(x21) # repeat store so it is available for checking
-  addi x21, x21, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x21 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x21, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeff0400_str)
 
@@ -2851,18 +1807,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400:
   fsh f9, 164(x15) # perform store
   addi x15, x15, 164 # restore base address
   addi x15, x15, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x15) # load stored value for checking
   # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x15, x5, x4, x14, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400_str)
-#else
-  fsh f9, 0(x15) # repeat store so it is available for checking
-  addi x15, x15, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x15, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfff8400_str)
 
@@ -2875,18 +1822,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff:
   fsh f24, 1839(x9) # perform store
   addi x9, x9, 1839 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x21 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x21, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff_str)
-#else
-  fsh f24, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xefff7bff_str)
 
@@ -2899,18 +1837,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff:
   fsh f13, 381(x14) # perform store
   addi x14, x14, 381 # restore base address
   addi x14, x14, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x16, -SIG_STRIDE(x14) # load stored value for checking
   # Check if x16 contains the expected result. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x14, x5, x4, x16, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff_str)
-#else
-  fsh f13, 0(x14) # repeat store so it is available for checking
-  addi x14, x14, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x14 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x14, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xc0defbff_str)
 
@@ -2923,18 +1852,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00:
   fsh f20, 1600(x12) # perform store
   addi x12, x12, 1600 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x23, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x23 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x23, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00_str)
-#else
-  fsh f20, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4f1a7c00_str)
 
@@ -2947,18 +1867,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00:
   fsh f27, 922(x27) # perform store
   addi x27, x27, 922 # restore base address
   addi x27, x27, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x21, -SIG_STRIDE(x27) # load stored value for checking
   # Check if x21 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x21, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00_str)
-#else
-  fsh f27, 0(x27) # repeat store so it is available for checking
-  addi x27, x27, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x27, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffffc00_str)
 
@@ -2971,18 +1882,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00:
   fsh f13, 1939(x22) # perform store
   addi x22, x22, 1939 # restore base address
   addi x22, x22, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x22) # load stored value for checking
   # Check if x14 contains the expected result. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x22, x5, x4, x14, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00_str)
-#else
-  fsh f13, 0(x22) # repeat store so it is available for checking
-  addi x22, x22, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x22 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x22, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xffef7e00_str)
 
@@ -2995,18 +1897,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff:
   fsh f9, 1058(x11) # perform store
   addi x11, x11, 1058 # restore base address
   addi x11, x11, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x17, -SIG_STRIDE(x11) # load stored value for checking
   # Check if x17 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x17, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff_str)
-#else
-  fsh f9, 0(x11) # repeat store so it is available for checking
-  addi x11, x11, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x11, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xfeef7fff_str)
 
@@ -3019,18 +1912,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01:
   fsh f21, 27(x2) # perform store
   addi x2, x2, 27 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x1, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x1 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x1, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01_str)
-#else
-  fsh f21, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0xa1b27c01_str)
 
@@ -3043,18 +1927,9 @@ Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff:
   fsh f17, -327(x1) # perform store
   addi x1, x1, -327 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x15 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x15, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff_str)
-#else
-  fsh f17, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff, Zfhmin_fsh_cg_cp_fs2_badNB_S_H_b0x4fd77dff_str)
 

--- a/tests/rv64i/ZfhminD/ZfhminD-fsh-00.S
+++ b/tests/rv64i/ZfhminD/ZfhminD-fsh-00.S
@@ -42,18 +42,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000:
   fsh f3, 289(x25) # perform store
   addi x25, x25, 289 # restore base address
   addi x25, x25, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x9, -SIG_STRIDE(x25) # load stored value for checking
   # Check if x9 contains the expected result. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x25, x5, x4, x9, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000_str)
-#else
-  fsh f3, 0(x25) # repeat store so it is available for checking
-  addi x25, x25, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x25 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x25, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff00000000_str)
 
@@ -66,18 +57,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000:
   fsh f9, 449(x16) # perform store
   addi x16, x16, 449 # restore base address
   addi x16, x16, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x16) # load stored value for checking
   # Check if x11 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x16, x5, x4, x11, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000_str)
-#else
-  fsh f9, 0(x16) # repeat store so it is available for checking
-  addi x16, x16, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x16, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffffffe8000_str)
 
@@ -90,18 +72,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00:
   fsh f10, -1605(x24) # perform store
   addi x24, x24, -1605 # restore base address
   addi x24, x24, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x24) # load stored value for checking
   # Check if x30 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x24, x5, x4, x30, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00_str)
-#else
-  fsh f10, 0(x24) # repeat store so it is available for checking
-  addi x24, x24, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x24, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0x7fffffffffff3c00_str)
 
@@ -114,18 +87,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00:
   fsh f10, -555(x13) # perform store
   addi x13, x13, -555 # restore base address
   addi x13, x13, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x11, -SIG_STRIDE(x13) # load stored value for checking
   # Check if x11 contains the expected result. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x13, x5, x4, x11, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00_str)
-#else
-  fsh f10, 0(x13) # repeat store so it is available for checking
-  addi x13, x13, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x13 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x13, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfeedbee5beefbc00_str)
 
@@ -138,18 +102,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400:
   fsh f25, 372(x17) # perform store
   addi x17, x17, 372 # restore base address
   addi x17, x17, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x18, -SIG_STRIDE(x17) # load stored value for checking
   # Check if x18 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x17, x5, x4, x18, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400_str)
-#else
-  fsh f25, 0(x17) # repeat store so it is available for checking
-  addi x17, x17, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x17, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff0400_str)
 
@@ -162,18 +117,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400:
   fsh f7, 158(x10) # perform store
   addi x10, x10, 158 # restore base address
   addi x10, x10, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x30, -SIG_STRIDE(x10) # load stored value for checking
   # Check if x30 contains the expected result. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x10, x5, x4, x30, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400_str)
-#else
-  fsh f7, 0(x10) # repeat store so it is available for checking
-  addi x10, x10, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x10, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffff8400_str)
 
@@ -186,18 +132,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff:
   fsh f5, 737(x1) # perform store
   addi x1, x1, 737 # restore base address
   addi x1, x1, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x1) # load stored value for checking
   # Check if x26 contains the expected result. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x1, x5, x4, x26, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff_str)
-#else
-  fsh f5, 0(x1) # repeat store so it is available for checking
-  addi x1, x1, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x1 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x1, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xefffffffffff7bff_str)
 
@@ -210,18 +147,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff:
   fsh f16, -174(x23) # perform store
   addi x23, x23, -174 # restore base address
   addi x23, x23, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x29, -SIG_STRIDE(x23) # load stored value for checking
   # Check if x29 contains the expected result. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x23, x5, x4, x29, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff_str)
-#else
-  fsh f16, 0(x23) # repeat store so it is available for checking
-  addi x23, x23, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x23 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x23, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xc0dec0dec0defbff_str)
 
@@ -234,18 +162,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00:
   fsh f16, 779(x19) # perform store
   addi x19, x19, 779 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x7, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x7 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x7, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00_str)
-#else
-  fsh f16, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa83ef1cc4f1a7c00_str)
 
@@ -258,18 +177,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00:
   fsh f6, -824(x2) # perform store
   addi x2, x2, -824 # restore base address
   addi x2, x2, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x24, -SIG_STRIDE(x2) # load stored value for checking
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00_str)
-#else
-  fsh f6, 0(x2) # repeat store so it is available for checking
-  addi x2, x2, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x2, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffff0ffffc00_str)
 
@@ -282,18 +192,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00:
   fsh f1, -1991(x9) # perform store
   addi x9, x9, -1991 # restore base address
   addi x9, x9, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x10, -SIG_STRIDE(x9) # load stored value for checking
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00_str)
-#else
-  fsh f1, 0(x9) # repeat store so it is available for checking
-  addi x9, x9, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x9, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffeffffffff7e00_str)
 
@@ -306,18 +207,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff:
   fsh f30, 1358(x12) # perform store
   addi x12, x12, 1358 # restore base address
   addi x12, x12, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x14, -SIG_STRIDE(x12) # load stored value for checking
   # Check if x14 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x12, x5, x4, x14, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff_str)
-#else
-  fsh f30, 0(x12) # repeat store so it is available for checking
-  addi x12, x12, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x12, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xffffffefffff7fff_str)
 
@@ -330,18 +222,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01:
   fsh f17, 1468(x7) # perform store
   addi x7, x7, 1468 # restore base address
   addi x7, x7, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x15, -SIG_STRIDE(x7) # load stored value for checking
   # Check if x15 contains the expected result. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x7, x5, x4, x15, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01_str)
-#else
-  fsh f17, 0(x7) # repeat store so it is available for checking
-  addi x7, x7, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x7 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x7, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xa1b2c3d4e5f67c01_str)
 
@@ -354,18 +237,9 @@ ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff:
   fsh f7, 472(x19) # perform store
   addi x19, x19, 472 # restore base address
   addi x19, x19, SIG_STRIDE # increment signature pointer
-#ifdef RVTEST_SELFCHECK
   LREG x26, -SIG_STRIDE(x19) # load stored value for checking
   # Check if x26 contains the expected result. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x19, x5, x4, x26, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff_str)
-#else
-  fsh f7, 0(x19) # repeat store so it is available for checking
-  addi x19, x19, SIG_STRIDE # adjust base address for offset
-  # nops to ensure length matches SELFCHECK
-  nop
-  nop
-  nop
-#endif
   # Check fflags. x19 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD_FFLAGS(x19, x5, x4, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff, ZfhminD_fsh_cg_cp_fs2_badNB_D_H_b0xfffffffcffff7dff_str)
 


### PR DESCRIPTION
Updates generated store tests to use the same signature update path in signature and self-check builds, keeping `.text.rvtest` and test-visible data addresses stable.

Also fixes CSS stack-pointer stores so self-check compares the result slot against the expected signature slot instead of comparing the slot to itself.