### PR TITLE
More restrictive testing of mcause

### DIFF
--- a/coverpoints/priv/Sm_coverage.svh
+++ b/coverpoints/priv/Sm_coverage.svh
@@ -82,18 +82,28 @@ covergroup Sm_mcause_cg with function sample(ins_t ins);
         // exclude reserved and custom fields
         //bins b_0_reserved = {0};
         bins b_1_supervisor_software = {1};
-        bins b_2_vs_software = {2};
+        `ifdef H_SUPPORTED
+            bins b_2_vs_software = {2};
+        `endif
         bins b_3_machine_software = {3};
         //bins b_4_reserved = {4};
         bins b_5_supervisor_timer = {5};
-        bins b_6_vs_timer = {6};
+        `ifdef H_SUPPORTED
+            bins b_6_vs_timer = {6};
+        `endif
         bins b_7_machine_timer = {7};
         //bins b_8_reserved = {8};
         bins b_9_supervisor_external = {9};
-        bins b_10_vs_external = {10};
+        `ifdef H_SUPPORTED
+            bins b_10_vs_external = {10};
+        `endif
         bins b_11_machine_external = {11};
-        bins b_12_supervisor_guest_external = {12};
-        bins b_13_counter_overflow = {13};
+        `ifdef H_SUPPORTED
+            bins b_12_supervisor_guest_external = {12};
+        `endif
+        `ifdef SSCOFPMF_SUPPORTED
+            bins b_13_counter_overflow = {13};
+        `endif
         //bins b_14_reserved = {14};
         //bins b_15_reserved = {15};
     }

--- a/generators/testgen/src/testgen/priv/extensions/Sm.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sm.py
@@ -104,9 +104,20 @@ def _generate_mcause_tests(test_data: TestData) -> list[str]:
     ######################################
     coverpoint = "cp_mcause_write_interrupt"
     ######################################
+    gated_interrupts = {
+        2: "#ifdef H_SUPPORTED",  # VS software interrupt
+        6: "#ifdef H_SUPPORTED",  # VS timer interrupt
+        10: "#ifdef H_SUPPORTED",  # VS external interrupt
+        12: "#ifdef H_SUPPORTED",  # S guest external interrupt
+        13: "#ifdef SSCOFPMF_SUPPORTED",  # local counter overflow interrupt
+    }
+
     for i in range(14):
         if i in {0, 4, 8}:  # skip reserved causes
             continue
+        guard = gated_interrupts.get(i)
+        if guard is not None:
+            lines.append(guard)
         lines.extend(
             [
                 "",
@@ -117,6 +128,8 @@ def _generate_mcause_tests(test_data: TestData) -> list[str]:
                 gen_csr_write_sigupd(check_reg, "mcause", test_data),
             ]
         )
+        if guard is not None:
+            lines.append("#endif")
 
     lines.append(f"\ncsrw mcause, x{save_reg}       # restore CSR")
 


### PR DESCRIPTION
Avoid writing potentially illegal values to WLRL field