### PR TITLE
Parse Sail CLINT and SIG bases from sail.json

### DIFF
--- a/framework/src/act/build_plan.py
+++ b/framework/src/act/build_plan.py
@@ -12,6 +12,8 @@ import importlib.resources
 from collections import defaultdict
 from pathlib import Path
 
+import pyjson5
+
 from act.build_types import BuildTask, PythonAction, SubprocessAction, SymlinkAction
 from act.config import CompilerType, Config, CoverageSimulator, RefModelType, spike_isa_string
 from act.coverreport import generate_report, merge_summaries
@@ -36,6 +38,47 @@ _OBJDUMP_FLAGS_DEBUG = [*_OBJDUMP_FLAGS_COMMON, "-t", "-s"]
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _sail_platform_base(data: dict[object, object], name: str, path: Path) -> int:
+    platform = data.get("platform")
+    if not isinstance(platform, dict):
+        raise TypeError(f"Sail config {path} is missing the `platform` object.")
+
+    device = platform.get(name)
+    if not isinstance(device, dict):
+        raise TypeError(f"Sail config {path} is missing the `platform.{name}` object.")
+
+    if device.get("supported") is not True:
+        raise ValueError(
+            f"Sail config {path} must set `platform.{name}.supported` to true. "
+            "ACT signature generation requires this Sail device even when the DUT uses a different "
+            "interrupt mechanism or does not provide the same device. Enable the device in the sail "
+            "config and place it in an IO memory region. Select an address that does not map to DUT "
+            "memory, or it may overlap the DUT's own IO memory."
+        )
+
+    base = device.get("base")
+    if not isinstance(base, int):
+        raise TypeError(f"Sail config {path} must set `platform.{name}.base` to an integer.")
+    return base
+
+
+def _sail_platform_defines(sail_config_path: Path) -> tuple[str, ...]:
+    """Build compiler defines for Sail platform devices used by sail_macros.h."""
+    if not sail_config_path.exists():
+        raise FileNotFoundError(f"Sail config file not found: {sail_config_path}")
+
+    config_data = pyjson5.loads(sail_config_path.read_text())
+    if not isinstance(config_data, dict):
+        raise TypeError(f"Sail config {sail_config_path} must contain a JSON object.")
+
+    clint_base = _sail_platform_base(config_data, "clint", sail_config_path)
+    sig_base = _sail_platform_base(config_data, "simple_interrupt_generator", sail_config_path)
+    return (
+        f"-DSAIL_CLINT_BASE_ADDRESS=0x{clint_base:x}",
+        f"-DSAIL_SIMPLE_INTERRUPT_GENERATOR_BASE_ADDRESS=0x{sig_base:x}",
+    )
 
 
 def _compiler_cmd(config: Config, xlen: int, tests_dir: Path, udb_header_dir: Path) -> list[str]:
@@ -101,6 +144,7 @@ def gen_compile_tasks(
     xlen: int,
     config: Config,
     compiler_cmd: list[str],
+    signature_compile_flags: tuple[str, ...] = (),
     compile_inputs: tuple[Path, ...] = (),
     c_runtime_sources: tuple[Path, ...] = (),
     ref_model_inputs: tuple[Path, ...] = (),
@@ -164,6 +208,7 @@ def gen_compile_tasks(
             f"-march={march}",
             f"-mabi={mabi}",
             "-DSIGNATURE",
+            *signature_compile_flags,
             f"-DTEST_FLEN={test_flen}",
             f'-DTEST_FILE="{test_name.name}"',
             *test_sources,
@@ -524,10 +569,11 @@ def generate_build_plan(
 
     # Sail config affects reference model output (Spike has no equivalent file).
     ref_model_inputs: tuple[Path, ...] = ()
+    signature_compile_flags: tuple[str, ...] = ()
     if config.ref_model_type == RefModelType.SAIL:
         sail_config = config.dut_include_dir / "sail.json"
-        if sail_config.exists():
-            ref_model_inputs = (sail_config.absolute(),)
+        signature_compile_flags = _sail_platform_defines(sail_config)
+        ref_model_inputs = (sail_config.absolute(),)
 
     for test_name_str, test_metadata in sorted(selected_tests.items()):
         test_name = Path(test_name_str)
@@ -541,6 +587,7 @@ def generate_build_plan(
                 xlen,
                 config,
                 compiler_cmd,
+                signature_compile_flags,
                 compile_inputs,
                 c_runtime_sources,
                 ref_model_inputs,

--- a/tests/env/sail_macros.h
+++ b/tests/env/sail_macros.h
@@ -12,7 +12,18 @@
 #ifndef _SAIL_MACROS_H
 #define _SAIL_MACROS_H
 
-#define SAIL_CLINT_BASE_ADDRESS 0x02000000
+#ifndef SAIL_CLINT_BASE_ADDRESS
+  #error "SAIL_CLINT_BASE_ADDRESS is not defined, should have been passed by the ACT compilation framework."
+#endif
+
+#ifndef SAIL_SIMPLE_INTERRUPT_GENERATOR_BASE_ADDRESS
+  #error "SAIL_SIMPLE_INTERRUPT_GENERATOR_BASE_ADDRESS is not defined, should have been passed by the ACT compilation framework."
+#endif
+
+#define SAIL_MSIP_ADDRESS (SAIL_CLINT_BASE_ADDRESS + 0x0)
+#define SAIL_MTIMECMP_ADDRESS (SAIL_CLINT_BASE_ADDRESS + 0x4000)
+#define SAIL_MTIME_ADDRESS (SAIL_CLINT_BASE_ADDRESS + 0xBFF8)
+#define SAIL_SIG_ADDRESS (SAIL_SIMPLE_INTERRUPT_GENERATOR_BASE_ADDRESS + 0x4)
 
 #undef RVMODEL_DATA_SECTION
 #define RVMODEL_DATA_SECTION \
@@ -89,11 +100,20 @@
 
 ##### Machine Timer #####
 
-#undef RVMODEL_MTIMECMP_ADDRESS
-#define RVMODEL_MTIMECMP_ADDRESS  0x02004000  /* Address of mtimecmp CSR */
+#ifdef RVMODEL_MTIMECMP_ADDRESS
+  #undef RVMODEL_MTIMECMP_ADDRESS
+  #define RVMODEL_MTIMECMP_ADDRESS SAIL_MTIMECMP_ADDRESS
+#endif
 
-#undef RVMODEL_MTIME_ADDRESS
-#define RVMODEL_MTIME_ADDRESS  0x0200BFF8  /* Address of mtime CSR */
+#ifdef RVMODEL_MTIME_ADDRESS
+  #undef RVMODEL_MTIME_ADDRESS
+  #define RVMODEL_MTIME_ADDRESS SAIL_MTIME_ADDRESS
+#endif
+
+#ifdef RVMODEL_MSIP_ADDRESS
+  #undef RVMODEL_MSIP_ADDRESS
+  #define RVMODEL_MSIP_ADDRESS SAIL_MSIP_ADDRESS
+#endif
 
 ##### Machine Interrupts #####
 
@@ -104,7 +124,6 @@
 #undef RVMODEL_TIMER_INT_SOON_DELAY
 #define RVMODEL_TIMER_INT_SOON_DELAY 100
 
-#define SAIL_SIG_ADDRESS  (0xC000000 + 0x4)  /* Address of memory mapped simple interrupt generator */
 #undef RVMODEL_SET_MEXT_INT
 #define RVMODEL_SET_MEXT_INT(_R1, _R2)        \
   li _R1, (1 << 31) | (1 << 11);               \
@@ -118,7 +137,6 @@
   li _R2, SAIL_SIG_ADDRESS;    \
   sw _R1, 0(_R2)            ; /* Clear MEXT interrupt */ \
 
-#define SAIL_MSIP_ADDRESS (SAIL_CLINT_BASE_ADDRESS + 0x0)
 #undef RVMODEL_SET_MSW_INT
 #define RVMODEL_SET_MSW_INT(_R1, _R2)        \
   li _R1, 1;                 \


### PR DESCRIPTION
Parse the CLINT and SIG addresses from `sail.json` instead of hardcoding them in `sail_macros.h`. This is required to support users who move the CLINT to a different memory address.

Also add a check to ensure the CLINT and SIG are enabled in sail.json and provide guidance on what to do if your DUT does not support a CLINT.

Fixes #1630