### PR TITLE
Extend test selection metadata

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -136,15 +136,15 @@ REQUIRED_EXTENSIONS:
 
 Each top-level item is required. A string requires that extension. A nested
 list requires at least one extension in that list. More than one nested list
-can be used. For example, `[I, [A, B], [F, D]]` means `I AND (A OR B) AND
-(F OR D)`.
+can be used. For example, `[I, [Zicboz, Zicbom, Zicbop], [Sm, U]]` means `I AND
+(Zicboz OR Zicbom OR Zicbop) AND (Sm OR U)`.
 
 #### `FORBIDDEN_EXTENSIONS`
 
 An optional YAML list of extensions that the DUT must not implement:
 
 ```yaml
-FORBIDDEN_EXTENSIONS: [Zca]
+FORBIDDEN_EXTENSIONS: [S]
 ```
 
 The framework skips the test if the DUT implements one or more extensions in

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -110,28 +110,46 @@ assembly code in the file.
 The following top-level keys are recognized. No other keys are permitted
 (the parser uses strict validation and will reject unknown keys).
 
-| Key                   | Type            | Required | Description                                                                                                                                          |
-| --------------------- | --------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `REQUIRED_EXTENSIONS` | list of strings | **Yes**  | RISC-V extensions required by this test. The test is only selected for a DUT whose implemented extensions list contains **all** of these extensions. |
-| `MARCH`               | string          | **Yes**  | The `-march` string passed to the compiler. Must match the pattern `rv(32\|64\|${XLEN})(i\|e\|g)...` (e.g., `rv32i_zba`, `rv64ifd_zfh`).             |
-| `params`              | mapping         | No       | A dictionary of parameter constraints that must match the DUT's UDB configuration for the test to be selected.                                       |
+| Key                    | Type                                | Required | Description                                                                                                              |
+| ---------------------- | ----------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `REQUIRED_EXTENSIONS`  | list of strings or lists of strings | **Yes**  | Extensions required by this test. A nested list indicates at least one of the extensions in the sublist must be present. |
+| `FORBIDDEN_EXTENSIONS` | list of strings                     | No       | Extensions that the DUT must NOT implement for the test to be selected.                                                  |
+| `MARCH`                | string                              | **Yes**  | The `-march` string passed to the compiler, such as `rv32i_zba` or `rv64ifd_zfh`.                                        |
+| `params`               | mapping                             | No       | Parameter constraints that must match the DUT's UDB configuration for the test to be selected.                           |
 
 #### `REQUIRED_EXTENSIONS`
 
-A YAML list of extension name strings. Both quoted and unquoted styles are
-accepted:
+A YAML list of extension name strings or nested lists.
+Nested lists indicate at least one of the extensions must be supported
+Both quoted and unquoted strings are accepted:
 
 ```yaml
-# Quoted style (common in generated tests)
-REQUIRED_EXTENSIONS: ["I", "Zba"]
-
-# Unquoted style (common in hand-written tests)
-REQUIRED_EXTENSIONS: [I, S, Zicsr, Sm]
+# All listed extensions are required.
+REQUIRED_EXTENSIONS: [I, Zba]
 ```
 
-During test selection, the framework checks that every extension in this list
-is present in the DUT's implemented extensions (derived from the UDB
-configuration). A test is skipped if any required extension is missing.
+```yaml
+# I and at least one of Sm or U are required.
+REQUIRED_EXTENSIONS:
+  - I
+  - [Sm, U]
+```
+
+Each top-level item is required. A string requires that extension. A nested
+list requires at least one extension in that list. More than one nested list
+can be used. For example, `[I, [A, B], [F, D]]` means `I AND (A OR B) AND
+(F OR D)`.
+
+#### `FORBIDDEN_EXTENSIONS`
+
+An optional YAML list of extensions that the DUT must not implement:
+
+```yaml
+FORBIDDEN_EXTENSIONS: [Zca]
+```
+
+The framework skips the test if the DUT implements one or more extensions in
+this list.
 
 #### `MARCH`
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -120,7 +120,6 @@ The following top-level keys are recognized. No other keys are permitted
 #### `REQUIRED_EXTENSIONS`
 
 A YAML list of extension name strings or nested lists.
-Nested lists indicate at least one of the extensions must be supported
 Both quoted and unquoted strings are accepted:
 
 ```yaml

--- a/framework/src/act/parse_test_constraints.py
+++ b/framework/src/act/parse_test_constraints.py
@@ -9,6 +9,7 @@
 
 import re
 from pathlib import Path
+from typing import Annotated
 
 from pydantic import BaseModel, Field, FilePath, ValidationError
 from rich.console import Console
@@ -17,6 +18,8 @@ from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
 _TEST_FILE_SUFFIXES = (".S", ".c")
+
+ExtensionRequirement = str | Annotated[frozenset[str], Field(min_length=1)]
 
 
 class TestYamlHeaderError(Exception):
@@ -43,7 +46,8 @@ class TestMetadata(BaseModel):
     """Metadata for a RISC-V test case extracted from YAML configuration."""
 
     test_path: FilePath
-    required_extensions: set[str] = Field(alias="REQUIRED_EXTENSIONS", min_length=1)
+    required_extensions: frozenset[ExtensionRequirement] = Field(alias="REQUIRED_EXTENSIONS", min_length=1)
+    forbidden_extensions: frozenset[str] = Field(alias="FORBIDDEN_EXTENSIONS", default_factory=frozenset)
     march: str = Field(alias="MARCH", pattern=r"rv(?:32|64|\$\{XLEN\})[ieg].*")
     needs_signature: bool = Field(alias="NEEDS_SIGNATURE", default=True)
     params: dict[str, int | bool | str] = Field(default_factory=dict)

--- a/framework/src/act/select_tests.py
+++ b/framework/src/act/select_tests.py
@@ -12,7 +12,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from act.config import Config, load_config
-from act.parse_test_constraints import TestMetadata
+from act.parse_test_constraints import ExtensionRequirement, TestMetadata
 from act.parse_udb_config import get_config_params, get_implemented_extensions, prepare_dut_outputs
 
 PRIV_EXTENSIONS = {"Sm", "S", "U"}
@@ -53,6 +53,31 @@ def _compare_param(test_value: object, config_value: object) -> bool:
     return test_value == config_value
 
 
+def check_test_extensions(
+    required_extensions: frozenset[ExtensionRequirement],
+    forbidden_extensions: frozenset[str],
+    implemented_extensions: set[str],
+) -> bool:
+    """Check required, alternative, and forbidden extension constraints."""
+    if not forbidden_extensions.isdisjoint(implemented_extensions):
+        return False
+
+    return all(
+        requirement in implemented_extensions
+        if isinstance(requirement, str)
+        else not requirement.isdisjoint(implemented_extensions)
+        for requirement in required_extensions
+    )
+
+
+def _requires_privilege_extension(required_extensions: frozenset[ExtensionRequirement]) -> bool:
+    """Check whether the requirements can only be met with a privilege extension."""
+    return any(
+        requirement in PRIV_EXTENSIONS if isinstance(requirement, str) else requirement.issubset(PRIV_EXTENSIONS)
+        for requirement in required_extensions
+    )
+
+
 def check_test_params(test_params: dict[str, int | bool | str], config_params: dict[str, ConfigParamValue]) -> bool:
     """Check if all parameters in test_params match those in config_params."""
     for param, value in test_params.items():
@@ -74,10 +99,14 @@ def select_tests(
     selected_tests: dict[str, TestMetadata] = {}
     for test_name, test_metadata in test_dict.items():
         # Skip privileged tests if disabled
-        if not include_priv_tests and not test_metadata.required_extensions.isdisjoint(PRIV_EXTENSIONS):
+        if not include_priv_tests and _requires_privilege_extension(test_metadata.required_extensions):
             continue
-        # Check if all required extensions are implemented
-        if test_metadata.required_extensions.issubset(implemented_extensions):
+        # Check if all extensions match
+        if check_test_extensions(
+            test_metadata.required_extensions,
+            test_metadata.forbidden_extensions,
+            implemented_extensions,
+        ):
             # Check if all parameters match
             test_params = test_metadata.params
             if check_test_params(test_params, config_params):

--- a/generators/testgen/src/testgen/data/config.py
+++ b/generators/testgen/src/testgen/data/config.py
@@ -38,7 +38,7 @@ class TestConfig:
     testsuite: str
     E_ext: bool = False
     sew: int | None = None
-    required_extensions: list[str] | None = None
+    required_extensions: list[str | list[str]] | None = None
     march_extensions: list[str] | None = None
     extra_params: list[str] | None = None
 

--- a/generators/testgen/src/testgen/io/templates.py
+++ b/generators/testgen/src/testgen/io/templates.py
@@ -46,7 +46,15 @@ def insert_header_template(
     testsuite = test_config.testsuite
     E_ext = test_config.E_ext
     required_extensions = test_config.required_extensions
+    alternative_extensions = (
+        [] if required_extensions is None else [ext for ext in required_extensions if isinstance(ext, list)]
+    )
+    required_extensions = (
+        None if required_extensions is None else [ext for ext in required_extensions if isinstance(ext, str)]
+    )
     ext_components, params = canonicalize_extensions(testsuite, xlen, E_ext, required_extensions, sew, instr_name)
+    extension_requirements = [*ext_components, *alternative_extensions]
+    flat_ext_components = ext_components + [ext for alternatives in alternative_extensions for ext in alternatives]
     if test_config.extra_params:
         params.extend(test_config.extra_params)
     march_extensions = test_config.march_extensions
@@ -54,16 +62,16 @@ def insert_header_template(
         march_ext_components, _ = canonicalize_extensions(testsuite, xlen, E_ext, march_extensions, sew, instr_name)
         march = generate_march_string(march_ext_components, xlen)
         # combine required_extensions and march_extensions for extra_defines
-        all_extensions = list(dict.fromkeys(ext_components + march_ext_components))
+        all_extensions = list(dict.fromkeys(flat_ext_components + march_ext_components))
     else:
-        march = generate_march_string(ext_components, xlen)
-        all_extensions = ext_components
+        all_extensions = flat_ext_components
+        march = generate_march_string(all_extensions, xlen)
     all_defines = [*(extra_defines or []), *generate_defines_from_extensions(all_extensions)]
     # Replace placeholders
     template = (
         template.replace("@TEST_PATH@", f"{test_file}")
-        .replace("@EXTENSION_LIST@", f"{ext_components}")
-        .replace("@PARAMS@", format_params(params, ext_components))
+        .replace("@EXTENSION_LIST@", f"{extension_requirements}")
+        .replace("@PARAMS@", format_params(params, flat_ext_components))
         .replace("@MARCH@", march)
         .replace("@EXTRA_DEFINES@", "\n".join(all_defines))
         .replace("@SIGUPD_COUNT_FROM_TESTGEN@", str(sigupd_count))

--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsZicboS.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsZicboS.py
@@ -339,7 +339,7 @@ def _generate_cbo_misaligned_tests(test_data: TestData) -> list[str]:
 
 @add_priv_test_generator(
     "ExceptionsZicboS",
-    required_extensions=["S"],
+    required_extensions=["S", ["Zicbom", "Zicboz", "Zicbop"]],
     march_extensions=["Zicbom", "Zicboz", "Zicbop"],
 )
 def make_exceptionszicbos(test_data: TestData) -> list[TestChunk]:

--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsZicboU.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsZicboU.py
@@ -295,7 +295,7 @@ def _generate_cbo_misaligned_tests(test_data: TestData) -> list[str]:
 
 @add_priv_test_generator(
     "ExceptionsZicboU",
-    required_extensions=["U"],
+    required_extensions=["U", ["Zicbom", "Zicboz", "Zicbop"]],
     march_extensions=["Zicbom", "Zicboz", "Zicbop"],
 )
 def make_exceptionszicbou(test_data: TestData) -> list[TestChunk]:

--- a/generators/testgen/src/testgen/priv/registry.py
+++ b/generators/testgen/src/testgen/priv/registry.py
@@ -42,7 +42,7 @@ class PrivTestRegistryEntry:
 
     generator: PrivTestGenerator
     extra_defines: list[str] = field(default_factory=list)
-    required_extensions: list[str] | None = None
+    required_extensions: list[str | list[str]] | None = None
     march_extensions: list[str] | None = None
     params: list[str] | None = None
     testcases_per_file: int = TESTCASES_PER_PRIV_FILE
@@ -56,7 +56,7 @@ def add_priv_test_generator(
     testsuite: str,
     *,
     extra_defines: list[str] | None = None,
-    required_extensions: list[str] | None = None,
+    required_extensions: list[str | list[str]] | None = None,
     march_extensions: list[str] | None = None,
     params: list[str] | None = None,
     testcases_per_file: int = TESTCASES_PER_PRIV_FILE,
@@ -115,7 +115,7 @@ def get_priv_test_defines(testsuite: str) -> list[str]:
     return _get_entry(testsuite).extra_defines
 
 
-def get_priv_test_required_extensions(testsuite: str) -> list[str] | None:
+def get_priv_test_required_extensions(testsuite: str) -> list[str | list[str]] | None:
     """Get the required RISC-V extensions for a priv testsuite."""
     return _get_entry(testsuite).required_extensions
 


### PR DESCRIPTION
- Adds support for a list of prohibited extensions for each test
- Adds nested lists to indicate one extension out of a list is required
- Updates ExceptionsZicbo{U/S} to require at least one of Zicbom, Zicboz, Zicbop