### PR TITLE
ExceptionsZicbo: describe the misaligned CBO helper as the negative test it is

### DIFF
--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsZicboCommon.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsZicboCommon.py
@@ -247,7 +247,7 @@ def cbo_misaligned_helper(
     mode: str,
     cross_senvcfg: bool = False,
 ) -> list[str]:
-    """Generate cbo/prefetch misaligned-address trap tests."""
+    """Generate cbo/prefetch tests showing a misaligned address does not trap."""
     assert not (mode == "Sm" and cross_senvcfg), "senvcfg is not applicable in M-mode"
     coverpoint = "cp_cbo_address_misaligned"
     addr_reg, cfg_reg = test_data.int_regs.get_registers(2)


### PR DESCRIPTION
Issue #2146 item 10.

Most of this item was resolved by the refactor into ExceptionsZicboCommon.py: the banner now reads
"to a misaligned address do not trap", and the RVMODEL_ACCESS_FAULT_ADDRESS text the issue flagged
belongs to cbo_access_fault_helper, a separate and correct helper.

What was left is the docstring on cbo_misaligned_helper, which still called these "trap tests". CBOs
and prefetches ignore the low address bits, so nothing here traps; it is a negative test.

Documentation only, no generated output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMfd3C27pJZ2HVDscpzohT