### PR TITLE
Added support to continue catching errors 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ help:
 .DEFAULT_GOAL := elfs
 .PHONY: elfs
 elfs: tests
-	@$(UV_RUN) act $(CONFIG_FILES) \
+	@$(UV_RUN) act $(CONFIG_FILES)  -k \
 		--workdir $(WORKDIR) \
 		--test-dir $(TESTDIR) \
 		--jobs $(JOBS) \


### PR DESCRIPTION
Instead of catching test errors one at a time, this will allow all errors to be outputted at once.