### PR TITLE
SmVF: fix swapped vs1/vs2 bin names on the mixed-operand patterns

### DIFF
--- a/generators/testgen/src/testgen/priv/extensions/SmVF.py
+++ b/generators/testgen/src/testgen/priv/extensions/SmVF.py
@@ -18,6 +18,15 @@ _CG = "SmVF_cg"
 _FS_MASK = 3 << 13  # mstatus.FS = bits [14:13]
 _VS_MASK = 3 << 9  # mstatus.VS = bits [10:9]
 
+# vfadd.vv operand patterns as (vs2_reg, vs1_reg, name), covering the 4 vs1_zero x vs2_zero
+# combinations. v1 and v4 hold 1.0; v2 holds 0.
+_VFADD_PATTERNS = [
+    ("v2", "v2", "vs1_0_vs2_0"),  # both zero
+    ("v1", "v2", "vs1_0_vs2_n"),  # vs1=0, vs2!=0
+    ("v2", "v1", "vs1_n_vs2_0"),  # vs1!=0, vs2=0
+    ("v1", "v4", "vs1_n_vs2_n"),  # both nonzero
+]
+
 
 def _set_fs_vs(fs: int, vs: int, temp_reg: int) -> list[str]:
     return [
@@ -106,16 +115,8 @@ def _gen_fs_state_nonaffecting(test_data: TestData, temp_reg: int) -> list[str]:
     lines = [
         comment_banner(coverpoint, "vfadd.vv under FS=Initial/Clean across all 4 vs1_zero × vs2_zero combinations"),
     ]
-    # 4 combinations, listed as (vs2_reg, vs1_reg, name) to match the unpack below.
-    # v1 and v4 hold 1.0; v2 holds 0.
-    pattern_pairs = [
-        ("v2", "v2", "vs1_0_vs2_0"),  # both zero
-        ("v1", "v2", "vs1_0_vs2_n"),  # vs1=0, vs2!=0
-        ("v2", "v1", "vs1_n_vs2_0"),  # vs1!=0, vs2=0
-        ("v1", "v4", "vs1_n_vs2_n"),  # both nonzero
-    ]
     for fs in (1, 2):
-        for vs2_reg, vs1_reg, name in pattern_pairs:
+        for vs2_reg, vs1_reg, name in _VFADD_PATTERNS:
             lines.extend(_set_fs_vs(fs=3, vs=3, temp_reg=temp_reg))
             lines.extend(_vector_setup(temp_reg))
             lines.extend(_load_v_zero_one(temp_reg))
@@ -135,13 +136,7 @@ def _gen_fs_off(test_data: TestData, temp_reg: int) -> list[str]:
             coverpoint, "vfadd.vv with FS=Off (VS=Dirty) -> illegal-instruction trap; cover all vs1/vs2 patterns"
         ),
     ]
-    pattern_pairs = [
-        ("v2", "v2", "vs1_0_vs2_0"),
-        ("v1", "v2", "vs1_0_vs2_n"),
-        ("v2", "v1", "vs1_n_vs2_0"),
-        ("v1", "v4", "vs1_n_vs2_n"),
-    ]
-    for vs2_reg, vs1_reg, name in pattern_pairs:
+    for vs2_reg, vs1_reg, name in _VFADD_PATTERNS:
         lines.extend(_set_fs_vs(fs=3, vs=3, temp_reg=temp_reg))
         lines.extend(_vector_setup(temp_reg))
         lines.extend(_load_v_zero_one(temp_reg))

--- a/generators/testgen/src/testgen/priv/extensions/SmVF.py
+++ b/generators/testgen/src/testgen/priv/extensions/SmVF.py
@@ -106,12 +106,12 @@ def _gen_fs_state_nonaffecting(test_data: TestData, temp_reg: int) -> list[str]:
     lines = [
         comment_banner(coverpoint, "vfadd.vv under FS=Initial/Clean across all 4 vs1_zero × vs2_zero combinations"),
     ]
-    # 4 combinations: (vs1_zero, vs2_zero)
-    # vs1 = v1 (1.0 nonzero) vs v2 (0) ; vs2 likewise
+    # 4 combinations, listed as (vs2_reg, vs1_reg, name) to match the unpack below.
+    # v1 and v4 hold 1.0; v2 holds 0.
     pattern_pairs = [
         ("v2", "v2", "vs1_0_vs2_0"),  # both zero
-        ("v1", "v2", "vs1_n_vs2_0"),  # vs1!=0, vs2=0
-        ("v2", "v1", "vs1_0_vs2_n"),  # vs1=0, vs2!=0
+        ("v1", "v2", "vs1_0_vs2_n"),  # vs1=0, vs2!=0
+        ("v2", "v1", "vs1_n_vs2_0"),  # vs1!=0, vs2=0
         ("v1", "v4", "vs1_n_vs2_n"),  # both nonzero
     ]
     for fs in (1, 2):
@@ -137,8 +137,8 @@ def _gen_fs_off(test_data: TestData, temp_reg: int) -> list[str]:
     ]
     pattern_pairs = [
         ("v2", "v2", "vs1_0_vs2_0"),
-        ("v1", "v2", "vs1_n_vs2_0"),
-        ("v2", "v1", "vs1_0_vs2_n"),
+        ("v1", "v2", "vs1_0_vs2_n"),
+        ("v2", "v1", "vs1_n_vs2_0"),
         ("v1", "v4", "vs1_n_vs2_n"),
     ]
     for vs2_reg, vs1_reg, name in pattern_pairs:


### PR DESCRIPTION
Issue #2146 item 35.

SmVF.py's pattern_pairs are (vs2_reg, vs1_reg, name), but the two mixed-operand rows were named
backwards: ("v1","v2") is vs1=0 / vs2 nonzero yet was labelled vs1_n_vs2_0, and vice versa. The
register tuples were correct; only the names and their comments change