### PR TITLE
Remove stale tests when regenerating tests

### DIFF
--- a/generators/testgen/scripts/vector-testgen-priv.py
+++ b/generators/testgen/scripts/vector-testgen-priv.py
@@ -16,7 +16,6 @@ import math
 import os
 import pathlib
 import re
-import shutil
 from random import randint, seed
 
 import priv  # priv coverpoint generator scripts
@@ -557,8 +556,7 @@ if __name__ == '__main__':
 
     testplans = readTestplans(priv=True)
     extensions = list(testplans.keys())
-    for extension in extensions:
-      shutil.rmtree(pathlib.Path(ARCH_VERIF) / "tests" / "priv" / extension, ignore_errors=True)
+    generated_files: dict[str, set[pathlib.Path]] = {extension: set() for extension in extensions}
 
     for xlen in xlens:
       for extension in extensions:
@@ -621,11 +619,6 @@ if __name__ == '__main__':
             CHUNK_SIZE = max(len(instructions), 1)
 
         chunks = [instructions[i:i + CHUNK_SIZE] for i in range(0, len(instructions), CHUNK_SIZE)]
-        # Discover existing chunk files so stale outputs from a larger split
-        # don't leak into the build (e.g. switching from 6 chunks to 4).
-        for stale in pathlib.Path(pathname).glob(f"{basename}_rv{xlen}*.S"):
-            os.system(f"rm -f {stale}")
-
         for chunk_idx, chunk_instructions in enumerate(chunks):
             # Reset per-file generator state (sigupd_count, testcase_count, sigReg, ...)
             # so each chunk starts clean and signature counts / label numbering
@@ -707,3 +700,9 @@ if __name__ == '__main__':
                     print("Updated " + fname)
             else:
                 os.system(f"mv {tempfname} {fname}")
+            generated_files[extension].add(pathlib.Path(fname))
+
+    for extension, extension_files in generated_files.items():
+        output_dir = pathlib.Path(ARCH_VERIF) / "tests" / "priv" / extension
+        for stale_file in set(output_dir.glob("*.S")) - extension_files:
+            stale_file.unlink()

--- a/generators/testgen/scripts/vector-testgen-priv.py
+++ b/generators/testgen/scripts/vector-testgen-priv.py
@@ -16,6 +16,7 @@ import math
 import os
 import pathlib
 import re
+import shutil
 from random import randint, seed
 
 import priv  # priv coverpoint generator scripts
@@ -556,6 +557,8 @@ if __name__ == '__main__':
 
     testplans = readTestplans(priv=True)
     extensions = list(testplans.keys())
+    for extension in extensions:
+      shutil.rmtree(pathlib.Path(ARCH_VERIF) / "tests" / "priv" / extension, ignore_errors=True)
 
     for xlen in xlens:
       for extension in extensions:

--- a/generators/testgen/scripts/vector-testgen-unpriv.py
+++ b/generators/testgen/scripts/vector-testgen-unpriv.py
@@ -16,7 +16,6 @@ import filecmp
 import math
 import os
 import re
-import shutil
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 from random import randint, seed
@@ -1621,7 +1620,6 @@ def generate_extension(xlen_arg: int, extension_arg: str) -> str:
   setXlen(xlen)
 
   pathname = f"{ARCH_VERIF}/tests/rv{xlen}i/{extension}"
-  shutil.rmtree(pathname, ignore_errors=True)
 
   redgesv = [0, 1, 2, 2**xlen-1, 2**xlen-2, 2**(xlen-1), 2**(xlen-1)+1, 2**(xlen-1)-1, 2**(xlen-1)-2]
   if (xlen == 32):
@@ -1654,6 +1652,7 @@ def generate_extension(xlen_arg: int, extension_arg: str) -> str:
       applicable_instructions.remove(test)
 
   written = 0
+  generated_files: set[Path] = set()
   for test in applicable_instructions:
     newInstruction()
 
@@ -1727,7 +1726,11 @@ def generate_extension(xlen_arg: int, extension_arg: str) -> str:
         tempfname_p.replace(fname_p)
     else:
       tempfname_p.replace(fname_p)
+    generated_files.add(fname_p)
     written += 1
+
+  for stale_file in set(Path(pathname).glob("*.S")) - generated_files:
+    stale_file.unlink()
 
   return f"rv{xlen}/{extension}: {written} test(s)"
 

--- a/generators/testgen/scripts/vector-testgen-unpriv.py
+++ b/generators/testgen/scripts/vector-testgen-unpriv.py
@@ -16,6 +16,7 @@ import filecmp
 import math
 import os
 import re
+import shutil
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 from random import randint, seed
@@ -1620,6 +1621,7 @@ def generate_extension(xlen_arg: int, extension_arg: str) -> str:
   setXlen(xlen)
 
   pathname = f"{ARCH_VERIF}/tests/rv{xlen}i/{extension}"
+  shutil.rmtree(pathname, ignore_errors=True)
 
   redgesv = [0, 1, 2, 2**xlen-1, 2**xlen-2, 2**(xlen-1), 2**(xlen-1)+1, 2**(xlen-1)-1, 2**(xlen-1)-2]
   if (xlen == 32):

--- a/generators/testgen/src/testgen/generate/priv.py
+++ b/generators/testgen/src/testgen/generate/priv.py
@@ -8,7 +8,6 @@
 
 """Privileged test generation orchestration."""
 
-import shutil
 from pathlib import Path
 from random import seed
 
@@ -31,13 +30,14 @@ def generate_priv_test(testsuite: str, output_test_dir: Path) -> None:
         testsuite: Testsuite name (e.g., "ExceptionsSm", "SsstrictSm")
         output_test_dir: Base directory to output generated tests
     """
-    entries = get_priv_test_generators(testsuite)
     output_path = output_test_dir / "priv" / testsuite
-    shutil.rmtree(output_path, ignore_errors=True)
-
+    generated_files: set[Path] = set()
     next_file_indices: dict[str | None, int] = {}
-    for entry in entries:
-        _generate_priv_test_entry(testsuite, output_test_dir, entry, next_file_indices)
+    for entry in get_priv_test_generators(testsuite):
+        generated_files.update(_generate_priv_test_entry(testsuite, output_test_dir, entry, next_file_indices))
+
+    for stale_file in set(output_path.glob("*.S")) - generated_files:
+        stale_file.unlink()
 
 
 def _generate_priv_test_entry(
@@ -45,10 +45,11 @@ def _generate_priv_test_entry(
     output_test_dir: Path,
     entry: PrivTestRegistryEntry,
     next_file_indices: dict[str | None, int],
-) -> None:
+) -> set[Path]:
     """Generate tests for one registry entry."""
     output_path = output_test_dir / "priv" / testsuite
     output_path.mkdir(parents=True, exist_ok=True)
+    generated_files: set[Path] = set()
 
     test_config = TestConfig(
         xlen=0,
@@ -81,9 +82,12 @@ def _generate_priv_test_entry(
         first_file_idx = next_file_indices.get(split_name, 0)
         for file_idx, test_file_chunks in enumerate(test_files, start=first_file_idx):
             extra_defines = entry.extra_defines
-            write_test_file(test_config, None, test_file_chunks, output_path, file_idx, extra_defines, split_name)
+            generated_files.add(
+                write_test_file(test_config, None, test_file_chunks, output_path, file_idx, extra_defines, split_name)
+            )
         next_file_indices[split_name] = first_file_idx + len(test_files)
 
     # Clean up (make sure all registers were returned)
     test_data.int_regs.return_registers(priv_exclude_regs)
     test_data.destroy()
+    return generated_files

--- a/generators/testgen/src/testgen/generate/priv.py
+++ b/generators/testgen/src/testgen/generate/priv.py
@@ -8,6 +8,7 @@
 
 """Privileged test generation orchestration."""
 
+import shutil
 from pathlib import Path
 from random import seed
 
@@ -30,8 +31,12 @@ def generate_priv_test(testsuite: str, output_test_dir: Path) -> None:
         testsuite: Testsuite name (e.g., "ExceptionsSm", "SsstrictSm")
         output_test_dir: Base directory to output generated tests
     """
+    entries = get_priv_test_generators(testsuite)
+    output_path = output_test_dir / "priv" / testsuite
+    shutil.rmtree(output_path, ignore_errors=True)
+
     next_file_indices: dict[str | None, int] = {}
-    for entry in get_priv_test_generators(testsuite):
+    for entry in entries:
         _generate_priv_test_entry(testsuite, output_test_dir, entry, next_file_indices)
 
 

--- a/generators/testgen/src/testgen/generate/unpriv.py
+++ b/generators/testgen/src/testgen/generate/unpriv.py
@@ -9,7 +9,6 @@
 """Unprivileged test generation from CSV testplans."""
 
 import re
-import shutil
 from pathlib import Path
 
 from testgen.constants import (
@@ -78,8 +77,8 @@ def generate_unpriv_extension_tests(
 
     # Create testsuite-wide test configuration
     output_dir = output_test_dir / f"rv{xlen}{'e' if E_ext else 'i'}/{testsuite}"
-    shutil.rmtree(output_dir, ignore_errors=True)
     output_dir.mkdir(parents=True, exist_ok=True)
+    generated_files: set[Path] = set()
 
     flen = get_flen_for_extension(testsuite)
     test_config = TestConfig(xlen=xlen, flen=flen, testsuite=testsuite, E_ext=E_ext, sew=sew)
@@ -93,14 +92,19 @@ def generate_unpriv_extension_tests(
         if is_vector and sew not in instr_data.sews_supported:
             continue
 
-        _generate_unpriv_tests_for_instruction(
-            instr_data.instr_name,
-            instr_data.instr_type,
-            instr_data.coverpoints,
-            test_config,
-            output_dir,
-            is_vector,
+        generated_files.update(
+            _generate_unpriv_tests_for_instruction(
+                instr_data.instr_name,
+                instr_data.instr_type,
+                instr_data.coverpoints,
+                test_config,
+                output_dir,
+                is_vector,
+            )
         )
+
+    for stale_file in set(output_dir.glob("*.S")) - generated_files:
+        stale_file.unlink()
 
 
 def _detect_sew(testsuite: str) -> int:
@@ -133,7 +137,7 @@ def _generate_unpriv_tests_for_instruction(
     test_config: TestConfig,
     output_dir: Path,
     is_vector: bool = False,
-) -> None:
+) -> set[Path]:
     """
     Generate tests for a specific instruction based on its coverpoints.
     Splits test chunks into multiple test files if they exceed TESTCASES_PER_FILE.
@@ -148,6 +152,7 @@ def _generate_unpriv_tests_for_instruction(
     """
     test_data = TestData(test_config, instr_name)
     all_test_chunks: list[TestChunk] = []
+    generated_files: set[Path] = set()
 
     # Iterate through each coverpoint and generate test chunks
     for coverpoint in coverpoints:
@@ -182,7 +187,10 @@ def _generate_unpriv_tests_for_instruction(
         else:
             extra_defines = []
 
-        write_test_file(test_config, instr_name, test_file_chunks, output_dir, file_idx, extra_defines)
+        generated_files.add(
+            write_test_file(test_config, instr_name, test_file_chunks, output_dir, file_idx, extra_defines)
+        )
 
     # Clean up (make sure all registers were returned)
     test_data.destroy()
+    return generated_files

--- a/generators/testgen/src/testgen/generate/unpriv.py
+++ b/generators/testgen/src/testgen/generate/unpriv.py
@@ -9,6 +9,7 @@
 """Unprivileged test generation from CSV testplans."""
 
 import re
+import shutil
 from pathlib import Path
 
 from testgen.constants import (
@@ -77,6 +78,7 @@ def generate_unpriv_extension_tests(
 
     # Create testsuite-wide test configuration
     output_dir = output_test_dir / f"rv{xlen}{'e' if E_ext else 'i'}/{testsuite}"
+    shutil.rmtree(output_dir, ignore_errors=True)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     flen = get_flen_for_extension(testsuite)

--- a/generators/testgen/src/testgen/io/writer.py
+++ b/generators/testgen/src/testgen/io/writer.py
@@ -53,9 +53,9 @@ def write_test_file(
     file_idx: int = 0,
     extra_defines: list[str] | None = None,
     split_name: str | None = None,
-) -> None:
+) -> Path:
     """
-    Write a single test file.
+    Write a single test file and return its path.
 
     Args:
         test_config: Test configuration
@@ -127,3 +127,5 @@ def write_test_file(
     # Write test file if different from existing file. This avoids unnecessary rebuilds.
     if not test_file.exists() or test_file.read_text() != test_string:
         test_file.write_text(test_string)
+
+    return test_file


### PR DESCRIPTION
When test names changed, the old version was left and could lead to
broken compilation or extra tests running. This removes old tests before
generating the new ones.

Fixes #2201

Signed-off-by: Jordan Carlin <jcarlin@qti.qualcomm.com>
