### PR TITLE
Normative rule mapping for supervisor extensions

### DIFF
--- a/coverpoints/norm/ExceptionsSv.yaml
+++ b/coverpoints/norm/ExceptionsSv.yaml
@@ -20,3 +20,44 @@ normative_rule_definitions:
   # instruction, not on the jump or branch instruction.
   - name: ia_fault_exc_on_target
     coverpoint: ["ExceptionsSv_cg/cp_instr_page_fault_m"]
+
+  #Attempting to fetch an instruction from a page that does not have
+  #execute permissions raises a fetch page-fault exception
+  - name: fetch_page_fault_no_x
+    coverpoint:
+      [
+        "ExceptionsSv_cg/{cp_instr_page_fault_m,cp_instr_page_fault_s,cp_instr_page_fault_u}",
+      ]
+
+  #Attempting to execute a load, load-reserved, or cache-block management
+  #instruction whose effective address lies
+  #within a page without read permissions raises a load page-fault exception.
+  - name: load_page_fault_no_r
+    coverpoint:
+      [
+        "ExceptionsSv_cg/{cp_load_page_fault_m,cp_load_page_fault_s,cp_load_page_fault_u}",
+      ]
+
+  #Attempting to execute a store, store-conditional, AMO, or cache-block zero instruction
+  #instruction whose effective address lies within a page without write
+  #permissions raises a store page-fault exception
+  - name: store_page_fault_no_w
+    coverpoint:
+      [
+        "ExceptionsSv_cg/{cp_store_page_fault_m,cp_store_page_fault_s,cp_store_page_fault_u}",
+      ]
+
+  #Load/store/AMO address-misaligned exceptions may have either higher or
+  #lower priority than load/store/AMO page-fault and access-fault exceptions.
+  - name: mcause_exccode_pri2
+    coverpoint:
+      [
+        "ExceptionsSv_cg/{cp_misaligned_priority_m,cp_misaligned_priority_s,cp_misaligned_priority_u}",
+      ]
+
+  #csr:medeleg[] has a bit position allocated for every synchronous exception
+  - name: medeleg_enc_txt
+    coverpoint:
+      [
+        "ExceptionsSv_cg/{cp_medeleg_m,cp_medeleg_s,cp_medeleg_u,cp_medeleg_fetch_m,cp_medeleg_fetch_s,cp_medeleg_fetch_u}",
+      ]

--- a/coverpoints/norm/ExceptionsSvZaamo.yaml
+++ b/coverpoints/norm/ExceptionsSvZaamo.yaml
@@ -1,1 +1,13 @@
 normative_rule_definitions:
+  #csr:medeleg[] has a bit position allocated for every synchronous exception
+  - name: medeleg_enc_txt
+    coverpoint:
+      ["ExceptionsSvZaamo_cg/{cp_medeleg_m,cp_medeleg_s,cp_medeleg_u}"]
+
+  #Load/store/AMO address-misaligned exceptions may have either higher or
+  #lower priority than load/store/AMO page-fault and access-fault exceptions.
+  - name: mcause_exccode_pri2
+    coverpoint:
+      [
+        "ExceptionsSvZaamo_cg/{cp_misaligned_priority_m,cp_misaligned_priority_s,cp_misaligned_priority_u}",
+      ]

--- a/coverpoints/norm/ExceptionsSvZalrsc.yaml
+++ b/coverpoints/norm/ExceptionsSvZalrsc.yaml
@@ -1,1 +1,13 @@
 normative_rule_definitions:
+  #csr:medeleg[] has a bit position allocated for every synchronous exception
+  - name: medeleg_enc_txt
+    coverpoint:
+      ["ExceptionsSvZalrsc_cg/{cp_medeleg_m,cp_medeleg_s,cp_medeleg_u}"]
+
+  #Load/store/AMO address-misaligned exceptions may have either higher or
+  #lower priority than load/store/AMO page-fault and access-fault exceptions.
+  - name: mcause_exccode_pri2
+    coverpoint:
+      [
+        "ExceptionsSvZalrsc_cg/{cp_misaligned_priority_m,cp_misaligned_priority_s,cp_misaligned_priority_u}",
+      ]

--- a/coverpoints/norm/Sv.yaml
+++ b/coverpoints/norm/Sv.yaml
@@ -357,7 +357,7 @@ normative_rule_definitions:
 
   # This section describes a simple paged virtual-memory system for SXLEN=64.
   - name: Sv48_sxlen
-    coverpoint: [""]
+    coverpoint: ["checked by UDB"]
 
   # Sv48 supports 48-bit virtual address spaces.
   - name: Sv48_va_sz
@@ -365,7 +365,7 @@ normative_rule_definitions:
 
   # Implementations that support Sv48 must also support Sv39.
   - name: Sv48_requires_Sv39
-    coverpoint: [""]
+    coverpoint: ["checked by UDB"]
 
   # Instruction fetch addresses and load and store effective addresses, which are 64
   # bits, must have bits 63-48 all equal to bit 47, or else a page-fault exception

--- a/coverpoints/norm/Sv.yaml
+++ b/coverpoints/norm/Sv.yaml
@@ -6,8 +6,11 @@ normative_rule_definitions:
   # ) will succeed. When MXR=1, loads from pages marked either readable or
   # executable (R=1 or X=1) will succeed. MXR has no effect when page-based virtual
   # memory is not in effect.
-  - names: [sstatus_mxr_sz, sstatus_mxr_acc, sstatus_mxr_op]
-    coverpoint: [""]
+  - name: sstatus_mxr
+    coverpoint:
+      [
+        "Sv_vm_permissions_cg/{cp_xpage_mxrunset_read_s,cp_xpage_mxrunset_read_u,cp_xpage_mxrset_read_s,cp_xpage_mxrset_read_u}",
+      ]
 
   # The SUM (permit Supervisor User Memory access) bit modifies the privilege with
   # which S-mode loads and stores access virtual memory. When SUM=0, S-mode memory
@@ -15,7 +18,15 @@ normative_rule_definitions:
   # SUM=1, these accesses are permitted. SUM has no effect when page-based virtual
   # memory is not in effect, nor when executing in U-mode. Note that S-mode can
   # never execute instructions from user pages, regardless of the state of SUM.
-  - names: [sstatus_sum_sz, sstatus_sum_acc, sstatus_sum_op]
+  - name: sstatus_sum
+    coverpoint:
+      [
+        "Sv_vm_permissions_cg/{cp_upage_smode_sumunset_noexec_s,cp_upage_smode_sumunset_noread_s,cp_upage_smode_sumunset_nowrite_s,cp_upage_smode_sumset_noexec_s,cp_upage_smode_sumset_read_s,cp_upage_smode_sumset_write_s,cp_spage_exec_s_i,cp_spage_noexec_s_i,cp_spage_read_s_d,cp_spage_noread_s_d,cp_spage_write_s_d,cp_spage_nowrite_s_d}",
+        "Sv_mstatus_mprv_cg/{cp_mprv_upage_smode_sumunset_noread,cp_mprv_upage_smode_sumunset_nowrite,cp_mprv_upage_smode_sumunset_noexec,cp_mprv_upage_smode_sumset_exec,cp_mprv_upage_smode_sumset_read,cp_mprv_upage_smode_sumset_write}",
+      ]
+
+  # SUM is read-only 0 if satp.MODE is read-only 0.
+  - name: sstatus_sum_satp_mode
     coverpoint: [""]
 
   # The satp CSR is an SXLEN-bit read/write register, formatted as shown in for
@@ -26,25 +37,29 @@ normative_rule_definitions:
   # per-address-space basis; and the MODE field, which selects the current
   # address-translation scheme. Further details on the access to this register are
   # described in .
-  - names: [satp_sz, satp_acc, satp_op, satp_mode]
-    coverpoint: ["Sv_satp_cg/access_m_s, TODO rest of the bits"]
+  - name: satp
+    coverpoint:
+      [
+        "Sv_satp_cg/{cp_access_m_s,cp_access_u}",
+        "Sv_mstatus_mprv_cg/cp_tvm_exception_s",
+      ]
 
   # shows the encodings of the MODE field when SXLEN=32 and SXLEN=64. When
   # MODE=Bare, supervisor virtual addresses are equal to supervisor physical
   # addresses, and there is no additional memory protection beyond the physical
   # memory protection scheme described in . To select MODE=Bare, software must write
-  # zero to the remaining fields of satp (bits 30–0 when SXLEN=32, or bits 59–0 when
+  # zero to the remaining fields of satp (bits 30-0 when SXLEN=32, or bits 59-0 when
   # SXLEN=64). Attempting to select MODE=Bare with a nonzero pattern in the
   # remaining fields has an UNSPECIFIED effect on the value that the remaining
   # fields assume and an UNSPECIFIED effect on address translation and protection
   # behavior.
-  - names: [satp_mode_sz, satp_mode_acc, satp_mode_op]
-    coverpoint: [""]
+  - name: satp_mode
+    coverpoint: ["Sv_satp_cg/satp_asid_PPN"]
 
   # When SXLEN=32, the only other valid setting for MODE is Sv32, a paged
   # virtual-memory scheme described in .
   - name: satp_mode_sxlen32
-    coverpoint: ["Sv_VA_cg/VA_d_mode"]
+    coverpoint: ["Sv_VA_cg/{cp_VA_i_mode,cp_VA_d_mode}"]
 
   # When SXLEN=64, three paged virtual-memory schemes are defined: Sv39, Sv48, and
   # Sv57, described in , , and , respectively. One additional scheme, Sv64, will be
@@ -52,7 +67,7 @@ normative_rule_definitions:
   # are reserved for future use and may define different interpretations of the
   # other fields in satp.
   - name: satp_mode_sxlen64
-    coverpoint: ["Sv_satp_cg/satp_bare, Sv_VA_cg/VA_d_mode"]
+    coverpoint: ["Sv_VA_cg/{cp_VA_i_mode,cp_VA_d_mode}"]
 
   # Implementations are not required to support all MODE settings, and if satp is
   # written with an unsupported MODE, the entire write has no effect; no fields in
@@ -67,8 +82,8 @@ normative_rule_definitions:
   # are implemented first: that is, if ASIDLEN &gt; 0, ASID[ASIDLEN-1:0] is
   # writable. The maximal value of ASIDLEN, termed ASIDMAX, is 9 for Sv32 or 16 for
   # Sv39, Sv48, and Sv57.
-  - name: satp-asidlen
-    coverpoint: [""]
+  - name: asidlen
+    coverpoint: ["Sv_satp_cg/asid_length"]
 
   # The satp CSR is considered active when the effective privilege mode is S-mode or
   # U-mode. Executions of the address-translation algorithm may only begin using a
@@ -89,16 +104,9 @@ normative_rule_definitions:
   # synchronize updates to in-memory memory-management data structures with current
   # execution. Instruction execution causes implicit reads and writes to these data
   # structures; however, these implicit references are ordinarily not ordered with
-  # respect to explicit loads and stores. Executing an SFENCE.VMA instruction
-  # guarantees that any previous stores already visible to the current RISC-V hart
-  # are ordered before certain implicit references by subsequent instructions in
-  # that hart to the memory-management data structures. The specific set of
-  # operations ordered by SFENCE.VMA is determined by rs1 and rs2, as described
-  # below. SFENCE.VMA is also used to invalidate entries in the address-translation
-  # cache associated with a hart (see ). Further details on the behavior of this
-  # instruction are described in and .
+  # respect to explicit loads and stores.
   - name: sfence_vma_op
-    coverpoint: [""]
+    coverpoint: ["Sv_sfence_cg/cp_ins"]
 
   # Executing an SFENCE.VMA instruction guarantees that any previous stores already
   # visible to the current RISC-V hart are ordered before certain implicit
@@ -111,13 +119,13 @@ normative_rule_definitions:
   # SFENCE.VMA is also used to invalidate entries in the address-translation cache
   # associated with a hart (see &lt;&lt;sv32algorithm&gt;&gt;).
   - name: sfence_vma_invalidation
-    coverpoint: [""]
+    coverpoint: ["Sv_sfence_cg/cp_ins"]
 
   # If rs1=x0 and rs2=x0, the fence orders all reads and writes made to any level of
   # the page tables, for all address spaces. The fence also invalidates all
   # address-translation cache entries, for all address spaces.
   - name: sfence_vma_all_asid_va
-    coverpoint: [""]
+    coverpoint: ["Sv_sfence_cg/cp_ins"]
 
   # If rs1=x0 and rs2{ne}x0, the fence orders all reads and writes made to any level
   # of the page tables, but only for the address space identified by integer
@@ -151,7 +159,7 @@ normative_rule_definitions:
   - name: sfence_vma_invalid_va
     coverpoint: [""]
 
-  # When rs2≠x0, bits SXLEN-1:ASIDMAX of the value held in rs2 are reserved for
+  # When rs2!=x0, bits SXLEN-1:ASIDMAX of the value held in rs2 are reserved for
   # future standard use. Until their use is defined by a standard extension, they
   # should be zeroed by software and ignored by current implementations.
   # Furthermore, if ASIDLEN&lt;ASIDMAX, the implementation shall ignore bits
@@ -206,167 +214,277 @@ normative_rule_definitions:
   # For implementations that make satp.MODE read-only zero (always Bare), attempts
   # to execute an SFENCE.VMA instruction might raise an illegal-instruction
   # exception.
-  - name: satp-mode_roz_sfence_illegal
+  - name: satp_mode_roz_sfence_illegal
     coverpoint: [""]
+
+  # The 20-bit VPN is translated into a 22-bit physical page number (PPN) for Sv32.
+  - name: satp_ppn_sv32_sz
+    coverpoint: ["Sv_satp_cg/satp_PPN"]
 
   # Attempting to fetch an instruction from a page that does not have execute
   # permissions raises a fetch page-fault exception.
   - name: fetch_page_fault_no_x
-    coverpoint: [""]
+    coverpoint:
+      [
+        "Sv_vm_permissions_cg/{cp_spage_noexec_s_i,cp_upage_umode_noexec_u,cp_spage_rwx_s_i_noexec,cp_upage_smode_sumunset_noexec_s,cp_upage_smode_sumset_noexec_s,cp_PTE_nonleaf_lvl0_s_i_exec,cp_PTE_nonleaf_lvl0_u_i_exec}",
+        "Sv_mstatus_mprv_cg/cp_mprv_upage_smode_sumunset_noexec",
+      ]
 
   # Attempting to execute a load, load-reserved, or cache-block management
   # instruction whose effective address lies within a page without read permissions
   # raises a load page-fault exception.
   - name: load_page_fault_no_r
-    coverpoint: [""]
+    coverpoint:
+      [
+        "Sv_vm_permissions_cg/{cp_spage_noread_s_d,cp_upage_umode_noread_u,cp_spage_rwx_s_d_noread,cp_upage_smode_sumunset_noread_s,cp_xpage_mxrunset_read_s,cp_xpage_mxrunset_read_u,cp_PTE_nonleaf_lvl0_s_d_read,cp_PTE_nonleaf_lvl0_u_d_read}",
+        "Sv_mstatus_mprv_cg/cp_mprv_upage_smode_sumunset_noread",
+      ]
 
   # Attempting to execute a store, store-conditional, AMO, or cache-block zero
   # instruction instruction whose effective address lies within a page without write
   # permissions raises a store page-fault exception.
   - name: store_page_fault_no_w
-    coverpoint: [""]
+    coverpoint:
+      [
+        "Sv_vm_permissions_cg/{cp_spage_nowrite_s_d,cp_upage_umode_nowrite_u,cp_spage_rwx_s_d_nowrite,cp_upage_smode_sumunset_nowrite_s,cp_PTE_nonleaf_lvl0_s_d_write,cp_PTE_nonleaf_lvl0_u_d_write}",
+        "Sv_mstatus_mprv_cg/cp_mprv_upage_smode_sumunset_nowrite",
+      ]
 
+  # This section describes a simple paged virtual-memory system for SXLEN=64.
   - name: Sv39_sxlen
     coverpoint: [""]
 
+  # Sv39 supports 39-bit virtual address spaces.
   - name: Sv39_va_sz
-    coverpoint: [""]
+    coverpoint: ["Sv_VA_cg/{cp_VA_i_mode,cp_VA_d_mode}"]
 
+  # Instruction fetch addresses and load and store effective addresses, which are 64
+  # bits, must have bits 63-39 all equal to bit 38, or else a page-fault exception
+  # will occur.
   - name: Sv39_va_signext
-    coverpoint: [""]
+    coverpoint:
+      [
+        "Sv_vm_permissions_cg/{cp_canonical_exec_s,cp_canonical_exec_u,cp_canonical_read_s,cp_canonical_read_u,cp_canonical_write_s,cp_canonical_write_u}",
+      ]
 
+  # The 27-bit VPN is translated via a three-level page table.
   - name: Sv39_vpn_sz
     coverpoint: [""]
 
+  # The VPN is translated into a 44-bit PPN.
   - name: satp_ppn_sv39_sz
-    coverpoint: [""]
+    coverpoint: ["Sv_satp_cg/satp_PPN"]
 
+  # The 27-bit VPN is translated into a 44-bit PPN via a three-level page table.
   - name: Sv39_levels
-    coverpoint: [""]
+    coverpoint: ["Sv_vm_permissions_cg/{PageType_i,PageType_d}"]
 
+  # The 12-bit page offset is untranslated.
   - name: Sv39_page_offset_sz
     coverpoint: [""]
 
+  # Sv39 page tables contain 2^9 page table entries (PTEs).
   - name: Sv39_pte_count
     coverpoint: [""]
 
+  # Sv39 PTEs are eight bytes each.
   - name: Sv39_pte_sz
     coverpoint: [""]
 
+  # A page table is exactly the size of a page.
   - name: Sv39_pt_sz
     coverpoint: [""]
 
+  # A page table must always be aligned to a page boundary.
   - name: Sv39_pt_align
     coverpoint: [""]
 
+  # If Svnapot is not implemented, bit 63 remains reserved and must be zeroed by
+  # software for forward compatibility, or else a page-fault exception is raised.
   - name: Sv39_pte_svnapot_rsv
-    coverpoint: [""]
+    coverpoint:
+      [
+        "Sv_add_feature_cg/{cp_svnapot_read_fault,cp_svnapot_write_fault,cp_svnapot_exec_fault,cp_read_nofault,cp_write_nofault,cp_exec_nofault}",
+      ]
 
+  # If Svpbmt is not implemented, bits 62-61 remain reserved and must be zeroed by
+  # software for forward compatibility, or else a page-fault exception is raised.
   - name: Sv39_pte_svpbmt_rsv
-    coverpoint: [""]
+    coverpoint:
+      [
+        "Sv_add_feature_cg/{cp_svpbmt_read_fault,cp_svpbmt_write_fault,cp_svpbmt_exec_fault,cp_read_nofault,cp_write_nofault,cp_exec_nofault}",
+      ]
 
+  # Bits 60-54 are reserved for future standard use and must be zeroed by software
+  # for forward compatibility. If any of these bits are set, a page-fault exception
+  # is raised.
   - name: Sv39_pte_future_rsv
-    coverpoint: [""]
+    coverpoint:
+      [
+        "Sv_add_feature_cg/{cp_reserved_read_fault,cp_reserved_write_fault,cp_reserved_exec_fault,cp_read_nofault,cp_write_nofault,cp_exec_nofault}",
+      ]
 
+  # Any level of PTE may be a leaf PTE.
   - name: Sv39_leaf_any_level
-    coverpoint: [""]
+    coverpoint: ["Sv_vm_permissions_cg/{PageType_i,PageType_d}"]
 
+  # In addition to 4 KiB pages, Sv39 supports 2 MiB megapages and 1 GiB gigapages.
   - name: Sv39_page_sizes
-    coverpoint: [""]
+    coverpoint: ["Sv_vm_permissions_cg/{PageType_i,PageType_d}"]
 
+  # Each superpage must be virtually and physically aligned to a boundary equal to
+  # its size.
   - name: Sv39_superpage_align
     coverpoint: [""]
 
+  # A page-fault exception is raised if the physical address is insufficiently
+  # aligned.
   - name: Sv39_superpage_align_fault
-    coverpoint: [""]
+    coverpoint:
+      [
+        "Sv_vm_permissions_cg/{cp_misaligned_exec_s,cp_misaligned_exec_u,cp_misaligned_read_s,cp_misaligned_read_u,cp_misaligned_write_s,cp_misaligned_write_u}",
+      ]
 
+  # The algorithm for virtual-to-physical address translation is the same as for
+  # Sv32, except LEVELS equals 3.
   - name: Sv39_LEVELS
-    coverpoint: [""]
+    coverpoint: ["Sv_vm_permissions_cg/{PageType_i,PageType_d}"]
 
+  # The algorithm for virtual-to-physical address translation is the same as for
+  # Sv32, except PTESIZE equals 8.
   - name: Sv39_PTESIZE
     coverpoint: [""]
 
+  # This section describes a simple paged virtual-memory system for SXLEN=64.
   - name: Sv48_sxlen
     coverpoint: [""]
 
+  # Sv48 supports 48-bit virtual address spaces.
   - name: Sv48_va_sz
-    coverpoint: [""]
+    coverpoint: ["Sv_VA_cg/{cp_VA_i_mode,cp_VA_d_mode}"]
 
+  # Implementations that support Sv48 must also support Sv39.
   - name: Sv48_requires_Sv39
     coverpoint: [""]
 
+  # Instruction fetch addresses and load and store effective addresses, which are 64
+  # bits, must have bits 63-48 all equal to bit 47, or else a page-fault exception
+  # will occur.
   - name: Sv48_va_signext
-    coverpoint: [""]
+    coverpoint:
+      [
+        "Sv_vm_permissions_cg/{cp_canonical_exec_s,cp_canonical_exec_u,cp_canonical_read_s,cp_canonical_read_u,cp_canonical_write_s,cp_canonical_write_u}",
+      ]
 
+  # The 36-bit VPN is translated via a four-level page table.
   - name: Sv48_vpn_sz
     coverpoint: [""]
 
+  # The VPN is translated into a 44-bit PPN.
   - name: satp_ppn_sv48_sz
-    coverpoint: [""]
+    coverpoint: ["Sv_satp_cg/satp_PPN"]
 
+  # The 36-bit VPN is translated into a 44-bit PPN via a four-level page table.
   - name: Sv48_levels
-    coverpoint: [""]
+    coverpoint: ["Sv_vm_permissions_cg/{PageType_i,PageType_d}"]
 
+  # The 12-bit page offset is untranslated.
   - name: Sv48_page_offset_sz
     coverpoint: [""]
 
+  # Any level of PTE may be a leaf PTE.
   - name: Sv48_leaf_any_level
-    coverpoint: [""]
+    coverpoint: ["Sv_vm_permissions_cg/{PageType_i,PageType_d}"]
 
+  # In addition to 4 KiB pages, Sv48 supports 2 MiB megapages, 1 GiB gigapages, and
+  # 512 GiB terapages.
   - name: Sv48_page_sizes
-    coverpoint: [""]
+    coverpoint: ["Sv_vm_permissions_cg/{PageType_i,PageType_d}"]
 
+  # Each superpage must be virtually and physically aligned to a boundary equal to
+  # its size.
   - name: Sv48_superpage_align
     coverpoint: [""]
 
+  # A page-fault exception is raised if the physical address is insufficiently
+  # aligned.
   - name: Sv48_superpage_align_fault
-    coverpoint: [""]
+    coverpoint:
+      [
+        "Sv_vm_permissions_cg/{cp_misaligned_exec_s,cp_misaligned_exec_u,cp_misaligned_read_s,cp_misaligned_read_u,cp_misaligned_write_s,cp_misaligned_write_u}",
+      ]
 
+  # The algorithm for virtual-to-physical address translation is the same as for
+  # Sv32, except LEVELS equals 4.
   - name: Sv48_LEVELS
-    coverpoint: [""]
+    coverpoint: ["Sv_vm_permissions_cg/{PageType_i,PageType_d}"]
 
+  # The algorithm for virtual-to-physical address translation is the same as for
+  # Sv32, except PTESIZE equals 8.
   - name: Sv48_PTESIZE
     coverpoint: [""]
 
+  # This section describes a simple paged virtual-memory system designed for RV64
+  # systems.
   - name: Sv57_sxlen
     coverpoint: [""]
 
+  # Sv57 supports 57-bit virtual address spaces.
   - name: Sv57_va_sz
-    coverpoint: [""]
+    coverpoint: ["Sv_VA_cg/{cp_VA_i_mode,cp_VA_d_mode}"]
 
+  # Implementations that support Sv57 must also support Sv48.
   - name: Sv57_requires_Sv48
     coverpoint: [""]
 
+  # Instruction fetch addresses and load and store effective addresses, which are 64
+  # bits, must have bits 63-57 all equal to bit 56, or else a page-fault exception
+  # will occur.
   - name: Sv57_va_signext
     coverpoint: [""]
 
+  # The 45-bit VPN is translated via a five-level page table.
   - name: Sv57_vpn_sz
     coverpoint: [""]
 
+  # The VPN is translated into a 44-bit PPN.
   - name: satp_ppn_sv57_sz
-    coverpoint: [""]
+    coverpoint: ["Sv_satp_cg/satp_PPN"]
 
+  # The 45-bit VPN is translated into a 44-bit PPN via a five-level page table.
   - name: Sv57_levels
     coverpoint: [""]
 
+  # The 12-bit page offset is untranslated.
   - name: Sv57_page_offset_sz
     coverpoint: [""]
 
+  # Any level of PTE may be a leaf PTE.
   - name: Sv57_leaf_any_level
     coverpoint: [""]
 
+  # In addition to 4 KiB pages, Sv57 supports 2 MiB megapages, 1 GiB gigapages,
+  # 512 GiB terapages, and 256 TiB petapages.
   - name: Sv57_page_sizes
     coverpoint: [""]
 
+  # Each superpage must be virtually and physically aligned to a boundary equal to
+  # its size.
   - name: Sv57_superpage_align
     coverpoint: [""]
 
+  # A page-fault exception is raised if the physical address is insufficiently
+  # aligned.
   - name: Sv57_superpage_align_fault
     coverpoint: [""]
 
+  # The algorithm for virtual-to-physical address translation is the same as for
+  # Sv32, except LEVELS equals 5.
   - name: Sv57_LEVELS
     coverpoint: [""]
 
+  # The algorithm for virtual-to-physical address translation is the same as for
+  # Sv32, except PTESIZE equals 8.
   - name: Sv57_PTESIZE
     coverpoint: [""]
 
@@ -374,4 +492,4 @@ normative_rule_definitions:
   # access-fault, page-fault, or hardware-error exception occurs on an instruction
   # fetch, load, or store, then stval will contain the faulting virtual address.
   - name: stval_op_faulting_addr
-    coverpoint: ["TODO: page faults"]
+    coverpoint: [""]

--- a/coverpoints/norm/Sv.yaml
+++ b/coverpoints/norm/Sv.yaml
@@ -119,13 +119,13 @@ normative_rule_definitions:
   # SFENCE.VMA is also used to invalidate entries in the address-translation cache
   # associated with a hart (see &lt;&lt;sv32algorithm&gt;&gt;).
   - name: sfence_vma_invalidation
-    coverpoint: ["Sv_sfence_cg/cp_ins"]
+    coverpoint: [""]
 
   # If rs1=x0 and rs2=x0, the fence orders all reads and writes made to any level of
   # the page tables, for all address spaces. The fence also invalidates all
   # address-translation cache entries, for all address spaces.
   - name: sfence_vma_all_asid_va
-    coverpoint: ["Sv_sfence_cg/cp_ins"]
+    coverpoint: [""]
 
   # If rs1=x0 and rs2{ne}x0, the fence orders all reads and writes made to any level
   # of the page tables, but only for the address space identified by integer
@@ -277,7 +277,7 @@ normative_rule_definitions:
 
   # The 27-bit VPN is translated into a 44-bit PPN via a three-level page table.
   - name: Sv39_levels
-    coverpoint: ["Sv_vm_permissions_cg/{PageType_i,PageType_d}"]
+    coverpoint: [""]
 
   # The 12-bit page offset is untranslated.
   - name: Sv39_page_offset_sz
@@ -326,11 +326,11 @@ normative_rule_definitions:
 
   # Any level of PTE may be a leaf PTE.
   - name: Sv39_leaf_any_level
-    coverpoint: ["Sv_vm_permissions_cg/{PageType_i,PageType_d}"]
+    coverpoint: [""]
 
   # In addition to 4 KiB pages, Sv39 supports 2 MiB megapages and 1 GiB gigapages.
   - name: Sv39_page_sizes
-    coverpoint: ["Sv_vm_permissions_cg/{PageType_i,PageType_d}"]
+    coverpoint: [""]
 
   # Each superpage must be virtually and physically aligned to a boundary equal to
   # its size.
@@ -348,7 +348,7 @@ normative_rule_definitions:
   # The algorithm for virtual-to-physical address translation is the same as for
   # Sv32, except LEVELS equals 3.
   - name: Sv39_LEVELS
-    coverpoint: ["Sv_vm_permissions_cg/{PageType_i,PageType_d}"]
+    coverpoint: [""]
 
   # The algorithm for virtual-to-physical address translation is the same as for
   # Sv32, except PTESIZE equals 8.
@@ -386,7 +386,7 @@ normative_rule_definitions:
 
   # The 36-bit VPN is translated into a 44-bit PPN via a four-level page table.
   - name: Sv48_levels
-    coverpoint: ["Sv_vm_permissions_cg/{PageType_i,PageType_d}"]
+    coverpoint: [""]
 
   # The 12-bit page offset is untranslated.
   - name: Sv48_page_offset_sz
@@ -394,12 +394,12 @@ normative_rule_definitions:
 
   # Any level of PTE may be a leaf PTE.
   - name: Sv48_leaf_any_level
-    coverpoint: ["Sv_vm_permissions_cg/{PageType_i,PageType_d}"]
+    coverpoint: [""]
 
   # In addition to 4 KiB pages, Sv48 supports 2 MiB megapages, 1 GiB gigapages, and
   # 512 GiB terapages.
   - name: Sv48_page_sizes
-    coverpoint: ["Sv_vm_permissions_cg/{PageType_i,PageType_d}"]
+    coverpoint: [""]
 
   # Each superpage must be virtually and physically aligned to a boundary equal to
   # its size.
@@ -417,7 +417,7 @@ normative_rule_definitions:
   # The algorithm for virtual-to-physical address translation is the same as for
   # Sv32, except LEVELS equals 4.
   - name: Sv48_LEVELS
-    coverpoint: ["Sv_vm_permissions_cg/{PageType_i,PageType_d}"]
+    coverpoint: [""]
 
   # The algorithm for virtual-to-physical address translation is the same as for
   # Sv32, except PTESIZE equals 8.

--- a/coverpoints/norm/SvPMP.yaml
+++ b/coverpoints/norm/SvPMP.yaml
@@ -1,0 +1,8 @@
+# Mapping of normative rules to coverpoints for a test suite
+
+normative_rule_definitions:
+  - name: pmp_check_pagetable_access
+    coverpoint:
+      [
+        "SvPMP_cg/{pmp0_pte_noread_s,pmp0_pte_noread_u,pmp0_pte_nowrite_s,pmp0_pte_nowrite_u,pmp0_pte_noexec_s,pmp0_pte_noexec_u}",
+      ]

--- a/coverpoints/norm/Svade.yaml
+++ b/coverpoints/norm/Svade.yaml
@@ -1,0 +1,36 @@
+# Mapping of normative rules to coverpoints for a test suite
+normative_rule_definitions:
+  #The _Svade_ extension: when a virtual page is accessed and the A bit is
+  #clear, or is written and the D bit is clear, a page-fault exception is
+  #raised.#
+  - name: svade_access_ad_bit_clear
+    coverpoint:
+      [
+        "Svade_cg/{Abit_unset_exec_s,Abit_unset_exec_u,Abit_unset_read_s,Abit_unset_read_u,Abit_unset_write_s,Abit_unset_write_u,Dbit_unset_write_s,Dbit_unset_write_u}",
+      ]
+
+  #If the Svadu extension is implemented, the ADUE bit controls whether hardware
+  #updating of PTE A/D bits is enabled for S-mode and G-stage address translations.
+  #When ADUE=1, hardware updating of PTE A/D bits is enabled during S-mode
+  #address translation, and the implementation behaves as though the Svade
+  #extension were not implemented for S-mode address translation.
+  #When the hypervisor extension is implemented, if ADUE=1, hardware updating of
+  #PTE A/D bits is enabled during G-stage address translation, and the
+  #implementation behaves as though the Svade extension were not implemented for
+  #G-stage address translation.
+  #When ADUE=0, the implementation behaves as though Svade were implemented for
+  #S-mode and G-stage address translation.#
+  - name: menvcfg_adue_op
+    coverpoint:
+      [
+        "Svade_cg/{Abit_unset_exec_s,Abit_unset_exec_u,Abit_unset_read_s,Abit_unset_read_u,Abit_unset_write_s,Abit_unset_write_u,Dbit_unset_write_s,Dbit_unset_write_u}",
+      ]
+
+  - name: fetch_page_fault_no_x
+    coverpoint: ["Svade_cg/ins_page_fault"]
+
+  - name: load_page_fault_no_r
+    coverpoint: ["Svade_cg/load_page_fault"]
+
+  - name: store_page_fault_no_w
+    coverpoint: ["Svade_cg/store_page_fault"]

--- a/coverpoints/norm/Svadu.yaml
+++ b/coverpoints/norm/Svadu.yaml
@@ -2,10 +2,13 @@
 
 normative_rule_definitions:
   - name: Svadu_hw_update_a_d_bits
-    coverpoint: [""]
+    coverpoint:
+      [
+        "Svadu_cg/{PTE_Abit_unset_s_i,PTE_Abit_unset_u_i,PTE_Abit_unset_s_d,PTE_Abit_unset_u_d,PTE_Dbit_unset_s_d,PTE_Dbit_unset_u_d}",
+      ]
 
   - name: Svadu_hypervisor_adue_writable
     coverpoint: [""]
 
   - name: Svadu_disabled_hw_update_falls_back_to_svade
-    coverpoint: [""]
+    coverpoint: ["Svadu_cg/Svadu_enabled"]

--- a/coverpoints/norm/SvaduPMP.yaml
+++ b/coverpoints/norm/SvaduPMP.yaml
@@ -1,0 +1,27 @@
+# Mapping of normative rules to coverpoints for a test suite
+
+normative_rule_definitions:
+  #If the Svadu extension is implemented, the ADUE bit controls whether hardware
+  #updating of PTE A/D bits is enabled for S-mode and G-stage address translations.
+  #When ADUE=1, hardware updating of PTE A/D bits is enabled during S-mode
+  #address translation, and the implementation behaves as though the Svade
+  #extension were not implemented for S-mode address translation.
+  #When the hypervisor extension is implemented, if ADUE=1, hardware updating of
+  #PTE A/D bits is enabled during G-stage address translation, and the
+  #implementation behaves as though the Svade extension were not implemented for
+  #G-stage address translation.
+  #When ADUE=0, the implementation behaves as though Svade were implemented for
+  #S-mode and G-stage address translation.#
+  - name: menvcfg_adue_op
+    coverpoint:
+      [
+        "SvaduPMP_cg/{Abit_unset_pmpW_unset_exec_s,Abit_unset_pmpW_unset_exec_u,Abit_unset_pmpW_unset_read_s,Abit_unset_pmpW_unset_read_u,Abit_unset_pmpW_unset_write_s,Abit_unset_pmpW_unset_write_u,Dbit_unset_pmpW_unset_write_s,Dbit_unset_pmpW_unset_write_u}",
+      ]
+
+  #Failed memory operations generate an instruction, load, or store access-fault
+  #exception.
+  - name: pmp_access_fault_exception
+    coverpoint:
+      [
+        "SvaduPMP_cg/{Abit_unset_pmpW_unset_exec_s,Abit_unset_pmpW_unset_exec_u,Abit_unset_pmpW_unset_read_s,Abit_unset_pmpW_unset_read_u,Abit_unset_pmpW_unset_write_s,Abit_unset_pmpW_unset_write_u,Dbit_unset_pmpW_unset_write_s,Dbit_unset_pmpW_unset_write_u}",
+      ]

--- a/coverpoints/norm/Svbare.yaml
+++ b/coverpoints/norm/Svbare.yaml
@@ -1,6 +1,17 @@
 # Mapping of normative rules to coverpoints for a test suite
 
 normative_rule_definitions:
-  # TODO when rules from profiles are merged
-  - name: satp_mode_op
-    coverpoint: ["Svbare_cg/cp_satp_bare"]
+  - name: satp_mode
+    coverpoint:
+      ["Svbare_cg/{cp_satp_bare_load,cp_satp_bare_store,cp_satp_bare_exec}"]
+
+  #When csr::[mprv]=0, explicit memory accesses
+  #behave as normal, using the translation and
+  #protection mechanisms of the current privilege mode. When csr::[mprv]=1, load
+  #and store memory addresses are translated and protected, and endianness
+  #is applied, as though the current privilege mode were set to csr::[mpp].#
+  - name: mstatus_mprv_ldst_op
+    coverpoint: ["Svbare_cg/{cp_satp_bare_mprv_load,cp_satp_bare_mprv_store}"]
+
+  - name: mstatus_mprv_inst_xlat_op
+    coverpoint: ["Svbare_cg/cp_satp_bare_mprv_exec"]

--- a/coverpoints/norm/Svinval.yaml
+++ b/coverpoints/norm/Svinval.yaml
@@ -5,10 +5,10 @@ normative_rule_definitions:
     coverpoint: [""]
 
   - name: Svinval_sinval_vma_invalidates_same_as_sfence_vma
-    coverpoint: [""]
+    coverpoint: ["Svinval_cg/cp_instr"]
 
   - name: Svinval_sfence_w_inval_orders_before_sinval_vma
-    coverpoint: [""]
+    coverpoint: ["Svinval_cg/cp_instr"]
 
   - name: Svinval_sequence_rs1_rs2
     coverpoint: [""]

--- a/coverpoints/norm/Svinval.yaml
+++ b/coverpoints/norm/Svinval.yaml
@@ -5,10 +5,10 @@ normative_rule_definitions:
     coverpoint: [""]
 
   - name: Svinval_sinval_vma_invalidates_same_as_sfence_vma
-    coverpoint: ["Svinval_cg/cp_instr"]
+    coverpoint: [""]
 
   - name: Svinval_sfence_w_inval_orders_before_sinval_vma
-    coverpoint: ["Svinval_cg/cp_instr"]
+    coverpoint: [""]
 
   - name: Svinval_sequence_rs1_rs2
     coverpoint: [""]

--- a/coverpoints/norm/Svpbmt.yaml
+++ b/coverpoints/norm/Svpbmt.yaml
@@ -8,10 +8,16 @@ normative_rule_definitions:
     coverpoint: [""]
 
   - name: Svpbmt_nonleaf_pte_pbmt_must_be_zero
-    coverpoint: [""]
+    coverpoint:
+      [
+        "Svpbmt_cg/{nonleaf_PTE_pbmt_i,nonleaf_PTE_pbmt_d,ins_page_fault,load_page_fault,store_page_fault,jalr,lw,sw}",
+      ]
 
   - name: Svpbmt_leaf_pte_pbmt_reserved_3_fault
-    coverpoint: [""]
+    coverpoint:
+      [
+        "Svpbmt_cg/{leaf_PTE_pbmt_res_s_i,leaf_PTE_pbmt_res_u_i,leaf_PTE_pbmt_res_s_d,leaf_PTE_pbmt_res_u_d,ins_page_fault,load_page_fault,store_page_fault,,jalr,lw,sw}",
+      ]
 
   - name: Svpbmt_obeys_mem_ordering
     coverpoint: [""]

--- a/docs/ctp/src/pmp.adoc
+++ b/docs/ctp/src/pmp.adoc
@@ -22,6 +22,7 @@ include::norm/PMPSm_norm_rules.adoc[]
 https://docs.google.com/spreadsheets/d/1VuBt-H9VVWh8k-USAJEplrgEJETjQ-iNjD4Iq_ZOnN0/edit?gid=1908943019#gid=1908943019[Google Sheet Testplan]
 ,===
 
+include::norm/PMPS_norm_rules.adoc[]
 
 ==== PMPU
 
@@ -43,6 +44,7 @@ include::norm/PMPU_norm_rules.adoc[]
 https://docs.google.com/spreadsheets/d/1VuBt-H9VVWh8k-USAJEplrgEJETjQ-iNjD4Iq_ZOnN0/edit?gid=1472001893#gid=1472001893[Google Sheet Testplan]
 ,===
 
+include::norm/PMPF_norm_rules.adoc[]
 
 ==== PMPZca
 
@@ -53,7 +55,7 @@ https://docs.google.com/spreadsheets/d/1VuBt-H9VVWh8k-USAJEplrgEJETjQ-iNjD4Iq_ZO
 https://docs.google.com/spreadsheets/d/1VuBt-H9VVWh8k-USAJEplrgEJETjQ-iNjD4Iq_ZOnN0/edit?gid=1336315481#gid=1336315481[Google Sheet Testplan]
 ,===
 
-
+include::norm/PMPZca_norm_rules.adoc[]
 
 ==== PMPZicbo
 
@@ -74,6 +76,7 @@ include::norm/PMPZicbo_norm_rules.adoc[]
 https://docs.google.com/spreadsheets/d/1VuBt-H9VVWh8k-USAJEplrgEJETjQ-iNjD4Iq_ZOnN0/edit?gid=343093009#gid=343093009[Google Sheet Testplan]
 ,===
 
+include::norm/PMPZaamo_norm_rules.adoc[]
 
 ==== PMPZalrsc
 
@@ -83,3 +86,5 @@ https://docs.google.com/spreadsheets/d/1VuBt-H9VVWh8k-USAJEplrgEJETjQ-iNjD4Iq_ZO
 ,===
 https://docs.google.com/spreadsheets/d/1VuBt-H9VVWh8k-USAJEplrgEJETjQ-iNjD4Iq_ZOnN0/edit?gid=613653829#gid=613653829[Google Sheet Testplan]
 ,===
+
+include::norm/PMPZalrsc_norm_rules.adoc[]

--- a/docs/ctp/src/sv.adoc
+++ b/docs/ctp/src/sv.adoc
@@ -37,6 +37,8 @@ include::norm/Svbare_norm_rules.adoc[]
 https://docs.google.com/spreadsheets/d/1LGwD2e01j4SN9tg85nt6gPwpp7nXyXMF7hqbw3jvXko/edit?gid=726223656#gid=726223656[Google Sheet Testplan]
 ,===
 
+include::norm/SvPMP_norm_rules.adoc[]
+
 ==== SvZicbo VirtMem + CBOM/CBOZ
 
 [[t-SvZicbo-coverpoints]]
@@ -69,6 +71,8 @@ The Svinval extension defines instructions to update memory management tables fo
 https://docs.google.com/spreadsheets/d/1M78FrWvnva08vg-_5ejIkTZBhW1z5mW7NkYjl5lXH5g/edit?gid=1987812700#gid=1987812700[Google Sheet Testplan]
 ,===
 
+include::norm/Svinval_norm_rules.adoc[]
+
 ==== Svade A/D Bit Page Fault Exception
 
 [[t-Svade-coverpoints]]
@@ -76,6 +80,8 @@ https://docs.google.com/spreadsheets/d/1M78FrWvnva08vg-_5ejIkTZBhW1z5mW7NkYjl5lX
 ,===
 https://docs.google.com/spreadsheets/d/1LGwD2e01j4SN9tg85nt6gPwpp7nXyXMF7hqbw3jvXko/edit?gid=1346750896#gid=1346750896[Google Sheet Testplan]
 ,===
+
+include::norm/Svade_norm_rules.adoc[]
 
 ==== Svadu A/D Bit Hardware Update
 
@@ -85,6 +91,8 @@ https://docs.google.com/spreadsheets/d/1LGwD2e01j4SN9tg85nt6gPwpp7nXyXMF7hqbw3jv
 https://docs.google.com/spreadsheets/d/1LGwD2e01j4SN9tg85nt6gPwpp7nXyXMF7hqbw3jvXko/edit?gid=1484908158#gid=1484908158[Google Sheet Testplan]
 ,===
 
+include::norm/Svadu_norm_rules.adoc[]
+
 ==== Svadu A/D Bit Hardware Update + PMP
 
 [[t-SvaduPMP-coverpoints]]
@@ -92,6 +100,8 @@ https://docs.google.com/spreadsheets/d/1LGwD2e01j4SN9tg85nt6gPwpp7nXyXMF7hqbw3jv
 ,===
 https://docs.google.com/spreadsheets/d/1LGwD2e01j4SN9tg85nt6gPwpp7nXyXMF7hqbw3jvXko/edit?gid=1568813008#gid=1568813008[Google Sheet Testplan]
 ,===
+
+include::norm/SvaduPMP_norm_rules.adoc[]
 
 ==== Svpbmt Page-Based Memory Types
 
@@ -101,6 +111,8 @@ https://docs.google.com/spreadsheets/d/1LGwD2e01j4SN9tg85nt6gPwpp7nXyXMF7hqbw3jv
 https://docs.google.com/spreadsheets/d/1LGwD2e01j4SN9tg85nt6gPwpp7nXyXMF7hqbw3jvXko/edit?gid=375458051#gid=375458051[Google Sheet Testplan]
 ,===
 
+include::norm/Svpbmt_norm_rules.adoc[]
+
 ==== Svnapot Naturally-Aligned Power-of-Two Page Sizes
 
 [[t-Svnapot-coverpoints]]
@@ -108,3 +120,5 @@ https://docs.google.com/spreadsheets/d/1LGwD2e01j4SN9tg85nt6gPwpp7nXyXMF7hqbw3jv
 ,===
 https://docs.google.com/spreadsheets/d/1LGwD2e01j4SN9tg85nt6gPwpp7nXyXMF7hqbw3jvXko/edit?gid=375458051#gid=375458051[Google Sheet Testplan]
 ,===
+
+include::norm/Svnapot_norm_rules.adoc[]


### PR DESCRIPTION
Added normative rule mappings for 
Sv,
Svadu, 
Svade, 
SvaduPMP, 
Svbare, 
Svinval, 
Svpbmt, 
ExceptionsSv, 
ExceptionsSvZaamo, 
ExceptionsSvZalrsc