### PR TITLE
Exceptions: document why the illegal-instruction word is 32 bits of zero

### DIFF
--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsCommon.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsCommon.py
@@ -167,6 +167,26 @@ def generate_ecall_tests(
 
 
 def generate_illegal_instruction_tests(test_data: TestData, covergroup: str) -> list[str]:
+    """Illegal-instruction traps from two reserved 32-bit encodings.
+
+    The all-zero word is deliberate, and so is the .p2align 2 in front of it. Both
+    encodings advance execution by exactly 4 bytes whether or not the DUT implements
+    Zca, which is what lets this generator serve every configuration:
+
+    - Without Zca the handler adds 4 unconditionally (IALIGN=32), so 0x00000000 traps
+      once and resumes at the next instruction.
+    - With Zca the handler re-fetches the halfword at xEPC and advances by its width
+      (rvtest_trap_handler.h, adj_epc_rtn). 0x0000 is a reserved illegal compressed
+      encoding, so the word traps twice, at A and again at A+2, and resumes at A+4.
+
+    The extra trap record is harmless: TRAP_SIGUPD_COUNT is a capacity bound checked
+    only for overflow, and the reference signature is regenerated per configuration, so
+    each DUT is compared against a reference with its own record count.
+
+    Do not "fix" this to the 2-byte .insn 0x00 that ExceptionsZc uses. That suite
+    requires Zca, so it always has IALIGN=16; here a 2-byte hole would leave every
+    following instruction at 2 mod 4 and fault on an IALIGN=32 machine.
+    """
     coverpoint = "cp_illegal_instruction"
 
     lines = [

--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsCommon.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsCommon.py
@@ -169,19 +169,12 @@ def generate_ecall_tests(
 def generate_illegal_instruction_tests(test_data: TestData, covergroup: str) -> list[str]:
     """Illegal-instruction traps from two reserved 32-bit encodings.
 
-    The all-zero word is deliberate, and so is the .p2align 2 in front of it. Both
-    encodings advance execution by exactly 4 bytes whether or not the DUT implements
-    Zca, which is what lets this generator serve every configuration:
-
-    - Without Zca the handler adds 4 unconditionally (IALIGN=32), so 0x00000000 traps
-      once and resumes at the next instruction.
-    - With Zca the handler re-fetches the halfword at xEPC and advances by its width
-      (rvtest_trap_handler.h, adj_epc_rtn). 0x0000 is a reserved illegal compressed
-      encoding, so the word traps twice, at A and again at A+2, and resumes at A+4.
-
-    The extra trap record is harmless: TRAP_SIGUPD_COUNT is a capacity bound checked
-    only for overflow, and the reference signature is regenerated per configuration, so
-    each DUT is compared against a reference with its own record count.
+    The all-zero word and its .p2align 2 are deliberate: both encodings advance execution
+    by exactly 4 bytes with or without Zca, which is what lets this generator serve every
+    configuration. Without Zca the handler adds 4 unconditionally (IALIGN=32) and the word
+    traps once; with Zca it advances by the width of the halfword at xEPC
+    (rvtest_trap_handler.h, adj_epc_rtn), so the reserved 0x0000 compressed encoding traps
+    twice, at A and again at A+2, before resuming at A+4.
 
     Do not "fix" this to the 2-byte .insn 0x00 that ExceptionsZc uses. That suite
     requires Zca, so it always has IALIGN=16; here a 2-byte hole would leave every

--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsS.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsS.py
@@ -77,6 +77,8 @@ def _generate_stvec_tests(test_data: TestData, mode_tag: str, priv_mode: int) ->
     elif priv_mode == 0:
         lines.append("RVTEST_TSBI_GOTO_UMODE")
 
+    # Both words advance execution by 4 with or without Zca; see
+    # generate_illegal_instruction_tests in ExceptionsCommon.py for why.
     for name, word in (("zeros", "0x00000000"), ("ones", "0xFFFFFFFF")):
         lines.extend(
             [

--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsSm.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsSm.py
@@ -85,7 +85,8 @@ def _generate_medeleg_msu_tests(test_data: TestData, mode_tag: str, priv_mode: i
             ]
         )
 
-        # Illegal instruction zeros
+        # Illegal instruction zeros. The all-zero word advances execution by 4 with or
+        # without Zca; see generate_illegal_instruction_tests in ExceptionsCommon.py.
         lines.extend(
             [
                 test_data.add_testcase(f"illegalinstr_zeros_{tag}", coverpoint, covergroup),


### PR DESCRIPTION
Issue #2146 item 46, which was filed as a bug. It is not one. Comments only, and the generated tests
are byte-identical.

generate_illegal_instruction_tests emits .p2align 2 followed by .word 0x00000000. The finding was
that on a Zca DUT this produces two illegal-instruction traps instead of one. That is the intended
behaviour, and the .p2align 2 in front of it is load-bearing.

The trap handler's xEPC advance is split on ZCA_SUPPORTED. Without Zca it takes li T2, 4 and never
re-fetches: one trap, resume at A+4. With Zca it re-fetches the low halfword at xEPC and advances 2
or 4 from bits[1:0]. 0x0000 is a reserved illegal compressed encoding, so it traps at A, resumes at
A+2 on the upper halfword which is also 0x0000, traps again, and resumes at A+4. Both land on the
same next instruction, with no misaligned fetch and no skipped instruction. Only the number of trap
records differs, 8 signature words with Zca against 4 without. That is safe because
TRAP_SIGUPD_COUNT is a capacity bound checked only for overflow, and the reference signature is
regenerated per configuration from the same ELF.

The obvious fix would be the 2-byte .insn 0x00 that ExceptionsZc.py uses. That is portable only
there, because ExceptionsZc always has IALIGN=16. In the mode-generic ExceptionsCommon.py a 2-byte
hole would leave every following instruction at 2 mod 4 and fault on an IALIGN=32 machine.

This PR writes that down as a docstring on the generator, plus a one-line cross-reference at the two
other sites that use the same idiom, so the next reader does not re-file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMw4mDyFq6c1c2dTtfR7yF
