### PR TITLE
SmV, SmVF: commit what each testcase actually produced

### DIFF
--- a/generators/testgen/src/testgen/priv/extensions/SmV.py
+++ b/generators/testgen/src/testgen/priv/extensions/SmV.py
@@ -8,7 +8,8 @@
 
 """SmV privileged test generator: vector CSRs and vtype/vl/vstart behavior in M-mode."""
 
-from testgen.asm.helpers import comment_banner
+from testgen.asm.csr import gen_csr_read_sigupd, gen_csr_write_sigupd
+from testgen.asm.helpers import comment_banner, write_sigupd
 from testgen.data.state import TestData
 from testgen.data.test_chunk import TestChunk
 from testgen.priv.registry import add_priv_test_generator
@@ -16,6 +17,19 @@ from testgen.priv.registry import add_priv_test_generator
 _CG = "SmV_cg"
 
 _VS_MASK = 3 << 9  # mstatus.VS = bits [10:9]
+
+
+def _check_vset(rd_reg: int, check_reg: int, test_data: TestData) -> list[str]:
+    """Commit what a vset* produced: the vl written to rd, and the resulting vtype.
+
+    Given the config's VLEN, ELEN and SEW_MIN the spec fully determines both, so they are
+    exact checks rather than WARL noise: an illegal request yields vill=1 with the rest of
+    vtype zero, and vl follows from the AVL and VLMAX.
+    """
+    return [
+        write_sigupd(rd_reg, test_data),
+        gen_csr_read_sigupd(check_reg, ("vtype", None), test_data),
+    ]
 
 
 def _set_vs(vs: int, temp_reg: int) -> list[str]:
@@ -43,20 +57,23 @@ def _gen_vcsrrswc(test_data: TestData, temp_reg: int) -> list[str]:
         ),
     ]
     lines.extend(_set_vs(vs=3, temp_reg=temp_reg))
-    save_reg = test_data.int_regs.get_register()
+    save_reg, check_reg = test_data.int_regs.get_registers(2)
     lines.append(f"LI(x{save_reg}, -1)  # all 1s mask for csr ops")
     for csr in _VECTOR_CSRS:
         for op_name, op in (("csrrs", "csrs"), ("csrrc", "csrc"), ("csrrw", "csrw")):
             lines.append(test_data.add_testcase(f"{csr}_{op_name}", coverpoint, _CG))
             lines.append(f"{op} {csr}, x{save_reg}  # {op_name} {csr}")
-    test_data.int_regs.return_registers([save_reg])
+            # Read the CSR under test back. vl, vtype and vlenb are read-only, so the
+            # write traps and this shows the CSR kept its value.
+            lines.append(gen_csr_read_sigupd(check_reg, (csr, None), test_data))
+    test_data.int_regs.return_registers([save_reg, check_reg])
     return lines
 
 
 def _gen_vcsrs_walking1s(test_data: TestData, temp_reg: int, test_chunks: list[TestChunk]) -> None:
     """cp_vcsrs_walking1s: csrrw with walking-1s rs1 against each writable vector CSR."""
     coverpoint = "cp_vcsrs_walking1s"
-    walk_reg, mask_reg = test_data.int_regs.get_registers(2)
+    walk_reg, mask_reg, check_reg = test_data.int_regs.get_registers(3)
     for idx, csr in enumerate(_VECTOR_CSRS_WR):
         tc = test_data.new_test_chunk(test_chunks, "vcsr")
         if idx == 0:
@@ -71,19 +88,22 @@ def _gen_vcsrs_walking1s(test_data: TestData, temp_reg: int, test_chunks: list[T
             tc.code.append(f"csrc {csr}, x{mask_reg}  # clear all bits")
             tc.code.append(test_data.add_testcase(f"{csr}_bit_{i}", coverpoint, _CG))
             tc.code.append(f"csrw {csr}, x{walk_reg}  # walking-1 bit {i}")
+            tc.code.append(gen_csr_read_sigupd(check_reg, (csr, None), test_data))
             tc.code.append(f"slli x{walk_reg}, x{walk_reg}, 1")
         tc.code.append("#if __riscv_xlen == 64")
         for i in range(32, 64):
             tc.code.append(f"csrc {csr}, x{mask_reg}  # clear all bits")
             tc.code.append(test_data.add_testcase(f"{csr}_bit_{i}", coverpoint, _CG))
             tc.code.append(f"csrw {csr}, x{walk_reg}  # walking-1 bit {i}")
+            tc.code.append(gen_csr_read_sigupd(check_reg, (csr, None), test_data))
             tc.code.append(f"slli x{walk_reg}, x{walk_reg}, 1")
         tc.code.append("#endif")
-    test_data.int_regs.return_registers([walk_reg, mask_reg])
+    test_data.int_regs.return_registers([walk_reg, mask_reg, check_reg])
 
 
 def _gen_mstatus_vs_dirty(test_data: TestData, temp_reg: int) -> list[str]:
     """cp_mstatus_vs_set_dirty_arithmetic / cp_mstatus_vs_set_dirty_csr."""
+    check_reg = test_data.int_regs.get_register()
     lines = [
         comment_banner(
             "cp_mstatus_vs_set_dirty_arithmetic",
@@ -97,7 +117,7 @@ def _gen_mstatus_vs_dirty(test_data: TestData, temp_reg: int) -> list[str]:
         lines.extend(_set_vs(vs=vs, temp_reg=temp_reg))
         lines.append(test_data.add_testcase(f"vadd_vs{vs}", "cp_mstatus_vs_set_dirty_arithmetic", _CG))
         lines.append("vadd.vv v3, v1, v2")
-        lines.append("nop")
+        lines.append(gen_csr_read_sigupd(check_reg, ("mstatus", None), test_data))
 
     lines.append(comment_banner("cp_mstatus_vs_set_dirty_csr", "VS=Initial/Clean -> vsetvli -> expect Dirty"))
     for vs in (1, 2):
@@ -105,7 +125,8 @@ def _gen_mstatus_vs_dirty(test_data: TestData, temp_reg: int) -> list[str]:
         lines.extend(_set_vs(vs=vs, temp_reg=temp_reg))
         lines.append(test_data.add_testcase(f"vsetvli_vs{vs}", "cp_mstatus_vs_set_dirty_csr", _CG))
         lines.append(f"vsetvli x{temp_reg}, x0, e16, m2, tu, mu")
-        lines.append("nop")
+        lines.append(gen_csr_read_sigupd(check_reg, ("mstatus", None), test_data))
+    test_data.int_regs.return_registers([check_reg])
     return lines
 
 
@@ -145,12 +166,19 @@ def _gen_misa_v(test_data: TestData, temp_reg: int) -> list[str]:
     lines = [
         comment_banner(coverpoint, "csrrs/csrrc misa with rs1[21]=1 to attempt to clear/set V"),
     ]
+    check_reg = test_data.int_regs.get_register()
     lines.append(f"LI(x{temp_reg}, 0x200000)  # misa.V")
     lines.append(test_data.add_testcase("misa_v_csrrc", coverpoint, _CG))
     lines.append(f"csrc misa, x{temp_reg}")
+    # No signature word here: misa's extension bits are WARL and whether V can be
+    # disabled is implementation-defined, so the value after the clear is not
+    # architecturally determined. Sail keeps V set; QEMU clears it. Both conform.
     lines.append(test_data.add_testcase("misa_v_csrrs", coverpoint, _CG))
     lines.append(f"csrs misa, x{temp_reg}")
-    lines.append("nop")
+    # After the set, V must read 1 on any machine that implements V, whether or not the
+    # clear above took effect. temp_reg already holds the bit-21 mask.
+    lines.append(gen_csr_read_sigupd(check_reg, ("misa", 0x200000), test_data, temp_reg))
+    test_data.int_regs.return_registers([check_reg])
     return lines
 
 
@@ -168,7 +196,7 @@ def _gen_sew_lmul_vsetvl(test_data: TestData, temp_reg: int) -> list[str]:
         comment_banner(coverpoint, "vsetvl over all (sew, lmul) pairs via rs2"),
     ]
     lines.extend(_set_vs(vs=3, temp_reg=temp_reg))
-    rs1_reg, rs2_reg = test_data.int_regs.get_registers(2)
+    rs1_reg, rs2_reg, check_reg = test_data.int_regs.get_registers(3)
     lines.append(f"LI(x{rs1_reg}, 1)  # vl = 1")
     for sew_name, sew_v in _SEW_VALUES:
         for lmul_name, lmul_v in _LMUL_VALUES:
@@ -176,7 +204,8 @@ def _gen_sew_lmul_vsetvl(test_data: TestData, temp_reg: int) -> list[str]:
             lines.append(f"LI(x{rs2_reg}, 0x{vtype:02x})  # SEW={sew_name}, LMUL={lmul_name}")
             lines.append(test_data.add_testcase(f"vsetvl_{sew_name}_{lmul_name}", coverpoint, _CG))
             lines.append(f"vsetvl x{temp_reg}, x{rs1_reg}, x{rs2_reg}")
-    test_data.int_regs.return_registers([rs1_reg, rs2_reg])
+            lines.extend(_check_vset(temp_reg, check_reg, test_data))
+    test_data.int_regs.return_registers([rs1_reg, rs2_reg, check_reg])
     return lines
 
 
@@ -187,15 +216,22 @@ def _gen_sew_lmul_vset_i_vli(test_data: TestData, temp_reg: int) -> list[str]:
         comment_banner(coverpoint, "vsetvli/vsetivli over all (sew, lmul) immediate combos"),
     ]
     lines.extend(_set_vs(vs=3, temp_reg=temp_reg))
-    rs1_reg = test_data.int_regs.get_register()
+    rs1_reg, check_reg = test_data.int_regs.get_registers(2)
     lines.append(f"LI(x{rs1_reg}, 1)  # vl = 1")
     for sew_name, _ in _SEW_VALUES:
         for lmul_name, _ in _LMUL_VALUES:
+            # The coverpoint reads SEW/LMUL from ins.prev.insn, so each testcase needs a
+            # vset with the same SEW/LMUL immediately before it. Use ta,ma and a different
+            # AVL so the testcase instruction still changes vtype and vl observably.
+            lines.append(f"vsetvli x{temp_reg}, x0, {sew_name}, {lmul_name}, ta, ma  # prime prev.insn")
             lines.append(test_data.add_testcase(f"vsetvli_{sew_name}_{lmul_name}", coverpoint, _CG))
             lines.append(f"vsetvli x{temp_reg}, x{rs1_reg}, {sew_name}, {lmul_name}, tu, mu")
+            lines.extend(_check_vset(temp_reg, check_reg, test_data))
+            lines.append(f"vsetivli x{temp_reg}, 0, {sew_name}, {lmul_name}, ta, ma  # prime prev.insn")
             lines.append(test_data.add_testcase(f"vsetivli_{sew_name}_{lmul_name}", coverpoint, _CG))
             lines.append(f"vsetivli x{temp_reg}, 1, {sew_name}, {lmul_name}, tu, mu")
-    test_data.int_regs.return_registers([rs1_reg])
+            lines.extend(_check_vset(temp_reg, check_reg, test_data))
+    test_data.int_regs.return_registers([rs1_reg, check_reg])
     return lines
 
 
@@ -206,7 +242,7 @@ def _gen_vill_vsetvl(test_data: TestData, temp_reg: int) -> list[str]:
         comment_banner(coverpoint, "vsetvl from vill=1 with each supported sew, lmul=8"),
     ]
     lines.extend(_set_vs(vs=3, temp_reg=temp_reg))
-    rs1_reg, rs2_reg = test_data.int_regs.get_registers(2)
+    rs1_reg, rs2_reg, check_reg = test_data.int_regs.get_registers(3)
     lines.append(f"LI(x{rs1_reg}, 1)")
     for sew_name, sew_v in _SEW_VALUES:
         # set vill via illegal vtype (SEW=64, LMUL=1/8 -> 0x1D)
@@ -217,7 +253,8 @@ def _gen_vill_vsetvl(test_data: TestData, temp_reg: int) -> list[str]:
         lines.append(f"LI(x{rs2_reg}, 0x{vtype:02x})  # SEW={sew_name}, LMUL=8")
         lines.append(test_data.add_testcase(f"vill_vsetvl_{sew_name}", coverpoint, _CG))
         lines.append(f"vsetvl x{temp_reg}, x{rs1_reg}, x{rs2_reg}")
-    test_data.int_regs.return_registers([rs1_reg, rs2_reg])
+        lines.extend(_check_vset(temp_reg, check_reg, test_data))
+    test_data.int_regs.return_registers([rs1_reg, rs2_reg, check_reg])
     return lines
 
 
@@ -228,7 +265,7 @@ def _gen_vill_vset_i_vli(test_data: TestData, temp_reg: int) -> list[str]:
         comment_banner(coverpoint, "vsetvli/vsetivli from vill=1 with each supported sew, lmul=8"),
     ]
     lines.extend(_set_vs(vs=3, temp_reg=temp_reg))
-    rs1_reg, rs2_reg = test_data.int_regs.get_registers(2)
+    rs1_reg, rs2_reg, check_reg = test_data.int_regs.get_registers(3)
     lines.append(f"LI(x{rs1_reg}, 1)")
     for sew_name, _ in _SEW_VALUES:
         # set vill
@@ -236,12 +273,14 @@ def _gen_vill_vset_i_vli(test_data: TestData, temp_reg: int) -> list[str]:
         lines.append(f"vsetvl x{temp_reg}, x{rs1_reg}, x{rs2_reg}")
         lines.append(test_data.add_testcase(f"vill_vsetvli_{sew_name}", coverpoint, _CG))
         lines.append(f"vsetvli x{temp_reg}, x{rs1_reg}, {sew_name}, m8, tu, mu")
+        lines.extend(_check_vset(temp_reg, check_reg, test_data))
         # set vill again
         lines.append(f"LI(x{rs2_reg}, 0x1D)")
         lines.append(f"vsetvl x{temp_reg}, x{rs1_reg}, x{rs2_reg}")
         lines.append(test_data.add_testcase(f"vill_vsetivli_{sew_name}", coverpoint, _CG))
         lines.append(f"vsetivli x{temp_reg}, 1, {sew_name}, m8, tu, mu")
-    test_data.int_regs.return_registers([rs1_reg, rs2_reg])
+        lines.extend(_check_vset(temp_reg, check_reg, test_data))
+    test_data.int_regs.return_registers([rs1_reg, rs2_reg, check_reg])
     return lines
 
 
@@ -252,7 +291,7 @@ def _gen_vill_vsetvl_rs2_vill(test_data: TestData, temp_reg: int) -> list[str]:
         comment_banner(coverpoint, "vsetvl with rs2[XLEN-1]=1 + valid lower bits, starting from vill=1"),
     ]
     lines.extend(_set_vs(vs=3, temp_reg=temp_reg))
-    rs1_reg, rs2_reg, msb_reg = test_data.int_regs.get_registers(3)
+    rs1_reg, rs2_reg, msb_reg, check_reg = test_data.int_regs.get_registers(4)
     lines.append(f"LI(x{rs1_reg}, 1)")
     lines.append("#if __riscv_xlen == 32")
     lines.append(f"LI(x{msb_reg}, 0x80000000)")
@@ -269,7 +308,8 @@ def _gen_vill_vsetvl_rs2_vill(test_data: TestData, temp_reg: int) -> list[str]:
         lines.append(f"or x{rs2_reg}, x{rs2_reg}, x{msb_reg}  # set MSB")
         lines.append(test_data.add_testcase(f"vill_rs2_vill_{sew_name}", coverpoint, _CG))
         lines.append(f"vsetvl x{temp_reg}, x{rs1_reg}, x{rs2_reg}")
-    test_data.int_regs.return_registers([rs1_reg, rs2_reg, msb_reg])
+        lines.extend(_check_vset(temp_reg, check_reg, test_data))
+    test_data.int_regs.return_registers([rs1_reg, rs2_reg, msb_reg, check_reg])
     return lines
 
 
@@ -280,7 +320,7 @@ def _gen_vsetvl_rs2_vill(test_data: TestData, temp_reg: int) -> list[str]:
         comment_banner(coverpoint, "vsetvl with rs2 vill bit set + valid (sew, lmul=1), starting from vill=0"),
     ]
     lines.extend(_set_vs(vs=3, temp_reg=temp_reg))
-    rs1_reg, rs2_reg, msb_reg = test_data.int_regs.get_registers(3)
+    rs1_reg, rs2_reg, msb_reg, check_reg = test_data.int_regs.get_registers(4)
     lines.append(f"LI(x{rs1_reg}, 1)")
     lines.append("#if __riscv_xlen == 32")
     lines.append(f"LI(x{msb_reg}, 0x80000000)")
@@ -299,7 +339,8 @@ def _gen_vsetvl_rs2_vill(test_data: TestData, temp_reg: int) -> list[str]:
         lines.append(f"or x{rs2_reg}, x{rs2_reg}, x{msb_reg}  # set MSB (vill bit in rs2)")
         lines.append(test_data.add_testcase(f"rs2_vill_{sew_name}", coverpoint, _CG))
         lines.append(f"vsetvl x{temp_reg}, x{rs1_reg}, x{rs2_reg}")
-    test_data.int_regs.return_registers([rs1_reg, rs2_reg, msb_reg])
+        lines.extend(_check_vset(temp_reg, check_reg, test_data))
+    test_data.int_regs.return_registers([rs1_reg, rs2_reg, msb_reg, check_reg])
     return lines
 
 
@@ -310,7 +351,7 @@ def _gen_vtype_vill_set_vl_0(test_data: TestData, temp_reg: int) -> list[str]:
         comment_banner(coverpoint, "vsetvl with rs2 vill bit set (rs1!=0 nonzero AVL); expect vl=0"),
     ]
     lines.extend(_set_vs(vs=3, temp_reg=temp_reg))
-    rs1_reg, rs2_reg = test_data.int_regs.get_registers(2)
+    rs1_reg, rs2_reg, check_reg = test_data.int_regs.get_registers(3)
     lines.append(f"LI(x{rs1_reg}, 1)  # nonzero AVL")
     lines.append("#if __riscv_xlen == 32")
     lines.append(f"LI(x{rs2_reg}, 0x80000000)")
@@ -319,7 +360,8 @@ def _gen_vtype_vill_set_vl_0(test_data: TestData, temp_reg: int) -> list[str]:
     lines.append("#endif")
     lines.append(test_data.add_testcase("vill_set_vl_0", coverpoint, _CG))
     lines.append(f"vsetvl x{temp_reg}, x{rs1_reg}, x{rs2_reg}  # rs2 vill set -> vl=0")
-    test_data.int_regs.return_registers([rs1_reg, rs2_reg])
+    lines.extend(_check_vset(temp_reg, check_reg, test_data))  # the promised vl=0 check
+    test_data.int_regs.return_registers([rs1_reg, rs2_reg, check_reg])
     return lines
 
 
@@ -331,7 +373,7 @@ def _gen_vsetvl_i_rd_rs1(test_data: TestData, temp_reg: int) -> list[str]:
         comment_banner(cp1, "vsetvli/vsetvl with rs1=x0, rd!=x0 over all (sew, lmul) combos"),
     ]
     lines.extend(_set_vs(vs=3, temp_reg=temp_reg))
-    rs2_reg = test_data.int_regs.get_register()
+    rs2_reg, check_reg = test_data.int_regs.get_registers(2)
     # First, ensure vl != vlmax for the new config: load a small vl, then run with rs1=x0 to set vl=vlmax
     for sew_name, sew_v in _SEW_VALUES:
         for lmul_name, lmul_v in _LMUL_VALUES:
@@ -340,6 +382,7 @@ def _gen_vsetvl_i_rd_rs1(test_data: TestData, temp_reg: int) -> list[str]:
             # vsetvli with rs1=x0, rd!=x0 -> vl=vlmax
             lines.append(test_data.add_testcase(f"vsetvli_rdnx0_{sew_name}_{lmul_name}", cp1, _CG))
             lines.append(f"vsetvli x{temp_reg}, x0, {sew_name}, {lmul_name}, tu, mu")
+            lines.extend(_check_vset(temp_reg, check_reg, test_data))
             # Reset vl != vlmax again
             lines.append(f"vsetivli x{temp_reg}, 1, {sew_name}, {lmul_name}, tu, mu")
             # vsetvl with rs1=x0, rd!=x0
@@ -347,19 +390,25 @@ def _gen_vsetvl_i_rd_rs1(test_data: TestData, temp_reg: int) -> list[str]:
             lines.append(f"LI(x{rs2_reg}, 0x{vtype:02x})")
             lines.append(test_data.add_testcase(f"vsetvl_rdnx0_{sew_name}_{lmul_name}", cp1, _CG))
             lines.append(f"vsetvl x{temp_reg}, x0, x{rs2_reg}")
+            lines.extend(_check_vset(temp_reg, check_reg, test_data))
 
     lines.append(comment_banner(cp2, "vsetvli/vsetvl with rs1=x0, rd=x0 -> keep vl unchanged when vlmax matches"))
     # Set vl != 0 via vsetivli, then run rd=x0/rs1=x0 with same SEW/LMUL ratio
     lines.append(f"vsetivli x{temp_reg}, 1, e8, m1, tu, mu  # vl=1")
     lines.append(test_data.add_testcase("vsetvli_rdx0", cp2, _CG))
     lines.append("vsetvli x0, x0, e8, m1, tu, mu  # rd=x0/rs1=x0; vlmax matches")
+    # rd is x0, so read vl from the CSR instead of committing the destination register
+    lines.append(gen_csr_read_sigupd(check_reg, ("vl", None), test_data))
+    lines.append(gen_csr_read_sigupd(check_reg, ("vtype", None), test_data))
     # Same with vsetvl. Use rs2=x0 so insn[25:20]=000000 (SEW=8/LMUL=1),
     # which is what vset_i_vli_vlmax_unchanged compares against (it reads
     # SEW/LMUL from insn[25:20], not rs2_val).
     lines.append(f"vsetivli x{temp_reg}, 1, e8, m1, tu, mu  # vl=1")
     lines.append(test_data.add_testcase("vsetvl_rdx0", cp2, _CG))
     lines.append("vsetvl x0, x0, x0  # rs2=x0 makes insn-encoded SEW/LMUL = e8/m1")
-    test_data.int_regs.return_registers([rs2_reg])
+    lines.append(gen_csr_read_sigupd(check_reg, ("vl", None), test_data))
+    lines.append(gen_csr_read_sigupd(check_reg, ("vtype", None), test_data))
+    test_data.int_regs.return_registers([rs2_reg, check_reg])
     return lines
 
 
@@ -367,7 +416,7 @@ def _gen_avl_corners(test_data: TestData, temp_reg: int) -> list[str]:
     """cp_vsetvl_i_avl_eq_zero / eq_vlmax / lt_2x_vlmax / eq_2x_vlmax / gt_2x_vlmax."""
     lines = [comment_banner("cp_vsetvl_i_avl_*", "AVL corner cases for vsetvli and vsetvl")]
     lines.extend(_set_vs(vs=3, temp_reg=temp_reg))
-    rs1_reg, rs2_reg = test_data.int_regs.get_registers(2)
+    rs1_reg, rs2_reg, check_reg = test_data.int_regs.get_registers(3)
 
     # AVL = 0
     cp = "cp_vsetvl_i_avl_eq_zero"
@@ -375,9 +424,11 @@ def _gen_avl_corners(test_data: TestData, temp_reg: int) -> list[str]:
     lines.append(f"LI(x{rs1_reg}, 0)")
     lines.append(test_data.add_testcase("vsetvli_avl0", cp, _CG))
     lines.append(f"vsetvli x{temp_reg}, x{rs1_reg}, e8, m1, tu, mu")
+    lines.extend(_check_vset(temp_reg, check_reg, test_data))
     lines.append(f"LI(x{rs2_reg}, 0x00)")
     lines.append(test_data.add_testcase("vsetvl_avl0", cp, _CG))
     lines.append(f"vsetvl x{temp_reg}, x{rs1_reg}, x{rs2_reg}")
+    lines.extend(_check_vset(temp_reg, check_reg, test_data))
 
     # AVL = VLMAX (sew=8, lmul=1: VLMAX = VLEN/8)
     cp = "cp_vsetvl_i_avl_eq_vlmax"
@@ -385,10 +436,12 @@ def _gen_avl_corners(test_data: TestData, temp_reg: int) -> list[str]:
     lines.append(f"vsetvli x{rs1_reg}, x0, e8, m1, tu, mu  # rs1 = VLMAX")
     lines.append(test_data.add_testcase("vsetvli_avl_eq", cp, _CG))
     lines.append(f"vsetvli x{temp_reg}, x{rs1_reg}, e8, m1, tu, mu")
+    lines.extend(_check_vset(temp_reg, check_reg, test_data))
     lines.append(f"vsetvli x{rs1_reg}, x0, e8, m1, tu, mu  # reload VLMAX")
     lines.append(f"LI(x{rs2_reg}, 0x00)")
     lines.append(test_data.add_testcase("vsetvl_avl_eq", cp, _CG))
     lines.append(f"vsetvl x{temp_reg}, x{rs1_reg}, x{rs2_reg}")
+    lines.extend(_check_vset(temp_reg, check_reg, test_data))
 
     # AVL between VLMAX and 2*VLMAX (use sew=8, lmul=2 to ensure VLMAX>=2)
     cp = "cp_vsetvl_i_avl_lt_2x_vlmax"
@@ -397,11 +450,13 @@ def _gen_avl_corners(test_data: TestData, temp_reg: int) -> list[str]:
     lines.append(f"addi x{rs1_reg}, x{rs1_reg}, 1  # VLMAX+1 (between VLMAX and 2*VLMAX)")
     lines.append(test_data.add_testcase("vsetvli_avl_lt2x", cp, _CG))
     lines.append(f"vsetvli x{temp_reg}, x{rs1_reg}, e8, m2, tu, mu")
+    lines.extend(_check_vset(temp_reg, check_reg, test_data))
     lines.append(f"vsetvli x{rs1_reg}, x0, e8, m2, tu, mu")
     lines.append(f"addi x{rs1_reg}, x{rs1_reg}, 1")
     lines.append(f"LI(x{rs2_reg}, 0x01)  # SEW=8, LMUL=2")
     lines.append(test_data.add_testcase("vsetvl_avl_lt2x", cp, _CG))
     lines.append(f"vsetvl x{temp_reg}, x{rs1_reg}, x{rs2_reg}")
+    lines.extend(_check_vset(temp_reg, check_reg, test_data))
 
     # AVL = 2 * VLMAX
     cp = "cp_vsetvl_i_avl_eq_2x_vlmax"
@@ -410,11 +465,13 @@ def _gen_avl_corners(test_data: TestData, temp_reg: int) -> list[str]:
     lines.append(f"slli x{rs1_reg}, x{rs1_reg}, 1  # 2*VLMAX")
     lines.append(test_data.add_testcase("vsetvli_avl_eq2x", cp, _CG))
     lines.append(f"vsetvli x{temp_reg}, x{rs1_reg}, e8, m2, tu, mu")
+    lines.extend(_check_vset(temp_reg, check_reg, test_data))
     lines.append(f"vsetvli x{rs1_reg}, x0, e8, m2, tu, mu")
     lines.append(f"slli x{rs1_reg}, x{rs1_reg}, 1")
     lines.append(f"LI(x{rs2_reg}, 0x01)")
     lines.append(test_data.add_testcase("vsetvl_avl_eq2x", cp, _CG))
     lines.append(f"vsetvl x{temp_reg}, x{rs1_reg}, x{rs2_reg}")
+    lines.extend(_check_vset(temp_reg, check_reg, test_data))
 
     # AVL > 2 * VLMAX
     cp = "cp_vsetvl_i_avl_gt_2x_vlmax"
@@ -424,14 +481,16 @@ def _gen_avl_corners(test_data: TestData, temp_reg: int) -> list[str]:
     lines.append(f"addi x{rs1_reg}, x{rs1_reg}, 1  # 2*VLMAX+1")
     lines.append(test_data.add_testcase("vsetvli_avl_gt2x", cp, _CG))
     lines.append(f"vsetvli x{temp_reg}, x{rs1_reg}, e8, m2, tu, mu")
+    lines.extend(_check_vset(temp_reg, check_reg, test_data))
     lines.append(f"vsetvli x{rs1_reg}, x0, e8, m2, tu, mu")
     lines.append(f"slli x{rs1_reg}, x{rs1_reg}, 1")
     lines.append(f"addi x{rs1_reg}, x{rs1_reg}, 1")
     lines.append(f"LI(x{rs2_reg}, 0x01)")
     lines.append(test_data.add_testcase("vsetvl_avl_gt2x", cp, _CG))
     lines.append(f"vsetvl x{temp_reg}, x{rs1_reg}, x{rs2_reg}")
+    lines.extend(_check_vset(temp_reg, check_reg, test_data))
 
-    test_data.int_regs.return_registers([rs1_reg, rs2_reg])
+    test_data.int_regs.return_registers([rs1_reg, rs2_reg, check_reg])
     return lines
 
 
@@ -440,16 +499,20 @@ def _gen_vsetivli_avl_edges(test_data: TestData, temp_reg: int) -> list[str]:
     coverpoint = "cp_vsetivli_avl_edges"
     lines = [comment_banner(coverpoint, "vsetivli imm5 across [0..31] for each supported sew, lmul=1")]
     lines.extend(_set_vs(vs=3, temp_reg=temp_reg))
+    check_reg = test_data.int_regs.get_register()
     for sew_name, _ in _SEW_VALUES:
         for imm in range(32):
             lines.append(test_data.add_testcase(f"vsetivli_imm{imm}_{sew_name}", coverpoint, _CG))
             lines.append(f"vsetivli x{temp_reg}, {imm}, {sew_name}, m1, tu, mu")
+            lines.extend(_check_vset(temp_reg, check_reg, test_data))
     # Cross bin <vsetivli, sixtyfour, auto[0], one> requires BEFORE vtype = (e64, m1)
     # with imm=0. The loop above never produces this because imm=0 is always the first
     # iteration of each sew block (so BEFORE vtype.SEW reflects the prior sew).
     # Run one more vsetivli imm=0,e64,m1 after the e64 block has set vtype=(e64,m1).
     lines.append(test_data.add_testcase("vsetivli_imm0_e64_after", coverpoint, _CG))
     lines.append(f"vsetivli x{temp_reg}, 0, e64, m1, tu, mu")
+    lines.extend(_check_vset(temp_reg, check_reg, test_data))
+    test_data.int_regs.return_registers([check_reg])
     return lines
 
 
@@ -461,7 +524,9 @@ def _gen_vstart_oob(test_data: TestData, temp_reg: int) -> list[str]:
     rs1_reg = test_data.int_regs.get_register()
     lines.append(f"LI(x{rs1_reg}, 0x10000)  # 2^16")
     lines.append(test_data.add_testcase("vstart_oob", coverpoint, _CG))
-    lines.append(f"csrw vstart, x{rs1_reg}")
+    # vstart has only enough writable bits to hold the largest element index, so the
+    # read-back value is determined by the config's VLEN and SEW_MIN.
+    lines.append(gen_csr_write_sigupd(rs1_reg, "vstart", test_data))
     test_data.int_regs.return_registers([rs1_reg])
     return lines
 
@@ -469,7 +534,7 @@ def _gen_vstart_oob(test_data: TestData, temp_reg: int) -> list[str]:
 def _gen_vl_walking1s_sew_lmul(test_data: TestData, temp_reg: int, test_chunks: list[TestChunk]) -> None:
     """cp_vl_walking1s_sew_lmul: csrrw vl walking-1s after vsetivli for each (sew, lmul)."""
     coverpoint = "cp_vl_walking1s_sew_lmul"
-    walk_reg = test_data.int_regs.get_register()
+    walk_reg, check_reg = test_data.int_regs.get_registers(2)
     first = True
     for sew_name, _ in _SEW_VALUES:
         for lmul_name, _ in _LMUL_VALUES:
@@ -488,15 +553,19 @@ def _gen_vl_walking1s_sew_lmul(test_data: TestData, temp_reg: int, test_chunks: 
                 tc.code.append(f"vsetivli x{temp_reg}, 1, {sew_name}, {lmul_name}, tu, mu")
                 tc.code.append(test_data.add_testcase(f"vl_walk_{sew_name}_{lmul_name}_b{i}", coverpoint, _CG))
                 tc.code.append(f"csrw vl, x{walk_reg}  # bit {i}")
+                # vl is read-only, so the write traps; this shows vl still holds what the
+                # vsetivli above set.
+                tc.code.append(gen_csr_read_sigupd(check_reg, ("vl", None), test_data))
                 tc.code.append(f"slli x{walk_reg}, x{walk_reg}, 1")
             tc.code.append("#if __riscv_xlen == 64")
             for i in range(32, 64):
                 tc.code.append(f"vsetivli x{temp_reg}, 1, {sew_name}, {lmul_name}, tu, mu")
                 tc.code.append(test_data.add_testcase(f"vl_walk_{sew_name}_{lmul_name}_b{i}", coverpoint, _CG))
                 tc.code.append(f"csrw vl, x{walk_reg}  # bit {i}")
+                tc.code.append(gen_csr_read_sigupd(check_reg, ("vl", None), test_data))
                 tc.code.append(f"slli x{walk_reg}, x{walk_reg}, 1")
             tc.code.append("#endif")
-    test_data.int_regs.return_register(walk_reg)
+    test_data.int_regs.return_registers([walk_reg, check_reg])
 
 
 @add_priv_test_generator(

--- a/generators/testgen/src/testgen/priv/extensions/SmV.py
+++ b/generators/testgen/src/testgen/priv/extensions/SmV.py
@@ -22,9 +22,8 @@ _VS_MASK = 3 << 9  # mstatus.VS = bits [10:9]
 def _check_vset(rd_reg: int, check_reg: int, test_data: TestData) -> list[str]:
     """Commit what a vset* produced: the vl written to rd, and the resulting vtype.
 
-    Given the config's VLEN, ELEN and SEW_MIN the spec fully determines both, so they are
-    exact checks rather than WARL noise: an illegal request yields vill=1 with the rest of
-    vtype zero, and vl follows from the AVL and VLMAX.
+    The config's VLEN, ELEN and SEW_MIN fully determine both, so these are exact checks
+    rather than WARL noise.
     """
     return [
         write_sigupd(rd_reg, test_data),
@@ -170,9 +169,8 @@ def _gen_misa_v(test_data: TestData, temp_reg: int) -> list[str]:
     lines.append(f"LI(x{temp_reg}, 0x200000)  # misa.V")
     lines.append(test_data.add_testcase("misa_v_csrrc", coverpoint, _CG))
     lines.append(f"csrc misa, x{temp_reg}")
-    # No signature word here: misa's extension bits are WARL and whether V can be
-    # disabled is implementation-defined, so the value after the clear is not
-    # architecturally determined. Sail keeps V set; QEMU clears it. Both conform.
+    # No signature word here: whether misa.V can be cleared is implementation-defined
+    # (Sail keeps V set, QEMU clears it), so the value after the clear is not determined.
     lines.append(test_data.add_testcase("misa_v_csrrs", coverpoint, _CG))
     lines.append(f"csrs misa, x{temp_reg}")
     # After the set, V must read 1 on any machine that implements V, whether or not the
@@ -220,9 +218,8 @@ def _gen_sew_lmul_vset_i_vli(test_data: TestData, temp_reg: int) -> list[str]:
     lines.append(f"LI(x{rs1_reg}, 1)  # vl = 1")
     for sew_name, _ in _SEW_VALUES:
         for lmul_name, _ in _LMUL_VALUES:
-            # The coverpoint reads SEW/LMUL from ins.prev.insn, so each testcase needs a
-            # vset with the same SEW/LMUL immediately before it. Use ta,ma and a different
-            # AVL so the testcase instruction still changes vtype and vl observably.
+            # The coverpoint reads SEW/LMUL from ins.prev.insn, so prime it with a matching
+            # vset; ta,ma and a different AVL keep the testcase's own effect observable.
             lines.append(f"vsetvli x{temp_reg}, x0, {sew_name}, {lmul_name}, ta, ma  # prime prev.insn")
             lines.append(test_data.add_testcase(f"vsetvli_{sew_name}_{lmul_name}", coverpoint, _CG))
             lines.append(f"vsetvli x{temp_reg}, x{rs1_reg}, {sew_name}, {lmul_name}, tu, mu")

--- a/generators/testgen/src/testgen/priv/extensions/SmVF.py
+++ b/generators/testgen/src/testgen/priv/extensions/SmVF.py
@@ -8,7 +8,8 @@
 
 """SmVF privileged test generator: vector-FP × mstatus.FS state."""
 
-from testgen.asm.helpers import comment_banner
+from testgen.asm.csr import gen_csr_read_sigupd
+from testgen.asm.helpers import comment_banner, write_sigupd
 from testgen.data.state import TestData
 from testgen.data.test_chunk import TestChunk
 from testgen.priv.registry import add_priv_test_generator
@@ -60,7 +61,7 @@ def _gen_fs_state_affecting_register(test_data: TestData, temp_reg: int) -> list
         lines.extend(_set_fs_vs(fs=fs, vs=3, temp_reg=temp_reg))
         lines.append(test_data.add_testcase(f"vfmv_f_s_fs{fs}", coverpoint, _CG))
         lines.append("vfmv.f.s f1, v2")
-        lines.append("nop")
+        lines.append(gen_csr_read_sigupd(temp_reg, ("mstatus", None), test_data))
     return lines
 
 
@@ -81,7 +82,9 @@ def _gen_fs_state_affecting_csr(test_data: TestData, temp_reg: int) -> list[str]
             lines.extend(_set_fs_vs(fs=fs, vs=3, temp_reg=temp_reg))
             lines.append(test_data.add_testcase(f"vfdiv_vv_fs{fs}_t{trial}", coverpoint, _CG))
             lines.append("vfdiv.vv v3, v1, v2  # 1.0/0.0 -> +inf, DZ flag")
-            lines.append("nop")
+            # mstatus first: reading fflags may itself dirty FS on a conservative DUT
+            lines.append(gen_csr_read_sigupd(temp_reg, ("mstatus", None), test_data))
+            lines.append(write_sigupd(None, test_data, "fflags"))
     # Also exercise an exception with vfadd inf-inf and vfmul 0*inf
     for fs in (1, 2):
         lines.extend(_set_fs_vs(fs=3, vs=3, temp_reg=temp_reg))
@@ -96,7 +99,8 @@ def _gen_fs_state_affecting_csr(test_data: TestData, temp_reg: int) -> list[str]
         lines.extend(_set_fs_vs(fs=fs, vs=3, temp_reg=temp_reg))
         lines.append(test_data.add_testcase(f"vfadd_inf_minf_fs{fs}", coverpoint, _CG))
         lines.append("vfadd.vv v3, v6, v7  # inf + -inf -> NV flag")
-        lines.append("nop")
+        lines.append(gen_csr_read_sigupd(temp_reg, ("mstatus", None), test_data))
+        lines.append(write_sigupd(None, test_data, "fflags"))
     return lines
 
 
@@ -119,11 +123,16 @@ def _gen_fs_state_nonaffecting(test_data: TestData, temp_reg: int) -> list[str]:
             lines.extend(_set_fs_vs(fs=3, vs=3, temp_reg=temp_reg))
             lines.extend(_vector_setup(temp_reg))
             lines.extend(_load_v_zero_one(temp_reg))
+            lines.append("csrwi fcsr, 0  # clear fcsr under FS=Dirty, as the sibling generator does")
             lines.extend(_set_fs_vs(fs=fs, vs=3, temp_reg=temp_reg))
             lines.append(test_data.add_testcase(f"vfadd_{name}_fs{fs}", coverpoint, _CG))
             # vfadd.vv vd, vs2, vs1  — operand order: result = vs2 + vs1
             lines.append(f"vfadd.vv v3, {vs2_reg}, {vs1_reg}")
-            lines.append("nop")
+            # All four operand patterns are exact, so no flag may be raised. That is the
+            # evidence no FP state moved. mstatus.FS is deliberately not committed: an
+            # instruction that does not deterministically update FP state may legally
+            # leave FS alone or dirty it, which is why SmF.py skips those cases too.
+            lines.append(write_sigupd(None, test_data, "fflags"))
     return lines
 
 

--- a/generators/testgen/src/testgen/priv/extensions/SmVF.py
+++ b/generators/testgen/src/testgen/priv/extensions/SmVF.py
@@ -128,10 +128,8 @@ def _gen_fs_state_nonaffecting(test_data: TestData, temp_reg: int) -> list[str]:
             lines.append(test_data.add_testcase(f"vfadd_{name}_fs{fs}", coverpoint, _CG))
             # vfadd.vv vd, vs2, vs1  — operand order: result = vs2 + vs1
             lines.append(f"vfadd.vv v3, {vs2_reg}, {vs1_reg}")
-            # All four operand patterns are exact, so no flag may be raised. That is the
-            # evidence no FP state moved. mstatus.FS is deliberately not committed: an
-            # instruction that does not deterministically update FP state may legally
-            # leave FS alone or dirty it, which is why SmF.py skips those cases too.
+            # All four patterns are exact, so no flag may be raised: that is the evidence
+            # no FP state moved. FS is not committed; it may legally stay or go dirty.
             lines.append(write_sigupd(None, test_data, "fflags"))
     return lines
 


### PR DESCRIPTION
Issue #2146 item 6.

Neither generator imported a signature helper. Every test emitted a label, the instruction under
test and sometimes a nop, and nothing was ever read back, so all seven generated files carried
SIGUPD_COUNT 10, the bare margin. Docstrings promised checks the code never performed: "expect
Dirty", "expect vl=0", walking 1s into CSRs that were never read.

Each instruction now commits the state it was supposed to change: mstatus after the VS-transition
cases, the CSR itself after each walking-1s write, rd and vtype after every vsetvl, vsetvli and
vsetivli including the rs2-vill "expect vl=0" case, vstart after csrw vstart, vl after the vl walk,
and mstatus then fflags for the FP cases.

Three things the reference model forced:

1. cp_sew_lmul_vset_i_vli bins SEW and LMUL from ins.prev.insn. A signature write between the
   back-to-back vsetvli and vsetivli would make prev the signature macro's trailing addi and
   collapse that cross from 28 bins to 1. Each testcase now gets a priming vset with the same SEW
   and LMUL, using ta,ma and a different AVL so the testcase instruction still changes vtype and vl
   observably. The cross stays at 100%.

2. misa is not committed after csrc misa. Whether V can be disabled is implementation-defined: Sail
   keeps the bit set, QEMU clears it, and both conform. I tried committing it and QEMU failed, which
   is the item 42 failure mode. Only the value after csrs is checked, masked to bit 21.

3. The FS-nonaffecting case commits fflags, not mstatus.FS. An instruction that does not
   deterministically update FP state may legally leave FS alone or dirty it, and SmF skips exactly
   those cases. Committing fflags == 0 is the spec-exact evidence that no FP state moved.

The VS-off and FS-off cases deliberately get no readback: they trap, already leave a trap record,
and a vector-CSR access there would trap a second time.

Note on scale: vl is read-only, so the 1,792 vl_walk testcases were already leaving trap records.
The genuinely unobservable set was 595 testcases, not the full 2,402.

Builds on #2276 and #2278, which touch the same two files.

On the review comment about the "clear vill" preamble in `_gen_vsetvl_rs2_vill`: the finding is
correct — the loop runs SEW 0-3 unconditionally and never tests whether one stuck, so vtype is always
left at the last attempt (SEW=64), which re-sets vill on a part where SEW=64 is unsupported.

That preamble is not touched by this PR, and it is already rewritten by #2278, which replaces the
loop with a single `vsetvl` at `UDB_SEW_MIN` with LMUL=1. I test-merged the two: they auto-merge
cleanly, and the merged `SmV.py` keeps the `UDB_SEW_MIN` preamble with no `try_sew` loop left. So no
change is needed here; #2278 is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMw4mDyFq6c1c2dTtfR7yF
