### PR TITLE
Zkr: add csrrw to the seed CSR-op sweep and rename the coverpoint to csrops

### DIFF
--- a/coverpoints/priv/ZkrS_coverage.svh
+++ b/coverpoints/priv/ZkrS_coverage.svh
@@ -22,12 +22,13 @@ covergroup ZkrS_cg with function sample(ins_t ins);
         wildcard bins csrrw = {CSRRW};
     }
 
-    csrops_illegal: coverpoint ins.current.insn {
+    csrops: coverpoint ins.current.insn {
         wildcard bins csrrs  = {CSRRS};
         wildcard bins csrrc  = {CSRRC};
-        wildcard bins csrrwi = {CSRRWI};
+        wildcard bins csrrwi = {CSRRWI};  // not a read of seed, so it does not trap
         wildcard bins csrrsi = {CSRRSI};
         wildcard bins csrrci = {CSRRCI};
+        wildcard bins csrrw  = {CSRRW};   // not a read of seed, so it does not trap
     }
 
     seed_csr: coverpoint ins.current.insn[31:20] {
@@ -50,7 +51,7 @@ covergroup ZkrS_cg with function sample(ins_t ins);
 
     // Main coverpoints (S-mode)
     cp_zkr_seed_csrrw:                 cross csrrw, seed_csr, rs1_imm_0_1, priv_mode_s, mseccfg_sseed, mseccfg_useed;
-    cp_zkr_seed_illegal_csr_op:        cross csrops_illegal, seed_csr, rs1_imm_0_1, priv_mode_s;
+    cp_zkr_seed_illegal_csr_op:        cross csrops, seed_csr, rs1_imm_0_1, priv_mode_s;
     cp_zkr_seed_entropy_zero_non_es16: cross seed_csr, csrrw, prev_csrrw, priv_mode_s;
 
 endgroup

--- a/coverpoints/priv/ZkrSm_coverage.svh
+++ b/coverpoints/priv/ZkrSm_coverage.svh
@@ -22,12 +22,13 @@ covergroup ZkrSm_cg with function sample(ins_t ins);
         wildcard bins csrrw = {CSRRW};
     }
 
-    csrops_illegal: coverpoint ins.current.insn {
+    csrops: coverpoint ins.current.insn {
         wildcard bins csrrs  = {CSRRS};
         wildcard bins csrrc  = {CSRRC};
-        wildcard bins csrrwi = {CSRRWI};
+        wildcard bins csrrwi = {CSRRWI};  // not a read of seed, so it does not trap
         wildcard bins csrrsi = {CSRRSI};
         wildcard bins csrrci = {CSRRCI};
+        wildcard bins csrrw  = {CSRRW};   // not a read of seed, so it does not trap
     }
 
     seed_csr: coverpoint ins.current.insn[31:20] {
@@ -50,7 +51,7 @@ covergroup ZkrSm_cg with function sample(ins_t ins);
 
     // Main coverpoints (M-mode)
     cp_zkr_seed_csrrw:                 cross csrrw, seed_csr, rs1_imm_0_1, priv_mode_m, mseccfg_sseed, mseccfg_useed;
-    cp_zkr_seed_illegal_csr_op:        cross csrops_illegal, seed_csr, rs1_imm_0_1, priv_mode_m;
+    cp_zkr_seed_illegal_csr_op:        cross csrops, seed_csr, rs1_imm_0_1, priv_mode_m;
     cp_zkr_seed_entropy_zero_non_es16: cross seed_csr, csrrw, prev_csrrw, priv_mode_m;
 
 endgroup

--- a/coverpoints/priv/ZkrU_coverage.svh
+++ b/coverpoints/priv/ZkrU_coverage.svh
@@ -22,12 +22,13 @@ covergroup ZkrU_cg with function sample(ins_t ins);
         wildcard bins csrrw = {CSRRW};
     }
 
-    csrops_illegal: coverpoint ins.current.insn {
+    csrops: coverpoint ins.current.insn {
         wildcard bins csrrs  = {CSRRS};
         wildcard bins csrrc  = {CSRRC};
-        wildcard bins csrrwi = {CSRRWI};
+        wildcard bins csrrwi = {CSRRWI};  // not a read of seed, so it does not trap
         wildcard bins csrrsi = {CSRRSI};
         wildcard bins csrrci = {CSRRCI};
+        wildcard bins csrrw  = {CSRRW};   // not a read of seed, so it does not trap
     }
 
     seed_csr: coverpoint ins.current.insn[31:20] {
@@ -50,7 +51,7 @@ covergroup ZkrU_cg with function sample(ins_t ins);
 
     // Main coverpoints (U-mode)
     cp_zkr_seed_csrrw:                 cross csrrw, seed_csr, rs1_imm_0_1, priv_mode_u, mseccfg_sseed, mseccfg_useed;
-    cp_zkr_seed_illegal_csr_op:        cross csrops_illegal, seed_csr, rs1_imm_0_1, priv_mode_u;
+    cp_zkr_seed_illegal_csr_op:        cross csrops, seed_csr, rs1_imm_0_1, priv_mode_u;
     cp_zkr_seed_entropy_zero_non_es16: cross seed_csr, csrrw, prev_csrrw, priv_mode_u;
 
 endgroup

--- a/generators/testgen/src/testgen/priv/extensions/ZkrCommon.py
+++ b/generators/testgen/src/testgen/priv/extensions/ZkrCommon.py
@@ -68,14 +68,14 @@ def gen_seed_csrrw_tests(test_data: TestData, covergroup: str, mode: str) -> lis
 
 
 def gen_seed_illegal_csr_op_tests(test_data: TestData, covergroup: str, mode: str) -> list[str]:
-    """Read-only CSR ops on seed cause an illegal instruction in this suite's mode."""
+    """CSR ops on seed in this suite's mode; only the read-only forms cause an illegal instruction."""
     coverpoint = "cp_zkr_seed_illegal_csr_op"
 
     dest_reg, mseccfg_reg, rs1_reg, save_reg = test_data.int_regs.get_registers(4)
 
     sseed_useed_enabled = (1 << 9) | (1 << 8)
     lines = [
-        comment_banner(coverpoint, f"CSR read ops on seed cause illegal instruction in {mode}-mode"),
+        comment_banner(coverpoint, f"CSR ops on seed in {mode}-mode; only the read-only forms trap"),
         *_gate(
             mode,
             [
@@ -91,10 +91,10 @@ def gen_seed_illegal_csr_op_tests(test_data: TestData, covergroup: str, mode: st
     csr_ops: list[tuple[str, bool]] = [
         ("csrrs", False),
         ("csrrc", False),
-        ("csrrwi", True),
+        ("csrrwi", True),  # not a read of seed, so it does not trap
         ("csrrsi", True),
         ("csrrci", True),
-        ("csrrw", False),
+        ("csrrw", False),  # not a read of seed, so it does not trap
     ]
 
     for op, is_imm in csr_ops:


### PR DESCRIPTION
Issue #2146 item 54.

Rename `csrops_illegal` to `csrops` in the Zkr coverpoints and add `csrrw`.