### PR TITLE
Add test generators for the Smcfiss, Smucfiss, Smpmpind and Sspmpss shadow-stack bundle

### DIFF
--- a/generators/testgen/src/testgen/priv/extensions/Smcfiss.py
+++ b/generators/testgen/src/testgen/priv/extensions/Smcfiss.py
@@ -1,0 +1,406 @@
+##################################
+# priv/extensions/Smcfiss.py
+#
+# Smcfiss M-mode shadow-stack test generator.
+# Copyright (C) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+##################################
+
+"""Smcfiss M-mode shadow-stack test generator.
+
+Smcfiss marks a PMP entry as an M-mode shadow-stack region: the entry carries
+the Smpmpind enable bit E=1 together with the otherwise-reserved XWR=010
+encoding, and mseccfg.MSSE enables the feature. Within such a region M-mode
+shadow-stack instructions and explicit loads are permitted, ordinary stores
+fault, and shadow-stack stores to any other matched region fault.
+
+The three groups are split into separate files because their reset-state
+assumptions conflict: m_ss_negative needs mseccfg.MSSE clear, m_ss_basic
+sets it, and m_ss_interlock needs no locked entry and then creates one
+irreversibly.
+"""
+
+from __future__ import annotations
+
+from testgen.asm.csr import gen_csr_read_sigupd
+from testgen.asm.helpers import comment_banner, write_sigupd
+from testgen.constants import INDENT
+from testgen.data.state import TestData
+from testgen.data.test_chunk import TestChunk
+from testgen.priv.registry import add_priv_test_generator
+
+covergroup = "Smcfiss_cg"
+
+# miselect value selecting a PMP entry in the Smcsrind indirect window.
+_MISELECT_PMPIND_BASE = 0x300
+
+_MIREG2_E = 1 << 63
+
+# mseccfg.MSSE. Not yet defined by encoding.h.
+_MSECCFG_MSSE = 1 << 11
+
+# Shadow-stack region encoding: TOR with XWR=010.
+_CFG_SS_TOR = "(PMP_TOR | PMP_W)"
+
+# Ordinary read/write NAPOT region, used as the deliberately non-shadow-stack
+# target of the exclusivity case.
+_CFG_ORDINARY_NAPOT = "(PMP_NAPOT | PMP_R | PMP_W)"
+
+_PAGE = 4096
+
+# Byte offset probed inside the shadow-stack region. Any in-region offset works.
+_PROBE_OFFSET = 0x100
+
+# Offset of ssp into the ordinary region for the exclusivity case. The push
+# targets ssp-8, which must still fall inside the region.
+_NONSS_SSP_OFFSET = 0x400
+
+
+def _select_entry(reg: int, entry: int) -> list[str]:
+    """Point miselect at one PMP entry."""
+    return [
+        f"{INDENT}li x{reg}, {_MISELECT_PMPIND_BASE | entry:#x}    # miselect = PMP indirect base | entry {entry}",
+        f"{INDENT}csrw CSR_MISELECT, x{reg}",
+    ]
+
+
+def _region_data_section(labels: list[tuple[str, str]]) -> list[str]:
+    """Emit page-aligned regions, each as a start label, a page, and an end label."""
+    lines = [
+        "",
+        "# Regions under test. Injected into .data via .pushsection. Page-aligned so",
+        "# the TOR bounds and NAPOT encodings are exact.",
+        ".pushsection .data",
+    ]
+    for label, description in labels:
+        lines.extend(
+            [
+                ".p2align 12",
+                f"{label}_start:    # {description}",
+                f"{INDENT}.fill {_PAGE}, 1, 0",
+                f"{label}_end:",
+            ]
+        )
+    lines.extend([".popsection", ""])
+    return lines
+
+
+def _reset_entry_zero(addr_reg: int, tmp_reg: int, region: str) -> list[str]:
+    """Retire the boot-time all-RWX entry 0 and reuse it as a TOR lower bound.
+
+    Written through the indirect window so that only entry 0 is touched: a
+    direct pmpcfg0 write would rewrite every packed entry in the same register.
+    """
+    lines = [
+        f"{INDENT}LA(x{addr_reg}, {region}_start)",
+        f"{INDENT}srli x{addr_reg}, x{addr_reg}, 2    # TOR lower bound",
+    ]
+    lines.extend(_select_entry(tmp_reg, 0))
+    lines.extend(
+        [
+            f"{INDENT}csrw CSR_MIREG, x{addr_reg}",
+            f"{INDENT}csrw CSR_MIREG2, x0    # cfg = OFF, E = 0",
+            "",
+        ]
+    )
+    return lines
+
+
+def _generate_m_ss_basic(test_data: TestData) -> TestChunk:
+    """Positive path: configure a shadow-stack region, enable it, and exercise it."""
+    tc = test_data.begin_test_chunk("m_ss_basic")
+    coverpoint = "cp_m_ss_region"
+
+    addr_reg, cfg_reg, tmp_reg, check_reg = test_data.int_regs.get_registers(4)
+    push_reg = 1  # Zicfiss constrains sspush/sspopchk to x1 or x5.
+
+    tc.code.extend(_region_data_section([("ss", "shadow-stack region"), ("nonss", "ordinary region")]))
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "Configure the entry as a shadow-stack region: TOR, XWR=010, enable bit set.",
+        )
+    )
+    tc.code.extend(_reset_entry_zero(addr_reg, tmp_reg, "ss"))
+    tc.code.extend(
+        [
+            f"{INDENT}LA(x{addr_reg}, ss_end)",
+            f"{INDENT}srli x{addr_reg}, x{addr_reg}, 2    # TOR upper bound",
+            f"{INDENT}li x{cfg_reg}, {_CFG_SS_TOR}",
+            f"{INDENT}li x{tmp_reg}, {_MIREG2_E:#x}    # enable bit at MXLEN-1",
+            f"{INDENT}or x{cfg_reg}, x{cfg_reg}, x{tmp_reg}",
+        ]
+    )
+    tc.code.extend(_select_entry(tmp_reg, 1))
+    tc.code.extend(
+        [
+            f"{INDENT}csrw CSR_MIREG, x{addr_reg}",
+            f"{INDENT}csrw CSR_MIREG2, x{cfg_reg}",
+            "",
+            f"{INDENT}csrr x{check_reg}, pmpcfg0",
+            f"{INDENT}srli x{check_reg}, x{check_reg}, 8    # entry 1 occupies bits[15:8]",
+            f"{INDENT}andi x{check_reg}, x{check_reg}, 0xFF",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("direct_cfg_byte", coverpoint, covergroup))
+    tc.code.append(write_sigupd(check_reg, test_data))
+
+    tc.code.extend(_select_entry(tmp_reg, 1))
+    tc.code.append(test_data.add_testcase("indirect_cfg_and_enable", coverpoint, covergroup))
+    tc.code.append(gen_csr_read_sigupd(check_reg, ("CSR_MIREG2", None), test_data))
+
+    tc.code.append(comment_banner(coverpoint, "mseccfg.MSSE enables the M-mode shadow stack."))
+    tc.code.extend(
+        [
+            f"{INDENT}csrr x{check_reg}, CSR_MSECCFG",
+            f"{INDENT}li x{tmp_reg}, {_MSECCFG_MSSE:#x}    # mseccfg.MSSE",
+            f"{INDENT}or x{check_reg}, x{check_reg}, x{tmp_reg}",
+            f"{INDENT}csrw CSR_MSECCFG, x{check_reg}",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("msse_set", coverpoint, covergroup))
+    tc.code.append(gen_csr_read_sigupd(check_reg, ("CSR_MSECCFG", None), test_data))
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "A shadow-stack push followed by a matching pop leaves ssp unchanged.\n"
+            "Neither is permitted to fault inside an enabled shadow-stack region.",
+        )
+    )
+    tc.code.extend(
+        [
+            f"{INDENT}LA(x{addr_reg}, ss_end)",
+            f"{INDENT}csrw CSR_SSP, x{addr_reg}    # ssp = top of the region",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("ssp_initialised", coverpoint, covergroup))
+    tc.code.append(gen_csr_read_sigupd(check_reg, ("CSR_SSP", None), test_data))
+
+    tc.code.extend(
+        [
+            f"{INDENT}LI(x{push_reg}, 0x0DEADBEEFCAFEBABE)    # x{push_reg}: sspush/sspopchk take x1 or x5",
+            f"{INDENT}sspush x{push_reg}",
+            f"{INDENT}sspopchk x{push_reg}",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("ssp_after_push_pop", coverpoint, covergroup))
+    tc.code.append(gen_csr_read_sigupd(check_reg, ("CSR_SSP", None), test_data))
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "Inside a shadow-stack region an ordinary store raises a store/AMO\n"
+            "access fault while an explicit load is permitted.",
+        )
+    )
+    tc.code.extend(
+        [
+            f"{INDENT}LA(x{addr_reg}, ss_start)",
+            f"{INDENT}addi x{addr_reg}, x{addr_reg}, {_PROBE_OFFSET:#x}",
+            f"{INDENT}LI(x{cfg_reg}, 0x55AA55AA55AA55AA)    # value the faulting store attempts",
+            f"{INDENT}sw x{cfg_reg}, 0(x{addr_reg})    # store/AMO access fault",
+            f"{INDENT}nop",
+            "",
+            f"{INDENT}ld x{check_reg}, 0(x{addr_reg})    # permitted, reads the zero-filled region",
+            f"{INDENT}nop",
+            "",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("ordinary_store_faults", coverpoint, covergroup))
+    tc.code.append(write_sigupd(cfg_reg, test_data))
+    tc.code.append(test_data.add_testcase("ordinary_load_permitted", coverpoint, covergroup))
+    tc.code.append(write_sigupd(check_reg, test_data))
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "A shadow-stack store to a matched non-shadow-stack region raises a store/AMO\n"
+            "access fault. The region carries ordinary read/write permission so only the\n"
+            "shadow-stack restriction can deny the push, and it must match: unmatched\n"
+            "M-mode accesses are allowed by default.",
+        )
+    )
+    napot_low_bits = (_PAGE >> 3) - 1
+    tc.code.extend(
+        [
+            f"{INDENT}LA(x{addr_reg}, nonss_start)",
+            f"{INDENT}srli x{addr_reg}, x{addr_reg}, 2",
+            f"{INDENT}li x{tmp_reg}, {napot_low_bits:#x}    # NAPOT low bits encoding a {_PAGE}-byte region",
+            f"{INDENT}or x{addr_reg}, x{addr_reg}, x{tmp_reg}",
+            f"{INDENT}li x{cfg_reg}, {_CFG_ORDINARY_NAPOT}    # ordinary region: enable bit clear",
+        ]
+    )
+    tc.code.extend(_select_entry(tmp_reg, 2))
+    tc.code.extend(
+        [
+            f"{INDENT}csrw CSR_MIREG, x{addr_reg}",
+            f"{INDENT}csrw CSR_MIREG2, x{cfg_reg}",
+            "",
+            f"{INDENT}LA(x{addr_reg}, nonss_start)",
+            f"{INDENT}addi x{addr_reg}, x{addr_reg}, {_NONSS_SSP_OFFSET:#x}",
+            f"{INDENT}csrw CSR_SSP, x{addr_reg}    # push targets ssp-8, inside the region",
+            f"{INDENT}LI(x{push_reg}, 0x0123456789ABCDEF)",
+            f"{INDENT}sspush x{push_reg}    # store/AMO access fault",
+            f"{INDENT}nop",
+            "",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("ss_store_to_matched_non_ss_region", coverpoint, covergroup))
+    tc.code.append(gen_csr_read_sigupd(check_reg, ("CSR_SSP", None), test_data))
+
+    test_data.int_regs.return_registers([addr_reg, cfg_reg, tmp_reg, check_reg])
+    return test_data.end_test_chunk()
+
+
+def _generate_m_ss_negative(test_data: TestData) -> TestChunk:
+    """The shadow-stack encoding stays reserved while mseccfg.MSSE is clear."""
+    tc = test_data.begin_test_chunk("m_ss_negative")
+    coverpoint = "cp_reserved_when_msse_clear"
+
+    addr_reg, cfg_reg, tmp_reg, check_reg = test_data.int_regs.get_registers(4)
+
+    tc.code.extend(_region_data_section([("ss", "region under test")]))
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "With mseccfg.MSSE clear, an entry with the enable bit set and XWR=010\n"
+            "is neither a shadow-stack region nor a legal ordinary encoding, so it\n"
+            "denies every access. A plain load raises a load access fault.",
+        )
+    )
+    tc.code.extend(_reset_entry_zero(addr_reg, tmp_reg, "ss"))
+
+    # Pin the precondition: if boot ever set MSSE the case would silently invert.
+    tc.code.append(test_data.add_testcase("msse_clear", coverpoint, covergroup))
+    tc.code.append(gen_csr_read_sigupd(check_reg, ("CSR_MSECCFG", None), test_data))
+
+    tc.code.extend(
+        [
+            f"{INDENT}LA(x{addr_reg}, ss_end)",
+            f"{INDENT}srli x{addr_reg}, x{addr_reg}, 2    # TOR upper bound",
+            f"{INDENT}li x{cfg_reg}, {_CFG_SS_TOR}",
+            f"{INDENT}li x{tmp_reg}, {_MIREG2_E:#x}    # enable bit at MXLEN-1",
+            f"{INDENT}or x{cfg_reg}, x{cfg_reg}, x{tmp_reg}",
+        ]
+    )
+    tc.code.extend(_select_entry(tmp_reg, 1))
+    tc.code.extend(
+        [
+            f"{INDENT}csrw CSR_MIREG, x{addr_reg}",
+            f"{INDENT}csrw CSR_MIREG2, x{cfg_reg}",
+            "",
+            f"{INDENT}LI(x{check_reg}, 0x0BADF00DBADF00D)    # poison: visible if the load wrongly succeeds",
+            f"{INDENT}LA(x{addr_reg}, ss_start)",
+            f"{INDENT}addi x{addr_reg}, x{addr_reg}, {_PROBE_OFFSET:#x}",
+            f"{INDENT}ld x{check_reg}, 0(x{addr_reg})    # load access fault",
+            f"{INDENT}nop",
+            "",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("load_denied", coverpoint, covergroup))
+    tc.code.append(write_sigupd(check_reg, test_data))
+
+    test_data.int_regs.return_registers([addr_reg, cfg_reg, tmp_reg, check_reg])
+    return test_data.end_test_chunk()
+
+
+def _generate_m_ss_interlock(test_data: TestData) -> TestChunk:
+    """The Smepmp interlock makes mseccfg.MSSE read-only once a PMP entry is locked."""
+    tc = test_data.begin_test_chunk("m_ss_interlock")
+    coverpoint = "cp_smepmp_interlock"
+
+    cfg_reg, tmp_reg, check_reg = test_data.int_regs.get_registers(3)
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "With no PMP entry locked and RLB clear, mseccfg.MSSE is writable.",
+        )
+    )
+    tc.code.extend(
+        [
+            f"{INDENT}csrr x{check_reg}, CSR_MSECCFG",
+            f"{INDENT}li x{tmp_reg}, {_MSECCFG_MSSE:#x}    # mseccfg.MSSE",
+            f"{INDENT}or x{check_reg}, x{check_reg}, x{tmp_reg}",
+            f"{INDENT}csrw CSR_MSECCFG, x{check_reg}",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("msse_writable_before_lock", coverpoint, covergroup))
+    tc.code.append(gen_csr_read_sigupd(check_reg, ("CSR_MSECCFG", None), test_data))
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "Lock an A=OFF entry to arm the interlock without matching memory.",
+        )
+    )
+    tc.code.extend(
+        [
+            f"{INDENT}li x{cfg_reg}, PMP_L    # L only: A=OFF, XWR=000",
+        ]
+    )
+    tc.code.extend(_select_entry(tmp_reg, 7))
+    tc.code.extend(
+        [
+            f"{INDENT}csrw CSR_MIREG, x0    # address unused while A=OFF",
+            f"{INDENT}csrw CSR_MIREG2, x{cfg_reg}",
+            "",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("entry_locked", coverpoint, covergroup))
+    tc.code.append(gen_csr_read_sigupd(check_reg, ("CSR_MIREG2", None), test_data))
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "With an entry locked and RLB clear, mseccfg.MSSE is read-only, so an\n"
+            "attempt to clear it leaves the field set.",
+        )
+    )
+    tc.code.extend(
+        [
+            f"{INDENT}csrr x{check_reg}, CSR_MSECCFG",
+            f"{INDENT}li x{tmp_reg}, {_MSECCFG_MSSE:#x}",
+            f"{INDENT}not x{tmp_reg}, x{tmp_reg}",
+            f"{INDENT}and x{check_reg}, x{check_reg}, x{tmp_reg}    # clear MSSE in the written value",
+            f"{INDENT}csrw CSR_MSECCFG, x{check_reg}",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("msse_read_only_after_lock", coverpoint, covergroup))
+    tc.code.append(gen_csr_read_sigupd(check_reg, ("CSR_MSECCFG", None), test_data))
+
+    test_data.int_regs.return_registers([cfg_reg, tmp_reg, check_reg])
+    return test_data.end_test_chunk()
+
+
+@add_priv_test_generator(
+    "Smcfiss",
+    # The MSSE lock interlock is defined only with Smepmp.
+    required_extensions=["Sm", "Smepmp", "Smcfiss"],
+    march_extensions=["Zicfiss"],
+    params=[
+        "MXLEN: 64",
+        # Entries 0-2 are programmed and entry 7 is locked to arm the interlock.
+        # Entry 1 is TOR, entry 2 is NAPOT. Usable, not implemented: an entry
+        # whose registers read as zero cannot guard a region.
+        "NUM_USABLE_PMP_ENTRIES: '>=8'",
+        "PMP_TOR_SUPPORTED: true",
+        "PMP_NAPOT_SUPPORTED: true",
+        # Fixed 4 KiB regions, so the granule must be no coarser (log2 of the
+        # smallest supported region).
+        "PMP_GRANULARITY: '<=12'",
+    ],
+    extra_defines=[
+        "#define BOOT_TO_MMODE",
+        # Two traps in m_ss_basic.
+        "#define TRAP_SIGUPD_COUNT 14",
+    ],
+)
+def make_smcfiss(test_data: TestData) -> list[TestChunk]:
+    return [
+        _generate_m_ss_basic(test_data),
+        _generate_m_ss_negative(test_data),
+        _generate_m_ss_interlock(test_data),
+    ]

--- a/generators/testgen/src/testgen/priv/extensions/Smpmpind.py
+++ b/generators/testgen/src/testgen/priv/extensions/Smpmpind.py
@@ -1,0 +1,234 @@
+##################################
+# priv/extensions/Smpmpind.py
+#
+# Smpmpind indirect PMP CSR access-path test generator.
+# Copyright (C) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+##################################
+
+"""Smpmpind indirect PMP CSR access-path test generator.
+
+Smpmpind exposes the PMP configuration registers through the Smcsrind indirect
+window. miselect selects a PMP entry, mireg aliases that entry's pmpaddr,
+and mireg2 aliases its configuration byte plus an enable bit E at MXLEN-1.
+The direct pmpcfg CSRs alias only the low configuration byte, so they carry no
+encoding for E and a direct write must leave it untouched.
+"""
+
+from __future__ import annotations
+
+from testgen.asm.csr import gen_csr_read_sigupd
+from testgen.asm.helpers import comment_banner, write_sigupd
+from testgen.constants import INDENT
+from testgen.data.state import TestData
+from testgen.data.test_chunk import TestChunk
+from testgen.priv.registry import add_priv_test_generator
+
+covergroup = "Smpmpind_cg"
+coverpoint = "cp_pmp_indirect_access"
+
+# miselect value selecting a PMP entry in the Smcsrind indirect window.
+_MISELECT_PMPIND_BASE = 0x300
+
+# The entry under test. It shares its packed direct pmpcfg CSR with other
+# entries, so a direct write to that CSR also rewrites its neighbours.
+_ENTRY = 4
+_MISELECT_ENTRY = _MISELECT_PMPIND_BASE | _ENTRY
+
+
+def _direct_cfg_view(xlen: int) -> tuple[str, int]:
+    """Return the packed direct CSR holding the entry's configuration byte and its shift.
+
+    RV64 packs eight entries per pmpcfg CSR and numbers those CSRs evenly, so
+    entry 4 lives in pmpcfg0 bits[39:32]. RV32 packs four per CSR and numbers
+    them consecutively, so the same entry lives in pmpcfg1 bits[7:0]. The direct
+    view therefore differs by XLEN even though the indirect view does not.
+    """
+    entries_per_csr = xlen // 8
+    csr_index = _ENTRY // entries_per_csr
+    if xlen == 64:
+        csr_index *= 2  # RV64 uses only even-numbered pmpcfg CSRs
+    return f"pmpcfg{csr_index}", 8 * (_ENTRY % entries_per_csr)
+
+
+# Configuration byte under test: NAPOT, readable, writable (0x1B).
+_CFG = "(PMP_NAPOT | PMP_R | PMP_W)"
+
+_PAGE = 4096
+
+# Backing region for the pmpaddr value. Never accessed, so only alignment matters.
+_REGION = "smpmpind_pmp_region"
+
+
+def _select_entry(reg: int) -> list[str]:
+    """Point miselect at the entry under test."""
+    return [
+        (
+            f"{INDENT}li x{reg}, {_MISELECT_ENTRY:#x}"
+            f"    # miselect = PMP indirect base {_MISELECT_PMPIND_BASE:#x} | entry {_ENTRY}"
+        ),
+        f"{INDENT}csrw CSR_MISELECT, x{reg}",
+    ]
+
+
+def _read_direct_cfg_byte(dest: int) -> list[str]:
+    """Extract the entry's configuration byte from the packed direct CSR."""
+    lines: list[str] = []
+    for xlen, guard in ((64, "#if __riscv_xlen == 64"), (32, "#else")):
+        csr, shift = _direct_cfg_view(xlen)
+        lines.append(guard)
+        lines.append(f"{INDENT}csrr x{dest}, {csr}")
+        if shift:
+            lines.append(
+                f"{INDENT}srli x{dest}, x{dest}, {shift}"
+                f"    # entry {_ENTRY} occupies bits[{shift + 7}:{shift}] of {csr}"
+            )
+        else:
+            lines.append(f"{INDENT}# entry {_ENTRY} occupies bits[7:0] of {csr}")
+    lines.append("#endif")
+    lines.append(f"{INDENT}andi x{dest}, x{dest}, 0xFF")
+    return lines
+
+
+def _round_trip_direct_cfg(reg: int) -> list[str]:
+    """Read the packed direct CSR and write it straight back, unmodified."""
+    lines: list[str] = []
+    for xlen, guard in ((64, "#if __riscv_xlen == 64"), (32, "#else")):
+        csr, _ = _direct_cfg_view(xlen)
+        lines.extend(
+            [
+                guard,
+                f"{INDENT}csrr x{reg}, {csr}",
+                f"{INDENT}csrw {csr}, x{reg}    # round-trip the packed register",
+            ]
+        )
+    lines.append("#endif")
+    return lines
+
+
+def _region_data_section() -> list[str]:
+    return [
+        "",
+        "# Backing region for the pmpaddr value under test. Injected into .data via",
+        "# .pushsection. Page-aligned so the address is a legal NAPOT base.",
+        ".pushsection .data",
+        ".p2align 12",
+        f"{_REGION}:",
+        f"{INDENT}.fill {_PAGE}, 1, 0",
+        ".popsection",
+        "",
+    ]
+
+
+def _generate_indirect_pmpcfg(test_data: TestData) -> TestChunk:
+    """Indirect PMP configuration access path, no traps."""
+    tc = test_data.begin_test_chunk("indirect_pmpcfg")
+
+    addr_reg, cfg_reg, tmp_reg, check_reg = test_data.int_regs.get_registers(4)
+
+    tc.code.extend(_region_data_section())
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "Write a PMP entry through the indirect window with the enable bit set, then read it back.",
+        )
+    )
+    tc.code.extend(
+        [
+            f"{INDENT}LA(x{addr_reg}, {_REGION})",
+            f"{INDENT}srli x{addr_reg}, x{addr_reg}, 2    # address -> pmpaddr encoding",
+            "",
+            f"{INDENT}li x{cfg_reg}, {_CFG}    # configuration byte",
+            "#if __riscv_xlen == 64",
+            f"{INDENT}li x{tmp_reg}, 0x8000000000000000    # E occupies bit MXLEN-1",
+            "#else",
+            f"{INDENT}li x{tmp_reg}, 0x80000000",
+            "#endif",
+            f"{INDENT}or x{cfg_reg}, x{cfg_reg}, x{tmp_reg}    # mireg2 value = E | cfg",
+            "",
+        ]
+    )
+    tc.code.extend(_select_entry(tmp_reg))
+    tc.code.extend(
+        [
+            f"{INDENT}csrw CSR_MIREG, x{addr_reg}     # mireg aliases pmpaddr",
+            f"{INDENT}csrw CSR_MIREG2, x{cfg_reg}     # mireg2 aliases cfg | E",
+            "",
+        ]
+    )
+    tc.code.extend(_select_entry(tmp_reg))
+    tc.code.append(test_data.add_testcase("indirect_readback_e1", coverpoint, covergroup))
+    tc.code.append(gen_csr_read_sigupd(check_reg, ("CSR_MIREG2", None), test_data))
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "The direct pmpcfg CSR aliases the low configuration byte of the same entry.",
+        )
+    )
+    tc.code.extend(_read_direct_cfg_byte(check_reg))
+    tc.code.append(test_data.add_testcase("direct_byte_matches", coverpoint, covergroup))
+    tc.code.append(write_sigupd(check_reg, test_data))
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "A direct pmpcfg round-trip must preserve E, which has no direct encoding.",
+        )
+    )
+    tc.code.extend(_round_trip_direct_cfg(check_reg))
+    tc.code.append("")
+    tc.code.extend(_select_entry(tmp_reg))
+    tc.code.append(test_data.add_testcase("e_preserved_across_direct_write", coverpoint, covergroup))
+    tc.code.append(gen_csr_read_sigupd(check_reg, ("CSR_MIREG2", None), test_data))
+
+    tc.code.extend(_read_direct_cfg_byte(check_reg))
+    tc.code.append(test_data.add_testcase("direct_byte_after_direct_write", coverpoint, covergroup))
+    tc.code.append(write_sigupd(check_reg, test_data))
+
+    for bin_name, e_set, description in (
+        ("indirect_readback_e0", False, "Clearing E through mireg2 leaves the configuration byte in place."),
+        ("indirect_readback_e1_again", True, "Setting E again round-trips through the indirect window."),
+    ):
+        tc.code.append(comment_banner(coverpoint, description))
+        tc.code.extend(_select_entry(tmp_reg))
+        tc.code.append(f"{INDENT}li x{cfg_reg}, {_CFG}")
+        if e_set:
+            tc.code.extend(
+                [
+                    "#if __riscv_xlen == 64",
+                    f"{INDENT}li x{tmp_reg}, 0x8000000000000000",
+                    "#else",
+                    f"{INDENT}li x{tmp_reg}, 0x80000000",
+                    "#endif",
+                    f"{INDENT}or x{cfg_reg}, x{cfg_reg}, x{tmp_reg}",
+                ]
+            )
+        tc.code.append(f"{INDENT}csrw CSR_MIREG2, x{cfg_reg}")
+        tc.code.append("")
+        tc.code.extend(_select_entry(tmp_reg))
+        tc.code.append(test_data.add_testcase(bin_name, coverpoint, covergroup))
+        tc.code.append(gen_csr_read_sigupd(check_reg, ("CSR_MIREG2", None), test_data))
+
+    test_data.int_regs.return_registers([addr_reg, cfg_reg, tmp_reg, check_reg])
+    return test_data.end_test_chunk()
+
+
+@add_priv_test_generator(
+    "Smpmpind",
+    required_extensions=["Sm", "Smpmpind"],
+    march_extensions=[],
+    params=[
+        # Entry 4, encoded as NAPOT. Usable, not implemented: an entry whose
+        # registers read as zero cannot be configured.
+        f"NUM_USABLE_PMP_ENTRIES: '>={_ENTRY + 1}'",
+        "PMP_NAPOT_SUPPORTED: true",
+    ],
+    extra_defines=[
+        "#define BOOT_TO_MMODE",
+        "#define TRAP_SIGUPD_COUNT 0",
+    ],
+)
+def make_smpmpind(test_data: TestData) -> list[TestChunk]:
+    return [_generate_indirect_pmpcfg(test_data)]

--- a/generators/testgen/src/testgen/priv/extensions/Smucfiss.py
+++ b/generators/testgen/src/testgen/priv/extensions/Smucfiss.py
@@ -1,0 +1,236 @@
+##################################
+# priv/extensions/Smucfiss.py
+#
+# Smucfiss U-mode shadow-stack test generator.
+# Copyright (C) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+##################################
+
+"""Smucfiss U-mode shadow-stack test generator.
+
+Smucfiss provides a U-mode shadow stack on systems that implement M-mode and U-mode
+but no S-mode, where page tables are not available to mark shadow-stack pages. A
+PMP entry with the Smpmpind enable bit and XWR=110 denotes the region, and
+menvcfg.SSE enables it for U-mode. Note the encoding differs from Smcfiss,
+which marks its M-mode region with XWR=010.
+"""
+
+from __future__ import annotations
+
+from testgen.asm.csr import gen_csr_read_sigupd
+from testgen.asm.helpers import comment_banner, write_sigupd
+from testgen.constants import INDENT
+from testgen.data.state import TestData
+from testgen.data.test_chunk import TestChunk
+from testgen.priv.registry import add_priv_test_generator
+
+covergroup = "Smucfiss_cg"
+coverpoint = "cp_u_ss_region"
+
+# miselect value selecting a PMP entry in the Smcsrind indirect window.
+_MISELECT_PMPIND_BASE = 0x300
+
+_MIREG2_E = 1 << 63
+
+_PAGE = 4096
+_PROBE_OFFSET = 0x100
+_POISON_M_LOAD = 0xBAD0BAD0BAD0BAD0
+
+# Configuration bytes for the three entries programmed from M-mode. Entry 1 is
+# the shadow-stack region. Entries 0 and 2 bracket it so U-mode can still reach
+# its own code, stack and the signature area.
+_CFG_BELOW = "(PMP_TOR | PMP_X | PMP_W | PMP_R)"
+_CFG_SS = "(PMP_TOR | PMP_X | PMP_W)"
+_CFG_ABOVE = "(PMP_NAPOT | PMP_X | PMP_W | PMP_R)"
+
+
+def _select_entry(reg: int, entry: int) -> list[str]:
+    """Point miselect at one PMP entry."""
+    return [
+        f"{INDENT}li x{reg}, {_MISELECT_PMPIND_BASE | entry:#x}    # miselect = PMP indirect base | entry {entry}",
+        f"{INDENT}csrw CSR_MISELECT, x{reg}",
+    ]
+
+
+def _generate_u_ss_basic(test_data: TestData) -> TestChunk:
+    """Configure a U-mode shadow-stack region, then exercise it from U-mode."""
+    tc = test_data.begin_test_chunk("u_ss_basic")
+
+    addr_reg, cfg_reg, tmp_reg, check_reg, val_reg = test_data.int_regs.get_registers(5)
+    # Zicfiss constrains sspush/sspopchk to x1 or x5.
+    push_reg = 1
+
+    tc.code.extend(
+        [
+            "",
+            "# Shadow-stack region. Injected into .data via .pushsection, page-aligned",
+            "# so the TOR bounds are exact.",
+            ".pushsection .data",
+            ".p2align 12",
+            "uss_start:",
+            f"{INDENT}.fill {_PAGE}, 1, 0",
+            "uss_end:",
+            ".popsection",
+            "",
+        ]
+    )
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "Program three PMP entries from M-mode: an ordinary region below the\n"
+            "shadow stack, the shadow-stack region itself, and a catch-all above\n"
+            "it. The brackets are what let U-mode reach its own code and data, so\n"
+            "that only the shadow-stack rules can deny an access.",
+        )
+    )
+    tc.code.extend(
+        [
+            f"{INDENT}LA(x{addr_reg}, uss_start)",
+            f"{INDENT}srli x{addr_reg}, x{addr_reg}, 2",
+            f"{INDENT}csrw pmpaddr0, x{addr_reg}    # TOR bound: below the region",
+            f"{INDENT}LA(x{addr_reg}, uss_end)",
+            f"{INDENT}srli x{addr_reg}, x{addr_reg}, 2",
+            f"{INDENT}csrw pmpaddr1, x{addr_reg}    # TOR bound: top of the region",
+            f"{INDENT}li x{addr_reg}, -1",
+            f"{INDENT}csrw pmpaddr2, x{addr_reg}    # NAPOT catch-all: everything above",
+            "",
+            f"{INDENT}li x{cfg_reg}, ({_CFG_ABOVE} << 16) | ({_CFG_SS} << 8) | {_CFG_BELOW}",
+            f"{INDENT}csrw pmpcfg0, x{cfg_reg}    # entries 0, 1 and 2 in one packed write",
+            "",
+        ]
+    )
+
+    # The direct write does not encode the enable bit, so entry 1 is rewritten
+    # through the indirect window to set it.
+    tc.code.extend(
+        [
+            f"{INDENT}li x{cfg_reg}, {_CFG_SS}",
+            f"{INDENT}li x{tmp_reg}, {_MIREG2_E:#x}    # enable bit at MXLEN-1",
+            f"{INDENT}or x{cfg_reg}, x{cfg_reg}, x{tmp_reg}",
+        ]
+    )
+    tc.code.extend(_select_entry(tmp_reg, 1))
+    tc.code.extend(
+        [
+            f"{INDENT}LA(x{addr_reg}, uss_end)",
+            f"{INDENT}srli x{addr_reg}, x{addr_reg}, 2",
+            f"{INDENT}csrw CSR_MIREG, x{addr_reg}",
+            f"{INDENT}csrw CSR_MIREG2, x{cfg_reg}",
+            "",
+            f"{INDENT}csrr x{check_reg}, pmpcfg0",
+            f"{INDENT}srli x{check_reg}, x{check_reg}, 8    # entry 1 occupies bits[15:8]",
+            f"{INDENT}andi x{check_reg}, x{check_reg}, 0xFF",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("direct_cfg_byte", coverpoint, covergroup))
+    tc.code.append(write_sigupd(check_reg, test_data))
+
+    tc.code.extend(_select_entry(tmp_reg, 1))
+    tc.code.append(test_data.add_testcase("indirect_cfg_and_enable", coverpoint, covergroup))
+    tc.code.append(gen_csr_read_sigupd(check_reg, ("CSR_MIREG2", None), test_data))
+
+    tc.code.append(comment_banner(coverpoint, "menvcfg.SSE enables the shadow stack for U-mode."))
+    tc.code.extend(
+        [
+            f"{INDENT}csrr x{check_reg}, CSR_MENVCFG",
+            f"{INDENT}ori x{check_reg}, x{check_reg}, MENVCFG_SSE",
+            f"{INDENT}csrw CSR_MENVCFG, x{check_reg}",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("sse_enabled", coverpoint, covergroup))
+    tc.code.append(gen_csr_read_sigupd(check_reg, ("CSR_MENVCFG", None), test_data))
+
+    tc.code.extend(
+        [
+            f"{INDENT}LA(x{addr_reg}, uss_end)",
+            f"{INDENT}csrw CSR_SSP, x{addr_reg}    # ssp = top of the region",
+            "",
+        ]
+    )
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "In U-mode a shadow-stack push and pop round-trip inside the region,\n"
+            "an explicit load from it is permitted, and an ordinary store to it\n"
+            "raises a store/AMO access fault.",
+        )
+    )
+    tc.code.extend(
+        [
+            f"{INDENT}RVTEST_GOTO_LOWER_MODE Umode",
+            "",
+            f"{INDENT}LI(x{push_reg}, 0x0CAFEF00DDEADBEEF)    # x{push_reg}: sspush/sspopchk take x1 or x5",
+            f"{INDENT}sspush x{push_reg}",
+            f"{INDENT}nop",
+            f"{INDENT}sspopchk x{push_reg}",
+            f"{INDENT}nop",
+            "",
+            f"{INDENT}LA(x{addr_reg}, uss_start)",
+            f"{INDENT}addi x{addr_reg}, x{addr_reg}, {_PROBE_OFFSET:#x}",
+            f"{INDENT}ld x{check_reg}, 0(x{addr_reg})    # permitted",
+            f"{INDENT}nop",
+            "",
+            f"{INDENT}LI(x{val_reg}, 0xA55AA55AA55AA55A)    # value the faulting store attempts",
+            f"{INDENT}sw x{val_reg}, 0(x{addr_reg})    # store/AMO access fault",
+            f"{INDENT}nop",
+            "",
+            f"{INDENT}RVTEST_GOTO_MMODE",
+            "",
+        ]
+    )
+
+    tc.code.append(test_data.add_testcase("push_pop_round_trip", coverpoint, covergroup))
+    tc.code.append(write_sigupd(push_reg, test_data))
+    tc.code.append(test_data.add_testcase("load_permitted", coverpoint, covergroup))
+    tc.code.append(write_sigupd(check_reg, test_data))
+    tc.code.append(test_data.add_testcase("ordinary_store_faults", coverpoint, covergroup))
+    tc.code.append(write_sigupd(val_reg, test_data))
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "M-mode cannot use its normal unlocked-PMP bypass to reach an active\n"
+            "U-mode shadow-stack region. An explicit load raises a load access fault,\n"
+            "leaving the destination register unchanged.",
+        )
+    )
+    tc.code.extend(
+        [
+            f"{INDENT}LA(x{addr_reg}, uss_start)",
+            f"{INDENT}addi x{addr_reg}, x{addr_reg}, {_PROBE_OFFSET:#x}",
+            f"{INDENT}LI(x{check_reg}, {_POISON_M_LOAD:#x})",
+            f"{INDENT}ld x{check_reg}, 0(x{addr_reg})    # load access fault",
+            f"{INDENT}nop",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("m_mode_load_faults", coverpoint, covergroup))
+    tc.code.append(write_sigupd(check_reg, test_data))
+
+    test_data.int_regs.return_registers([addr_reg, cfg_reg, tmp_reg, check_reg, val_reg])
+    return test_data.end_test_chunk()
+
+
+@add_priv_test_generator(
+    "Smucfiss",
+    required_extensions=["Sm", "U", "Smucfiss"],
+    march_extensions=["Zicfiss"],
+    params=[
+        "MXLEN: 64",
+        # Entries 0 and 1 are TOR, entry 2 is NAPOT. Usable, not implemented: an
+        # entry whose registers read as zero cannot guard a region.
+        "NUM_USABLE_PMP_ENTRIES: '>=3'",
+        "PMP_TOR_SUPPORTED: true",
+        "PMP_NAPOT_SUPPORTED: true",
+        # Fixed 4 KiB TOR range, so the granule must be no coarser (log2 of the
+        # smallest supported region).
+        "PMP_GRANULARITY: '<=12'",
+    ],
+    extra_defines=[
+        "#define BOOT_TO_MMODE",
+        "#define TRAP_SIGUPD_COUNT 12",
+    ],
+)
+def make_smucfiss(test_data: TestData) -> list[TestChunk]:
+    return [_generate_u_ss_basic(test_data)]

--- a/generators/testgen/src/testgen/priv/extensions/Sspmpss.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sspmpss.py
@@ -1,0 +1,397 @@
+##################################
+# priv/extensions/Sspmpss.py
+#
+# Sspmpss S-mode shadow-stack test generator.
+# Copyright (C) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+##################################
+
+"""Sspmpss S-mode shadow-stack test generator.
+
+Sspmpss marks an SPMP entry as a shadow-stack region for S-mode and U-mode on
+systems that use SPMP rather than page tables. An SPMP entry with XWR=010 and
+SHARED=0 denotes the region. The encoding is otherwise reserved. The feature
+requires menvcfg.SSE and applies only while satp.MODE is Bare.
+"""
+
+from __future__ import annotations
+
+from testgen.asm.helpers import comment_banner, write_sigupd
+from testgen.constants import INDENT
+from testgen.data.state import TestData
+from testgen.data.test_chunk import TestChunk
+from testgen.priv.registry import add_priv_test_generator
+
+covergroup = "Sspmpss_cg"
+
+# Not yet defined by encoding.h.
+_CSR_MPMPDELEG = 0x316
+_CSR_SPMPEN = 0x183
+
+# Hardware entries below this stay PMP. Entries from here up become SPMP.
+_SPMP_PMPNUM = 8
+
+# SPMP logical entries the suite programs: the shadow-stack region, an ordinary
+# region, and the catch-all.
+_SPMP_ENTRIES_USED = 3
+
+# *select value for SPMP logical entry 0.
+_SPMP_SEL_ENTRY0 = 0x100
+
+# spmpcfg encodings. Bit layout is R:0 W:1 X:2 A:4:3 SHARED:9.
+_CFG_SHARED = 1 << 9
+_CFG_SS_REGION = 0x1A  # A=NAPOT, XWR=010, SHARED=0: the shadow-stack region
+_CFG_RW_REGION = 0x1B  # A=NAPOT, XWR=011: ordinary read/write
+_CFG_RWX_CATCHALL = 0x1F  # A=NAPOT, XWR=111: S-mode catch-all
+_CFG_RESERVED = _CFG_SHARED | _CFG_SS_REGION  # SHARED=1 with U=0 stays reserved
+
+# Mask covering the configuration field as read back through the indirect window.
+_CFG_MASK = 0x3FF
+
+_PAGE = 4096
+# NAPOT low-address bits encoding a 4 KiB region.
+_NAPOT_4K = (_PAGE >> 3) - 1
+
+# Deterministic sentinels, each distinctive in a signature dump.
+_SENT_PUSH = 0xF1F1F1F1F1F1F1F1
+_SENT_LR = 0xF5F5F5F5F5F5F5F5
+_SENT_NONSS = 0xF2F2F2F2F2F2F2F2
+_SENT_SW = 0x5757575757575757
+_SENT_LD = 0x1D1D1D1D1D1D1D1D
+_POISON_PUSH = 0xDEAD0001DEAD0001
+_POISON_LR = 0xDEAD0002DEAD0002
+_POISON_NONSS = 0xDEAD0003DEAD0003
+_POISON_SW = 0xDEAD0004DEAD0004
+
+
+def _select_spmp_entry(reg: int, logical: int, csr: str = "CSR_MISELECT") -> list[str]:
+    """Point an indirect-window select register at one SPMP logical entry."""
+    return [
+        f"{INDENT}li x{reg}, {_SPMP_SEL_ENTRY0 + logical:#x}    # select SPMP logical entry {logical}",
+        f"{INDENT}csrw {csr}, x{reg}",
+    ]
+
+
+def _enable_and_delegate(reg: int) -> list[str]:
+    """Enable the shadow stack and split the hardware array between PMP and SPMP."""
+    return [
+        f"{INDENT}li x{reg}, MENVCFG_SSE",
+        f"{INDENT}csrs CSR_MENVCFG, x{reg}    # Sspmpss has no effect while SSE is clear",
+        f"{INDENT}li x{reg}, {_SPMP_PMPNUM}",
+        f"{INDENT}csrw {_CSR_MPMPDELEG:#x}, x{reg}    # mpmpdeleg.pmpnum: entries {_SPMP_PMPNUM}+ are SPMP",
+        "",
+    ]
+
+
+def _generate_spmp_ss_region(test_data: TestData) -> TestChunk:
+    """Configuration path: the shadow-stack encoding is accepted and readable."""
+    tc = test_data.begin_test_chunk("spmp_ss_region")
+    coverpoint = "cp_spmp_ss_region_config"
+
+    tmp_reg, check_reg = test_data.int_regs.get_registers(2)
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "Write the shadow-stack configuration through the indirect window and read it\n"
+            "back. Without Sspmpss the encoding is reserved and the write is dropped, so a\n"
+            "faithful readback is what distinguishes a supporting implementation.",
+        )
+    )
+    tc.code.extend(_enable_and_delegate(tmp_reg))
+    tc.code.extend(_select_spmp_entry(tmp_reg, 0))
+    tc.code.extend(
+        [
+            f"{INDENT}li x{tmp_reg}, {_CFG_SS_REGION:#x}    # A=NAPOT, XWR=010, SHARED=0",
+            f"{INDENT}csrw CSR_MIREG2, x{tmp_reg}",
+            f"{INDENT}csrr x{check_reg}, CSR_MIREG2",
+            f"{INDENT}andi x{check_reg}, x{check_reg}, {_CFG_MASK:#x}",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("ss_cfg_accepted", coverpoint, covergroup))
+    tc.code.append(write_sigupd(check_reg, test_data))
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "The S-mode alias of the indirect window addresses the same SPMP entry.",
+        )
+    )
+    tc.code.extend(_select_spmp_entry(tmp_reg, 0, csr="CSR_SISELECT"))
+    tc.code.extend(
+        [
+            f"{INDENT}csrr x{check_reg}, CSR_SIREG2",
+            f"{INDENT}andi x{check_reg}, x{check_reg}, {_CFG_MASK:#x}",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("ss_cfg_via_s_alias", coverpoint, covergroup))
+    tc.code.append(write_sigupd(check_reg, test_data))
+
+    tc.code.append(comment_banner(coverpoint, "The entry's address register round-trips through the window."))
+    tc.code.extend(_select_spmp_entry(tmp_reg, 0))
+    tc.code.extend(
+        [
+            f"{INDENT}li x{tmp_reg}, 0x2000FFFF    # NAPOT pattern chosen to survive grain masking",
+            f"{INDENT}csrw CSR_MIREG, x{tmp_reg}",
+            f"{INDENT}csrr x{check_reg}, CSR_MIREG",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("ss_addr_round_trip", coverpoint, covergroup))
+    tc.code.append(write_sigupd(check_reg, test_data))
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "The carve-out is specific to XWR=010 with SHARED=0. An encoding that\n"
+            "is reserved for another reason must still be dropped, and dropping it\n"
+            "must not disturb the entry configured above.",
+        )
+    )
+    tc.code.extend(_select_spmp_entry(tmp_reg, 1))
+    tc.code.extend(
+        [
+            f"{INDENT}li x{tmp_reg}, {_CFG_RESERVED:#x}    # SHARED=1 with U=0",
+            f"{INDENT}csrw CSR_MIREG2, x{tmp_reg}",
+            f"{INDENT}csrr x{check_reg}, CSR_MIREG2",
+            f"{INDENT}andi x{check_reg}, x{check_reg}, {_CFG_MASK:#x}",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("reserved_cfg_dropped", coverpoint, covergroup))
+    tc.code.append(write_sigupd(check_reg, test_data))
+
+    tc.code.extend(_select_spmp_entry(tmp_reg, 0))
+    tc.code.extend(
+        [
+            f"{INDENT}csrr x{check_reg}, CSR_MIREG2",
+            f"{INDENT}andi x{check_reg}, x{check_reg}, {_CFG_MASK:#x}",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("ss_cfg_still_set", coverpoint, covergroup))
+    tc.code.append(write_sigupd(check_reg, test_data))
+
+    test_data.int_regs.return_registers([tmp_reg, check_reg])
+    return test_data.end_test_chunk()
+
+
+def _generate_spmp_ss_access(test_data: TestData) -> TestChunk:
+    """Access policy at effective privilege S. Five sub-cases, two expected to fault."""
+    tc = test_data.begin_test_chunk("spmp_ss_access")
+    coverpoint = "cp_spmp_ss_access"
+
+    # Allocated registers survive RVTEST_GOTO_MMODE; a0 is excluded.
+    addr_reg, val_reg, tmp_reg, check_reg, lr_reg = test_data.int_regs.get_registers(5)
+    push_reg = 1  # Zicfiss constrains sspush/sspopchk to x1 or x5.
+
+    tc.code.extend(
+        [
+            "",
+            "# Two page-aligned regions. Injected into .data via .pushsection. The",
+            "# slots sit at the start of each page so their offsets are fixed.",
+            ".pushsection .data",
+            ".p2align 12",
+            "ss_page_start:",
+            f"ss_lr_slot:{INDENT}.dword 0    # +0x00 source for the load-reserved case",
+            f"ss_ld_slot:{INDENT}.dword 0    # +0x08 source for the ordinary load case",
+            f"ss_sw_slot:{INDENT}.dword 0    # +0x10 target of the faulting ordinary store",
+            f"ss_push_slot:{INDENT}.dword 0    # +0x18 target of the shadow-stack push",
+            f"{INDENT}.fill {_PAGE - 32}, 1, 0",
+            "ss_page_end:",
+            ".p2align 12",
+            "nonss_page_start:",
+            f"nonss_slot:{INDENT}.dword 0    # +0x00 target of the faulting shadow-stack push",
+            f"{INDENT}.fill {_PAGE - 8}, 1, 0",
+            "nonss_page_end:",
+            ".popsection",
+            "",
+        ]
+    )
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "Set up from M-mode, where accesses bypass SPMP. satp.MODE must be\n"
+            "Bare: Sspmpss does not apply under a page-based translation mode.",
+        )
+    )
+    tc.code.append(f"{INDENT}csrw satp, zero")
+    tc.code.extend(_enable_and_delegate(tmp_reg))
+
+    for label, value, note in (
+        ("ss_push_slot", _POISON_PUSH, "read back if the push faulted"),
+        ("ss_lr_slot", _SENT_LR, "source for the load-reserved case"),
+        ("ss_ld_slot", _SENT_LD, "source for the ordinary load case"),
+        ("ss_sw_slot", _SENT_SW, "must survive the faulting store"),
+        ("nonss_slot", _SENT_NONSS, "must survive the faulting push"),
+    ):
+        tc.code.extend(
+            [
+                f"{INDENT}LA(x{addr_reg}, {label})",
+                f"{INDENT}LI(x{val_reg}, {value:#x})    # {note}",
+                f"{INDENT}sd x{val_reg}, 0(x{addr_reg})",
+            ]
+        )
+    tc.code.append("")
+
+    for logical, region, cfg, note in (
+        (0, "ss_page_start", _CFG_SS_REGION, "shadow-stack region"),
+        (1, "nonss_page_start", _CFG_RW_REGION, "ordinary read/write region"),
+    ):
+        tc.code.extend(_select_spmp_entry(tmp_reg, logical))
+        tc.code.extend(
+            [
+                f"{INDENT}LA(x{addr_reg}, {region})",
+                f"{INDENT}srli x{addr_reg}, x{addr_reg}, 2",
+                f"{INDENT}ori x{addr_reg}, x{addr_reg}, {_NAPOT_4K:#x}",
+                f"{INDENT}csrw CSR_MIREG, x{addr_reg}",
+                f"{INDENT}li x{tmp_reg}, {cfg:#x}    # {note}",
+                f"{INDENT}csrw CSR_MIREG2, x{tmp_reg}",
+                "",
+            ]
+        )
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "A catch-all entry of lowest priority grants S-mode access to code,\n"
+            "data, handlers and the signature area. It is required because once\n"
+            "any SPMP entry is active an unmatched S or U access is denied.",
+        )
+    )
+    tc.code.extend(_select_spmp_entry(tmp_reg, 2))
+    tc.code.extend(
+        [
+            f"{INDENT}li x{addr_reg}, -1    # NAPOT all-ones: the whole address space",
+            f"{INDENT}csrw CSR_MIREG, x{addr_reg}",
+            f"{INDENT}li x{tmp_reg}, {_CFG_RWX_CATCHALL:#x}",
+            f"{INDENT}csrw CSR_MIREG2, x{tmp_reg}",
+            "",
+        ]
+    )
+
+    # spmpen is indexed by hardware entry, not by SPMP logical entry.
+    activate = ((1 << _SPMP_ENTRIES_USED) - 1) << _SPMP_PMPNUM
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "Set spmpen for all three entries and fence before entering S-mode.\n"
+            "Without spmpen the accesses below are unrestricted.",
+        )
+    )
+    tc.code.extend(
+        [
+            f"{INDENT}li x{tmp_reg}, {activate:#x}    # switch bits for the three entries",
+            f"{INDENT}csrw {_CSR_SPMPEN:#x}, x{tmp_reg}",
+            f"{INDENT}sfence.vma x0, x0",
+            "",
+            f"{INDENT}LA(x{addr_reg}, ss_push_slot)",
+            f"{INDENT}addi x{addr_reg}, x{addr_reg}, 8    # a push stores at ssp-8",
+            f"{INDENT}csrw CSR_SSP, x{addr_reg}",
+            f"{INDENT}LI(x{lr_reg}, {_POISON_LR:#x})    # survives if the load-reserved faults",
+            "",
+        ]
+    )
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "At effective privilege S. A load-reserved is a distinct access type\n"
+            "from an ordinary load, so both are checked.",
+        )
+    )
+    tc.code.extend(
+        [
+            f"{INDENT}RVTEST_GOTO_LOWER_MODE Smode",
+            "",
+            f"{INDENT}LI(x{push_reg}, {_SENT_PUSH:#x})",
+            f"{INDENT}sspush x{push_reg}    # permitted",
+            f"{INDENT}nop",
+            "",
+            f"{INDENT}LA(x{addr_reg}, ss_lr_slot)",
+            f"{INDENT}lr.d x{lr_reg}, (x{addr_reg})    # permitted",
+            f"{INDENT}nop",
+            "",
+            f"{INDENT}LA(x{addr_reg}, nonss_slot)",
+            f"{INDENT}addi x{addr_reg}, x{addr_reg}, 8",
+            f"{INDENT}csrw CSR_SSP, x{addr_reg}    # repoint ssp into the ordinary region",
+            f"{INDENT}LI(x{push_reg}, {_POISON_NONSS:#x})",
+            f"{INDENT}sspush x{push_reg}    # store/AMO access fault",
+            f"{INDENT}nop",
+            "",
+            f"{INDENT}LA(x{addr_reg}, ss_sw_slot)",
+            f"{INDENT}LI(x{val_reg}, {_POISON_SW:#x})",
+            f"{INDENT}sw x{val_reg}, 0(x{addr_reg})    # store/AMO access fault",
+            f"{INDENT}nop",
+            "",
+            f"{INDENT}LA(x{addr_reg}, ss_ld_slot)",
+            f"{INDENT}ld x{val_reg}, 0(x{addr_reg})    # permitted",
+            f"{INDENT}nop",
+            "",
+            f"{INDENT}RVTEST_GOTO_MMODE",
+            "",
+        ]
+    )
+
+    tc.code.append(
+        comment_banner(
+            coverpoint,
+            "Every observable is read back from M-mode, which bypasses SPMP, so\n"
+            "recording cannot itself perturb the outcome.",
+        )
+    )
+    tc.code.extend(
+        [
+            f"{INDENT}LA(x{addr_reg}, ss_push_slot)",
+            f"{INDENT}ld x{check_reg}, 0(x{addr_reg})",
+        ]
+    )
+    tc.code.append(test_data.add_testcase("push_to_ss_region", coverpoint, covergroup))
+    tc.code.append(write_sigupd(check_reg, test_data))
+
+    # The load-reserved result was carried back in a register, so it needs no read.
+    tc.code.append(test_data.add_testcase("load_reserved_from_ss_region", coverpoint, covergroup))
+    tc.code.append(write_sigupd(lr_reg, test_data))
+
+    for label, bin_name in (
+        ("nonss_slot", "push_to_non_ss_region_faults"),
+        ("ss_sw_slot", "ordinary_store_to_ss_region_faults"),
+    ):
+        tc.code.extend(
+            [
+                f"{INDENT}LA(x{addr_reg}, {label})",
+                f"{INDENT}ld x{check_reg}, 0(x{addr_reg})",
+            ]
+        )
+        tc.code.append(test_data.add_testcase(bin_name, coverpoint, covergroup))
+        tc.code.append(write_sigupd(check_reg, test_data))
+
+    tc.code.append(test_data.add_testcase("ordinary_load_from_ss_region", coverpoint, covergroup))
+    tc.code.append(write_sigupd(val_reg, test_data))
+
+    test_data.int_regs.return_registers([addr_reg, val_reg, tmp_reg, check_reg, lr_reg])
+    return test_data.end_test_chunk()
+
+
+@add_priv_test_generator(
+    "Sspmpss",
+    # Zalrsc, not A: lr.d is the only atomic used.
+    # Smpmpind stands in for the SPMP base, which UDB cannot represent.
+    required_extensions=["Sm", "S", "Zalrsc", "Smcsrind", "Smpmpind", "Sspmpss"],
+    march_extensions=["Zalrsc", "Zicfiss"],
+    params=[
+        "MXLEN: 64",
+        # Proxy: SPMP entries are carved from the shared PMP array, so entries
+        # 8 to 10 must be usable. No NAPOT or granularity claim, since those PMP
+        # parameters describe a different structure.
+        f"NUM_USABLE_PMP_ENTRIES: '>={_SPMP_PMPNUM + _SPMP_ENTRIES_USED}'",
+    ],
+    extra_defines=[
+        "#define BOOT_TO_MMODE",
+        # Two traps in spmp_ss_access.
+        "#define TRAP_SIGUPD_COUNT 20",
+    ],
+)
+def make_sspmpss(test_data: TestData) -> list[TestChunk]:
+    return [
+        _generate_spmp_ss_region(test_data),
+        _generate_spmp_ss_access(test_data),
+    ]


### PR DESCRIPTION
Adds test generators for four pre-ratification shadow-stack extensions: Smpmpind for indirect PMP CSR access,
Smcfiss and Smucfiss for M-mode and U-mode shadow stacks on PMP, and Sspmpss for S-mode and U-mode shadow stacks
on SPMP. The corresponding extension definitions are proposed in riscv/riscv-unified-db#2510.

Verified against the proposed Sail implementations in riscv/sail-riscv#1864, riscv/sail-riscv#1865,
riscv/sail-riscv#1866 and riscv/sail-riscv#1870. Smpmpind, Smcfiss and Smucfiss were also run against a Spike
fork. Sspmpss has no independent DUT because Spike does not implement SPMP.
