### PR TITLE
Don't access time/timeh in ZicntrU test if UDB_TIME_CSR_IMPLEMENTED is not defined

### DIFF
--- a/generators/testgen/src/testgen/priv/extensions/ZicntrU.py
+++ b/generators/testgen/src/testgen/priv/extensions/ZicntrU.py
@@ -44,6 +44,8 @@ def _generate_mcounteren_access_u_tests(test_data: TestData) -> list[str]:
             ]
         )
         if i < 3:
+            if reg_list[i] == "time":
+                lines.append("#ifdef UDB_TIME_CSR_IMPLEMENTED")
             lines.extend(
                 [
                     f"csrr x{read_reg}, {reg_list[i]}",
@@ -52,6 +54,8 @@ def _generate_mcounteren_access_u_tests(test_data: TestData) -> list[str]:
                     "#endif",
                 ]
             )
+            if reg_list[i] == "time":
+                lines.append("#endif")
         else:
             lines.extend(
                 [
@@ -88,6 +92,8 @@ def _generate_mcounteren_access_u_tests(test_data: TestData) -> list[str]:
             ]
         )
         if i < 3:
+            if reg_list[i] == "time":
+                lines.append("#ifdef UDB_TIME_CSR_IMPLEMENTED")
             lines.extend(
                 [
                     f"csrr x{read_reg}, {reg_list[i]}",
@@ -96,6 +102,8 @@ def _generate_mcounteren_access_u_tests(test_data: TestData) -> list[str]:
                     "#endif",
                 ]
             )
+            if reg_list[i] == "time":
+                lines.append("#endif")
         else:
             lines.extend(
                 [
@@ -146,6 +154,8 @@ def _generate_mcounteren_access_m_tests(test_data: TestData) -> list[str]:
             ]
         )
         if i < 3:
+            if reg_list[i] == "time":
+                lines.append("#ifdef UDB_TIME_CSR_IMPLEMENTED")
             lines.extend(
                 [
                     f"csrr x{read_reg}, {reg_list[i]}",
@@ -154,6 +164,8 @@ def _generate_mcounteren_access_m_tests(test_data: TestData) -> list[str]:
                     "#endif",
                 ]
             )
+            if reg_list[i] == "time":
+                lines.append("#endif")
         else:
             lines.extend(
                 [
@@ -188,6 +200,8 @@ def _generate_mcounteren_access_m_tests(test_data: TestData) -> list[str]:
             ]
         )
         if i < 3:
+            if reg_list[i] == "time":
+                lines.append("#ifdef UDB_TIME_CSR_IMPLEMENTED")
             lines.extend(
                 [
                     f"csrr x{read_reg}, {reg_list[i]}",
@@ -196,6 +210,8 @@ def _generate_mcounteren_access_m_tests(test_data: TestData) -> list[str]:
                     "#endif",
                 ]
             )
+            if reg_list[i] == "time":
+                lines.append("#endif")
         else:
             lines.extend(
                 [


### PR DESCRIPTION

These CSRs are optional even when Zicntr is implemented, and even when the address-mapped `time`/`timeh` registers (e.g. in CLINT) are implemented.

UDB configuration can express this using the `TIME_CSR_IMPLEMENTED` boolean, but the SAIL model just provides `Zicntr.supported` and `clint.supported`, so it's not sufficiently granular to cover this (common) configuration.

As a compromise, skip the time/timeh tests when the UDB says the CSR is not implemented.