### PR TITLE
Fix: scale mismatch index by eew_bytes in failedtest_saveregs

### DIFF
--- a/tests/env/rvtest_failure_code.h
+++ b/tests/env/rvtest_failure_code.h
@@ -763,7 +763,7 @@
         add  x6, x7, x6
 
         # offset by mismatch index
-        slli x8, x8, 0                    # already scaled above
+        mul  x8, x8, x17                  # failing_index * eew_bytes
         add  x6, x6, x8
 
         # store SEW-length expected value bytewise


### PR DESCRIPTION
## Summary

This PR fixes incorrect diagnostic output from `failedtest_saveregs` when a vector test fails. The actual value extraction was missing index scaling by element width, causing the reported **Bad Value** and **Expected Value** to be unreliable.

## Problem

In `tests/env/rvtest_failure_code.h`, the actual value extraction in
`failedtest_saveregs` (around line 766) used:

```asm
slli x8, x8, 0        # no-op
```

instead of scaling the mismatch index by `eew_bytes`. The comment `already scaled above` was incorrect.

As a result, the diagnostic reads the actual value from the wrong memory offset:

- Expected value: `sigptr + failing_index * eew_bytes` ✅
- Actual value: `vecreg_scratch + vd_offset + failing_index` ❌

For example, with `e16` (2 bytes per element) and `index = 1`:

- Expected reads from `sigptr + 1 * 2 = sigptr + 2` ✅
- Actual reads from `vecreg_scratch + 1` ❌, but should read from
  `vecreg_scratch + 2`

This causes the UART diagnostic to report the same value for both **Bad Value** and **Expected Value**, even though the **Mismatch Mask** shows multiple mismatched elements. The diagnostic becomes misleading and useless for debugging.

### Before fix

```text
RVCP: Element Index: 1
RVCP: Bad Value:      0x0003
RVCP: Expected Value: 0x0003
RVCP: Mismatch Mask: 0x000d000d000d000d000d000d000d000d000d000d000d000d000d000d000d000e
```

## Root Cause

The expected value extraction correctly scales the index:

```asm
mul  x8, x8, x17       # failing_index * eew_bytes
add  x6, x6, x8        # sigptr + failing_index * eew_bytes
```

But the actual value extraction does not:

```asm
slli x8, x8, 0         # no-op, does not scale
add  x6, x6, x8        # vecreg_scratch + vd_offset + failing_index
```

`x17` already contains `eew_bytes`, computed earlier from the SEW encoding.

## Fix

Replace the no-op shift with the correct scaling:

```diff
         # offset by mismatch index
-        slli x8, x8, 0            # already scaled above
+        mul  x8, x8, x17          # failing_index * eew_bytes
         add  x6, x6, x8
```

This makes the actual value extraction use the same element granularity as the expected value extraction.

## Expected behavior after fix

```text
RVCP: Element Index: 1
RVCP: Bad Value:      0x0017
RVCP: Expected Value: 0x0003
RVCP: Mismatch Mask: 0x000d000d000d000d000d000d000d000d000d000d000d000d000d000d000d000e
```