### PR TITLE
Split CI exclusion lists

### DIFF
--- a/.github/scripts/ci_config.py
+++ b/.github/scripts/ci_config.py
@@ -35,7 +35,7 @@ import heapq
 import json
 import os
 import sys
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from functools import cache
 from pathlib import Path
 
@@ -123,6 +123,26 @@ def load_simulator_ci_yaml(ci_yaml_path: Path) -> dict:
     return data if data else {}
 
 
+def normalize_exclude_extensions(value: object, ci_yaml_path: Path) -> str:
+    """Return exclude_extensions as ACT's comma-separated string."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Sequence):
+        extensions: list[str] = []
+        for extension in value:
+            if not isinstance(extension, str):
+                raise TypeError(f"{ci_yaml_path}: 'exclude_extensions' entries must be strings, got {extension!r}")
+            extension = extension.strip()
+            if extension:
+                extensions.append(extension)
+        return ",".join(extensions)
+    raise TypeError(
+        f"{ci_yaml_path}: 'exclude_extensions' must be a string or list of strings, got {type(value).__name__}"
+    )
+
+
 def file_hash(path: Path) -> str:
     """Return the first 12 hex chars of the SHA-256 hash of a file's contents."""
     return hashlib.sha256(path.read_bytes()).hexdigest()[:12]
@@ -170,7 +190,7 @@ def discover_configs(config_dir: Path, workdir: Path | None = None) -> list[dict
             continue
 
         # Extract settings from ci.yaml
-        exclude_extensions = sim_config.get("exclude_extensions", "")
+        exclude_extensions = normalize_exclude_extensions(sim_config.get("exclude_extensions", ""), sim_ci_yaml)
         install_script = sim_config.get("install_script", "")
         apt_packages = sim_config.get("apt_packages", "")
         setup_script = sim_config.get("setup_script", "")

--- a/config/cores/cve2/ci.yaml
+++ b/config/cores/cve2/ci.yaml
@@ -3,9 +3,9 @@
 # CI configuration for the cve2 family: CV32E20
 
 ci_enabled: true
-# Sm excluded: Insufficient WARL configuration options.
-# Ssstrict excluded: blocked by https://github.com/riscv/riscv-arch-test/issues/1601
-exclude_extensions: "Sm,SsstrictSm"
+exclude_extensions:
+  - Sm # Insufficient WARL configuration options.
+  - SsstrictSm # Blocked by https://github.com/riscv/riscv-arch-test/issues/1601
 apt_packages: "autoconf flex bison help2man libfl-dev ccache"
 install_script: ".github/scripts/install-cve2.sh"
 setup_script: ".github/scripts/setup-cve2.sh"

--- a/config/cores/cve4/ci.yaml
+++ b/config/cores/cve4/ci.yaml
@@ -3,8 +3,10 @@
 # CI configuration for the cve4 family: CV32E40P and CV32E40X
 
 ci_enabled: true
-exclude_extensions: "Sm,SmF,SsstrictSm"
-# SmF: cv32e40p-rv32imcf DUT bug - https://github.com/openhwgroup/cv32e40p/issues/1060; SsstrictSm not supported
+exclude_extensions:
+  - Sm # Privileged tests are not supported by the current CVE4 CI configs.
+  - SmF # cv32e40p-rv32imcf DUT bug: https://github.com/openhwgroup/cv32e40p/issues/1060
+  - SsstrictSm # Not supported
 apt_packages: "autoconf flex bison help2man libfl-dev ccache"
 install_script: ".github/scripts/install-cve4.sh"
 setup_script: ".github/scripts/setup-cve4.sh"

--- a/config/cores/cvw/ci.yaml
+++ b/config/cores/cvw/ci.yaml
@@ -3,13 +3,12 @@
 # CI configuration for CORE-V Wally (CVW)
 # Requires Verilator and the CVW repository
 
-# Remaining exclusions are CVW/Sail behavior mismatches under the current configs.
-# Sm: Insufficient WARL configuration options.
-# Sv: https://github.com/openhwgroup/cvw/issues/1766
-# Svpbmt: unknown
-# ExceptionsSvZalrsc: Wally should produce access fault rather than misaligned fault on misaligned LRSC. https://github.com/openhwgroup/cvw/issues/1809
 ci_enabled: true
-exclude_extensions: "Sm,ExceptionsSvZalrsc,Sv,Svpbmt"
+exclude_extensions:
+  - Sm # Insufficient WARL configuration options.
+  - ExceptionsSvZalrsc # Wally should produce access fault rather than misaligned fault on misaligned LRSC: https://github.com/openhwgroup/cvw/issues/1809
+  - Sv # https://github.com/openhwgroup/cvw/issues/1766
+  - Svpbmt # Unknown CVW/Sail behavior mismatch under the current configs.
 apt_packages: "autoconf flex bison help2man libfl-dev ccache"
 install_script: ".github/scripts/install-cvw.sh"
 setup_script: ".github/scripts/setup-cvw.sh"

--- a/config/imperas/ci.yaml
+++ b/config/imperas/ci.yaml
@@ -3,15 +3,20 @@
 # CI configuration for Imperas simulator
 # Imperas is proprietary and cannot run in public CI.
 
-# These exclusions don't affect CI because it doesn't run, but they help tracking incomplete features
-#  - Sm: Insufficient WARL configuration options.
-#  - SsstrictSm/S/U: Sail does not yet implement hypervisor instructions/CSRs
-#  - Zkr: https://github.com/riscv/sail-riscv/issues/1829
-# - InterruptsSm/S/SSm/U: Imperas does not implement interrupts
-# - Smstateen: Sail does not implement all state yet to match
-# - ExceptionsSvZalrsc: misaligned LR under Sv39: Imperas raises load page fault (13, translation
-#   first); Sail rv64-max config checks misaligned LR/SC pre-translation and raises load access
-#   fault (5). No Imperas parameter changes this priority.
-#
 ci_enabled: false
-exclude_extensions: "Sm,SsstrictSm,SsstrictS,SsstrictU,SsstrictV,Zkr,ExceptionsSvZalrsc,InterruptsSm,InterruptsS,InterruptsSSm,InterruptsU,Smstateen,SdtrigSm,SdtrigS,SdtrigU"
+exclude_extensions: # These exclusions don't affect CI because it doesn't run, but they help tracking incomplete features
+  - Sm # Insufficient WARL configuration options.
+  - SsstrictSm # Sail does not yet implement hypervisor instructions/CSRs.
+  - SsstrictS # Sail does not yet implement hypervisor instructions/CSRs.
+  - SsstrictU # Sail does not yet implement hypervisor instructions/CSRs.
+  - SsstrictV # Sail does not yet implement SsstrictV.
+  - Zkr # https://github.com/riscv/sail-riscv/issues/1829
+  - ExceptionsSvZalrsc # Imperas raises load page fault before misaligned LR access fault under Sv39; no Imperas parameter changes this priority.
+  - InterruptsSm # Imperas does not implement interrupts.
+  - InterruptsS # Imperas does not implement interrupts.
+  - InterruptsSSm # Imperas does not implement interrupts.
+  - InterruptsU # Imperas does not implement interrupts.
+  - Smstateen # Sail does not implement all state yet to match.
+  - SdtrigSm # Sail does not yet support Sdtrig; Imperas also does not yet match Spike.
+  - SdtrigS # Sail does not yet support Sdtrig; Imperas also does not yet match Spike.
+  - SdtrigU # Sail does not yet support Sdtrig; Imperas also does not yet match Spike.

--- a/config/qemu/ci.yaml
+++ b/config/qemu/ci.yaml
@@ -4,25 +4,30 @@
 # Shared across all QEMU configs
 
 ci_enabled: true
-# Status as of QEMU v11.0.3:
-# Sm: medeleg WARL parameter mismatch (config issue, not a QEMU bug)
-# S: sstatus WARL mismatch (QEMU supports dynamic XLEN)
-# Zacas/ZacasZabha: amocas with rd=x0 corrupts subsequent branch on x0 (https://gitlab.com/qemu-project/qemu/-/work_items/3526)
-# PMPSm: pmpcfg bits [6:5] writable (https://gitlab.com/qemu-project/qemu/-/work_items/3531);
-#        causes pmpsm_csr_walk-* to fail on real QEMU (10/54 pmp64/PMPSm tests,
-#        4/36 pmp32/PMPSm tests).
-# ExceptionsZalrsc/ExceptionsSvZalrsc: sc.w to no-permission region returns failure instead of raising
-#        store/AMO access fault (https://gitlab.com/qemu-project/qemu/-/work_items/3323, still failing in v11.0.3)
-# ExceptionsZicboU/S, SvZicbo: Zicbom CBOs skip PMA/PMP permission checks (https://gitlab.com/qemu-project/qemu/-/work_items/3501)
-# Svinval: sfence.w.inval/sfence.inval.ir U-mode illegal-instruction checks still fail
-#        (https://gitlab.com/qemu-project/qemu/-/work_items/3493)
-# ExceptionsZaamo/Zama16b: QEMU zama16b handling is incomplete: misaligned Zabha/Zacas AMOs fault,
-#        but cross-granule word/doubleword AMOs execute instead of trapping.
-# TODO: Remove SsstrictV when sail SsstrictV is implemented
-# Smstateen will be added back once sail starts supporting SM1P13 too
-# ZawrsU and ZawrsS fail on qemu due to stval mismatching, filed QEMU issue https://gitlab.com/qemu-project/qemu/-/work_items/4080
-# ZicntrS and ZicntrU fail on qemu because ecall increments instret. Filed QEMU issue: https://gitlab.com/qemu-project/qemu/-/work_items/4087
-exclude_extensions: "Sm,S,Zacas,ZacasZabha,PMPSm,ExceptionsZalrsc,ExceptionsZicboU,ExceptionsZicboS,SvZicbo,Svinval,ExceptionsZaamo,ExceptionsSvZalrsc,Zama16b,SsstrictV,Smstateen,Zkr,ZawrsS,ZawrsU,SdtrigSm,SdtrigS,SdtrigU,ZicntrS,ZicntrU"
+exclude_extensions:
+  - Sm # QEMU v11.0.3: medeleg WARL parameter mismatch (config issue, not a QEMU bug).
+  - S # QEMU v11.0.3: sstatus WARL mismatch because QEMU supports dynamic XLEN.
+  - Zacas # QEMU v11.0.3: amocas with rd=x0 corrupts subsequent branch on x0: https://gitlab.com/qemu-project/qemu/-/work_items/3526
+  - ZacasZabha # QEMU v11.0.3: amocas with rd=x0 corrupts subsequent branch on x0: https://gitlab.com/qemu-project/qemu/-/work_items/3526
+  - PMPSm # QEMU v11.0.3: pmpcfg bits [6:5] writable; causes pmpsm_csr_walk-* to fail: https://gitlab.com/qemu-project/qemu/-/work_items/3531
+  - ExceptionsZalrsc # QEMU v11.0.3: sc.w to no-permission region returns failure instead of raising store/AMO access fault: https://gitlab.com/qemu-project/qemu/-/work_items/3323
+  - ExceptionsZicboU # QEMU v11.0.3: Zicbom CBOs skip PMA/PMP permission checks: https://gitlab.com/qemu-project/qemu/-/work_items/3501
+  - ExceptionsZicboS # QEMU v11.0.3: Zicbom CBOs skip PMA/PMP permission checks: https://gitlab.com/qemu-project/qemu/-/work_items/3501
+  - SvZicbo # QEMU v11.0.3: Zicbom CBOs skip PMA/PMP permission checks: https://gitlab.com/qemu-project/qemu/-/work_items/3501
+  - Svinval # QEMU v11.0.3: sfence.w.inval/sfence.inval.ir U-mode illegal-instruction checks still fail: https://gitlab.com/qemu-project/qemu/-/work_items/3493
+  - ExceptionsZaamo # QEMU v11.0.3: zama16b handling is incomplete; cross-granule word/doubleword AMOs execute instead of trapping.
+  - ExceptionsSvZalrsc # QEMU v11.0.3: sc.w to no-permission region returns failure instead of raising store/AMO access fault: https://gitlab.com/qemu-project/qemu/-/work_items/3323
+  - Zama16b # QEMU v11.0.3: zama16b handling is incomplete; misaligned Zabha/Zacas AMOs fault, but cross-granule word/doubleword AMOs execute instead of trapping.
+  - SsstrictV # TODO: Remove when Sail SsstrictV is implemented.
+  - Smstateen # Will be added back once Sail starts supporting SM1P13 too.
+  - Zkr # Blocked by Sail Zkr issue: https://github.com/riscv/sail-riscv/issues/1829
+  - ZawrsS # QEMU stval mismatch: https://gitlab.com/qemu-project/qemu/-/work_items/4080
+  - ZawrsU # QEMU stval mismatch: https://gitlab.com/qemu-project/qemu/-/work_items/4080
+  - SdtrigSm # Sail does not yet support Sdtrig.
+  - SdtrigS # Sail does not yet support Sdtrig.
+  - SdtrigU # Sail does not yet support Sdtrig.
+  - ZicntrS # QEMU ecall increments instret: https://gitlab.com/qemu-project/qemu/-/work_items/4087
+  - ZicntrU # QEMU ecall increments instret: https://gitlab.com/qemu-project/qemu/-/work_items/4087
 install_script: ".github/scripts/install-qemu.sh"
 apt_packages: "libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build"
 shards: 1

--- a/config/sail/ci.yaml
+++ b/config/sail/ci.yaml
@@ -3,7 +3,11 @@
 # CI configuration for Sail reference model
 
 ci_enabled: true
-exclude_extensions: "Zkr,SdtrigSm,SdtrigS,SdtrigU"
+exclude_extensions:
+  - Zkr # Blocked by Sail Zkr issue: https://github.com/riscv/sail-riscv/issues/1829
+  - SdtrigSm # Sail does not yet support Sdtrig.
+  - SdtrigS # Sail does not yet support Sdtrig.
+  - SdtrigU # Sail does not yet support Sdtrig.
 shards: 1
 config_shards:
   sail-RVA22S64-optional: 2

--- a/config/spike/ci.yaml
+++ b/config/spike/ci.yaml
@@ -3,12 +3,18 @@
 # CI configuration for Spike simulator
 # Shared across all Spike configs
 
-# SsstrictSm, SsstrictS, SsstrictU excluded because of Sail bugs and not all instructions in spike-max supported by Sail
 ci_enabled: true
-# TODO: Priv tests mismatch due to config issues.
-# TODO: Remove SsstrictV when sail SsstrictV is implemented
-# Smstateen will be added back once sail starts supporting Sscsrind too
-exclude_extensions: "Sm,SsstrictSm,SsstrictS,SsstrictU,SsstrictV,Smstateen,Zkr,SdtrigSm,SdtrigS,SdtrigU"
+exclude_extensions:
+  - Sm # TODO: Priv tests mismatch due to config issues.
+  - SsstrictSm # Sail bugs and not all instructions in spike-max supported by Sail.
+  - SsstrictS # Sail bugs and not all instructions in spike-max supported by Sail.
+  - SsstrictU # Sail bugs and not all instructions in spike-max supported by Sail.
+  - SsstrictV # TODO: Remove when Sail SsstrictV is implemented.
+  - Smstateen # Will be added back once Sail starts supporting Sscsrind too.
+  - Zkr # Blocked by Sail Zkr issue: https://github.com/riscv/sail-riscv/issues/1829
+  - SdtrigSm # Sail does not yet support Sdtrig.
+  - SdtrigS # Sail does not yet support Sdtrig.
+  - SdtrigU # Sail does not yet support Sdtrig.
 install_script: ".github/scripts/install-spike.sh"
 apt_packages: "device-tree-compiler libboost-regex-dev libboost-system-dev"
 shards: 1

--- a/config/whisper/ci.yaml
+++ b/config/whisper/ci.yaml
@@ -2,19 +2,25 @@
 # Jordan Carlin jcarlin@hmc.edu April 2026
 # CI configuration for Whisper simulator
 
-# SsstrictSm, SsstrictS, SsstrictU excluded because of Sail bugs and not all instructions in whisper-max supported by Sail
-# Smstateen will be added back once issue related srmcfg in whisper is resolved
-# S excluded due to Whisper bug (to be reported upstream): SRET that drops below M-mode must
-# clear mstatus.MPRV (priv spec 3.1.6.3), but whisper's execSret applies the clear through the
-# SSTATUS shadow view whose write mask excludes MPRV, so the clear is silently dropped
-# The MRET path writes MSTATUS directly and is unaffected. The S suite's
-# cp_sret_m mprv=1 bins catch this: sail clears MPRV, whisper keeps it -> selfcheck mismatch.
-# ExceptionsSvZalrsc: Whisper reports page faults where Sail expects access faults.
-# InterruptsSSm excluded because whisper supports M mode interrupt delegation and Sail currently only supports S mode interrupt delegation. https://github.com/riscv/sail-riscv/issues/1836
-# Vx excluded because of https://github.com/tenstorrent/whisper/issues/35
 ci_enabled: true
-# TODO: Remove SsstrictV when sail SsstrictV is implemented
-exclude_extensions: "S,Sm,SsstrictSm,SsstrictS,SsstrictU,ExceptionsSvZalrsc,SsstrictV,Smstateen,InterruptsSSm,Zkr,Vx8,Vx16,Vx32,Vx64,SdtrigSm,SdtrigS,SdtrigU"
+exclude_extensions:
+  - S # Whisper bug: SRET that drops below M-mode must clear mstatus.MPRV, but whisper's execSret applies the clear through the SSTATUS shadow view whose write mask excludes MPRV, so the clear is silently dropped. The cp_sret_m mprv=1 bins catch this: Sail clears MPRV, whisper keeps it.
+  - Sm # Insufficient WARL configuration options.
+  - SsstrictSm # Not all instructions in whisper-max supported by Sail.
+  - SsstrictS # Not all instructions in whisper-max supported by Sail.
+  - SsstrictU # Not all instructions in whisper-max supported by Sail.
+  - ExceptionsSvZalrsc # Whisper reports page faults where Sail expects access faults.
+  - SsstrictV # TODO: Remove when Sail SsstrictV is implemented.
+  - Smstateen # Will be added back once issue related srmcfg in whisper is resolved.
+  - InterruptsSSm # Whisper supports M-mode interrupt delegation and Sail currently only supports S-mode interrupt delegation: https://github.com/riscv/sail-riscv/issues/1836
+  - Zkr # Blocked by Sail Zkr issue: https://github.com/riscv/sail-riscv/issues/1829
+  - Vx8 # https://github.com/tenstorrent/whisper/issues/35
+  - Vx16 # https://github.com/tenstorrent/whisper/issues/35
+  - Vx32 # https://github.com/tenstorrent/whisper/issues/35
+  - Vx64 # https://github.com/tenstorrent/whisper/issues/35
+  - SdtrigSm # Sail does not yet support Sdtrig; exercise with whisper-rv*-max-spike-ref instead.
+  - SdtrigS # Sail does not yet support Sdtrig; exercise with whisper-rv*-max-spike-ref instead.
+  - SdtrigU # Sail does not yet support Sdtrig; exercise with whisper-rv*-max-spike-ref instead.
 exclude_configs:
   - whisper-rv32-max-spike-ref
   - whisper-rv64-max-spike-ref


### PR DESCRIPTION
Convert ci.yaml exclude_extensions to YAML lists with one exclusion per line and move exclusion reasons inline with their entries. This will help avoid merge conflicts.