### PR TITLE
ExceptionsF: make csrrs/csrrc frm actually set and clear a bit

### DIFF
--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsF.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsF.py
@@ -237,14 +237,14 @@ def add_csr_instructions(
         "",
         tsbi_call(f"csrc mstatus, x{clear_mask_reg}"),
         tsbi_call(f"csrs mstatus, x{set_mask_reg}"),
-        f"LI(x{check_reg}, -1)",
+        # frm is 0 here, from the csrw above, so this sets it to RMM
         test_data.add_testcase(f"csrrs_frm_{fs_val}_{coverpoint[2:]}", coverpoint, covergroup),
         f"csrrs x{check_reg}, frm, x{frm_reg}",
         gen_csr_read_sigupd(check_reg, ("frm", None), test_data),
         "",
         tsbi_call(f"csrc mstatus, x{clear_mask_reg}"),
         tsbi_call(f"csrs mstatus, x{set_mask_reg}"),
-        f"LI(x{check_reg}, 0)",
+        # and this clears it back to 0
         test_data.add_testcase(f"csrrc_frm_{fs_val}_{coverpoint[2:]}", coverpoint, covergroup),
         f"csrrc x{check_reg}, frm, x{frm_reg}",
         gen_csr_read_sigupd(check_reg, ("frm", None), test_data),
@@ -272,6 +272,10 @@ def add_csr_instructions(
 
     test_data.int_regs.return_register(check_reg)
     return t_lines
+
+
+# rs1 for the csrrs/csrrc frm read-modify-write cases: RMM (0b100), a legal rounding mode.
+_FRM_RMW_BIT = 0b100
 
 
 def add_fp_load_misaligned_test(
@@ -401,7 +405,10 @@ def _generate_mstatus_fs_legal_tests(test_data: TestData) -> list[str]:
     lines = [
         comment_banner(coverpoint, "Test that instructions execute correctly when mstatus.fs is set to 1 (Clean)\n"),
         f"LI(x{clear_mask_reg}, 0x6000) # MSTATUS_FS mask",
-        f"LI(x{frm_reg}, 0)",
+        # rs1 for the csrrs/csrrc frm cases below. It must be non-zero or those
+        # instructions set and clear nothing, and it must leave frm legal: frm values
+        # 5-7 are reserved, and a later FP op with dynamic rounding would then trap.
+        f"LI(x{frm_reg}, {_FRM_RMW_BIT}) # frm = RMM, a legal rounding mode",
     ]
 
     for i in range(1, 4):

--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsF.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsF.py
@@ -274,10 +274,6 @@ def add_csr_instructions(
     return t_lines
 
 
-# rs1 for the csrrs/csrrc frm read-modify-write cases: RMM (0b100), a legal rounding mode.
-_FRM_RMW_BIT = 0b100
-
-
 def add_fp_load_misaligned_test(
     op: str,
     offset: int,
@@ -405,10 +401,9 @@ def _generate_mstatus_fs_legal_tests(test_data: TestData) -> list[str]:
     lines = [
         comment_banner(coverpoint, "Test that instructions execute correctly when mstatus.fs is set to 1 (Clean)\n"),
         f"LI(x{clear_mask_reg}, 0x6000) # MSTATUS_FS mask",
-        # rs1 for the csrrs/csrrc frm cases below. It must be non-zero or those
-        # instructions set and clear nothing, and it must leave frm legal: frm values
-        # 5-7 are reserved, and a later FP op with dynamic rounding would then trap.
-        f"LI(x{frm_reg}, {_FRM_RMW_BIT}) # frm = RMM, a legal rounding mode",
+        # rs1 for the csrrs/csrrc frm cases below. Must be non-zero, or they set and clear
+        # nothing, and must leave frm legal: 5-7 are reserved rounding modes.
+        f"LI(x{frm_reg}, 0b100) # frm = RMM, a legal rounding mode",
     ]
 
     for i in range(1, 4):


### PR DESCRIPTION
Issue #2146 item 14.

add_csr_instructions runs csrrs and csrrc on frm with frm_reg, which is only ever loaded with 0, so
the set clears nothing and the clear sets nothing. frm stays 0 for the entire suite and the
read-modify-write path is untested at every mstatus.FS value. The tell is the two LI(x{check_reg},
...) lines above them, which are dead because check_reg is only the destination.

Copying the fcsr and fflags siblings is not the right fix: check_reg is loaded with -1, which would
write frm = 0b111, a reserved rounding mode. That is almost certainly why the original author routed
rs1 to a zero register, and it walks into the separate item 41. Instead frm_reg is loaded with RMM
(0b100) and the dead LIs dropped, so the sequence is frm = 0 | 4 = 4, read back as 4, then
frm = 4 & ~4 = 0, read back as 0. frm is never left in a reserved state.

Independent of #2277 and #2279, which touch the load and store helpers in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMw4mDyFq6c1c2dTtfR7yF
