### PR TITLE
Update udb gem to 0.1.16

### DIFF
--- a/framework/src/act/data/Gemfile
+++ b/framework/src/act/data/Gemfile
@@ -19,10 +19,10 @@ if udb_local_path && !udb_local_path.empty?
 else
   # Pin to the latest published versions so every contributor pulls the same
   # gem versions. Bump these in lockstep with Gemfile.lock when upgrading.
-  gem "udb",         "0.1.15"
-  gem "udb-gen",     "0.1.14"
+  gem "udb",         "0.1.16"
+  gem "udb-gen",     "0.1.15"
   gem "udb_helpers", "0.1.3"
-  gem "idlc",        "0.1.6"
+  gem "idlc",        "0.1.7"
 end
 
 # Mirrors udb's own required_ruby_version (~> 3.2).

--- a/framework/src/act/data/Gemfile.lock
+++ b/framework/src/act/data/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
     highline (3.0.1)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
-    idlc (0.1.6)
+    idlc (0.1.7)
       activesupport
       commander (~> 5)
       pp
@@ -84,11 +84,10 @@ GEM
     pastel (0.8.0)
       tty-color (~> 0.5)
     pdf-core (0.9.0)
-    pdf-reader (2.15.1)
+    pdf-reader (2.16.0)
       Ascii85 (>= 1.0, < 3.0, != 2.0.0)
       afm (>= 0.2.1, < 2)
       hashery (~> 2.0)
-      ruby-rc4
       ttfunk
     polyglot (0.3.5)
     pp (0.6.4)
@@ -114,11 +113,10 @@ GEM
     rake (13.4.2)
     regexp_parser (2.12.0)
     rexml (3.4.4)
-    ruby-rc4 (0.1.5)
     rubyzip (3.4.1)
     securerandom (0.4.1)
     simpleidn (0.2.3)
-    sorbet-runtime (0.6.13393)
+    sorbet-runtime (0.6.13427)
     strings (0.2.1)
       strings-ansi (~> 0.2)
       unicode-display_width (>= 1.5, < 3.0)
@@ -151,12 +149,12 @@ GEM
       tty-screen (~> 0.8)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    udb (0.1.15)
+    udb (0.1.16)
       activesupport
       asciidoctor
       awesome_print
       concurrent-ruby
-      idlc (= 0.1.6)
+      idlc (= 0.1.7)
       json_schemer
       numbers_and_words
       ostruct
@@ -171,7 +169,7 @@ GEM
       tty-progressbar
       udb_helpers (= 0.1.3)
       z3
-    udb-gen (0.1.14)
+    udb-gen (0.1.15)
       asciidoctor
       asciidoctor-diagram
       asciidoctor-pdf
@@ -181,7 +179,7 @@ GEM
       tty-option
       tty-progressbar
       tty-table
-      udb (= 0.1.15)
+      udb (= 0.1.16)
       write_xlsx
     udb_helpers (0.1.3)
     unicode-display_width (2.6.0)
@@ -207,9 +205,9 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  idlc (= 0.1.6)
-  udb (= 0.1.15)
-  udb-gen (= 0.1.14)
+  idlc (= 0.1.7)
+  udb (= 0.1.16)
+  udb-gen (= 0.1.15)
   udb_helpers (= 0.1.3)
 
 CHECKSUMS
@@ -244,7 +242,7 @@ CHECKSUMS
   hashery (2.1.2) sha256=d239cc2310401903f6b79d458c2bbef5bf74c46f3f974ae9c1061fb74a404862
   highline (3.0.1) sha256=ca18b218fd581b1fae832f89bfeaf2b34d3a93429c44fd4411042ffce286f009
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
-  idlc (0.1.6) sha256=b71af28e3de0a378491a4a0237f292e01aeb1224a1e1777091720f16e527a54a
+  idlc (0.1.7) sha256=65c82ab33a038905ea6e3f2ca887af2d97c0238fa47b872b64ba68972020dc8a
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   json_schemer (2.5.0) sha256=2f01fb4cce721a4e08dd068fc2030cffd0702a7f333f1ea2be6e8991f00ae396
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
@@ -255,7 +253,7 @@ CHECKSUMS
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   pastel (0.8.0) sha256=481da9fb7d2f6e6b1a08faf11fa10363172dc40fd47848f096ae21209f805a75
   pdf-core (0.9.0) sha256=4f368b2f12b57ec979872d4bf4bd1a67e8648e0c81ab89801431d2fc89f4e0bb
-  pdf-reader (2.15.1) sha256=18c6a986a84a3117fa49f4279fc2de51f5d2399b71833df5d2bccd595c7068ce
+  pdf-reader (2.16.0) sha256=bf1b5564c085264d8279bde3cf1467778b75841494d20c0fe7da3dad475f3732
   polyglot (0.3.5) sha256=59d66ef5e3c166431c39cb8b7c1d02af419051352f27912f6a43981b3def16af
   pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
   prawn (2.4.0) sha256=82062744f7126c2d77501da253a154271790254dfa8c309b8e52e79bc5de2abd
@@ -269,11 +267,10 @@ CHECKSUMS
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
-  ruby-rc4 (0.1.5) sha256=00cc40a39d20b53f5459e7ea006a92cf584e9bc275e2a6f7aa1515510e896c03
   rubyzip (3.4.1) sha256=0a79e745b5c25872ebd148457df5665da8530ed8626c993b01457128f173ca02
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
-  sorbet-runtime (0.6.13393) sha256=920a2d35f69cb268fd8a1da8fe721b543cc2d8e9b3ae90df55105fa191bdcf96
+  sorbet-runtime (0.6.13427) sha256=62ceb3186afd62694bf854a455adb00f6804291b44eba8554b357b9fb93a9275
   strings (0.2.1) sha256=933293b3c95cf85b81eb44b3cf673e3087661ba739bbadfeadf442083158d6fb
   strings-ansi (0.2.0) sha256=90262d760ea4a94cc2ae8d58205277a343409c288cbe7c29416b1826bd511c88
   terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
@@ -291,8 +288,8 @@ CHECKSUMS
   tty-screen (0.8.2) sha256=c090652115beae764336c28802d633f204fb84da93c6a968aa5d8e319e819b50
   tty-table (0.12.0) sha256=fdc27a4750835c1a16efe19a0b857e3ced3652cc7aceafe6dca94908965b9939
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
-  udb (0.1.15) sha256=df63cb04c917c1d0258b112130a59e179f79a9f2faf2e44eaec4bf3bf504999e
-  udb-gen (0.1.14) sha256=3e5946249627a528cbf0816b8f0051bf135328efa933ec63699f1f10d78a9ee6
+  udb (0.1.16) sha256=fb0f2fcb656507587ebe390d61b310f34fd0564e23e3dd5084b84a5996b5d6d8
+  udb-gen (0.1.15) sha256=1bbca4e06494dc225a30ffc4c55bb2a327f2e9089ee61c2b7cc3ac1287a47ba5
   udb_helpers (0.1.3) sha256=aecac68e124b4294d134c4ecb5268fdc3fad20b0bb1f1c4aeab8f42785654c48
   unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   unicode_utils (1.4.0) sha256=b922d0cf2313b6b7136ada6645ce7154ffc86418ca07d53b058efe9eb72f2a40


### PR DESCRIPTION
Bump the UDB Ruby gems to their latest published versions:
- udb 0.1.15 -> 0.1.16
- udb-gen 0.1.14 -> 0.1.15 (required by udb 0.1.16)
- idlc 0.1.6 -> 0.1.7 (required by udb 0.1.16)

Transitive dependency updates: pdf-reader 2.15.1 -> 2.16.0, sorbet-runtime 0.6.13393 -> 0.6.13427.