### PR TITLE
Use RVMODEL_MAX_CYCLES_PER_TIMER_TICK for `mtime` wraparound test.

### DIFF
--- a/config/spike/spike-rv64-max/rvmodel_macros.h
+++ b/config/spike/spike-rv64-max/rvmodel_macros.h
@@ -108,10 +108,7 @@
 
 #define RVMODEL_TIMER_INT_SOON_DELAY 100
 
-// Spike ticks the CLINT timer every 100 instructions (default --insns-per-tick).
-// Define a 100x multiplier to convert between timer tick and processor cycle count.
-
-#define RVMODEL_MAX_CYCLES_PER_TIMER_TICK 100
+#define RVMODEL_MAX_CYCLES_PER_TIMER_TICK 5000
 
 #define CLINT_BASE_ADDRESS 0x02000000
 #define RVMODEL_MSIP_ADDRESS (CLINT_BASE_ADDRESS + 0x0)

--- a/generators/testgen/src/testgen/priv/extensions/Sm.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sm.py
@@ -1333,7 +1333,7 @@ def _generate_mcsr_cntr_tests(test_data: TestData) -> list[str]:
             "#endif",
             test_data.add_testcase("mtime_wrap", coverpoint, covergroup),
             f"SREG x{r_val}, 0(x{r_temp})          # write all-ones to the base word; arms the counter",
-            f"LI(x{r_counter}, 1000)                # Wait loop for counter ticks",
+            f"LI(x{r_counter}, RVMODEL_MAX_CYCLES_PER_TIMER_TICK * 2) # Wait loop for two timer ticks",
             "1:",
             "nop",
             f"addi x{r_counter}, x{r_counter}, -1",


### PR DESCRIPTION
Also fix RVMODEL_MAX_CYCLES_PER_TIMER_TICK for Spike.