### PR TITLE
Name the suites that generate no RVE tests

### DIFF
--- a/generators/testgen/src/testgen/cli.py
+++ b/generators/testgen/src/testgen/cli.py
@@ -118,6 +118,11 @@ def generate_all_tests(
     # Build list of test generation tasks
     tasks: list[UnprivTask | PrivTask] = []
 
+    skipped_for_e = sorted(set(unpriv_ext_list) - E_EXTENSION_TESTS)
+    if skipped_for_e:
+        # An RVE part gets no tests at all for these, which is otherwise indistinguishable from passing.
+        print(f"No RV32E/RV64E tests generated for: {', '.join(skipped_for_e)}")
+
     for xlen in [32, 64]:
         for E_ext in [False, True]:
             for testsuite in sorted(unpriv_ext_list):


### PR DESCRIPTION
Issue #2147 item 50, partial.

Suites outside `E_EXTENSION_TESTS` are skipped for RV32E/RV64E by a bare `continue`, so an RVE part
gets an empty test set with no error and no warning — indistinguishable from a passing run. This
prints the list once.

Today that is 56 suites, including `Zicsr`, `Zifencei`, the atomics, the scalar crypto set and
`Misalign*`. Notably `ZcbM`, `ZcbZba` and `ZcbZbb` are skipped while `Zcb`, `M`, `Zba` and `Zbb` are
all included, which looks like an oversight rather than a decision.

Expanding the list is deliberately left out of this PR — whether each family should generate E tests
is a per-family call. Generated output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTjX9BBLNAQkWwTTq6vfxq
