### PR TITLE
Correct cp_/cr_ prefixes in the Zbb and D norm YAMLs

### DIFF
--- a/coverpoints/norm/D.yaml
+++ b/coverpoints/norm/D.yaml
@@ -2,7 +2,7 @@
 
 normative_rule_definitions:
   - name: D_fpr_regs
-    coverpoint: ["D_fadd_d_cg/{cp_fs1_fs2_edges_frm_D}"] # one of many possible
+    coverpoint: ["D_fadd_d_cg/{cr_fs1_fs2_edges_frm_D}"] # one of many possible
   - names: ["fsd_atomic_align, fld_atomic_align"]
     coverpoint: ["UNCHECKED"]
   - name: fsd_bits_maintained
@@ -183,7 +183,7 @@ normative_rule_definitions:
     # frm
     coverpoint:
       [
-        "D_fcvt_l_d_cg/{cp_rd, cp_fs1, cp_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
+        "D_fcvt_l_d_cg/{cp_rd, cp_fs1, cr_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
       ]
   - name: fcvt-lu-d_op
     # FCVT.WU.D, FCVT.LU.D, FCVT.D.WU, and FCVT.D.LU variants convert to
@@ -209,7 +209,7 @@ normative_rule_definitions:
     # frm
     coverpoint:
       [
-        "D_fcvt_lu_d_cg/{cp_rd, cp_fs1, cp_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
+        "D_fcvt_lu_d_cg/{cp_rd, cp_fs1, cr_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
       ]
   - name: fcvt-s-d_op
     # The double-precision to single-precision and single-precision to
@@ -222,7 +222,7 @@ normative_rule_definitions:
     # never round
     coverpoint:
       [
-        "D_fcvt_s_d_cg/{cp_fs1, cp_fd, cp_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_voun, cp_csr_frm, cp_NaNBox_D_S}",
+        "D_fcvt_s_d_cg/{cp_fs1, cp_fd, cr_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_voun, cp_csr_frm, cp_NaNBox_D_S}",
       ]
   - name: fcvt-w-d_op
     # FCVT.W.D or
@@ -249,7 +249,7 @@ normative_rule_definitions:
     # frm
     coverpoint:
       [
-        "D_fcvt_w_d_cg/{cp_rd, cp_fs1, cp_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
+        "D_fcvt_w_d_cg/{cp_rd, cp_fs1, cr_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
       ]
   - name: fcvt-wu-d_op
     # FCVT.WU.D, FCVT.LU.D, FCVT.D.WU, and FCVT.D.LU variants convert to
@@ -274,7 +274,7 @@ normative_rule_definitions:
     # frm
     coverpoint:
       [
-        "D_fcvt_wu_d_cg/{cp_rd, cp_fs1, cp_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
+        "D_fcvt_wu_d_cg/{cp_rd, cp_fs1, cr_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
       ]
   - name: fdiv-d_op
     # FDIV.S performs the single-precision floating-point division of rs1 by rs2

--- a/coverpoints/norm/Zbb.yaml
+++ b/coverpoints/norm/Zbb.yaml
@@ -28,40 +28,40 @@ normative_rule_definitions:
     coverpoint: ["Zbb_andn_cg/cr_rs1_rs2_edges"]
 
   - name: clz_enc
-    coverpoint: ["Zbb_clz_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_clz_cg/cp_rs1_edges"]
 
   - name: clz_op
-    coverpoint: ["Zbb_clz_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_clz_cg/cp_rs1_edges"]
 
   - name: clzw_enc
-    coverpoint: ["Zbb_clzw_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_clzw_cg/cp_rs1_edges"]
 
   - name: clzw_op
-    coverpoint: ["Zbb_clzw_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_clzw_cg/cp_rs1_edges"]
 
   - name: cpop_enc
-    coverpoint: ["Zbb_cpop_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_cpop_cg/cp_rs1_edges"]
 
   - name: cpop_op
-    coverpoint: ["Zbb_cpop_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_cpop_cg/cp_rs1_edges"]
 
   - name: cpopw_enc
-    coverpoint: ["Zbb_cpopw_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_cpopw_cg/cp_rs1_edges"]
 
   - name: cpopw_op
-    coverpoint: ["Zbb_cpopw_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_cpopw_cg/cp_rs1_edges"]
 
   - name: ctz_enc
-    coverpoint: ["Zbb_ctz_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_ctz_cg/cp_rs1_edges"]
 
   - name: ctz_op
-    coverpoint: ["Zbb_ctz_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_ctz_cg/cp_rs1_edges"]
 
   - name: ctzw_enc
-    coverpoint: ["Zbb_ctzw_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_ctzw_cg/cp_rs1_edges"]
 
   - name: ctzw_op
-    coverpoint: ["Zbb_ctzw_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_ctzw_cg/cp_rs1_edges"]
 
   - name: max_enc
     coverpoint: ["Zbb_max_cg/cr_rs1_rs2_edges"]
@@ -100,10 +100,10 @@ normative_rule_definitions:
     coverpoint: ["Zbb_orn_cg/cr_rs1_rs2_edges"]
 
   - name: rev8_enc
-    coverpoint: ["Zbb_rev8_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_rev8_cg/cp_rs1_edges"]
 
   - name: rev8_op
-    coverpoint: ["Zbb_rev8_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_rev8_cg/cp_rs1_edges"]
 
   - name: rol_enc
     coverpoint: ["Zbb_rol_cg/cr_rs1_rs2_edges"]
@@ -142,13 +142,13 @@ normative_rule_definitions:
     coverpoint: ["Zbb_rorw_cg/cr_rs1_rs2_edges"]
 
   - name: sext_b_enc
-    coverpoint: ["Zbb_sext_b_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_sext_b_cg/cp_rs1_edges"]
 
   - name: sext_b_op
     coverpoint: ["Zbb_sext_b_cg/cp_rs1_edges"]
 
   - name: sext_h_enc
-    coverpoint: ["Zbb_sext_h_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_sext_h_cg/cp_rs1_edges"]
 
   - name: sext_h_op
     coverpoint: ["Zbb_sext_h_cg/cp_rs1_edges"]
@@ -160,7 +160,7 @@ normative_rule_definitions:
     coverpoint: ["Zbb_xnor_cg/cr_rs1_rs2_edges"]
 
   - name: zext_h_enc
-    coverpoint: ["Zbb_zext_h_cg/cr_rs1_edges"]
+    coverpoint: ["Zbb_zext_h_cg/cp_rs1_edges"]
 
   - name: zext_h_op
     coverpoint: ["Zbb_zext_h_cg/cp_rs1_edges"]


### PR DESCRIPTION
Issue #2147 item 53.