### PR TITLE
Update toolchain handling

### DIFF
--- a/framework/src/act/build_plan.py
+++ b/framework/src/act/build_plan.py
@@ -15,11 +15,12 @@ from pathlib import Path
 import pyjson5
 
 from act.build_types import BuildTask, PythonAction, SubprocessAction, SymlinkAction
-from act.config import CompilerType, Config, CoverageSimulator, RefModelType, spike_isa_string
+from act.config import Config, CoverageSimulator, RefModelType, spike_isa_string
 from act.coverreport import generate_report, merge_summaries
 from act.parse_test_constraints import TestMetadata
 from act.sail_to_rvvi import sailLog2Trace
 from act.sig_modify import process_signature_file
+from act.toolchain import Toolchain
 from act.trap_report import generate_trap_report
 
 # Flags used when generating .elf.objdump files.
@@ -33,7 +34,6 @@ _OBJDUMP_FLAGS_COMMON = ["-x", "-d", "-S", "-M", "no-aliases,numeric"]
 # -t: print the full symbol table
 # -s: print a full hex+ASCII dump of every section
 _OBJDUMP_FLAGS_DEBUG = [*_OBJDUMP_FLAGS_COMMON, "-t", "-s"]
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -81,28 +81,6 @@ def _sail_platform_defines(sail_config_path: Path) -> tuple[str, ...]:
     )
 
 
-def _compiler_cmd(config: Config, xlen: int, tests_dir: Path, udb_header_dir: Path) -> list[str]:
-    """Build the full compiler command list including compiler-specific and common flags."""
-    cmd = [str(config.compiler_exe)]
-    if config.compiler_type == CompilerType.CLANG:
-        cmd.extend([f"--target=riscv{xlen}", "-fuse-ld=lld"])
-    cmd.extend(
-        [
-            f"-I{config.dut_include_dir.absolute()}",
-            f"-T{config.linker_script.absolute()}",
-            "-O0",
-            "-g",
-            "-mcmodel=medany",
-            "-nostdlib",
-            f"-I{tests_dir}/env",
-            f"-I{udb_header_dir.absolute()}",
-        ]
-    )
-    if config.compiler_type == CompilerType.GCC:
-        cmd.extend(["-Wl,--no-warn-rwx-segments"])
-    return cmd
-
-
 def _ref_model_sig_cmd(
     config: Config,
     sig_elf: Path,
@@ -141,9 +119,10 @@ def gen_compile_tasks(
     test_name: Path,
     test_metadata: TestMetadata,
     base_dir: Path,
+    env_dir: Path,
     xlen: int,
     config: Config,
-    compiler_cmd: list[str],
+    toolchain: Toolchain,
     signature_compile_flags: tuple[str, ...] = (),
     compile_inputs: tuple[Path, ...] = (),
     c_runtime_sources: tuple[Path, ...] = (),
@@ -161,9 +140,10 @@ def gen_compile_tasks(
         test_name: Name of the test.
         test_metadata: Metadata for the test.
         base_dir: Base directory for the build.
+        env_dir: Directory that contains shared test-environment headers.
         xlen: XLEN (32 or 64).
         config: Configuration object.
-        compiler_cmd: Pre-built compiler command prefix (from _compiler_cmd).
+        toolchain: Toolchain used to resolve compiler ISA flags for this test.
         compile_inputs: Shared inputs for compilation.
         c_runtime_sources: Runtime sources compiled into C tests.
         ref_model_inputs: Shared inputs for the reference model (e.g. sail.json for Sail).
@@ -182,9 +162,25 @@ def gen_compile_tasks(
     sig_log_file = build_dir / test_name.with_suffix(".sig.log")
     final_elf = elf_dir / test_name.with_suffix(".elf")
 
-    # Metadata — substitute ${XLEN} placeholder used by priv tests
-    march = test_metadata.march.replace("${XLEN}", str(xlen))
-    # Always include zifencei so the trap handler's fence.i can be assembled.
+    compile_prefix = [
+        *toolchain.compile_prefix(xlen),
+        f"-I{config.dut_include_dir.absolute()}",
+        f"-T{config.linker_script.absolute()}",
+        "-O0",
+        "-g",
+        "-mcmodel=medany",
+        "-nostdlib",
+        f"-I{env_dir}",
+        f"-I{base_dir.absolute()}",
+    ]
+
+    # Metadata
+    march_flags = toolchain.march_flags(
+        xlen,
+        test_metadata.march,
+        assembly=not test_metadata.is_c_test,
+        e_ext=test_metadata.e_ext,
+    )
     test_flen = test_metadata.flen
     test_path = test_metadata.test_path
     mabi = f"{'i' if xlen == 32 else ''}lp{xlen}{'e' if test_metadata.e_ext else ''}"
@@ -201,11 +197,11 @@ def gen_compile_tasks(
     if test_metadata.needs_signature:
         # 1. sig.elf – compile with -DSIGNATURE
         sig_elf_cmd = [
-            *compiler_cmd,
+            *compile_prefix,
             *c_compile_flags,
             "-o",
             str(sig_elf),
-            f"-march={march}",
+            *march_flags,
             f"-mabi={mabi}",
             "-DSIGNATURE",
             *signature_compile_flags,
@@ -280,11 +276,11 @@ def gen_compile_tasks(
     # Non-signature tests start here
     # 4. final.elf – compile with -DRVTEST_SELFCHECK
     final_elf_cmd = [
-        *compiler_cmd,
+        *compile_prefix,
         *c_compile_flags,
         "-o",
         str(final_elf),
-        f"-march={march}",
+        *march_flags,
         f"-mabi={mabi}",
         "-DRVTEST_SELFCHECK",
         *([f'-DSIGNATURE_FILE="{result_file}"'] if test_metadata.needs_signature else ["-DRVTEST_NOSIG"]),
@@ -556,7 +552,7 @@ def generate_build_plan(
     config_report_dir = config_wkdir / "reports"
 
     coverage_targets: defaultdict[Path, list[Path]] = defaultdict(list)
-    compiler_cmd = _compiler_cmd(config, xlen, tests_dir, config_wkdir)
+    toolchain = Toolchain(config.compiler_exe, config.compiler_type)
 
     # Collect shared file dependencies that affect all compilations.
     # Any change to env headers, DUT headers, or the linker script should trigger recompilation.
@@ -584,9 +580,10 @@ def generate_build_plan(
                 test_name,
                 test_metadata,
                 config_wkdir,
+                env_dir,
                 xlen,
                 config,
-                compiler_cmd,
+                toolchain,
                 signature_compile_flags,
                 compile_inputs,
                 c_runtime_sources,

--- a/framework/src/act/config.py
+++ b/framework/src/act/config.py
@@ -18,6 +18,8 @@ import rich
 from pydantic import BaseModel, DirectoryPath, FilePath, ValidationInfo, field_validator, model_validator
 from ruamel.yaml import YAML
 
+from act.toolchain import CompilerType, Toolchain
+
 
 class RefModelType(str, Enum):
     """Reference model types with their associated flags."""
@@ -70,13 +72,6 @@ _SPIKE_ISA: dict[int, str] = {
 def spike_isa_string(xlen: int) -> str:
     """Return spike's ``--isa=`` string for the given XLEN."""
     return _SPIKE_ISA[xlen]
-
-
-class CompilerType(str, Enum):
-    """Compiler types."""
-
-    CLANG = "clang"
-    GCC = "gcc"
 
 
 class CoverageSimulator(str, Enum):
@@ -228,37 +223,23 @@ def check_ref_model_version(config: Config) -> None:
 
 
 def check_compiler_version(config: Config) -> None:
-    """Check that the compiler version is compatible."""
-    try:
-        result = subprocess.run(
-            [str(config.compiler_exe), "-dumpversion"],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=5,
+    """Check that the compiler is a new enough version."""
+    toolchain = Toolchain(config.compiler_exe, config.compiler_type)
+    version_str = toolchain.version()
+    major_version = int(version_str.split(".")[0])
+
+    if config.compiler_type == CompilerType.GCC:
+        required_major = REQUIRED_GCC_MAJOR_VERSION
+        compiler_name = "GCC"
+    else:
+        required_major = REQUIRED_CLANG_MAJOR_VERSION
+        compiler_name = "Clang"
+
+    if major_version < required_major:
+        raise ValueError(
+            f"Compiler version mismatch. ACT4 requires {compiler_name} {required_major} or later, but {version_str} was found. "
+            "Refer to the ACT4 README for details: https://github.com/riscv/riscv-arch-test/tree/act4?tab=readme-ov-file#3-risc-v-compiler",
         )
-        version_str = result.stdout.strip()
-        try:
-            major_version = int(version_str.split(".")[0])
-        except ValueError:
-            raise RuntimeError(f"Unable to parse compiler version from: {version_str!r}")
-
-        if config.compiler_type == CompilerType.GCC:
-            required_major = REQUIRED_GCC_MAJOR_VERSION
-            compiler_name = "GCC"
-        else:
-            required_major = REQUIRED_CLANG_MAJOR_VERSION
-            compiler_name = "Clang"
-
-        if major_version < required_major:
-            raise ValueError(
-                f"Compiler version mismatch. ACT4 requires {compiler_name} {required_major} or later, but {version_str} was found. "
-                "Refer to the ACT4 README for details: https://github.com/riscv/riscv-arch-test/tree/act4?tab=readme-ov-file#3-risc-v-compiler",
-            )
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"Failed to check compiler version: {e}") from e
-    except subprocess.TimeoutExpired as e:
-        raise RuntimeError(f"Timeout while checking compiler version: {e}") from e
 
 
 def load_config(config_file: Path, *, validate_tools: bool = True) -> Config:

--- a/framework/src/act/toolchain.py
+++ b/framework/src/act/toolchain.py
@@ -1,0 +1,165 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+"""Discover RISC-V compiler capabilities and build compiler flags."""
+
+import re
+import shutil
+import subprocess
+from enum import Enum
+from pathlib import Path
+
+
+class CompilerType(str, Enum):
+    """Supported RISC-V compiler drivers."""
+
+    CLANG = "clang"
+    GCC = "gcc"
+
+
+_MARCH_HELP_HEADER = "All available -march extensions for RISC-V"
+_EXPERIMENTAL_EXTENSIONS_HEADER = "Experimental extensions"
+_MARCH_HELP_END_HEADERS = ("Supported Profiles", "Experimental Profiles", "Use -march")
+_MARCH_HELP_ROW = re.compile(r"^\s*([a-z][a-z0-9]*)\s+([0-9][0-9., ]*)", re.IGNORECASE)
+_MARCH_PREFIX = re.compile(r"^(rv(?:32|64))(.*)$", re.IGNORECASE)
+_SINGLE_LETTER_EXTENSION = re.compile(r"[a-z](?:\d+p\d+)?", re.IGNORECASE)
+_MARCH_VERSION = re.compile(r"\d+p\d+$", re.IGNORECASE)
+
+
+def _parse_supported_extensions(output: str, tool: str) -> dict[str, str | None]:
+    """Parse RISC-V extensions from ``-march=help`` style output."""
+    _, header, output = output.partition(_MARCH_HELP_HEADER)
+    if not header:
+        raise RuntimeError(f"Unable to parse RISC-V extensions reported by {tool}.")
+
+    extensions: dict[str, str | None] = {}
+    experimental = False
+    for line in output.splitlines():
+        if any(header in line for header in _MARCH_HELP_END_HEADERS):
+            break
+        if _EXPERIMENTAL_EXTENSIONS_HEADER in line:
+            experimental = True
+            continue
+        if match := _MARCH_HELP_ROW.match(line):
+            name, versions = match.groups()
+            if experimental:
+                latest = max(tuple(int(part) for part in version.split(".")) for version in versions.split(","))
+                extensions[name.lower()] = "p".join(map(str, latest))
+            else:
+                extensions[name.lower()] = None
+
+    if not extensions:
+        raise RuntimeError(f"Unable to parse RISC-V extensions reported by {tool}.")
+    return extensions
+
+
+def _parse_march(march: str) -> tuple[str, list[str]]:
+    """Split a canonical ISA string into its base and extension tokens."""
+    parts = march.lower().split("_")
+    if not (match := _MARCH_PREFIX.match(parts.pop(0))):
+        raise ValueError(f"Invalid RISC-V ISA string: {march}")
+
+    extensions = _SINGLE_LETTER_EXTENSION.findall(match.group(2))
+    if (
+        not extensions
+        or "".join(extensions) != match.group(2)
+        or any(not extension.isalnum() or not extension[0].isalpha() for extension in parts)
+    ):
+        raise ValueError(f"Invalid RISC-V ISA string: {march}")
+
+    extensions.extend(f"_{extension}" for extension in parts)
+    return match.group(1), extensions
+
+
+class Toolchain:
+    """A configured RISC-V compiler driver and its related tools."""
+
+    def __init__(self, compiler_exe: Path, compiler_type: CompilerType) -> None:
+        self.compiler_exe = compiler_exe
+        self.compiler_type = compiler_type
+        self._version: str | None = None
+        self._assembler: Path | None = None
+        self._isa_support: dict[tuple[int, bool], dict[str, str | None]] = {}
+
+    def version(self) -> str:
+        """Return the compiler version reported by the driver."""
+        if self._version is None:
+            result = subprocess.run(
+                [str(self.compiler_exe), "-dumpversion"], capture_output=True, text=True, check=True, timeout=5
+            )
+            self._version = result.stdout.strip()
+        return self._version
+
+    def compile_prefix(self, xlen: int) -> tuple[str, ...]:
+        """Build the compiler command prefix for one RISC-V target."""
+        compiler = str(self.compiler_exe)
+        if self.compiler_type == CompilerType.CLANG:
+            return compiler, f"--target=riscv{xlen}", "-fuse-ld=lld"
+        return (compiler, "-Wl,--no-warn-rwx-segments")
+
+    def march_flags(self, xlen: int, march: str, *, assembly: bool, e_ext: bool = False) -> tuple[str, ...]:
+        """Build compiler flags that set and validate the ISA string."""
+        march = march.replace("${XLEN}", str(xlen))
+        base, extension_tokens = _parse_march(march)
+        extensions = {_MARCH_VERSION.sub("", token.removeprefix("_")) for token in extension_tokens}
+        if "g" in extensions:
+            extensions.remove("g")
+            extensions.update(("i", "m", "a", "f", "d", "zicsr", "zifencei"))
+
+        support = self._supported_extensions(xlen, assembly)
+        missing_extensions = sorted(extensions - support.keys())
+        if missing_extensions:
+            tool = "Clang" if self.compiler_type == CompilerType.CLANG else "GNU assembler" if assembly else "GCC"
+            raise ValueError(
+                f"{tool} does not support extension(s) {', '.join(missing_extensions)} required by -march={march}."
+            )
+
+        if self.compiler_type == CompilerType.CLANG:
+            experimental = False
+            resolved_extensions: list[str] = []
+            for token in extension_tokens:
+                name = _MARCH_VERSION.sub("", token.removeprefix("_"))
+                version = support.get(name)
+                experimental |= version is not None
+                resolved_extensions.append(
+                    f"{'_' if token.startswith('_') else ''}{name}{version}" if version else token
+                )
+            resolved_march = f"{base}{''.join(resolved_extensions)}"
+            experimental_flags = ("-menable-experimental-extensions",) if experimental else ()
+            return (*experimental_flags, f"-march={resolved_march}")
+
+        if not assembly:
+            return (f"-march={march}",)
+        base_march = f"rv{xlen}{'e' if e_ext else 'i'}"
+        return f"-march={base_march}", "-Xassembler", f"-march={march}"
+
+    def _supported_extensions(self, xlen: int, assembly: bool) -> dict[str, str | None]:
+        """Return cached ISA support for the program that receives MARCH flags."""
+        assembly &= self.compiler_type == CompilerType.GCC
+        key = xlen, assembly
+        if key not in self._isa_support:
+            if self.compiler_type == CompilerType.CLANG:
+                command = [str(self.compiler_exe), f"--target=riscv{xlen}", "-print-supported-extensions"]
+                tool = str(self.compiler_exe)
+            elif assembly:
+                if self._assembler is None:
+                    assembler = subprocess.run(
+                        [str(self.compiler_exe), "-print-prog-name=as"],
+                        capture_output=True,
+                        text=True,
+                        check=True,
+                        timeout=5,
+                    ).stdout.strip()
+                    if Path(assembler).is_absolute():
+                        self._assembler = Path(assembler)
+                    elif resolved := shutil.which(assembler):
+                        self._assembler = Path(resolved)
+                    else:
+                        raise FileNotFoundError(f"Assembler selected by {self.compiler_exe} was not found: {assembler}")
+                command = [str(self._assembler), "-march=help"]
+                tool = str(self._assembler)
+            else:
+                command = [str(self.compiler_exe), "-march=help"]
+                tool = str(self.compiler_exe)
+            result = subprocess.run(command, capture_output=True, text=True, check=True, timeout=5)
+            self._isa_support[key] = _parse_supported_extensions(f"{result.stdout}\n{result.stderr}", tool)
+        return self._isa_support[key]


### PR DESCRIPTION
- Extract all toolchain/compiler logic into a single toolchain.py file
- Check that the compiler supports all necessary instructions and print clear error message when it doesn't
- Add the enable-experimental-extensions flag to Clang when necessary (Zicilp, Zicfiss, Zibi, etc.)
- Bypass GCC and pass march directly to the GNU assembler so we can use instructions that are supported in Binutils but not yet in GCC (Q, Zvabd, etc.)