### PR TITLE
Fix: Poll mip.MTIP after mtimecmp=-1

### DIFF
--- a/generators/testgen/src/testgen/asm/interrupts.py
+++ b/generators/testgen/src/testgen/asm/interrupts.py
@@ -59,6 +59,7 @@ def clr_mtimer_int(r_temp: int, r_mtimecmp: int) -> list[str]:
         "#if __riscv_xlen == 32",
         f"sw x{r_temp}, 4(x{r_mtimecmp})",
         "#endif",
+        f"RVTEST_WAIT_MTIP_CLEAR x{r_temp}",
         "#endif",
     ]
 

--- a/tests/env/rvtest_trap_handler.h
+++ b/tests/env/rvtest_trap_handler.h
@@ -875,6 +875,18 @@
         #define  RVMODEL_CLR_VEXT_INT    RVTEST_DFLT_INT_HNDLR  // VS-mode ext interrupt clear: abort
 #endif
 
+// After a store to mtimecmp, mip.MTIP is guaranteed to fall eventually, not
+// necessarily on the next instruction. Fence the MMIO write, then spin until
+// MTIP reads 0. M-mode only (csrr mip). tmp is clobbered.
+.macro RVTEST_WAIT_MTIP_CLEAR tmp
+#ifdef RVMODEL_MTIMECMP_ADDRESS
+        fence
+1:      csrr    \tmp, mip
+        andi    \tmp, \tmp, 0x80
+        bnez    \tmp, 1b
+#endif
+.endm
+
 
 //==============================================================================
 //==============================================================================
@@ -2334,6 +2346,14 @@ excpt_\__MODE__\()hndlr_tbl:
         #if(UDB_MXLEN == 32)
                 sw T5, 4(T2)
         #endif
+        #ifdef RVMODEL_MTIMECMP_ADDRESS
+        .ifc \__MODE__ , M
+                RVTEST_WAIT_MTIP_CLEAR T5
+        .else
+                fence
+        .endif
+        #endif
+
         la      T2, resto_\__MODE__\()rtn
         jr      T2
 


### PR DESCRIPTION
ACLINT mtimecmp is MMIO. After software writes mtimecmp to drop a pending timer interrupt, mip.MTIP is only required to fall eventually, not on the next instruction.

According to spec, this delay in clearing mip.MTIP is valid behavior.

From section [2.1.2](https://docs.riscv.org/reference/isa/v20260120/priv/machine.html#2-1-2-machine-level-memory-mapped-registers):

> If the result of the comparison between mtime and mtimecmp changes, it is guaranteed to be reflected in MTIP eventually, but not necessarily immediately.
> A spurious timer interrupt might occur if an interrupt handler increments mtimecmp then immediately returns, because MTIP might not yet have fallen in the interim. All software should be written to assume this event is possible, but most software should assume this event is extremely unlikely. It is almost always more performant to incur an occasional spurious timer interrupt than to poll MTIP until it falls.

ACT tests cannot treat that as “extremely unlikely.” If mstatus.MIE / mie.MTIE is enabled (or mret restores it) while mip.MTIP is still 1, the unexpected MTI fails the test. This showed up on ZawrsSm-00 against a DUT whose ACLINT lags the ISS.

The current tests do not tolerate these "spurious timer interrupts". The changes in this PR poll the mip.MTIP value after executing/retiring `mtimecmp = -1`.

Two call sites:
1. Trap handler (clr_Mtmr_int): taken MTI. Fence + poll in M-mode before restore/mret. S/VS expansions only fence (csrr mip is illegal there).
2. Test body (clr_mtimer_int in testgen): Some bins (e.g. Zawrs) keep mstatus.MIE = 0 so a pending timer does not trap. They spin until mip.MTIP = 1, then write mtimecmp = -1 and immediately csrs mstatus to set mstatus.MIE (and MPIE) while mie.MTIE is still 1. The trap handler never ran, so the wait cannot live only in clr_Mtmr_int. Testgen must emit the same mip.MTIP poll after that store, or enabling mstatus.MIE can take a stale MTI.