### PR TITLE
Limit hash-pinned Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -144,7 +144,7 @@
   ],
   "packageRules": [
     {
-      "description": "Always use the latest version of specified packages",
+      "description": "Limit hash-pinned dependency updates to once per day",
       "matchDepNames": [
         "tenstorrent/whisper",
         "riscv/riscv-isa-sim",
@@ -152,13 +152,10 @@
         "openhwgroup/cv32e20-dv",
         "openhwgroup/cv32e40p-dv-review",
         "openhwgroup/cv32e40x-dv",
-        "openhwgroup/cv32e40x",
-        "udb",
-        "udb-gen",
-        "idlc",
-        "udb_helpers"
+        "openhwgroup/cv32e40x"
       ],
-      "minimumReleaseAge": null
+      "minimumReleaseAge": null,
+      "schedule": ["after 12am and before 5am"]
     },
     {
       "description": "Do not update Ruby major versions",
@@ -167,8 +164,9 @@
       "enabled": false
     },
     {
-      "description": "Keep UDB Ruby gems in one update PR",
+      "description": "Always use the latest version of UDB Ruby gems and keep in one update PR",
       "matchDepNames": ["udb", "udb-gen", "idlc", "udb_helpers"],
+      "minimumReleaseAge": null,
       "groupName": "udb ruby gems",
       "groupSlug": "udb-ruby-gems"
     },


### PR DESCRIPTION
Only update hash-pinned dependencies daily.