### PR TITLE
ExceptionsF: widen the misaligned-store readback to cover the widest store

### DIFF
--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsF.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsF.py
@@ -326,8 +326,7 @@ def add_fp_store_misaligned_test(
         f"addi x{addr_reg}, x{addr_reg}, {offset}",
         test_data.add_testcase(f"{op}_off{offset}", coverpoint, covergroup),
         f"{op} f{data_reg}, 0(x{addr_reg})",
-        # Read back scratch memory to verify store result. The window must cover the
-        # widest store at the highest offset: fsd (8 bytes) at offset 15 reaches byte 22.
+        # Read back scratch memory to verify store result
         f"LA(x{addr_reg}, scratch)",
     ]
     t_lines += [

--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsF.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsF.py
@@ -274,11 +274,6 @@ def add_csr_instructions(
     return t_lines
 
 
-# Bytes of scratch read back after a misaligned FP store: max offset (15) + widest store (fsd, 8),
-# rounded up to a word.
-_STORE_READBACK_BYTES = 24
-
-
 def add_fp_load_misaligned_test(
     op: str,
     offset: int,
@@ -331,7 +326,7 @@ def add_fp_store_misaligned_test(
     ]
     t_lines += [
         line
-        for word_off in range(0, _STORE_READBACK_BYTES, 4)
+        for word_off in range(0, 24, 4)
         for line in (
             f"lw x{check_reg}, {word_off}(x{addr_reg})",
             write_sigupd(check_reg, test_data),

--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsF.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsF.py
@@ -274,6 +274,11 @@ def add_csr_instructions(
     return t_lines
 
 
+# Bytes of scratch read back after a misaligned FP store: max offset (15) + widest store (fsd, 8),
+# rounded up to a word.
+_STORE_READBACK_BYTES = 24
+
+
 def add_fp_load_misaligned_test(
     op: str,
     offset: int,
@@ -321,16 +326,17 @@ def add_fp_store_misaligned_test(
         f"addi x{addr_reg}, x{addr_reg}, {offset}",
         test_data.add_testcase(f"{op}_off{offset}", coverpoint, covergroup),
         f"{op} f{data_reg}, 0(x{addr_reg})",
-        # Read back scratch memory to verify store result
+        # Read back scratch memory to verify store result. The window must cover the
+        # widest store at the highest offset: fsd (8 bytes) at offset 15 reaches byte 22.
         f"LA(x{addr_reg}, scratch)",
-        f"lw x{check_reg}, 0(x{addr_reg})",
-        write_sigupd(check_reg, test_data),
-        f"lw x{check_reg}, 4(x{addr_reg})",
-        write_sigupd(check_reg, test_data),
-        f"lw x{check_reg}, 8(x{addr_reg})",
-        write_sigupd(check_reg, test_data),
-        f"lw x{check_reg}, 12(x{addr_reg})",
-        write_sigupd(check_reg, test_data),
+    ]
+    t_lines += [
+        line
+        for word_off in range(0, _STORE_READBACK_BYTES, 4)
+        for line in (
+            f"lw x{check_reg}, {word_off}(x{addr_reg})",
+            write_sigupd(check_reg, test_data),
+        )
     ]
 
     test_data.int_regs.return_registers([addr_reg, check_reg])


### PR DESCRIPTION
Issue #2146 item 13.

add_fp_store_misaligned_test reads back bytes 0-15 after the store, but the sweep runs offsets 0-15
and the widest store is fsd at 8 bytes. So fsd at offset 15 writes bytes 15-22 and only byte 15 is
checked; every store at offset 9 or above is checked partially.

Fix: read back max offset plus widest store, rounded up to a word, i.e. 24 bytes.