### PR TITLE
Exceptions: align the misaligned-JAL testcase to 4 bytes

### DIFF
--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsCommon.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsCommon.py
@@ -84,6 +84,7 @@ def generate_instr_adr_misaligned_jal_tests(test_data: TestData, covergroup: str
 
     lines = [
         comment_banner(coverpoint, "Instruction Address Misaligned JAL"),
+        ".p2align 2",
         test_data.add_testcase("jal_misaligned", coverpoint, covergroup),
         "jal x0, .+6",
         "# branch by 6 lands in upper half of next instruction 0x0001 which is generated into a c.nop",


### PR DESCRIPTION
Issue #2146 item 50.

generate_instr_adr_misaligned_jal_tests has no .p2align 2, unlike its sibling
generate_instr_adr_misaligned_branch_tests, so the alignment of its jal x0, .+6 depends on whatever
precedes it in the chunk. If the JAL lands at 2 mod 4, its .+6 target is 4-byte aligned and the
testcase stops testing anything.

Fix: add the same .p2align 2 the branch generator already carries.