### PR TITLE
Remove *_intr RVVI signals

### DIFF
--- a/framework/src/act/fcov/coverage/RISCV_coverage_rvvi.svh
+++ b/framework/src/act/fcov/coverage/RISCV_coverage_rvvi.svh
@@ -62,10 +62,6 @@ function void save_rvvi_data(bit trap, int hart, int issue, string disass);
     rvviData.v_wb = 0;
     rvviData.csr = 0;
     rvviData.csr_wb = 0;
-    rvviData.m_ext_intr = 0;
-    rvviData.s_ext_intr = 0;
-    rvviData.m_timer_intr = 0;
-    rvviData.m_soft_intr = 0;
     rvviData.lrsc_cancel = 0;
     rvviData.virt_adr_i = 0;
     rvviData.virt_adr_d = 0;
@@ -144,12 +140,6 @@ function void save_rvvi_data(bit trap, int hart, int issue, string disass);
   // Todo: CSR values should use the current values and only update the changed ones
   rvviData.csr = this.rvvi.csr[hart][issue];
   rvviData.csr_wb = this.rvvi.csr_wb[hart][issue];
-
-  // Store interrupt signals from the current trace
-  rvviData.m_ext_intr = this.rvvi.m_ext_intr[hart][issue];
-  rvviData.s_ext_intr = this.rvvi.s_ext_intr[hart][issue];
-  rvviData.m_timer_intr = this.rvvi.m_timer_intr[hart][issue];
-  rvviData.m_soft_intr = this.rvvi.m_soft_intr[hart][issue];
 
   // Store virtual memory signals from the current trace
   rvviData.virt_adr_i = this.rvvi.virt_adr_i[hart][issue];

--- a/framework/src/act/fcov/coverage/RISCV_trace_data.svh
+++ b/framework/src/act/fcov/coverage/RISCV_trace_data.svh
@@ -64,12 +64,6 @@ class riscvTraceData
   logic [4095:0][(XLEN-1):0] csr   ;   // Full CSR Address range
   logic [4095:0]             csr_wb;   // CSR writeback (change) flag
 
-  // Interrupts
-  logic                      m_ext_intr;    // Machine external interrupt
-  logic                      s_ext_intr;    // Supervisor external interrupt
-  logic                      m_timer_intr;  // Machine timer interrupt
-  logic                      m_soft_intr;   // Machine software interrupt
-
   logic                      lrsc_cancel;   // Implementation defined cancel
 
 // Virtual Memory signals for verification

--- a/framework/src/act/fcov/rvviTrace.sv
+++ b/framework/src/act/fcov/rvviTrace.sv
@@ -96,12 +96,6 @@ interface rvviTrace
   wire [4095:0][(XLEN-1):0] csr        [(NHART-1):0][(RETIRE-1):0];   // Full CSR Address range
   wire [4095:0]             csr_wb     [(NHART-1):0][(RETIRE-1):0];   // CSR writeback (change) flag
 
-  // Interrupts
-  wire                      m_ext_intr  [(NHART-1):0][(RETIRE-1):0];   // Machine external interrupt
-  wire                      s_ext_intr  [(NHART-1):0][(RETIRE-1):0];   // Supervisor external interrupt
-  wire                      m_timer_intr[(NHART-1):0][(RETIRE-1):0];   // Machine timer interrupt
-  wire                      m_soft_intr [(NHART-1):0][(RETIRE-1):0];   // Machine software interrupt
-
   // Atomic Memory Control
   wire                      lrsc_cancel[(NHART-1):0][(RETIRE-1):0];   // Implementation defined cancel
 

--- a/framework/src/act/fcov/testbench.sv
+++ b/framework/src/act/fcov/testbench.sv
@@ -54,8 +54,6 @@ module testbench;
   logic [(XLEN-1):0] pc_rdata;
   logic [1:0]        mode;
   logic              mode_virt; // hypervisor bit
-  // Interrupts
-  logic m_ext_intr, s_ext_intr, m_timer_intr, m_soft_intr;
   // Virtual Memory
   logic [(XLEN-1):0]     virt_adr_i, virt_adr_d;
   logic [(PA_BITS-1):0]  phys_adr_i, phys_adr_d;
@@ -143,7 +141,6 @@ module testbench;
 
     // Reset all signals at the beginning of each iteration
     {valid, insn, trap, debug_mode, pc_rdata, mode, mode_virt,
-    m_ext_intr, s_ext_intr, m_timer_intr, m_soft_intr,
     virt_adr_i, virt_adr_d, phys_adr_i, phys_adr_d,
     pte_i, pte_d, ppn_i, ppn_d, page_type_i, page_type_d,
     read_access, write_access, execute_access,
@@ -238,12 +235,6 @@ module testbench;
   assign rvvi.pc_rdata[0][0] = pc_rdata;
   assign rvvi.mode[0][0] = mode;
   assign rvvi.mode_virt[0][0] = mode_virt;
-
-  // Interrupts
-  assign rvvi.m_ext_intr[0][0] = m_ext_intr;
-  assign rvvi.s_ext_intr[0][0] = s_ext_intr;
-  assign rvvi.m_timer_intr[0][0] = m_timer_intr;
-  assign rvvi.m_soft_intr[0][0] = m_soft_intr;
 
   // Virtual Memory
   assign rvvi.virt_adr_i[0][0] = virt_adr_i;


### PR DESCRIPTION
These signals are not used anywhere are not part of the RVVI spec. Drop
them to make it easier to migrate to the latest RVVI spec for virtual
memory coverage.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>