### PR TITLE
ExceptionsF: sign FP load results as floating point, not integer

### DIFF
--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsF.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsF.py
@@ -295,7 +295,7 @@ def add_fp_load_misaligned_test(
         [
             test_data.add_testcase(f"{op}_off{offset}", coverpoint, covergroup),
             f"{op} f{check_reg}, 0(x{addr_reg})",
-            write_sigupd(check_reg, test_data),
+            write_sigupd(check_reg, test_data, sig_type="float"),
         ]
     )
 


### PR DESCRIPTION
`add_fp_load_misaligned_test` used an integer sigupd instead of a float sigupd to check the result in a floating point register.

Issue #2146 item 12
Fixes #2297