### PR TITLE
Test interaction of delegation with mip/sip and mie/sie shadow registers

### DIFF
--- a/coverpoints/priv/Sm_coverage.svh
+++ b/coverpoints/priv/Sm_coverage.svh
@@ -609,9 +609,36 @@ covergroup Sm_mcsr_cg with function sample(ins_t ins);
             bins zero = { 0 };
             bins nonzero = { [1:$] };
         }
+        shadow_int : coverpoint {ins.prev.insn[31:20], ins.current.insn[31:20]} {
+            bins mie_sie         = { {CSR_MIE, CSR_SIE} };
+            bins mip_sip         = { {CSR_MIP, CSR_SIP} };
+            bins sie_mie         = { {CSR_SIE, CSR_MIE} };
+            bins sip_mip         = { {CSR_SIP, CSR_MIP} };
+        }
+        // S-level interrupt delegation bits {LCOFI, SEI, STI, SSI}; the VS bits are read-only without H
+        mideleg_s: coverpoint {ins.current.csr[CSR_MIDELEG][13], ins.current.csr[CSR_MIDELEG][9],
+                               ins.current.csr[CSR_MIDELEG][5],  ins.current.csr[CSR_MIDELEG][1]} {
+            bins none = {4'b0000};
+            bins all  = {4'b1111};
+        }
+        mideleg_s_walking: coverpoint {ins.current.csr[CSR_MIDELEG][13], ins.current.csr[CSR_MIDELEG][9],
+                                       ins.current.csr[CSR_MIDELEG][5],  ins.current.csr[CSR_MIDELEG][1]} {
+            bins lcofi = {4'b1000};
+            bins sei   = {4'b0100};
+            bins sti   = {4'b0010};
+            bins ssi   = {4'b0001};
+        }
+        sip_sie: coverpoint ins.current.insn[31:20] {
+            bins sip = {CSR_SIP};
+            bins sie = {CSR_SIE};
+        }
 
         cp_scsr_from_m :            cross priv_mode_m, scsrname, csraccesses;
         cp_shadow :                 cross priv_mode_m, shadow, csrw_prev, rs1_prev, csrr;
+        // sip/sie alias mip/mie only for delegated interrupts
+        cp_shadow_deleg :           cross priv_mode_m, shadow_int, csrw_prev, csrr, mideleg_s;
+        // delegate one interrupt at a time and read sip/sie
+        cp_shadow_deleg_walk :      cross priv_mode_m, csrr, sip_sie, mideleg_s_walking;
     `endif
 
 endgroup

--- a/generators/testgen/src/testgen/priv/extensions/Sm.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sm.py
@@ -422,6 +422,7 @@ def _add_shadow(
     coverpoint: str,
     covergroup: str,
     test_data: TestData,
+    bin_suffix: str = "",
 ) -> str:
     """Generate shadow CSR test lines for writing wreg and reading rreg (direct CSR access, M-mode)."""
     return str.join(
@@ -432,10 +433,10 @@ def _add_shadow(
             f"LI(x{rmask}, 0x{mask:x}) # mask specifying bits to keep",
             f"csrr x{rsave}, {wreg}       # save original value of {wreg}",
             f"csrw {wreg}, x{r1}       # write many 1s to {wreg}",
-            test_data.add_testcase(f"{wreg}_{rreg}_1s", coverpoint, covergroup),
+            test_data.add_testcase(f"{wreg}_{rreg}_1s{bin_suffix}", coverpoint, covergroup),
             gen_csr_read_sigupd(r2, (rreg, mask), test_data, rmask),
             f"csrw {wreg}, x0       # write all 0s to {wreg}",
-            test_data.add_testcase(f"{wreg}_{rreg}_0s", coverpoint, covergroup),
+            test_data.add_testcase(f"{wreg}_{rreg}_0s{bin_suffix}", coverpoint, covergroup),
             gen_csr_read_sigupd(r2, (rreg, mask), test_data, rmask),
             f"csrw {wreg}, x{rsave}       # write back saved value of {wreg}",
         ],
@@ -454,7 +455,7 @@ def _add_deleg_alias(r1: int, r2: int, coverpoint: str, covergroup: str, test_da
 
     lines = [
         "# Test mip/sip and mie/sie with delegation on and off",
-        f"LI(x{r1}, 0x3666) # all delegatable interrupts",
+        f"LI(x{r1}, 0x3EEE) # all S- and M-level interrupts",
         "csrw mideleg, zero # delegate nothing",
         "csrw mie, zero",
         "csrw mip, zero",
@@ -481,12 +482,13 @@ def _add_deleg_alias(r1: int, r2: int, coverpoint: str, covergroup: str, test_da
         f"csrw mie, x{r1} # set all interrupts in mie",
         *read("sie", "sie_readback_nonzero_deleg", "sie reads the delegated bits"),
         "csrw sie, zero # clears every delegated S-level enable",
-        *read("mie", "mie_readback_zero_deleg", "mie reads zero"),
+        *read("mie", "mie_readback_m_only_deleg", "mie keeps only the M-level enables"),
         "",
         "# Delegate one interrupt at a time; sip and sie show just that bit",
         f"csrw mip, x{r1} # set all interrupts in mip",
         f"csrw mie, x{r1} # set all interrupts in mie",
     ]
+    # Test all delegation bits individually. Machine mode bits should be read-only in mideleg and thus have no effect.
     for name, bit in [("SSI", 1), ("STI", 5), ("SEI", 9), ("LCOFI", 13), ("MSI", 3), ("MTI", 7), ("MEI", 11)]:
         lines += [
             f"LI(x{r1}, {1 << bit:#x})",
@@ -819,17 +821,19 @@ def _generate_mcsr_tests(test_data: TestData, test_chunks: list) -> None:
             _add_shadow(r1, r2, rmask, rsave, "sstatus", "mstatus", 0xCFFFFFFCF, coverpoint, covergroup, test_data),
             f"LI(x{r1}, 0xFFFF) # all interrupts",
             "# Without delegation, S-mode should not see any of the M-mode interrupts",
-            _add_shadow(r1, r2, rmask, rsave, "mie", "sie", 0x3666, coverpoint, covergroup, test_data),
-            _add_shadow(r1, r2, rmask, rsave, "mip", "sip", 0x3666, coverpoint, covergroup, test_data),
-            _add_shadow(r1, r2, rmask, rsave, "sie", "mie", 0x3666, coverpoint, covergroup, test_data),
-            _add_shadow(r1, r2, rmask, rsave, "sip", "mip", 0x3666, coverpoint, covergroup, test_data),
+            "csrw mideleg, zero # disable delegation",
+            _add_shadow(r1, r2, rmask, rsave, "mie", "sie", 0x3EEE, coverpoint, covergroup, test_data),
+            _add_shadow(r1, r2, rmask, rsave, "mip", "sip", 0x3EEE, coverpoint, covergroup, test_data),
+            _add_shadow(r1, r2, rmask, rsave, "sie", "mie", 0x3EEE, coverpoint, covergroup, test_data),
+            _add_shadow(r1, r2, rmask, rsave, "sip", "mip", 0x3EEE, coverpoint, covergroup, test_data),
             "# With delegation, S-mode should see the delegated M-mode interrupts",
             f"csrw mideleg, x{r1} # delegate all interrupts to S-mode",
-            _add_shadow(r1, r2, rmask, rsave, "mie", "sie", 0x3666, coverpoint, covergroup, test_data),
-            _add_shadow(r1, r2, rmask, rsave, "mip", "sip", 0x3666, coverpoint, covergroup, test_data),
-            _add_shadow(r1, r2, rmask, rsave, "sie", "mie", 0x3666, coverpoint, covergroup, test_data),
-            _add_shadow(r1, r2, rmask, rsave, "sip", "mip", 0x3666, coverpoint, covergroup, test_data),
+            _add_shadow(r1, r2, rmask, rsave, "mie", "sie", 0x3EEE, coverpoint, covergroup, test_data, "_deleg"),
+            _add_shadow(r1, r2, rmask, rsave, "mip", "sip", 0x3EEE, coverpoint, covergroup, test_data, "_deleg"),
+            _add_shadow(r1, r2, rmask, rsave, "sie", "mie", 0x3EEE, coverpoint, covergroup, test_data, "_deleg"),
+            _add_shadow(r1, r2, rmask, rsave, "sip", "mip", 0x3EEE, coverpoint, covergroup, test_data, "_deleg"),
             *_add_deleg_alias(r1, r2, coverpoint, covergroup, test_data),
+            "csrw mideleg, zero # disable delegation",
             "#endif // S_SUPPORTED",
         ]
     )

--- a/generators/testgen/src/testgen/priv/extensions/Sm.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sm.py
@@ -455,7 +455,7 @@ def _add_deleg_alias(r1: int, r2: int, coverpoint: str, covergroup: str, test_da
 
     lines = [
         "# Test mip/sip and mie/sie with delegation on and off",
-        f"LI(x{r1}, 0x3EEE) # all S- and M-level interrupts",
+        f"LI(x{r1}, 0x3EEE) # all S-, VS-, and M-level interrupts",
         "csrw mideleg, zero # delegate nothing",
         "csrw mie, zero",
         "csrw mip, zero",

--- a/generators/testgen/src/testgen/priv/extensions/Sm.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sm.py
@@ -442,6 +442,61 @@ def _add_shadow(
     )
 
 
+def _add_deleg_alias(r1: int, r2: int, coverpoint: str, covergroup: str, test_data: TestData) -> list[str]:
+    """sip/sie alias the delegated bits of mip/mie and read as zero for the bits mideleg does not delegate."""
+
+    def read(csr: str, bin_name: str, comment: str) -> list[str]:
+        return [
+            f"# {comment}",
+            test_data.add_testcase(bin_name, coverpoint, covergroup),
+            gen_csr_read_sigupd(r2, (csr, None), test_data),
+        ]
+
+    lines = [
+        "# Test mip/sip and mie/sie with delegation on and off",
+        f"LI(x{r1}, 0x3666) # all delegatable interrupts",
+        "csrw mideleg, zero # delegate nothing",
+        "csrw mie, zero",
+        "csrw mip, zero",
+        *read("sip", "sip_readback_zero", "sip reads zero"),
+        *read("sie", "sie_readback_zero", "sie reads zero"),
+        f"csrw mip, x{r1} # set all interrupts in mip",
+        *read("sip", "sip_readback_zero_masked", "sip reads zero because nothing is delegated"),
+        "csrw sip, zero # ignored because nothing is delegated",
+        *read("mip", "mip_readback_nonzero_masked", "mip keeps its value because the sip write is ignored"),
+        "csrw mip, zero",
+        f"csrw mie, x{r1} # set all interrupts in mie",
+        *read("sie", "sie_readback_zero_masked", "sie reads zero because nothing is delegated"),
+        "csrw sie, zero # ignored because nothing is delegated",
+        *read("mie", "mie_readback_nonzero_masked", "mie keeps its value because the sie write is ignored"),
+        "csrw mie, zero",
+        "",
+        f"csrw mideleg, x{r1} # delegate all interrupts to S-mode",
+        *read("sip", "sip_readback_zero_2", "sip reads zero"),
+        *read("sie", "sie_readback_zero_2", "sie reads zero"),
+        f"csrw mip, x{r1} # set all interrupts in mip",
+        *read("sip", "sip_readback_nonzero", "sip reads the delegated bits"),
+        "csrw sip, zero # clears SSIP and LCOFIP; STIP and SEIP are read-only in sip",
+        *read("mip", "mip_readback_partiallyzero", "mip keeps STIP and SEIP"),
+        f"csrw mie, x{r1} # set all interrupts in mie",
+        *read("sie", "sie_readback_nonzero_deleg", "sie reads the delegated bits"),
+        "csrw sie, zero # clears every delegated S-level enable",
+        *read("mie", "mie_readback_zero_deleg", "mie reads zero"),
+        "",
+        "# Delegate one interrupt at a time; sip and sie show just that bit",
+        f"csrw mip, x{r1} # set all interrupts in mip",
+        f"csrw mie, x{r1} # set all interrupts in mie",
+    ]
+    for name, bit in [("SSI", 1), ("STI", 5), ("SEI", 9), ("LCOFI", 13), ("MSI", 3), ("MTI", 7), ("MEI", 11)]:
+        lines += [
+            f"LI(x{r1}, {1 << bit:#x})",
+            f"csrw mideleg, x{r1} # delegate only {name}",
+            *read("sip", f"deleg_sip_{name}", f"sip reads only {name}P if delegable"),
+            *read("sie", f"deleg_sie_{name}", f"sie reads only {name}E if delegable"),
+        ]
+    return lines
+
+
 def _generate_mcsr_tests(test_data: TestData, test_chunks: list) -> None:
     """Generate CSR tests"""
     covergroup = "Sm_mcsr_cg"
@@ -763,10 +818,18 @@ def _generate_mcsr_tests(test_data: TestData, test_chunks: list) -> None:
             _add_shadow(r1, r2, rmask, rsave, "mstatus", "sstatus", 0xCFFFFFFCF, coverpoint, covergroup, test_data),
             _add_shadow(r1, r2, rmask, rsave, "sstatus", "mstatus", 0xCFFFFFFCF, coverpoint, covergroup, test_data),
             f"LI(x{r1}, 0xFFFF) # all interrupts",
+            "# Without delegation, S-mode should not see any of the M-mode interrupts",
             _add_shadow(r1, r2, rmask, rsave, "mie", "sie", 0x3666, coverpoint, covergroup, test_data),
             _add_shadow(r1, r2, rmask, rsave, "mip", "sip", 0x3666, coverpoint, covergroup, test_data),
             _add_shadow(r1, r2, rmask, rsave, "sie", "mie", 0x3666, coverpoint, covergroup, test_data),
             _add_shadow(r1, r2, rmask, rsave, "sip", "mip", 0x3666, coverpoint, covergroup, test_data),
+            "# With delegation, S-mode should see the delegated M-mode interrupts",
+            f"csrw mideleg, x{r1} # delegate all interrupts to S-mode",
+            _add_shadow(r1, r2, rmask, rsave, "mie", "sie", 0x3666, coverpoint, covergroup, test_data),
+            _add_shadow(r1, r2, rmask, rsave, "mip", "sip", 0x3666, coverpoint, covergroup, test_data),
+            _add_shadow(r1, r2, rmask, rsave, "sie", "mie", 0x3666, coverpoint, covergroup, test_data),
+            _add_shadow(r1, r2, rmask, rsave, "sip", "mip", 0x3666, coverpoint, covergroup, test_data),
+            *_add_deleg_alias(r1, r2, coverpoint, covergroup, test_data),
             "#endif // S_SUPPORTED",
         ]
     )

--- a/generators/testgen/src/testgen/priv/extensions/Sm.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sm.py
@@ -472,7 +472,7 @@ def _add_deleg_alias(r1: int, r2: int, coverpoint: str, covergroup: str, test_da
         *read("mie", "mie_readback_nonzero_masked", "mie keeps its value because the sie write is ignored"),
         "csrw mie, zero",
         "",
-        f"csrw mideleg, x{r1} # delegate all interrupts to S-mode",
+        f"csrw mideleg, x{r1} # delegate all delegable interrupts to S-mode",
         *read("sip", "sip_readback_zero_2", "sip reads zero"),
         *read("sie", "sie_readback_zero_2", "sie reads zero"),
         f"csrw mip, x{r1} # set all interrupts in mip",
@@ -838,7 +838,7 @@ def _generate_mcsr_tests(test_data: TestData, test_chunks: list) -> None:
             _add_shadow(r1, r2, rmask, rsave, "sie", "mie", 0x3EEE, coverpoint, covergroup, test_data, "_deleg"),
             _add_shadow(r1, r2, rmask, rsave, "sip", "mip", 0x3EEE, coverpoint, covergroup, test_data, "_deleg"),
             *_add_deleg_alias(r1, r2, coverpoint, covergroup, test_data),
-            "csrw mideleg, zero # disable delegation",
+            # mideleg restored to 0 by _add_deleg_alias()
             "#endif // S_SUPPORTED",
         ]
     )

--- a/generators/testgen/src/testgen/priv/extensions/Sm.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sm.py
@@ -496,11 +496,11 @@ def _add_deleg_alias(r1: int, r2: int, coverpoint: str, covergroup: str, test_da
             *read("sip", f"deleg_sip_{name}", f"sip reads only {name}P if delegable"),
             *read("sie", f"deleg_sie_{name}", f"sie reads only {name}E if delegable"),
         ]
-        lines += [
-            "csrw mip, zero # restore mip",
-            "csrw mie, zero # restore mie",
-            "csrw mideleg, zero # restore mideleg",
-        ]
+    lines += [
+        "csrw mip, zero # restore mip",
+        "csrw mie, zero # restore mie",
+        "csrw mideleg, zero # restore mideleg",
+    ]
     return lines
 
 

--- a/generators/testgen/src/testgen/priv/extensions/Sm.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sm.py
@@ -461,12 +461,12 @@ def _add_deleg_alias(r1: int, r2: int, coverpoint: str, covergroup: str, test_da
         "csrw mip, zero",
         *read("sip", "sip_readback_zero", "sip reads zero"),
         *read("sie", "sie_readback_zero", "sie reads zero"),
-        f"csrw mip, x{r1} # set all interrupts in mip",
+        f"csrw mip, x{r1} # set all writable interrupts in mip",
         *read("sip", "sip_readback_zero_masked", "sip reads zero because nothing is delegated"),
         "csrw sip, zero # ignored because nothing is delegated",
         *read("mip", "mip_readback_nonzero_masked", "mip keeps its value because the sip write is ignored"),
         "csrw mip, zero",
-        f"csrw mie, x{r1} # set all interrupts in mie",
+        f"csrw mie, x{r1} # set all writable interrupts in mie",
         *read("sie", "sie_readback_zero_masked", "sie reads zero because nothing is delegated"),
         "csrw sie, zero # ignored because nothing is delegated",
         *read("mie", "mie_readback_nonzero_masked", "mie keeps its value because the sie write is ignored"),
@@ -478,7 +478,7 @@ def _add_deleg_alias(r1: int, r2: int, coverpoint: str, covergroup: str, test_da
         f"csrw mip, x{r1} # set all interrupts in mip",
         *read("sip", "sip_readback_nonzero", "sip reads the delegated bits"),
         "csrw sip, zero # clears SSIP and LCOFIP; STIP and SEIP are read-only in sip",
-        *read("mip", "mip_readback_partiallyzero", "mip keeps STIP and SEIP"),
+        *read("mip", "mip_readback_partiallyzero", "mip typically keeps STIP and SEIP"),
         f"csrw mie, x{r1} # set all interrupts in mie",
         *read("sie", "sie_readback_nonzero_deleg", "sie reads the delegated bits"),
         "csrw sie, zero # clears every delegated S-level enable",
@@ -488,8 +488,20 @@ def _add_deleg_alias(r1: int, r2: int, coverpoint: str, covergroup: str, test_da
         f"csrw mip, x{r1} # set all interrupts in mip",
         f"csrw mie, x{r1} # set all interrupts in mie",
     ]
-    # Test all delegation bits individually. Machine mode bits should be read-only in mideleg and thus have no effect.
-    for name, bit in [("SSI", 1), ("STI", 5), ("SEI", 9), ("LCOFI", 13), ("MSI", 3), ("MTI", 7), ("MEI", 11)]:
+    # Test all delegation bits individually. Machine mode bits are usually but not necessarily read-only in mideleg and thus have no effect.
+    # https://github.com/riscv/riscv-isa-manual/issues/153
+    for name, bit in [
+        ("SSI", 1),
+        ("STI", 5),
+        ("SEI", 9),
+        ("LCOFI", 13),
+        ("MSI", 3),
+        ("MTI", 7),
+        ("MEI", 11),
+        ("VSSI", 2),
+        ("VSTI", 6),
+        ("VSEI", 10),
+    ]:
         lines += [
             f"LI(x{r1}, {1 << bit:#x})",
             f"csrw mideleg, x{r1} # delegate only {name}",

--- a/generators/testgen/src/testgen/priv/extensions/Sm.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sm.py
@@ -496,6 +496,11 @@ def _add_deleg_alias(r1: int, r2: int, coverpoint: str, covergroup: str, test_da
             *read("sip", f"deleg_sip_{name}", f"sip reads only {name}P if delegable"),
             *read("sie", f"deleg_sie_{name}", f"sie reads only {name}E if delegable"),
         ]
+        lines += [
+            "csrw mip, zero # restore mip",
+            "csrw mie, zero # restore mie",
+            "csrw mideleg, zero # restore mideleg",
+        ]
     return lines
 
 


### PR DESCRIPTION
Inspired by bug found in https://github.com/openhwgroup/cvw/issues/1832 (Part 1)
Needs https://github.com/openhwgroup/cvw/pull/1846 merged before this will pass CI (DONE)
