### PR TITLE
Disable Smpmpmt on QEMU

### DIFF
--- a/config/qemu/ci.yaml
+++ b/config/qemu/ci.yaml
@@ -8,9 +8,6 @@ ci_enabled: true
 # Sm: medeleg WARL parameter mismatch (config issue, not a QEMU bug)
 # S: sstatus WARL mismatch (QEMU supports dynamic XLEN)
 # Zacas/ZacasZabha: amocas with rd=x0 corrupts subsequent branch on x0 (https://gitlab.com/qemu-project/qemu/-/work_items/3526)
-# PMPSm: pmpcfg bits [6:5] writable (https://gitlab.com/qemu-project/qemu/-/work_items/3531);
-#        causes pmpsm_csr_walk-* to fail on real QEMU (10/54 pmp64/PMPSm tests,
-#        4/36 pmp32/PMPSm tests).
 # ExceptionsZalrsc/ExceptionsSvZalrsc: sc.w to no-permission region returns failure instead of raising
 #        store/AMO access fault (https://gitlab.com/qemu-project/qemu/-/work_items/3323, still failing in v11.0.3)
 # ExceptionsZicboU/S, SvZicbo: Zicbom CBOs skip PMA/PMP permission checks (https://gitlab.com/qemu-project/qemu/-/work_items/3501)
@@ -23,7 +20,7 @@ ci_enabled: true
 # Smstateen will be added back once sail starts supporting SM1P13 too
 # ZawrsU and ZawrsS fail on qemu due to stval mismatching, filed QEMU issue https://gitlab.com/qemu-project/qemu/-/work_items/4080
 # ZicntrS and ZicntrU fail on qemu because ecall increments instret. Filed QEMU issue: https://gitlab.com/qemu-project/qemu/-/work_items/4087
-exclude_extensions: "Sm,S,Zacas,ZacasZabha,PMPSm,ExceptionsZalrsc,ExceptionsZicboU,ExceptionsZicboS,SvZicbo,Svinval,ExceptionsZaamo,ExceptionsSvZalrsc,Zama16b,SsstrictV,Smstateen,Zkr,ZawrsS,ZawrsU,SdtrigSm,SdtrigS,SdtrigU,ZicntrS,ZicntrU"
+exclude_extensions: "Sm,S,Zacas,ZacasZabha,ExceptionsZalrsc,ExceptionsZicboU,ExceptionsZicboS,SvZicbo,Svinval,ExceptionsZaamo,ExceptionsSvZalrsc,Zama16b,SsstrictV,Smstateen,Zkr,ZawrsS,ZawrsU,SdtrigSm,SdtrigS,SdtrigU,ZicntrS,ZicntrU"
 install_script: ".github/scripts/install-qemu.sh"
 apt_packages: "libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build"
 shards: 1

--- a/config/qemu/qemu-rv32-max/run_cmd.txt
+++ b/config/qemu/qemu-rv32-max/run_cmd.txt
@@ -1,1 +1,1 @@
-qemu-system-riscv32 {debug:-d in_asm,int,mmu,unimp,cpu,fpu,vpu,exec,nochain -D __TRACEFILE__} -nographic -semihosting -icount shift=1 -machine virt -cpu max,pmu-mask=0xfffffff8,smdbltrp=true,ssdbltrp=true -bios
+qemu-system-riscv32 {debug:-d in_asm,int,mmu,unimp,cpu,fpu,vpu,exec,nochain -D __TRACEFILE__} -nographic -semihosting -icount shift=1 -machine virt -cpu max,smpmpmt=false,pmu-mask=0xfffffff8,smdbltrp=true,ssdbltrp=true -bios

--- a/config/qemu/qemu-rv64-max/run_cmd.txt
+++ b/config/qemu/qemu-rv64-max/run_cmd.txt
@@ -1,1 +1,1 @@
-qemu-system-riscv64 {debug:-d in_asm,int,mmu,unimp,cpu,fpu,vpu,exec,nochain -D __TRACEFILE__} -nographic -semihosting -icount shift=1 -machine virt -cpu max,pmu-mask=0xfffffff8,smdbltrp=true,ssdbltrp=true -bios
+qemu-system-riscv64 {debug:-d in_asm,int,mmu,unimp,cpu,fpu,vpu,exec,nochain -D __TRACEFILE__} -nographic -semihosting -icount shift=1 -machine virt -cpu max,smpmpmt=false,pmu-mask=0xfffffff8,smdbltrp=true,ssdbltrp=true -bios


### PR DESCRIPTION
QEMU enables Smpmpmt by default, which Sail does not support. It breaks
the PMP tests, so disable it for now. We will need to figure out a
different way of addressing this down the road.

Signed-off-by: Jordan Carlin <jcarlin@qti.qualcomm.com>
