### PR TITLE
Fix certification document release job

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -127,6 +127,8 @@ jobs:
           fi
 
           gh release create "$tag_name" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
             "${release_args[@]}" \
             ctp.pdf \
             ctp.html \


### PR DESCRIPTION
The release job has failed for the past few weeks. Create document releases without a checkout and tag their source commit.