### PR TITLE
Pin ruff target-version to py310, and drop the future imports it made redundant

### DIFF
--- a/.github/scripts/ci_config.py
+++ b/.github/scripts/ci_config.py
@@ -28,8 +28,6 @@ Usage:
     .github/scripts/ci_config.py    # JSON matrix for GitHub Actions
 """
 
-from __future__ import annotations
-
 import hashlib
 import heapq
 import json

--- a/framework/src/act/act.py
+++ b/framework/src/act/act.py
@@ -7,8 +7,6 @@
 # Main entry point for RISC-V architecture verification framework
 ##################################
 
-from __future__ import annotations
-
 import os
 import sys
 from pathlib import Path

--- a/framework/src/act/build.py
+++ b/framework/src/act/build.py
@@ -7,8 +7,6 @@
 # Python-native DAG build executor using graphlib.TopologicalSorter
 ##################################
 
-from __future__ import annotations
-
 import contextlib
 import os
 import re

--- a/framework/src/act/build_types.py
+++ b/framework/src/act/build_types.py
@@ -9,8 +9,6 @@
 
 """Build action and task definitions shared by the executor and cache layers."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path

--- a/framework/src/act/config.py
+++ b/framework/src/act/config.py
@@ -7,8 +7,6 @@
 # Parse test framework configuration files
 ##################################
 
-from __future__ import annotations
-
 import shutil
 import subprocess
 from enum import Enum

--- a/framework/src/act/dut_macros.py
+++ b/framework/src/act/dut_macros.py
@@ -10,8 +10,6 @@
 
 """Derive a minimal rvmodel_macros.svh from rvmodel_macros.h."""
 
-from __future__ import annotations
-
 import re
 from pathlib import Path
 

--- a/framework/src/act/parse_test_constraints.py
+++ b/framework/src/act/parse_test_constraints.py
@@ -7,8 +7,6 @@
 # Parse YAML comment header from test files
 ##################################
 
-from __future__ import annotations
-
 import re
 from pathlib import Path
 

--- a/framework/src/act/select_tests.py
+++ b/framework/src/act/select_tests.py
@@ -7,8 +7,6 @@
 # Select tests to run based on UDB config and test list
 ##################################
 
-from __future__ import annotations
-
 import re
 from collections.abc import Sequence
 from pathlib import Path

--- a/framework/src/act/trap_report.py
+++ b/framework/src/act/trap_report.py
@@ -7,8 +7,6 @@
 # Decode trap signature region and generate a human-readable trap report
 ##################################
 
-from __future__ import annotations
-
 import subprocess
 from bisect import bisect_right
 from dataclasses import dataclass

--- a/generators/coverage/src/covergroupgen/build_disasm_fallback.py
+++ b/generators/coverage/src/covergroupgen/build_disasm_fallback.py
@@ -14,8 +14,6 @@ to extend coverage.
 Output: framework/src/act/fcov/coverage/RISCV_disasm_fallback.svh
 """
 
-from __future__ import annotations
-
 import re
 from pathlib import Path
 

--- a/generators/coverage/src/covergroupgen/generate.py
+++ b/generators/coverage/src/covergroupgen/generate.py
@@ -7,8 +7,6 @@
 # Generate functional covergroups for RISC-V instructions
 ##################################
 
-from __future__ import annotations
-
 import csv
 import importlib.resources
 import math

--- a/generators/ctp/generate_norm_table.py
+++ b/generators/ctp/generate_norm_table.py
@@ -27,8 +27,6 @@ The script writes an .adoc file containing a table with columns:
 It also prints (and writes) a small report of names present in one file but not the other.
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import os

--- a/generators/ctp/google_sheet_to_yaml.py
+++ b/generators/ctp/google_sheet_to_yaml.py
@@ -43,8 +43,6 @@ Names in column I can be a comma-separated list, pipe-separated, or bracketed
 list (e.g. "[add_op, sub_op]"). Blank rows are ignored.
 """
 
-from __future__ import annotations
-
 import argparse
 import csv
 import re

--- a/generators/ctp/norm_yaml_gen.py
+++ b/generators/ctp/norm_yaml_gen.py
@@ -26,8 +26,6 @@ to rules in the JSON file, where dots in instruction names are replaced with
 underscores and "_op" is appended.
 """
 
-from __future__ import annotations
-
 import argparse
 import csv
 import json

--- a/generators/testgen/src/testgen/asm/csr.py
+++ b/generators/testgen/src/testgen/asm/csr.py
@@ -8,8 +8,6 @@
 
 """CSR test utilities for privileged test generation."""
 
-from __future__ import annotations
-
 from testgen.asm.helpers import write_sigupd
 from testgen.constants import INDENT
 from testgen.data.state import TestData

--- a/generators/testgen/src/testgen/asm/helpers.py
+++ b/generators/testgen/src/testgen/asm/helpers.py
@@ -8,8 +8,6 @@
 
 """Assembly generation helpers for test code."""
 
-from __future__ import annotations
-
 from typing import Literal
 
 from testgen.constants import INDENT

--- a/generators/testgen/src/testgen/asm/interrupts.py
+++ b/generators/testgen/src/testgen/asm/interrupts.py
@@ -7,8 +7,6 @@
 ##################################
 
 
-from __future__ import annotations
-
 from testgen.constants import INDENT
 
 

--- a/generators/testgen/src/testgen/asm/tsbi.py
+++ b/generators/testgen/src/testgen/asm/tsbi.py
@@ -8,8 +8,6 @@
 
 """Assembly generation helpers for test code."""
 
-from __future__ import annotations
-
 import re
 
 from testgen.constants import INDENT

--- a/generators/testgen/src/testgen/asm/vector_helpers.py
+++ b/generators/testgen/src/testgen/asm/vector_helpers.py
@@ -6,8 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 ##################################
 
-from __future__ import annotations
-
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Literal

--- a/generators/testgen/src/testgen/cli.py
+++ b/generators/testgen/src/testgen/cli.py
@@ -10,8 +10,6 @@
 
 """Top-level command-line interface for test generation."""
 
-from __future__ import annotations
-
 import os
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass

--- a/generators/testgen/src/testgen/coverpoints/registry.py
+++ b/generators/testgen/src/testgen/coverpoints/registry.py
@@ -7,8 +7,6 @@
 
 """Coverpoint generator registry with automatic discovery."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from pathlib import Path
 from random import seed

--- a/generators/testgen/src/testgen/coverpoints/vector/helpers.py
+++ b/generators/testgen/src/testgen/coverpoints/vector/helpers.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Helpers shared only by vector coverpoint generators."""
 
-from __future__ import annotations
-
 import re
 
 from testgen.constants import VLEN_MAX

--- a/generators/testgen/src/testgen/data/config.py
+++ b/generators/testgen/src/testgen/data/config.py
@@ -7,8 +7,6 @@
 
 """Test configuration for RISC-V test generation."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 
 

--- a/generators/testgen/src/testgen/data/params.py
+++ b/generators/testgen/src/testgen/data/params.py
@@ -9,8 +9,6 @@
 Instruction parameter dataclass.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from enum import Enum
 from typing import Literal

--- a/generators/testgen/src/testgen/data/state.py
+++ b/generators/testgen/src/testgen/data/state.py
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 ##################################
 
-from __future__ import annotations
-
 import re
 from typing import Literal
 

--- a/generators/testgen/src/testgen/data/test_chunk.py
+++ b/generators/testgen/src/testgen/data/test_chunk.py
@@ -7,8 +7,6 @@
 
 """TestChunk dataclass for holding test chunk output data."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass, field
 
 

--- a/generators/testgen/src/testgen/discovery.py
+++ b/generators/testgen/src/testgen/discovery.py
@@ -8,8 +8,6 @@
 
 """Shared module auto-discovery for decorator-based registries."""
 
-from __future__ import annotations
-
 from importlib import import_module
 from pathlib import Path
 

--- a/generators/testgen/src/testgen/exceptions.py
+++ b/generators/testgen/src/testgen/exceptions.py
@@ -8,8 +8,6 @@
 
 """Base exceptions for testgen."""
 
-from __future__ import annotations
-
 from difflib import get_close_matches
 from pathlib import Path
 

--- a/generators/testgen/src/testgen/formatters/registry.py
+++ b/generators/testgen/src/testgen/formatters/registry.py
@@ -8,8 +8,6 @@
 
 """Instruction formatter registration, lookup, and rendering."""
 
-from __future__ import annotations
-
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/generators/testgen/src/testgen/instructions/params.py
+++ b/generators/testgen/src/testgen/instructions/params.py
@@ -33,8 +33,6 @@ The InstructionTypeConfig supports:
   - imm_nonzero: Whether immediate must be nonzero
 """
 
-from __future__ import annotations
-
 from typing import Any
 
 from testgen.data.params import InstructionParams

--- a/generators/testgen/src/testgen/instructions/vector_params.py
+++ b/generators/testgen/src/testgen/instructions/vector_params.py
@@ -10,8 +10,6 @@
 # SPDX-License-Identifier: Apache-2.0
 ##################################
 
-from __future__ import annotations
-
 import dataclasses
 import math
 import random

--- a/generators/testgen/src/testgen/io/templates.py
+++ b/generators/testgen/src/testgen/io/templates.py
@@ -8,8 +8,6 @@
 
 """Template loading and insertion for test files."""
 
-from __future__ import annotations
-
 import importlib.resources
 import re
 from pathlib import Path

--- a/generators/testgen/src/testgen/io/writer.py
+++ b/generators/testgen/src/testgen/io/writer.py
@@ -8,8 +8,6 @@
 
 """Test file writing utilities."""
 
-from __future__ import annotations
-
 from pathlib import Path
 
 from testgen.asm.sections import generate_test_data_section, generate_test_string_section, generate_vector_data_section

--- a/generators/testgen/src/testgen/priv/extensions/SdtrigCommon.py
+++ b/generators/testgen/src/testgen/priv/extensions/SdtrigCommon.py
@@ -8,8 +8,6 @@
 
 """Shared Sdtrig debug-trigger test-case generators."""
 
-from __future__ import annotations
-
 from random import seed
 
 from testgen.asm.helpers import comment_banner, reproducible_hash, write_sigupd

--- a/generators/testgen/src/testgen/priv/extensions/Smstateen.py
+++ b/generators/testgen/src/testgen/priv/extensions/Smstateen.py
@@ -6,8 +6,6 @@
 
 """Smstateen privileged extension test generator."""
 
-from __future__ import annotations
-
 from testgen.asm.csr import csr_walk_test
 from testgen.asm.helpers import comment_banner
 from testgen.constants import INDENT

--- a/generators/testgen/src/testgen/priv/extensions/SsstrictCommon.py
+++ b/generators/testgen/src/testgen/priv/extensions/SsstrictCommon.py
@@ -24,8 +24,6 @@ base pointing at mapped memory; load/store/atomic templates use it as rs1 (the
 'B' field) so their accesses always land in the scratch region.
 """
 
-from __future__ import annotations
-
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from random import randint, seed

--- a/generators/testgen/src/testgen/priv/extensions/Sstvala.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sstvala.py
@@ -8,8 +8,6 @@
 
 """Sstvala S-mode test generator."""
 
-from __future__ import annotations
-
 from testgen.asm.helpers import comment_banner
 from testgen.data.state import TestData
 from testgen.data.test_chunk import TestChunk

--- a/generators/testgen/src/testgen/priv/extensions/Zama16b.py
+++ b/generators/testgen/src/testgen/priv/extensions/Zama16b.py
@@ -12,8 +12,6 @@ Verifies that misaligned loads, stores, and AMOs that do not cross a
 naturally aligned 16-byte boundary do NOT raise a misaligned fault.
 """
 
-from __future__ import annotations
-
 from testgen.asm.helpers import comment_banner, write_sigupd
 from testgen.data.state import TestData
 from testgen.data.test_chunk import TestChunk

--- a/generators/testgen/src/testgen/priv/registry.py
+++ b/generators/testgen/src/testgen/priv/registry.py
@@ -8,8 +8,6 @@
 
 """Privileged test generator registry with automatic discovery."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ workspace.members = [ "framework", "generators/coverage", "generators/testgen" ]
 
 ###### RUFF CONFIG #####
 [tool.ruff]
+# Pin explicitly: without it ruff infers the target from the nearest ancestor
+# requires-python, which is outside this repo when it is nested in another project.
+target-version = "py310"
 line-length = 120
 extend-exclude = [
   "docs/docs-resources",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ workspace.members = [ "framework", "generators/coverage", "generators/testgen" ]
 
 ###### RUFF CONFIG #####
 [tool.ruff]
-# Pin explicitly: without it ruff infers the target from the nearest ancestor
-# requires-python, which is outside this repo when it is nested in another project.
 target-version = "py310"
 line-length = 120
 extend-exclude = [

--- a/run_tests.py
+++ b/run_tests.py
@@ -8,8 +8,6 @@
 # Run all ELFs from a directory using the input command in parallel
 ##################################
 
-from __future__ import annotations
-
 import argparse
 import os
 import re


### PR DESCRIPTION
Explicitly declare Python version for Ruff.