### PR TITLE
ExceptionsZc: give float stores a source outside the readback window

### DIFF
--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsZc.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsZc.py
@@ -59,6 +59,16 @@ def _add_load_test(
     return t_lines
 
 
+# Bytes of scratch read back after each store, and primed before it.
+_READBACK_BYTES = 16
+# Offset into scratch of the value a float store sends. It must sit outside the window
+# read back below, or the offset-0 case stores the bytes it just read.
+_FLOAT_SRC_OFFSET = 32
+# Sentinel written across the readback window before each store; the low bits carry the
+# offset so consecutive testcases start from different memory.
+_PRIME_SENTINEL = 0x0C0DE000
+
+
 def _add_store_test(
     op: str,
     offset: int,
@@ -73,9 +83,21 @@ def _add_store_test(
     is_sp = op.endswith("sp")
     t_lines = []
 
-    # Initialize store register to a known value before setting up address
+    # Prime the readback window with a sentinel distinct from the value about to be
+    # stored, so every testcase starts from a known state. Without this, a store whose
+    # source happens to equal what a previous testcase left behind (the sp variants at
+    # offset 0) would be indistinguishable from no store at all.
+    t_lines.append(f"LA(x{addr_reg}, scratch)")
+    t_lines.append(f"LI(x{base_reg}, {_PRIME_SENTINEL | offset:#x})")
+    t_lines.extend(f"sw x{base_reg}, {word_off}(x{addr_reg})" for word_off in range(0, _READBACK_BYTES, 4))
+
+    # Initialize store register to a known value before setting up address. The float
+    # source must come from outside the readback window below: sourcing it from
+    # scratch+0 makes the offset-0 store write back the bytes it just read, so a DUT
+    # that performed no store at all would be indistinguishable from a correct one.
     if is_float:
         t_lines.append(f"LA(x{addr_reg}, scratch)")
+        t_lines.append(f"addi x{addr_reg}, x{addr_reg}, {_FLOAT_SRC_OFFSET}")
         if "fld" in op or "fsd" in op:
             t_lines.append(f"fld f{fp_reg}, 0(x{addr_reg})")
         else:
@@ -103,16 +125,11 @@ def _add_store_test(
         t_lines.append(test_data.add_testcase(f"{op.lower()}_off{offset}", coverpoint, covergroup))
         t_lines.append(f"{op} {reg_str}, 0(x{addr_reg})")
 
-    # Read 16 bytes from scratch as signature to verify the store result
+    # Read the primed window back as signature to verify the store result
     t_lines.append(f"LA(x{addr_reg}, scratch)")
-    t_lines.append(f"lw x{check_reg}, 0(x{addr_reg})")
-    t_lines.append(write_sigupd(check_reg, test_data))
-    t_lines.append(f"lw x{check_reg}, 4(x{addr_reg})")
-    t_lines.append(write_sigupd(check_reg, test_data))
-    t_lines.append(f"lw x{check_reg}, 8(x{addr_reg})")
-    t_lines.append(write_sigupd(check_reg, test_data))
-    t_lines.append(f"lw x{check_reg}, 12(x{addr_reg})")
-    t_lines.append(write_sigupd(check_reg, test_data))
+    for word_off in range(0, _READBACK_BYTES, 4):
+        t_lines.append(f"lw x{check_reg}, {word_off}(x{addr_reg})")
+        t_lines.append(write_sigupd(check_reg, test_data))
 
     test_data.int_regs.return_registers([addr_reg, base_reg, check_reg])
     test_data.float_regs.return_registers([fp_reg])

--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsZc.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsZc.py
@@ -83,18 +83,13 @@ def _add_store_test(
     is_sp = op.endswith("sp")
     t_lines = []
 
-    # Prime the readback window with a sentinel distinct from the value about to be
-    # stored, so every testcase starts from a known state. Without this, a store whose
-    # source happens to equal what a previous testcase left behind (the sp variants at
-    # offset 0) would be indistinguishable from no store at all.
+    # Prime the readback window so a store that never happened is distinguishable from a
+    # correct one, which it is not when the source matches what a previous testcase left.
     t_lines.append(f"LA(x{addr_reg}, scratch)")
     t_lines.append(f"LI(x{base_reg}, {_PRIME_SENTINEL | offset:#x})")
     t_lines.extend(f"sw x{base_reg}, {word_off}(x{addr_reg})" for word_off in range(0, _READBACK_BYTES, 4))
 
-    # Initialize store register to a known value before setting up address. The float
-    # source must come from outside the readback window below: sourcing it from
-    # scratch+0 makes the offset-0 store write back the bytes it just read, so a DUT
-    # that performed no store at all would be indistinguishable from a correct one.
+    # Initialize store register to a known value before setting up address
     if is_float:
         t_lines.append(f"LA(x{addr_reg}, scratch)")
         t_lines.append(f"addi x{addr_reg}, x{addr_reg}, {_FLOAT_SRC_OFFSET}")

--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsZc.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsZc.py
@@ -59,16 +59,6 @@ def _add_load_test(
     return t_lines
 
 
-# Bytes of scratch read back after each store, and primed before it.
-_READBACK_BYTES = 16
-# Offset into scratch of the value a float store sends. It must sit outside the window
-# read back below, or the offset-0 case stores the bytes it just read.
-_FLOAT_SRC_OFFSET = 32
-# Sentinel written across the readback window before each store; the low bits carry the
-# offset so consecutive testcases start from different memory.
-_PRIME_SENTINEL = 0x0C0DE000
-
-
 def _add_store_test(
     op: str,
     offset: int,
@@ -83,16 +73,22 @@ def _add_store_test(
     is_sp = op.endswith("sp")
     t_lines = []
 
-    # Prime the readback window so a store that never happened is distinguishable from a
-    # correct one, which it is not when the source matches what a previous testcase left.
-    t_lines.append(f"LA(x{addr_reg}, scratch)")
-    t_lines.append(f"LI(x{base_reg}, {_PRIME_SENTINEL | offset:#x})")
-    t_lines.extend(f"sw x{base_reg}, {word_off}(x{addr_reg})" for word_off in range(0, _READBACK_BYTES, 4))
+    # Initialize scratch before each store so a missing store changes the signature.
+    t_lines.extend(
+        (
+            f"LA(x{addr_reg}, scratch)",
+            f"LI(x{base_reg}, {0x0C0DE000 | offset:#x})",
+            f"sw x{base_reg}, 0(x{addr_reg})",
+            f"sw x{base_reg}, 4(x{addr_reg})",
+            f"sw x{base_reg}, 8(x{addr_reg})",
+            f"sw x{base_reg}, 12(x{addr_reg})",
+        )
+    )
 
-    # Initialize store register to a known value before setting up address
+    # Load the floating-point value from outside the bytes checked below.
     if is_float:
         t_lines.append(f"LA(x{addr_reg}, scratch)")
-        t_lines.append(f"addi x{addr_reg}, x{addr_reg}, {_FLOAT_SRC_OFFSET}")
+        t_lines.append(f"addi x{addr_reg}, x{addr_reg}, 32")
         if "fld" in op or "fsd" in op:
             t_lines.append(f"fld f{fp_reg}, 0(x{addr_reg})")
         else:
@@ -120,11 +116,16 @@ def _add_store_test(
         t_lines.append(test_data.add_testcase(f"{op.lower()}_off{offset}", coverpoint, covergroup))
         t_lines.append(f"{op} {reg_str}, 0(x{addr_reg})")
 
-    # Read the primed window back as signature to verify the store result
+    # Read scratch back as the signature to verify the store result
     t_lines.append(f"LA(x{addr_reg}, scratch)")
-    for word_off in range(0, _READBACK_BYTES, 4):
-        t_lines.append(f"lw x{check_reg}, {word_off}(x{addr_reg})")
-        t_lines.append(write_sigupd(check_reg, test_data))
+    t_lines.append(f"lw x{check_reg}, 0(x{addr_reg})")
+    t_lines.append(write_sigupd(check_reg, test_data))
+    t_lines.append(f"lw x{check_reg}, 4(x{addr_reg})")
+    t_lines.append(write_sigupd(check_reg, test_data))
+    t_lines.append(f"lw x{check_reg}, 8(x{addr_reg})")
+    t_lines.append(write_sigupd(check_reg, test_data))
+    t_lines.append(f"lw x{check_reg}, 12(x{addr_reg})")
+    t_lines.append(write_sigupd(check_reg, test_data))
 
     test_data.int_regs.return_registers([addr_reg, base_reg, check_reg])
     test_data.float_regs.return_registers([fp_reg])


### PR DESCRIPTION
Issue #2146 item 15.

_add_store_test primed the value a float store sends by loading it from the destination, so at
offset 0 the store is a bit-for-bit no-op and c.fsw_off0, c.fsd_off0, c.fswsp_off0 and c.fsdsp_off0
could not distinguish a correct store from no store at all. The integer path in the same function
already uses a distinct sentinel.

Two changes:

1. Load the float source from scratch+32, outside the 16-byte readback window.

2. Prime the readback window with a distinct sentinel before every store. Without this the fix is
   only half a fix: at offset 0 the sp variants run immediately after their non-sp twin, which has
   already written the source value into scratch[0..7].