### PR TITLE
SmV: clear vill with the config's smallest supported SEW

### DIFF
--- a/generators/testgen/src/testgen/priv/extensions/SmV.py
+++ b/generators/testgen/src/testgen/priv/extensions/SmV.py
@@ -288,11 +288,21 @@ def _gen_vsetvl_rs2_vill(test_data: TestData, temp_reg: int) -> list[str]:
     lines.append(f"LI(x{msb_reg}, 0x8000000000000000)")
     lines.append("#endif")
     for sew_name, sew_v in _SEW_VALUES:
-        # clear vill: try every supported sew with lmul=1 to find one that sticks
-        for try_sew in (0, 1, 2, 3):
-            vt = try_sew << 3
-            lines.append(f"LI(x{rs2_reg}, 0x{vt:02x})  # try clear vill with SEW={try_sew}")
-            lines.append(f"vsetvl x{temp_reg}, x{rs1_reg}, x{rs2_reg}")
+        # Clear vill with the config's smallest supported SEW and lmul=1, which is legal
+        # everywhere. A sweep of several SEWs would not work: each vsetvl overwrites the
+        # previous, so only the final vtype survives, and ending on an SEW the part does
+        # not implement leaves vill set and makes the coverpoint's vtype_prev_vill_clear
+        # term unreachable.
+        lines.append("#if UDB_SEW_MIN == 8")
+        lines.append(f"LI(x{rs2_reg}, 0x00)  # SEW=8, LMUL=1")
+        lines.append("#elif UDB_SEW_MIN == 16")
+        lines.append(f"LI(x{rs2_reg}, 0x08)  # SEW=16, LMUL=1")
+        lines.append("#elif UDB_SEW_MIN == 32")
+        lines.append(f"LI(x{rs2_reg}, 0x10)  # SEW=32, LMUL=1")
+        lines.append("#else")
+        lines.append(f"LI(x{rs2_reg}, 0x18)  # SEW=64, LMUL=1")
+        lines.append("#endif")
+        lines.append(f"vsetvl x{temp_reg}, x{rs1_reg}, x{rs2_reg}  # clear vill")
         # Now vsetvl with rs2_vill_set + valid sew+lmul=1
         vtype_low = sew_v << 3
         lines.append(f"LI(x{rs2_reg}, 0x{vtype_low:02x})")

--- a/generators/testgen/src/testgen/priv/extensions/SmV.py
+++ b/generators/testgen/src/testgen/priv/extensions/SmV.py
@@ -288,11 +288,9 @@ def _gen_vsetvl_rs2_vill(test_data: TestData, temp_reg: int) -> list[str]:
     lines.append(f"LI(x{msb_reg}, 0x8000000000000000)")
     lines.append("#endif")
     for sew_name, sew_v in _SEW_VALUES:
-        # Clear vill with the config's smallest supported SEW and lmul=1, which is legal
-        # everywhere. A sweep of several SEWs would not work: each vsetvl overwrites the
-        # previous, so only the final vtype survives, and ending on an SEW the part does
-        # not implement leaves vill set and makes the coverpoint's vtype_prev_vill_clear
-        # term unreachable.
+        # Clear vill with the config's smallest supported SEW and LMUL=1. Sweeping several
+        # SEWs would not work: only the last vsetvl survives, and ending on an unsupported
+        # SEW leaves vill set.
         lines.append("#if UDB_SEW_MIN == 8")
         lines.append(f"LI(x{rs2_reg}, 0x00)  # SEW=8, LMUL=1")
         lines.append("#elif UDB_SEW_MIN == 16")

--- a/generators/testgen/src/testgen/priv/extensions/SmV.py
+++ b/generators/testgen/src/testgen/priv/extensions/SmV.py
@@ -288,8 +288,7 @@ def _gen_vsetvl_rs2_vill(test_data: TestData, temp_reg: int) -> list[str]:
     lines.append(f"LI(x{msb_reg}, 0x8000000000000000)")
     lines.append("#endif")
     for sew_name, sew_v in _SEW_VALUES:
-        # Clear vill with the config's smallest supported SEW and LMUL=1, a combination
-        # every part implements.
+        # Clear vill with the config's smallest supported SEW and LMUL=1
         lines.append("#if UDB_SEW_MIN == 8")
         lines.append(f"LI(x{rs2_reg}, 0x00)  # SEW=8, LMUL=1")
         lines.append("#elif UDB_SEW_MIN == 16")

--- a/generators/testgen/src/testgen/priv/extensions/SmV.py
+++ b/generators/testgen/src/testgen/priv/extensions/SmV.py
@@ -288,17 +288,18 @@ def _gen_vsetvl_rs2_vill(test_data: TestData, temp_reg: int) -> list[str]:
     lines.append(f"LI(x{msb_reg}, 0x8000000000000000)")
     lines.append("#endif")
     for sew_name, sew_v in _SEW_VALUES:
-        # Clear vill with the config's smallest supported SEW and LMUL=1. Sweeping several
-        # SEWs would not work: only the last vsetvl survives, and ending on an unsupported
-        # SEW leaves vill set.
+        # Clear vill with the config's smallest supported SEW and LMUL=1, a combination
+        # every part implements.
         lines.append("#if UDB_SEW_MIN == 8")
         lines.append(f"LI(x{rs2_reg}, 0x00)  # SEW=8, LMUL=1")
         lines.append("#elif UDB_SEW_MIN == 16")
         lines.append(f"LI(x{rs2_reg}, 0x08)  # SEW=16, LMUL=1")
         lines.append("#elif UDB_SEW_MIN == 32")
         lines.append(f"LI(x{rs2_reg}, 0x10)  # SEW=32, LMUL=1")
-        lines.append("#else")
+        lines.append("#elif UDB_SEW_MIN == 64")
         lines.append(f"LI(x{rs2_reg}, 0x18)  # SEW=64, LMUL=1")
+        lines.append("#else")
+        lines.append('#error "UDB_SEW_MIN unsupported, expected 8, 16, 32, or 64"')
         lines.append("#endif")
         lines.append(f"vsetvl x{temp_reg}, x{rs1_reg}, x{rs2_reg}  # clear vill")
         # Now vsetvl with rs2_vill_set + valid sew+lmul=1


### PR DESCRIPTION
Issue #2146 item 36.

_gen_vsetvl_rs2_vill emits one vsetvl per SEW ascending, with no read-back and no branch, so the
vtype entering the measured instruction is always the last attempt: SEW=64, LMUL=1. On an ELEN=32
part that combination is unsupported, so the final vsetvl sets vill instead of clearing it, and all
four cp_vsetvl_rs2_vill bins become unreachable.

Fix: emit a single vsetvl at UDB_SEW_MIN with LMUL=1, selected with #if, which is legal by
construction for any (SEW_MIN, ELEN) pair. Reversing the sweep to end on SEW=8 was the first thing I
tried, but it reintroduces the same bug on a SEW_MIN >= 16 part. The dropped preamble vsetvls lose
nothing; their rs2 values are covered exhaustively by _gen_sew_lmul_vsetvl.

This is latent today. Every vector-capable config in config/ declares ELEN 64 and SEW_MIN 8, so the
existing preamble happens to end on a legal SEW. There is no coverage delta to look for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMw4mDyFq6c1c2dTtfR7yF
