### PR TITLE
ZicsrF, UF: keep frm writes to the legal rounding modes

### DIFF
--- a/coverpoints/priv/ZicsrF_coverage.svh
+++ b/coverpoints/priv/ZicsrF_coverage.svh
@@ -43,10 +43,12 @@ covergroup ZicsrF_cg with function sample(ins_t ins);
         bins fflags = {CSR_FFLAGS};
     }
     fcsr_frm_edges: coverpoint ins.current.rs1_val[7:5] {
-        // auto fills 0 through 7
+        // auto fills 0 through 7; 5-7 are reserved rounding modes, written only by the walk
+        ignore_bins reserved = {[5:7]};
     }
     frm_edges: coverpoint ins.current.rs1_val[2:0] {
-        // auto fills 0 through 7
+        // auto fills 0 through 7; 5-7 are reserved rounding modes, written only by the walk
+        ignore_bins reserved = {[5:7]};
     }
     fflags_edges: coverpoint ins.current.rs1_val[4:0] {
         // auto fills 0 through 15

--- a/generators/testgen/src/testgen/asm/csr.py
+++ b/generators/testgen/src/testgen/asm/csr.py
@@ -206,6 +206,15 @@ def _warl_reserved_check(
     return lines
 
 
+def frm_reserved_fields(lsb: int) -> list[tuple]:
+    """WARL entries for the reserved frm encodings 5-7, where frm is the three bits at `lsb`.
+
+    frm is bits 7:5 of fcsr and bits 2:0 of frm. A walk writes these encodings, so the
+    readback is checked only for holding some legal rounding mode.
+    """
+    return [("frm", lsb, 3, value) for value in (5, 6, 7)]
+
+
 def csr_walk_test(
     test_data: TestData,
     csr: tuple,

--- a/generators/testgen/src/testgen/priv/extensions/UF.py
+++ b/generators/testgen/src/testgen/priv/extensions/UF.py
@@ -46,8 +46,11 @@ def _generate_ufcsr_tests(test_data: TestData) -> list[str]:
         ),
     )
 
+    # frm 5-7 are reserved: the walk writes them, so those iterations check only that
+    # the field holds a legal rounding mode
+    FRM_RESERVED = {"fcsr": [("frm", 5, 3, v) for v in (5, 6, 7)], "frm": [("frm", 0, 3, v) for v in (5, 6, 7)]}
     for csr in csrf:
-        lines.extend(csr_walk_test(test_data, csr, covergroup, coverpoint))
+        lines.extend(csr_walk_test(test_data, csr, covergroup, coverpoint, warl_fields=FRM_RESERVED.get(csr[0])))
 
     return lines
 

--- a/generators/testgen/src/testgen/priv/extensions/UF.py
+++ b/generators/testgen/src/testgen/priv/extensions/UF.py
@@ -8,7 +8,7 @@
 
 """UF privileged extension test generator."""
 
-from testgen.asm.csr import csr_access_test, csr_walk_test
+from testgen.asm.csr import csr_access_test, csr_walk_test, frm_reserved_fields
 from testgen.asm.helpers import comment_banner
 from testgen.data.state import TestData
 from testgen.data.test_chunk import TestChunk
@@ -47,10 +47,14 @@ def _generate_ufcsr_tests(test_data: TestData) -> list[str]:
     )
 
     # frm 5-7 are reserved: the walk writes them, so those iterations check only that
-    # the field holds a legal rounding mode
-    FRM_RESERVED = {"fcsr": [("frm", 5, 3, v) for v in (5, 6, 7)], "frm": [("frm", 0, 3, v) for v in (5, 6, 7)]}
-    for csr in csrf:
-        lines.extend(csr_walk_test(test_data, csr, covergroup, coverpoint, warl_fields=FRM_RESERVED.get(csr[0])))
+    # the field holds a legal rounding mode.
+    walks = [
+        (("fcsr", None), frm_reserved_fields(5)),
+        (("frm", None), frm_reserved_fields(0)),
+        (("fflags", None), None),
+    ]
+    for csr, warl_fields in walks:
+        lines.extend(csr_walk_test(test_data, csr, covergroup, coverpoint, warl_fields=warl_fields))
 
     return lines
 

--- a/generators/testgen/src/testgen/priv/extensions/ZicsrF.py
+++ b/generators/testgen/src/testgen/priv/extensions/ZicsrF.py
@@ -54,8 +54,11 @@ def _generate_fcsr_walk(test_data: TestData) -> list[str]:
 
     csrf = [("fcsr", None), ("fflags", None), ("frm", None)]
 
+    # frm 5-7 are reserved: the walk writes them, so those iterations check only that
+    # the field holds a legal rounding mode
+    FRM_RESERVED = {"fcsr": [("frm", 5, 3, v) for v in (5, 6, 7)], "frm": [("frm", 0, 3, v) for v in (5, 6, 7)]}
     for csr in csrf:
-        lines.extend(csr_walk_test(test_data, csr, covergroup, coverpoint))
+        lines.extend(csr_walk_test(test_data, csr, covergroup, coverpoint, warl_fields=FRM_RESERVED.get(csr[0])))
 
     return lines
 
@@ -76,7 +79,8 @@ def _generate_fcsr_write(test_data: TestData) -> list[str]:
         )
     ]
 
-    for i in range(8):
+    # frm 5-7 are reserved, so only the legal rounding modes are written
+    for i in range(5):
         lines.extend(
             [
                 "",
@@ -122,7 +126,8 @@ def _generate_fcsr_write(test_data: TestData) -> list[str]:
         )
     )
 
-    for i in range(8):
+    # frm 5-7 are reserved, so only the legal rounding modes are written
+    for i in range(5):
         lines.extend(
             [
                 "",

--- a/generators/testgen/src/testgen/priv/extensions/ZicsrF.py
+++ b/generators/testgen/src/testgen/priv/extensions/ZicsrF.py
@@ -8,7 +8,13 @@
 
 """Unprivileged floating-point fcsr tests generator."""
 
-from testgen.asm.csr import csr_access_test, csr_walk_test, gen_csr_read_sigupd, gen_csr_write_sigupd
+from testgen.asm.csr import (
+    csr_access_test,
+    csr_walk_test,
+    frm_reserved_fields,
+    gen_csr_read_sigupd,
+    gen_csr_write_sigupd,
+)
 from testgen.asm.helpers import comment_banner, load_float_reg, write_sigupd
 from testgen.constants import INDENT
 from testgen.data.state import TestData
@@ -52,13 +58,15 @@ def _generate_fcsr_walk(test_data: TestData) -> list[str]:
         )
     ]
 
-    csrf = [("fcsr", None), ("fflags", None), ("frm", None)]
-
     # frm 5-7 are reserved: the walk writes them, so those iterations check only that
-    # the field holds a legal rounding mode
-    FRM_RESERVED = {"fcsr": [("frm", 5, 3, v) for v in (5, 6, 7)], "frm": [("frm", 0, 3, v) for v in (5, 6, 7)]}
-    for csr in csrf:
-        lines.extend(csr_walk_test(test_data, csr, covergroup, coverpoint, warl_fields=FRM_RESERVED.get(csr[0])))
+    # the field holds a legal rounding mode.
+    walks = [
+        (("fcsr", None), frm_reserved_fields(5)),
+        (("fflags", None), None),
+        (("frm", None), frm_reserved_fields(0)),
+    ]
+    for csr, warl_fields in walks:
+        lines.extend(csr_walk_test(test_data, csr, covergroup, coverpoint, warl_fields=warl_fields))
 
     return lines
 


### PR DESCRIPTION
Issue #2146 item 41.

frm values 5-7 are reserved. Two ZicsrF loops wrote them deliberately with range(8), and the walking
tests reach them as a side effect, in both cases exact-comparing the read-back.

Fix, in two parts. The explicit writes, cp_fcsr_frm_write and cp_frm_write, now sweep range(5), the
legal rounding modes only. For the walking tests, a walk over a 3-bit field writes 5-7 by
construction, so frm is declared to csr_walk_test through the existing warl_fields mechanism, fcsr
bits 7:5 and frm bits 2:0. Those iterations check that the field holds a legal mode instead of
matching exactly; every other iteration is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMfd3C27pJZ2HVDscpzohT
