### PR TITLE
Skip checking OpenHW links in CI

### DIFF
--- a/.markdown-link-check.config
+++ b/.markdown-link-check.config
@@ -3,6 +3,10 @@
     {
       "pattern": "^https://lists.riscv.org/g/sig-arch-test",
       "reason": "Random CI False Negative"
+    },
+    {
+      "pattern": "^https://(?:[a-z0-9-]+\\.)?openhwgroup\\.org",
+      "reason": "OpenHW sites rate limit CI requests"
     }
   ]
 }


### PR DESCRIPTION
Avoids random CI failures from rate limits

Signed-off-by: Jordan Carlin <jcarlin@qti.qualcomm.com>
