### PR TITLE
Increase CI shards

### DIFF
--- a/config/qemu/ci.yaml
+++ b/config/qemu/ci.yaml
@@ -25,3 +25,4 @@ apt_packages: "libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build"
 shards: 1
 config_shards:
   qemu-rv64-max: 2
+  qemu-rv32-max: 2

--- a/config/sail/ci.yaml
+++ b/config/sail/ci.yaml
@@ -10,7 +10,7 @@ config_shards:
   sail-RVA23S64: 2
   sail-RVA23S64-optional: 2
   sail-RVB23S64-optional: 2
-  sail-rv32-max: 3
-  sail-rv32-max-clang: 3
-  sail-rv64-max: 3
-  sail-rv64-max-clang: 3
+  sail-rv32-max: 4
+  sail-rv32-max-clang: 4
+  sail-rv64-max: 4
+  sail-rv64-max-clang: 4

--- a/config/spike/ci.yaml
+++ b/config/spike/ci.yaml
@@ -11,3 +11,5 @@ exclude_extensions: "Sm,Smstateen,SdtrigSm,SdtrigS,SdtrigU"
 install_script: ".github/scripts/install-spike.sh"
 apt_packages: "device-tree-compiler libboost-regex-dev libboost-system-dev"
 shards: 1
+config_shards:
+  spike-rv64-max: 2


### PR DESCRIPTION
Now that more vector tests are enabled by default, CI time has been
increasing. Split the longest running configs into more shards.
