### PR TITLE
Fixed testbench and made debug register tests conditional on Sdext

### DIFF
--- a/coverpoints/priv/Sm_coverage.svh
+++ b/coverpoints/priv/Sm_coverage.svh
@@ -332,9 +332,6 @@ covergroup Sm_mcsr_cg with function sample(ins_t ins);
         bins b_1[] = { [0:`UDB_MXLEN-1] };
     }
 
-    csr_debug: coverpoint ins.current.insn[31:20]  {
-        bins debug_only[] = {[12'h7B0:12'h7BF]};
-    }
     csr_ro: coverpoint ins.current.insn[31:20] {
         bins readonly[] = {[12'hC00:12'hFFF]};
     }
@@ -423,7 +420,6 @@ covergroup Sm_mcsr_cg with function sample(ins_t ins);
     cp_mcsr_access:             cross priv_mode_m, mcsrname, csraccesses;
     cp_mcsr_access_ro:          cross priv_mode_m, mcsrname_ro, csraccesses;
     cp_mcsrwalk :               cross priv_mode_m, mcsrname, csrop, walking_ones;
-    cp_csr_insufficient_priv:   cross priv_mode_m, csrr, csr_debug, nonzerord;
     cp_csr_ro:                  cross priv_mode_m, csrrw, csr_ro, rs1_ones;
 
     // counters
@@ -435,6 +431,14 @@ covergroup Sm_mcsr_cg with function sample(ins_t ins);
     cp_misa_mxl :               cross priv_mode_m, misa, misa_mxl_accesses;
     cp_misa_dependencies :      cross priv_mode_m, csrrw, misa, misa_dependencies;
     cp_misa_clear_c :           cross priv_mode_m, csrc, misa_c_0, pc_1;
+
+    `ifdef SDEXT_SUPPORTED
+        // debug registers should trap from M-mode if SDEXT is supported
+        csr_debug: coverpoint ins.current.insn[31:20]  {
+            bins debug_only[] = {[12'h7B0:12'h7B3]};
+        }
+        cp_csr_insufficient_priv:   cross priv_mode_m, csrr, csr_debug, nonzerord;
+    `endif
 
     `ifdef UDB_TIME_CSR_IMPLEMENTED
         cp_mtime_write :        cross priv_mode_m, csrr,  time_csr; // assumes mtime has been written

--- a/framework/src/act/fcov/testbench.sv
+++ b/framework/src/act/fcov/testbench.sv
@@ -166,11 +166,6 @@ module testbench;
           "PC":             num = $sscanf(val, "%h", pc_rdata);
           "MODE":           num = $sscanf(val, "%d", mode);
           "MODE_VIRT":      num = $sscanf(val, "%d", mode_virt);
-          // Interrupts
-          //"M_EXT_INTR":     num = $sscanf(val, "%b", m_ext_intr);
-          //"S_EXT_INTR":     num = $sscanf(val, "%b", s_ext_intr);
-          //"M_TIMER_INTR":   num = $sscanf(val, "%b", m_timer_intr);
-          //"M_SOFT_INTR":    num = $sscanf(val, "%b", m_soft_intr);
           // Virtual Memory
           "VIRT_ADR_I":     num = $sscanf(val, "%h", virt_adr_i);
           "VIRT_ADR_D":     num = $sscanf(val, "%h", virt_adr_d);

--- a/framework/src/act/fcov/testbench.sv
+++ b/framework/src/act/fcov/testbench.sv
@@ -167,10 +167,10 @@ module testbench;
           "MODE":           num = $sscanf(val, "%d", mode);
           "MODE_VIRT":      num = $sscanf(val, "%d", mode_virt);
           // Interrupts
-          "M_EXT_INTR":     num = $sscanf(val, "%b", m_ext_intr);
-          "S_EXT_INTR":     num = $sscanf(val, "%b", s_ext_intr);
-          "M_TIMER_INTR":   num = $sscanf(val, "%b", m_timer_intr);
-          "M_SOFT_INTR":    num = $sscanf(val, "%b", m_soft_intr);
+          //"M_EXT_INTR":     num = $sscanf(val, "%b", m_ext_intr);
+          //"S_EXT_INTR":     num = $sscanf(val, "%b", s_ext_intr);
+          //"M_TIMER_INTR":   num = $sscanf(val, "%b", m_timer_intr);
+          //"M_SOFT_INTR":    num = $sscanf(val, "%b", m_soft_intr);
           // Virtual Memory
           "VIRT_ADR_I":     num = $sscanf(val, "%h", virt_adr_i);
           "VIRT_ADR_D":     num = $sscanf(val, "%h", virt_adr_d);

--- a/generators/testgen/src/testgen/priv/extensions/Sm.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sm.py
@@ -459,10 +459,11 @@ def _generate_mcsr_tests(test_data: TestData) -> list[str]:
     lines.append(
         comment_banner(
             coverpoint,
-            "Attempt to read debug-mode registers.  Should throw illegal instruction",
+            "Attempt to read debug-mode registers.  Should throw illegal instruction if Sdext is implemented; otherwise, reserved and unpredictable.",
         ),
     )
-    for csr in range(0x7B0, 0x7C0):
+    lines.append("#ifdef SDEXT_SUPPORTED")
+    for csr in range(0x7B0, 0x7B4):
         lines.extend(
             [
                 "",
@@ -471,6 +472,7 @@ def _generate_mcsr_tests(test_data: TestData) -> list[str]:
                 f"csrr t0, 0x{csr:03x}    # attempt to read debug-mode CSR {csr:03x}; should get illegal instruction",
             ]
         )
+    lines.append("#endif // SDEXT_SUPPORTED")
 
     ######################################
     coverpoint = "cp_csr_ro"


### PR DESCRIPTION
Removed stale interrupt signals from testbench so make coverage passes
Only test debug CSRs are inaccessible from M-mode if Sdext is supported; otherwise they are reserved and unpredictable.