### PR TITLE
Check vxsat for all saturating instructions

### DIFF
--- a/generators/testgen/src/testgen/formatters/types/vvi_type.py
+++ b/generators/testgen/src/testgen/formatters/types/vvi_type.py
@@ -14,6 +14,7 @@ from testgen.asm.vector_helpers import (
     prep_mask_v,
     write_sigupd_v,
     write_sigupd_v_len,
+    write_sigupd_vxsat,
 )
 from testgen.data.params import InstructionParams
 from testgen.data.state import TestData
@@ -85,6 +86,7 @@ def format_vvi_sat(
 ) -> tuple[list[str], list[str], list[str]]:
     setup, test, check = format_vvi_like_type(instr_str, test_data, params, "VVI_SAT")
     setup = ["csrwi vxsat, 0"] + setup
+    check = write_sigupd_vxsat(test_data) + check
     return setup, test, check
 
 

--- a/generators/testgen/src/testgen/formatters/types/vvx_type.py
+++ b/generators/testgen/src/testgen/formatters/types/vvx_type.py
@@ -14,6 +14,7 @@ from testgen.asm.vector_helpers import (
     prep_mask_v,
     write_sigupd_v,
     write_sigupd_v_len,
+    write_sigupd_vxsat,
 )
 from testgen.data.params import InstructionParams
 from testgen.data.state import TestData
@@ -118,6 +119,7 @@ def format_vvx_sat(
 ) -> tuple[list[str], list[str], list[str]]:
     setup, test, check = format_vvx_like_type(instr_str, test_data, params, "VVX_SAT")
     setup = ["csrwi vxsat, 0"] + setup
+    check = write_sigupd_vxsat(test_data) + check
     return setup, test, check
 
 


### PR DESCRIPTION
VVI and VVX saturating instructions were not checking `vxsat`.