### PR TITLE
Include x31/f31 in the CILS and CFLS register ranges

### DIFF
--- a/generators/testgen/src/testgen/formatters/types/cfls_type.py
+++ b/generators/testgen/src/testgen/formatters/types/cfls_type.py
@@ -12,7 +12,7 @@ from testgen.formatters.registry import InstructionTypeConfig, add_instruction_f
 
 cfls_config = InstructionTypeConfig(
     required_params={"fd", "immval", "temp_reg", "temp_val"},
-    reg_range=range(1, 31),  # fd cannot be x0
+    reg_range=range(32),  # f0 is a valid float destination
     imm_bits=9,  # c.ldsp: [0, 504] in multiples of 8, c.lwsp: [0, 252] in multiples of 4
     imm_signed=False,
 )

--- a/generators/testgen/src/testgen/formatters/types/cils_type.py
+++ b/generators/testgen/src/testgen/formatters/types/cils_type.py
@@ -12,7 +12,7 @@ from testgen.formatters.registry import InstructionTypeConfig, add_instruction_f
 
 cils_config = InstructionTypeConfig(
     required_params={"rd", "immval", "temp_reg", "temp_val"},
-    reg_range=range(1, 31),  # rd cannot be x0
+    reg_range=range(1, 32),  # rd cannot be x0
     imm_bits=9,  # c.ldsp: [0, 504] in multiples of 8, c.lwsp: [0, 252] in multiples of 4
     imm_signed=False,
 )

--- a/tests/rv32i/Zca/Zca-c.lwsp-00.S
+++ b/tests/rv32i/Zca/Zca-c.lwsp-00.S
@@ -169,740 +169,740 @@ Zca_c_lwsp_cg_cp_rd_nx0_b14:
 
 # Testcase cp_rd_nx0 (Test destination rd = x15)
   mv sp, x28 # move data_ptr to sp
-  addi sp, sp, -244 # adjust base address for load
+  addi sp, sp, -252 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b15:
-  c.lwsp x15, 244(sp) # perform load (0x690308d2)
+  c.lwsp x15, 252(sp) # perform load (0x089aaf83)
   # Check if x15 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x15, Zca_c_lwsp_cg_cp_rd_nx0_b15, Zca_c_lwsp_cg_cp_rd_nx0_b15_str)
   addi x28, x28, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x16)
   mv sp, x28 # move data_ptr to sp
-  addi sp, sp, -48 # adjust base address for load
+  addi sp, sp, -76 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b16:
-  c.lwsp x16, 48(sp) # perform load (0x31dd325e)
+  c.lwsp x16, 76(sp) # perform load (0xd6716c54)
   # Check if x16 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x16, Zca_c_lwsp_cg_cp_rd_nx0_b16, Zca_c_lwsp_cg_cp_rd_nx0_b16_str)
   addi x28, x28, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x17)
   mv sp, x28 # move data_ptr to sp
-  addi sp, sp, -188 # adjust base address for load
+  addi sp, sp, -128 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b17:
-  c.lwsp x17, 188(sp) # perform load (0x8b2cfc2e)
+  c.lwsp x17, 128(sp) # perform load (0x8d2386a2)
   # Check if x17 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x17, Zca_c_lwsp_cg_cp_rd_nx0_b17, Zca_c_lwsp_cg_cp_rd_nx0_b17_str)
   addi x28, x28, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x18)
   mv sp, x28 # move data_ptr to sp
-  addi sp, sp, -28 # adjust base address for load
+  addi sp, sp, -164 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b18:
-  c.lwsp x18, 28(sp) # perform load (0xd1540c9c)
+  c.lwsp x18, 164(sp) # perform load (0x87d7cbd1)
   # Check if x18 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x18, Zca_c_lwsp_cg_cp_rd_nx0_b18, Zca_c_lwsp_cg_cp_rd_nx0_b18_str)
   addi x28, x28, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x19)
   mv sp, x28 # move data_ptr to sp
-  addi sp, sp, -224 # adjust base address for load
+  addi sp, sp, -28 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b19:
-  c.lwsp x19, 224(sp) # perform load (0xe9780bd1)
+  c.lwsp x19, 28(sp) # perform load (0x387da3d8)
   # Check if x19 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x19, Zca_c_lwsp_cg_cp_rd_nx0_b19, Zca_c_lwsp_cg_cp_rd_nx0_b19_str)
   addi x28, x28, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x20)
   mv sp, x28 # move data_ptr to sp
-  addi sp, sp, -216 # adjust base address for load
+  addi sp, sp, -192 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b20:
-  c.lwsp x20, 216(sp) # perform load (0x08f01362)
+  c.lwsp x20, 192(sp) # perform load (0x186552ad)
   # Check if x20 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x20, Zca_c_lwsp_cg_cp_rd_nx0_b20, Zca_c_lwsp_cg_cp_rd_nx0_b20_str)
   addi x28, x28, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x21)
   mv sp, x28 # move data_ptr to sp
-  addi sp, sp, -192 # adjust base address for load
+  addi sp, sp, -116 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b21:
-  c.lwsp x21, 192(sp) # perform load (0x186552ad)
+  c.lwsp x21, 116(sp) # perform load (0xf6635cb3)
   # Check if x21 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x21, Zca_c_lwsp_cg_cp_rd_nx0_b21, Zca_c_lwsp_cg_cp_rd_nx0_b21_str)
   addi x28, x28, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x22)
   mv sp, x28 # move data_ptr to sp
-  addi sp, sp, -116 # adjust base address for load
+  addi sp, sp, -16 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b22:
-  c.lwsp x22, 116(sp) # perform load (0xf6635cb3)
+  c.lwsp x22, 16(sp) # perform load (0xc7c416cb)
   # Check if x22 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x22, Zca_c_lwsp_cg_cp_rd_nx0_b22, Zca_c_lwsp_cg_cp_rd_nx0_b22_str)
   addi x28, x28, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x23)
   mv sp, x28 # move data_ptr to sp
-  addi sp, sp, -16 # adjust base address for load
+  addi sp, sp, -168 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b23:
-  c.lwsp x23, 16(sp) # perform load (0xc7c416cb)
+  c.lwsp x23, 168(sp) # perform load (0x9f01c7fa)
   # Check if x23 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x23, Zca_c_lwsp_cg_cp_rd_nx0_b23, Zca_c_lwsp_cg_cp_rd_nx0_b23_str)
   addi x28, x28, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x24)
   mv sp, x28 # move data_ptr to sp
-  addi sp, sp, -168 # adjust base address for load
+  addi sp, sp, -156 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b24:
-  c.lwsp x24, 168(sp) # perform load (0x9f01c7fa)
+  c.lwsp x24, 156(sp) # perform load (0x458c3ac0)
   # Check if x24 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x24, Zca_c_lwsp_cg_cp_rd_nx0_b24, Zca_c_lwsp_cg_cp_rd_nx0_b24_str)
   addi x28, x28, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x25)
   mv sp, x28 # move data_ptr to sp
-  addi sp, sp, -156 # adjust base address for load
+  addi sp, sp, -204 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b25:
-  c.lwsp x25, 156(sp) # perform load (0x458c3ac0)
+  c.lwsp x25, 204(sp) # perform load (0xeeceeeba)
   # Check if x25 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x25, Zca_c_lwsp_cg_cp_rd_nx0_b25, Zca_c_lwsp_cg_cp_rd_nx0_b25_str)
   addi x28, x28, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x26)
   mv sp, x28 # move data_ptr to sp
-  addi sp, sp, -204 # adjust base address for load
+  addi sp, sp, -72 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b26:
-  c.lwsp x26, 204(sp) # perform load (0xeeceeeba)
+  c.lwsp x26, 72(sp) # perform load (0xe8827eb1)
   # Check if x26 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x26, Zca_c_lwsp_cg_cp_rd_nx0_b26, Zca_c_lwsp_cg_cp_rd_nx0_b26_str)
   addi x28, x28, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x27)
   mv sp, x28 # move data_ptr to sp
-  addi sp, sp, -72 # adjust base address for load
+  addi sp, sp, -56 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b27:
-  c.lwsp x27, 72(sp) # perform load (0xe8827eb1)
+  c.lwsp x27, 56(sp) # perform load (0x7986f1dd)
   # Check if x27 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x27, Zca_c_lwsp_cg_cp_rd_nx0_b27, Zca_c_lwsp_cg_cp_rd_nx0_b27_str)
   addi x28, x28, SIG_STRIDE # increment data_ptr
 
-  mv x15, x28 # switch data pointer register to avoid conflict with test
+  mv x24, x28 # switch data pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x28)
-  mv sp, x15 # move data_ptr to sp
-  addi sp, sp, -200 # adjust base address for load
+  mv sp, x24 # move data_ptr to sp
+  addi sp, sp, -204 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b28:
-  c.lwsp x28, 200(sp) # perform load (0x346be914)
+  c.lwsp x28, 204(sp) # perform load (0xff305e15)
   # Check if x28 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x28, Zca_c_lwsp_cg_cp_rd_nx0_b28, Zca_c_lwsp_cg_cp_rd_nx0_b28_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x29)
-  mv sp, x15 # move data_ptr to sp
-  addi sp, sp, -204 # adjust base address for load
+  mv sp, x24 # move data_ptr to sp
+  addi sp, sp, 0 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b29:
-  c.lwsp x29, 204(sp) # perform load (0xff305e15)
+  c.lwsp x29, 0(sp) # perform load (0x0d381468)
   # Check if x29 contains the expected result. x30 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x30, x5, x4, x29, Zca_c_lwsp_cg_cp_rd_nx0_b29, Zca_c_lwsp_cg_cp_rd_nx0_b29_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
-  mv x24, x30 # switch signature pointer register to avoid conflict with test
+  mv x12, x30 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x30)
-  mv sp, x15 # move data_ptr to sp
-  addi sp, sp, -68 # adjust base address for load
+  mv sp, x24 # move data_ptr to sp
+  addi sp, sp, -196 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b30:
-  c.lwsp x30, 68(sp) # perform load (0xc088b356)
-  # Check if x30 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x30, Zca_c_lwsp_cg_cp_rd_nx0_b30, Zca_c_lwsp_cg_cp_rd_nx0_b30_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x30, 196(sp) # perform load (0x247f0502)
+  # Check if x30 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x30, Zca_c_lwsp_cg_cp_rd_nx0_b30, Zca_c_lwsp_cg_cp_rd_nx0_b30_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x31)
-  mv sp, x15 # move data_ptr to sp
-  addi sp, sp, -184 # adjust base address for load
+  mv sp, x24 # move data_ptr to sp
+  addi sp, sp, -116 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b31:
-  c.lwsp x31, 184(sp) # perform load (0x7898ffbd)
-  # Check if x31 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x31, Zca_c_lwsp_cg_cp_rd_nx0_b31, Zca_c_lwsp_cg_cp_rd_nx0_b31_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x31, 116(sp) # perform load (0x62cd65d9)
+  # Check if x31 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x31, Zca_c_lwsp_cg_cp_rd_nx0_b31, Zca_c_lwsp_cg_cp_rd_nx0_b31_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 /////////////////////////////////
 // cp_imm_mul_4sp
 /////////////////////////////////
 
 # Testcase cp_imm_mul_4sp: imm=0
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, 0 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x0:
   c.lwsp x29, 0(sp) # perform load (0xbb4ed7b7)
-  # Check if x29 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x29, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x0_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  # Check if x29 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x29, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x0_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=4
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -4 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x4:
   c.lwsp x21, 4(sp) # perform load (0x1ec9013b)
-  # Check if x21 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x21, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x4_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  # Check if x21 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x21, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x4_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=8
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -8 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x8:
-  c.lwsp x12, 8(sp) # perform load (0x52f84901)
-  # Check if x12 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x12, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x8_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x13, 8(sp) # perform load (0x52f84901)
+  # Check if x13 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x13, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x8_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=12
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -12 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc:
   c.lwsp x18, 12(sp) # perform load (0x916bbc73)
-  # Check if x18 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x18, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  # Check if x18 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x18, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=16
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -16 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x10:
   c.lwsp x1, 16(sp) # perform load (0x679bb905)
-  # Check if x1 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x1, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x10, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x10_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  # Check if x1 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x1, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x10, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x10_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=20
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -20 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x14:
   c.lwsp x2, 20(sp) # perform load (0x944f0c17)
-  # Check if x2 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x2, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x14, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x14_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  # Check if x2 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x2, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x14, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x14_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=24
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -24 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x18:
-  c.lwsp x9, 24(sp) # perform load (0x4a2d0947)
-  # Check if x9 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x9, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x18, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x18_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x31, 24(sp) # perform load (0xe8565dc5)
+  # Check if x31 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x31, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x18, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x18_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=28
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -28 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x1c:
-  c.lwsp x10, 28(sp) # perform load (0xa571a4a4)
-  # Check if x10 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x10, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x1c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x1c_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x27, 28(sp) # perform load (0x554726aa)
+  # Check if x27 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x27, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x1c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x1c_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=32
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -32 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x20:
-  c.lwsp x18, 32(sp) # perform load (0xfff3af14)
-  # Check if x18 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x18, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x20, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x20_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x19, 32(sp) # perform load (0xd3d7487b)
+  # Check if x19 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x19, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x20, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x20_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=36
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -36 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x24:
-  c.lwsp x8, 36(sp) # perform load (0xb168166a)
-  # Check if x8 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x24_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x20, 36(sp) # perform load (0xaf1cae29)
+  # Check if x20 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x20, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x24_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=40
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -40 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x28:
-  c.lwsp x1, 40(sp) # perform load (0x694d5b06)
-  # Check if x1 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x1, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x28_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x8, 40(sp) # perform load (0x4907e937)
+  # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x28_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=44
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -44 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x2c:
-  c.lwsp x1, 44(sp) # perform load (0xb7055546)
-  # Check if x1 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x1, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x2c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x2c_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x6, 44(sp) # perform load (0x98edb9d9)
+  # Check if x6 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x6, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x2c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x2c_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=48
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -48 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x30:
-  c.lwsp x27, 48(sp) # perform load (0x8eca0a28)
-  # Check if x27 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x27, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x30, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x30_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x17, 48(sp) # perform load (0x8eca0a28)
+  # Check if x17 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x17, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x30, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x30_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=52
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -52 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x34:
   c.lwsp x16, 52(sp) # perform load (0x9607e87c)
-  # Check if x16 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x16, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x34, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x34_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  # Check if x16 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x16, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x34, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x34_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=56
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -56 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x38:
   c.lwsp x18, 56(sp) # perform load (0x02c8f08e)
-  # Check if x18 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x18, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x38, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x38_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  # Check if x18 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x18, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x38, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x38_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=60
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -60 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x3c:
   c.lwsp x8, 60(sp) # perform load (0x0420ab59)
-  # Check if x8 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x3c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x3c_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x3c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x3c_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=64
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -64 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x40:
-  c.lwsp x26, 64(sp) # perform load (0xdd236d20)
-  # Check if x26 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x26, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x40_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x31, 64(sp) # perform load (0x19bd346d)
+  # Check if x31 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x31, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x40_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=68
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -68 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x44:
-  c.lwsp x14, 68(sp) # perform load (0x3d79ee8e)
-  # Check if x14 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x14, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x44_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x3, 68(sp) # perform load (0x75a676a3)
+  # Check if x3 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x3, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x44_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=72
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -72 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x48:
-  c.lwsp x7, 72(sp) # perform load (0xbe945e51)
-  # Check if x7 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x7, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x48_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x28, 72(sp) # perform load (0xa2b70c8a)
+  # Check if x28 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x28, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x48_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=76
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -76 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x4c:
-  c.lwsp x30, 76(sp) # perform load (0x9449892d)
-  # Check if x30 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x30, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x4c_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x15, 76(sp) # perform load (0xbe945e51)
+  # Check if x15 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x15, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x4c_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=80
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -80 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x50:
-  c.lwsp x3, 80(sp) # perform load (0x9cd81425)
-  # Check if x3 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x3, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x50_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x30, 80(sp) # perform load (0x9449892d)
+  # Check if x30 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x30, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x50_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=84
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -84 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x54:
-  c.lwsp x9, 84(sp) # perform load (0x537a59a9)
-  # Check if x9 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x9, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x54_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x3, 84(sp) # perform load (0x9cd81425)
+  # Check if x3 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x3, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x54_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=88
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -88 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x58:
-  c.lwsp x7, 88(sp) # perform load (0xa96fd7c7)
-  # Check if x7 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x7, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x58_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x9, 88(sp) # perform load (0x537a59a9)
+  # Check if x9 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x9, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x58_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=92
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -92 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x5c:
-  c.lwsp x6, 92(sp) # perform load (0x2b09593d)
-  # Check if x6 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x6, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x5c_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x7, 92(sp) # perform load (0xa96fd7c7)
+  # Check if x7 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x7, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x5c_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=96
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -96 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x60:
-  c.lwsp x3, 96(sp) # perform load (0xebd80cda)
-  # Check if x3 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x3, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x60_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x6, 96(sp) # perform load (0x2b09593d)
+  # Check if x6 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x6, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x60_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=100
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -100 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x64:
-  c.lwsp x6, 100(sp) # perform load (0x25587ca8)
-  # Check if x6 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x6, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x64_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x3, 100(sp) # perform load (0xebd80cda)
+  # Check if x3 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x3, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x64_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=104
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -104 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x68:
-  c.lwsp x27, 104(sp) # perform load (0x048a574f)
-  # Check if x27 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x27, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x68_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x31, 104(sp) # perform load (0xf43544cb)
+  # Check if x31 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x31, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x68_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=108
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -108 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x6c:
-  c.lwsp x27, 108(sp) # perform load (0x0e3b763e)
-  # Check if x27 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x27, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x6c_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x21, 108(sp) # perform load (0x40049a50)
+  # Check if x21 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x21, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x6c_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=112
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -112 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x70:
-  c.lwsp x1, 112(sp) # perform load (0x9a454554)
-  # Check if x1 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x1, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x70_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x30, 112(sp) # perform load (0x048a574f)
+  # Check if x30 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x30, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x70_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=116
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -116 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x74:
-  c.lwsp x23, 116(sp) # perform load (0xfe8cba05)
-  # Check if x23 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x23, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x74_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x31, 116(sp) # perform load (0x0e2a4020)
+  # Check if x31 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x31, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x74_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=120
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -120 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x78:
-  c.lwsp x6, 120(sp) # perform load (0x4a0a9926)
-  # Check if x6 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x6, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x78_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x30, 120(sp) # perform load (0xcdbf254c)
+  # Check if x30 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x30, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x78_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=124
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -124 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x7c:
-  c.lwsp x9, 124(sp) # perform load (0x9f876890)
-  # Check if x9 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x9, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x7c_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x3, 124(sp) # perform load (0x3be4f34c)
+  # Check if x3 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x3, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x7c_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=128
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -128 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x80:
-  c.lwsp x6, 128(sp) # perform load (0x4972725d)
-  # Check if x6 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x6, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x80_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x1, 128(sp) # perform load (0xfe77b638)
+  # Check if x1 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x1, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x80_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=132
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -132 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x84:
-  c.lwsp x12, 132(sp) # perform load (0xb92eb20a)
-  # Check if x12 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x12, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x84_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x8, 132(sp) # perform load (0x028f00d4)
+  # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x84_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=136
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -136 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x88:
-  c.lwsp x3, 136(sp) # perform load (0xd4f45dcf)
-  # Check if x3 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x3, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x88_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x18, 136(sp) # perform load (0xcbe357d2)
+  # Check if x18 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x18, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x88_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=140
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -140 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x8c:
-  c.lwsp x19, 140(sp) # perform load (0x301df2b7)
-  # Check if x19 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x19, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x8c_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x30, 140(sp) # perform load (0x6fe63562)
+  # Check if x30 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x30, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x8c_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=144
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -144 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x90:
-  c.lwsp x7, 144(sp) # perform load (0xe6169e43)
-  # Check if x7 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x7, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x90_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x9, 144(sp) # perform load (0x83bb81bd)
+  # Check if x9 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x9, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x90_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=148
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -148 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x94:
-  c.lwsp x8, 148(sp) # perform load (0x6ae63906)
-  # Check if x8 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x94_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x15, 148(sp) # perform load (0xab4c3d28)
+  # Check if x15 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x15, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x94_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=152
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -152 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x98:
-  c.lwsp x11, 152(sp) # perform load (0x1f36a21e)
-  # Check if x11 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x11, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x98_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x15, 152(sp) # perform load (0xe6169e43)
+  # Check if x15 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x15, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x98_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=156
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -156 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x9c:
-  c.lwsp x28, 156(sp) # perform load (0x32b5957c)
-  # Check if x28 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x28, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x9c_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x8, 156(sp) # perform load (0x6ae63906)
+  # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x9c_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=160
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -160 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa0:
-  c.lwsp x23, 160(sp) # perform load (0xd90f5d3f)
-  # Check if x23 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x23, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa0_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x11, 160(sp) # perform load (0x1f36a21e)
+  # Check if x11 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x11, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa0_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=164
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -164 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa4:
-  c.lwsp x22, 164(sp) # perform load (0x55bacb68)
-  # Check if x22 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x22, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa4_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x28, 164(sp) # perform load (0x32b5957c)
+  # Check if x28 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x28, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa4_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=168
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -168 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa8:
-  c.lwsp x8, 168(sp) # perform load (0x51f78d69)
-  # Check if x8 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa8_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x23, 168(sp) # perform load (0xd90f5d3f)
+  # Check if x23 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x23, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa8_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=172
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -172 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xac:
-  c.lwsp x12, 172(sp) # perform load (0xd59ebf41)
-  # Check if x12 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x12, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xac_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x22, 172(sp) # perform load (0x55bacb68)
+  # Check if x22 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x22, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xac_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=176
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -176 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb0:
-  c.lwsp x7, 176(sp) # perform load (0xf1929dbe)
-  # Check if x7 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x7, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb0_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x8, 176(sp) # perform load (0x51f78d69)
+  # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb0_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=180
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -180 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb4:
-  c.lwsp x7, 180(sp) # perform load (0x8d0f43c9)
-  # Check if x7 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x7, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb4_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x13, 180(sp) # perform load (0xd59ebf41)
+  # Check if x13 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x13, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb4_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=184
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -184 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb8:
-  c.lwsp x26, 184(sp) # perform load (0xc6ea2fdd)
-  # Check if x26 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x26, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb8_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x7, 184(sp) # perform load (0xf1929dbe)
+  # Check if x7 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x7, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb8_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=188
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -188 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xbc:
-  c.lwsp x25, 188(sp) # perform load (0x6cc45c95)
-  # Check if x25 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x25, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xbc_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x7, 188(sp) # perform load (0x8d0f43c9)
+  # Check if x7 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x7, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xbc_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=192
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -192 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc0:
-  c.lwsp x10, 192(sp) # perform load (0x98cd8028)
-  # Check if x10 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x10, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc0_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x26, 192(sp) # perform load (0xc6ea2fdd)
+  # Check if x26 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x26, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc0_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=196
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -196 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc4:
-  c.lwsp x20, 196(sp) # perform load (0xd2757a13)
-  # Check if x20 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x20, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc4_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x25, 196(sp) # perform load (0x6cc45c95)
+  # Check if x25 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x25, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc4_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=200
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -200 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc8:
-  c.lwsp x1, 200(sp) # perform load (0x69e352ae)
-  # Check if x1 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x1, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc8_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x10, 200(sp) # perform load (0x98cd8028)
+  # Check if x10 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x10, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc8_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=204
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -204 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xcc:
-  c.lwsp x23, 204(sp) # perform load (0x692f6df2)
-  # Check if x23 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x23, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xcc_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x20, 204(sp) # perform load (0xd2757a13)
+  # Check if x20 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x20, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xcc_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=208
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -208 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd0:
-  c.lwsp x20, 208(sp) # perform load (0xe5d1ca66)
-  # Check if x20 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x20, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd0_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x1, 208(sp) # perform load (0x69e352ae)
+  # Check if x1 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x1, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd0_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=212
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -212 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd4:
-  c.lwsp x16, 212(sp) # perform load (0x5e1096a8)
-  # Check if x16 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x16, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd4_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x23, 212(sp) # perform load (0x692f6df2)
+  # Check if x23 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x23, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd4_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=216
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -216 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd8:
-  c.lwsp x7, 216(sp) # perform load (0x5e13a1c4)
-  # Check if x7 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x7, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd8_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x20, 216(sp) # perform load (0xe5d1ca66)
+  # Check if x20 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x20, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd8_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=220
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -220 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xdc:
-  c.lwsp x27, 220(sp) # perform load (0xe7371470)
-  # Check if x27 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x27, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xdc_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x16, 220(sp) # perform load (0x5e1096a8)
+  # Check if x16 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x16, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xdc_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=224
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -224 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe0:
-  c.lwsp x8, 224(sp) # perform load (0x9eca5f99)
-  # Check if x8 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe0_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x7, 224(sp) # perform load (0x5e13a1c4)
+  # Check if x7 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x7, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe0_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=228
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -228 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe4:
-  c.lwsp x28, 228(sp) # perform load (0x133dd2f5)
-  # Check if x28 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x28, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe4_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x27, 228(sp) # perform load (0xe7371470)
+  # Check if x27 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x27, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe4_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=232
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -232 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe8:
-  c.lwsp x27, 232(sp) # perform load (0x691dca86)
-  # Check if x27 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x27, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe8_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x8, 232(sp) # perform load (0x9eca5f99)
+  # Check if x8 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe8_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=236
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -236 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xec:
-  c.lwsp x17, 236(sp) # perform load (0xa44e318e)
-  # Check if x17 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x17, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xec_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x28, 236(sp) # perform load (0x133dd2f5)
+  # Check if x28 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x28, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xec_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=240
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -240 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf0:
-  c.lwsp x9, 240(sp) # perform load (0xfda9e839)
-  # Check if x9 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x9, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf0_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x27, 240(sp) # perform load (0x691dca86)
+  # Check if x27 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x27, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf0_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=244
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -244 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf4:
-  c.lwsp x10, 244(sp) # perform load (0xca14c1ac)
-  # Check if x10 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x10, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf4_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x17, 244(sp) # perform load (0xa44e318e)
+  # Check if x17 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x17, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf4_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=248
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -248 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf8:
-  c.lwsp x16, 248(sp) # perform load (0x8d9cbe55)
-  # Check if x16 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x16, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf8_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x9, 248(sp) # perform load (0xfda9e839)
+  # Check if x9 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x9, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf8_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=252
-  mv sp, x15 # move data_ptr to sp
+  mv sp, x24 # move data_ptr to sp
   addi sp, sp, -252 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xfc:
-  c.lwsp x23, 252(sp) # perform load (0xeb3ba686)
-  # Check if x23 contains the expected result. x24 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x24, x5, x4, x23, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xfc_str)
-  addi x15, x15, SIG_STRIDE # increment data_ptr
+  c.lwsp x10, 252(sp) # perform load (0xca14c1ac)
+  # Check if x10 contains the expected result. x12 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x12, x5, x4, x10, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xfc_str)
+  addi x24, x24, SIG_STRIDE # increment data_ptr
 
-  mv x2, x24 # restore signature pointer to default register for teardown
+  mv x2, x12 # restore signature pointer to default register for teardown
 
 // Instantiate trap handlers and other epilog code, call RVMODEL_HALT at end of test
 RVTEST_CODE_END
@@ -925,12 +925,11 @@ RVTEST_DATA_BEGIN
 .word 0x9ad3a84e
 .word 0xddaf6e31
 .word 0x34112b22
-.word 0x690308d2
-.word 0x31dd325e
-.word 0x8b2cfc2e
-.word 0xd1540c9c
-.word 0xe9780bd1
-.word 0x08f01362
+.word 0x089aaf83
+.word 0xd6716c54
+.word 0x8d2386a2
+.word 0x87d7cbd1
+.word 0x387da3d8
 .word 0x186552ad
 .word 0xf6635cb3
 .word 0xc7c416cb
@@ -938,28 +937,30 @@ RVTEST_DATA_BEGIN
 .word 0x458c3ac0
 .word 0xeeceeeba
 .word 0xe8827eb1
-.word 0x346be914
+.word 0x7986f1dd
 .word 0xff305e15
-.word 0xc088b356
-.word 0x7898ffbd
+.word 0x0d381468
+.word 0x247f0502
+.word 0x62cd65d9
 .word 0xbb4ed7b7
 .word 0x1ec9013b
 .word 0x52f84901
 .word 0x916bbc73
 .word 0x679bb905
 .word 0x944f0c17
-.word 0x4a2d0947
-.word 0xa571a4a4
-.word 0xfff3af14
-.word 0xb168166a
-.word 0x694d5b06
-.word 0xb7055546
+.word 0xe8565dc5
+.word 0x554726aa
+.word 0xd3d7487b
+.word 0xaf1cae29
+.word 0x4907e937
+.word 0x98edb9d9
 .word 0x8eca0a28
 .word 0x9607e87c
 .word 0x02c8f08e
 .word 0x0420ab59
-.word 0xdd236d20
-.word 0x3d79ee8e
+.word 0x19bd346d
+.word 0x75a676a3
+.word 0xa2b70c8a
 .word 0xbe945e51
 .word 0x9449892d
 .word 0x9cd81425
@@ -967,17 +968,18 @@ RVTEST_DATA_BEGIN
 .word 0xa96fd7c7
 .word 0x2b09593d
 .word 0xebd80cda
-.word 0x25587ca8
+.word 0xf43544cb
+.word 0x40049a50
 .word 0x048a574f
-.word 0x0e3b763e
-.word 0x9a454554
-.word 0xfe8cba05
-.word 0x4a0a9926
-.word 0x9f876890
-.word 0x4972725d
-.word 0xb92eb20a
-.word 0xd4f45dcf
-.word 0x301df2b7
+.word 0x0e2a4020
+.word 0xcdbf254c
+.word 0x3be4f34c
+.word 0xfe77b638
+.word 0x028f00d4
+.word 0xcbe357d2
+.word 0x6fe63562
+.word 0x83bb81bd
+.word 0xab4c3d28
 .word 0xe6169e43
 .word 0x6ae63906
 .word 0x1f36a21e
@@ -1004,8 +1006,6 @@ RVTEST_DATA_BEGIN
 .word 0xa44e318e
 .word 0xfda9e839
 .word 0xca14c1ac
-.word 0x8d9cbe55
-.word 0xeb3ba686
 
 // Testcase strings
 Zca_c_lwsp_cg_cp_rd_nx0_b1_str: .string "\"test: 1; cg: Zca_c.lwsp_cg; cp: cp_rd_nx0; bin: b1\""

--- a/tests/rv32i/Zcd/Zcd-c.fldsp-00.S
+++ b/tests/rv32i/Zcd/Zcd-c.fldsp-00.S
@@ -137,9 +137,9 @@ Zcd_c_fldsp_cg_cp_fd_b9:
 # Testcase cp_fd (Test destination fd = f10)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -416 # adjust base address for load
+  addi sp, sp, -392 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b10:
-  c.fldsp f10, 416(sp) # perform load (0xb715ae5a)
+  c.fldsp f10, 392(sp) # perform load (0x736a03e6)
   # Check if f10 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f10, Zcd_c_fldsp_cg_cp_fd_b10, Zcd_c_fldsp_cg_cp_fd_b10_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -147,9 +147,9 @@ Zcd_c_fldsp_cg_cp_fd_b10:
 # Testcase cp_fd (Test destination fd = f11)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -56 # adjust base address for load
+  addi sp, sp, -464 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b11:
-  c.fldsp f11, 56(sp) # perform load (0xc06941be)
+  c.fldsp f11, 464(sp) # perform load (0x3d0d387c)
   # Check if f11 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f11, Zcd_c_fldsp_cg_cp_fd_b11, Zcd_c_fldsp_cg_cp_fd_b11_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -157,9 +157,9 @@ Zcd_c_fldsp_cg_cp_fd_b11:
 # Testcase cp_fd (Test destination fd = f12)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -312 # adjust base address for load
+  addi sp, sp, -72 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b12:
-  c.fldsp f12, 312(sp) # perform load (0x66709449)
+  c.fldsp f12, 72(sp) # perform load (0x05ac9a90)
   # Check if f12 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f12, Zcd_c_fldsp_cg_cp_fd_b12, Zcd_c_fldsp_cg_cp_fd_b12_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -167,9 +167,9 @@ Zcd_c_fldsp_cg_cp_fd_b12:
 # Testcase cp_fd (Test destination fd = f13)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -304 # adjust base address for load
+  addi sp, sp, -312 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b13:
-  c.fldsp f13, 304(sp) # perform load (0x735cf69d)
+  c.fldsp f13, 312(sp) # perform load (0x66709449)
   # Check if f13 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f13, Zcd_c_fldsp_cg_cp_fd_b13, Zcd_c_fldsp_cg_cp_fd_b13_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -177,9 +177,9 @@ Zcd_c_fldsp_cg_cp_fd_b13:
 # Testcase cp_fd (Test destination fd = f14)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -224 # adjust base address for load
+  addi sp, sp, -304 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b14:
-  c.fldsp f14, 224(sp) # perform load (0x1c4554ca)
+  c.fldsp f14, 304(sp) # perform load (0x735cf69d)
   # Check if f14 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f14, Zcd_c_fldsp_cg_cp_fd_b14, Zcd_c_fldsp_cg_cp_fd_b14_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -187,9 +187,9 @@ Zcd_c_fldsp_cg_cp_fd_b14:
 # Testcase cp_fd (Test destination fd = f15)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -112 # adjust base address for load
+  addi sp, sp, -224 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b15:
-  c.fldsp f15, 112(sp) # perform load (0xb92c11f5)
+  c.fldsp f15, 224(sp) # perform load (0x1c4554ca)
   # Check if f15 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f15, Zcd_c_fldsp_cg_cp_fd_b15, Zcd_c_fldsp_cg_cp_fd_b15_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -197,9 +197,9 @@ Zcd_c_fldsp_cg_cp_fd_b15:
 # Testcase cp_fd (Test destination fd = f16)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -208 # adjust base address for load
+  addi sp, sp, -112 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b16:
-  c.fldsp f16, 208(sp) # perform load (0xbd35d68c)
+  c.fldsp f16, 112(sp) # perform load (0xb92c11f5)
   # Check if f16 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f16, Zcd_c_fldsp_cg_cp_fd_b16, Zcd_c_fldsp_cg_cp_fd_b16_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -207,9 +207,9 @@ Zcd_c_fldsp_cg_cp_fd_b16:
 # Testcase cp_fd (Test destination fd = f17)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -56 # adjust base address for load
+  addi sp, sp, -208 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b17:
-  c.fldsp f17, 56(sp) # perform load (0x00d11e28)
+  c.fldsp f17, 208(sp) # perform load (0xbd35d68c)
   # Check if f17 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f17, Zcd_c_fldsp_cg_cp_fd_b17, Zcd_c_fldsp_cg_cp_fd_b17_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -217,9 +217,9 @@ Zcd_c_fldsp_cg_cp_fd_b17:
 # Testcase cp_fd (Test destination fd = f18)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -224 # adjust base address for load
+  addi sp, sp, -56 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b18:
-  c.fldsp f18, 224(sp) # perform load (0x80996992)
+  c.fldsp f18, 56(sp) # perform load (0x00d11e28)
   # Check if f18 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f18, Zcd_c_fldsp_cg_cp_fd_b18, Zcd_c_fldsp_cg_cp_fd_b18_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -227,9 +227,9 @@ Zcd_c_fldsp_cg_cp_fd_b18:
 # Testcase cp_fd (Test destination fd = f19)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -240 # adjust base address for load
+  addi sp, sp, -224 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b19:
-  c.fldsp f19, 240(sp) # perform load (0x19c66843)
+  c.fldsp f19, 224(sp) # perform load (0x80996992)
   # Check if f19 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f19, Zcd_c_fldsp_cg_cp_fd_b19, Zcd_c_fldsp_cg_cp_fd_b19_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -237,9 +237,9 @@ Zcd_c_fldsp_cg_cp_fd_b19:
 # Testcase cp_fd (Test destination fd = f20)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -72 # adjust base address for load
+  addi sp, sp, -240 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b20:
-  c.fldsp f20, 72(sp) # perform load (0x3047b44b)
+  c.fldsp f20, 240(sp) # perform load (0x19c66843)
   # Check if f20 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f20, Zcd_c_fldsp_cg_cp_fd_b20, Zcd_c_fldsp_cg_cp_fd_b20_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -247,9 +247,9 @@ Zcd_c_fldsp_cg_cp_fd_b20:
 # Testcase cp_fd (Test destination fd = f21)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -48 # adjust base address for load
+  addi sp, sp, -72 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b21:
-  c.fldsp f21, 48(sp) # perform load (0x9b8488a7)
+  c.fldsp f21, 72(sp) # perform load (0x3047b44b)
   # Check if f21 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f21, Zcd_c_fldsp_cg_cp_fd_b21, Zcd_c_fldsp_cg_cp_fd_b21_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -257,9 +257,9 @@ Zcd_c_fldsp_cg_cp_fd_b21:
 # Testcase cp_fd (Test destination fd = f22)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -464 # adjust base address for load
+  addi sp, sp, -48 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b22:
-  c.fldsp f22, 464(sp) # perform load (0xd962da28)
+  c.fldsp f22, 48(sp) # perform load (0x9b8488a7)
   # Check if f22 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f22, Zcd_c_fldsp_cg_cp_fd_b22, Zcd_c_fldsp_cg_cp_fd_b22_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -267,9 +267,9 @@ Zcd_c_fldsp_cg_cp_fd_b22:
 # Testcase cp_fd (Test destination fd = f23)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -120 # adjust base address for load
+  addi sp, sp, -464 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b23:
-  c.fldsp f23, 120(sp) # perform load (0xc24a74be)
+  c.fldsp f23, 464(sp) # perform load (0xd962da28)
   # Check if f23 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f23, Zcd_c_fldsp_cg_cp_fd_b23, Zcd_c_fldsp_cg_cp_fd_b23_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -277,9 +277,9 @@ Zcd_c_fldsp_cg_cp_fd_b23:
 # Testcase cp_fd (Test destination fd = f24)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -320 # adjust base address for load
+  addi sp, sp, -120 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b24:
-  c.fldsp f24, 320(sp) # perform load (0xef387c3e)
+  c.fldsp f24, 120(sp) # perform load (0xc24a74be)
   # Check if f24 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f24, Zcd_c_fldsp_cg_cp_fd_b24, Zcd_c_fldsp_cg_cp_fd_b24_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -287,9 +287,9 @@ Zcd_c_fldsp_cg_cp_fd_b24:
 # Testcase cp_fd (Test destination fd = f25)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -200 # adjust base address for load
+  addi sp, sp, -320 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b25:
-  c.fldsp f25, 200(sp) # perform load (0x0b2b7cd0)
+  c.fldsp f25, 320(sp) # perform load (0xef387c3e)
   # Check if f25 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f25, Zcd_c_fldsp_cg_cp_fd_b25, Zcd_c_fldsp_cg_cp_fd_b25_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -297,9 +297,9 @@ Zcd_c_fldsp_cg_cp_fd_b25:
 # Testcase cp_fd (Test destination fd = f26)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -360 # adjust base address for load
+  addi sp, sp, -200 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b26:
-  c.fldsp f26, 360(sp) # perform load (0x81732a00)
+  c.fldsp f26, 200(sp) # perform load (0x0b2b7cd0)
   # Check if f26 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f26, Zcd_c_fldsp_cg_cp_fd_b26, Zcd_c_fldsp_cg_cp_fd_b26_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -307,9 +307,9 @@ Zcd_c_fldsp_cg_cp_fd_b26:
 # Testcase cp_fd (Test destination fd = f27)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -488 # adjust base address for load
+  addi sp, sp, -360 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b27:
-  c.fldsp f27, 488(sp) # perform load (0x3c290366)
+  c.fldsp f27, 360(sp) # perform load (0x81732a00)
   # Check if f27 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f27, Zcd_c_fldsp_cg_cp_fd_b27, Zcd_c_fldsp_cg_cp_fd_b27_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -317,9 +317,9 @@ Zcd_c_fldsp_cg_cp_fd_b27:
 # Testcase cp_fd (Test destination fd = f28)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -200 # adjust base address for load
+  addi sp, sp, -488 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b28:
-  c.fldsp f28, 200(sp) # perform load (0x9af151e1)
+  c.fldsp f28, 488(sp) # perform load (0x3c290366)
   # Check if f28 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f28, Zcd_c_fldsp_cg_cp_fd_b28, Zcd_c_fldsp_cg_cp_fd_b28_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -327,9 +327,9 @@ Zcd_c_fldsp_cg_cp_fd_b28:
 # Testcase cp_fd (Test destination fd = f29)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -168 # adjust base address for load
+  addi sp, sp, -200 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b29:
-  c.fldsp f29, 168(sp) # perform load (0x7d7d3dfe)
+  c.fldsp f29, 200(sp) # perform load (0x9af151e1)
   # Check if f29 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f29, Zcd_c_fldsp_cg_cp_fd_b29, Zcd_c_fldsp_cg_cp_fd_b29_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -337,9 +337,9 @@ Zcd_c_fldsp_cg_cp_fd_b29:
 # Testcase cp_fd (Test destination fd = f30)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -344 # adjust base address for load
+  addi sp, sp, -168 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b30:
-  c.fldsp f30, 344(sp) # perform load (0x10d1b178)
+  c.fldsp f30, 168(sp) # perform load (0x7d7d3dfe)
   # Check if f30 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f30, Zcd_c_fldsp_cg_cp_fd_b30, Zcd_c_fldsp_cg_cp_fd_b30_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -347,9 +347,9 @@ Zcd_c_fldsp_cg_cp_fd_b30:
 # Testcase cp_fd (Test destination fd = f31)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -360 # adjust base address for load
+  addi sp, sp, -344 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b31:
-  c.fldsp f31, 360(sp) # perform load (0x360cdf80)
+  c.fldsp f31, 344(sp) # perform load (0x10d1b178)
   # Check if f31 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x26, x5, x4, f4, f31, Zcd_c_fldsp_cg_cp_fd_b31, Zcd_c_fldsp_cg_cp_fd_b31_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -363,9 +363,9 @@ Zcd_c_fldsp_cg_cp_fd_b31:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, 0 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x0:
-  c.fldsp f21, 0(sp) # perform load (0x0511cc30)
-  # Check if f21 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f21, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x0_str)
+  c.fldsp f20, 0(sp) # perform load (0x0511cc30)
+  # Check if f20 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f20, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=8
@@ -373,9 +373,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -8 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x8:
-  c.fldsp f12, 8(sp) # perform load (0x803e3902)
-  # Check if f12 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f12, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x8_str)
+  c.fldsp f11, 8(sp) # perform load (0x803e3902)
+  # Check if f11 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f11, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=16
@@ -383,9 +383,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -16 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x10:
-  c.fldsp f3, 16(sp) # perform load (0x4b53267a)
-  # Check if f3 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f3, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x10_str)
+  c.fldsp f2, 16(sp) # perform load (0x4b53267a)
+  # Check if f2 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f2, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x10_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=24
@@ -393,9 +393,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x10:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -24 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x18:
-  c.fldsp f14, 24(sp) # perform load (0x047d1d80)
-  # Check if f14 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f14, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x18, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x18_str)
+  c.fldsp f13, 24(sp) # perform load (0x047d1d80)
+  # Check if f13 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f13, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x18, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x18_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=32
@@ -403,9 +403,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x18:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -32 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x20:
-  c.fldsp f17, 32(sp) # perform load (0x243c8bb1)
-  # Check if f17 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f17, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x20, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x20_str)
+  c.fldsp f16, 32(sp) # perform load (0x243c8bb1)
+  # Check if f16 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f16, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x20, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x20_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=40
@@ -413,9 +413,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x20:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -40 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x28:
-  c.fldsp f3, 40(sp) # perform load (0xbe653780)
-  # Check if f3 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f3, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x28_str)
+  c.fldsp f2, 40(sp) # perform load (0xbe653780)
+  # Check if f2 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f2, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x28_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=48
@@ -423,9 +423,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x28:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -48 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x30:
-  c.fldsp f28, 48(sp) # perform load (0x3438b12d)
-  # Check if f28 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x30, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x30_str)
+  c.fldsp f27, 48(sp) # perform load (0x3438b12d)
+  # Check if f27 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f27, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x30, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x30_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=56
@@ -433,9 +433,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x30:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -56 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x38:
-  c.fldsp f7, 56(sp) # perform load (0xa678132b)
-  # Check if f7 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f7, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x38, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x38_str)
+  c.fldsp f6, 56(sp) # perform load (0xa678132b)
+  # Check if f6 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f6, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x38, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x38_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=64
@@ -443,9 +443,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x38:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -64 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x40:
-  c.fldsp f15, 64(sp) # perform load (0xa2dd13e0)
-  # Check if f15 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f15, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x40, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x40_str)
+  c.fldsp f14, 64(sp) # perform load (0xa2dd13e0)
+  # Check if f14 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f14, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x40, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x40_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=72
@@ -453,9 +453,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x40:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -72 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x48:
-  c.fldsp f27, 72(sp) # perform load (0x85be2c20)
-  # Check if f27 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f27, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x48, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x48_str)
+  c.fldsp f26, 72(sp) # perform load (0x85be2c20)
+  # Check if f26 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f26, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x48, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x48_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=80
@@ -463,9 +463,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x48:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -80 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x50:
-  c.fldsp f28, 80(sp) # perform load (0x7f7bb737)
-  # Check if f28 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x50, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x50_str)
+  c.fldsp f27, 80(sp) # perform load (0x7f7bb737)
+  # Check if f27 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f27, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x50, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x50_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=88
@@ -473,9 +473,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x50:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -88 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x58:
-  c.fldsp f28, 88(sp) # perform load (0x027c1e6a)
-  # Check if f28 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x58, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x58_str)
+  c.fldsp f27, 88(sp) # perform load (0x027c1e6a)
+  # Check if f27 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f27, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x58, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x58_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=96
@@ -483,9 +483,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x58:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -96 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x60:
-  c.fldsp f10, 96(sp) # perform load (0xf66f6dff)
-  # Check if f10 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x60, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x60_str)
+  c.fldsp f9, 96(sp) # perform load (0xf66f6dff)
+  # Check if f9 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x60, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x60_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=104
@@ -493,9 +493,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x60:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -104 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x68:
-  c.fldsp f14, 104(sp) # perform load (0xae7428cf)
-  # Check if f14 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f14, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x68, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x68_str)
+  c.fldsp f13, 104(sp) # perform load (0xae7428cf)
+  # Check if f13 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f13, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x68, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x68_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=112
@@ -503,9 +503,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x68:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -112 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x70:
-  c.fldsp f14, 112(sp) # perform load (0x646bb191)
-  # Check if f14 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f14, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x70, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x70_str)
+  c.fldsp f13, 112(sp) # perform load (0x646bb191)
+  # Check if f13 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f13, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x70, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x70_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=120
@@ -513,9 +513,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x70:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -120 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x78:
-  c.fldsp f29, 120(sp) # perform load (0xc901a8ba)
-  # Check if f29 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f29, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x78, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x78_str)
+  c.fldsp f28, 120(sp) # perform load (0xc901a8ba)
+  # Check if f28 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x78, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x78_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=128
@@ -523,9 +523,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x78:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -128 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x80:
-  c.fldsp f13, 128(sp) # perform load (0x7aadc3d0)
-  # Check if f13 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f13, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x80, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x80_str)
+  c.fldsp f31, 128(sp) # perform load (0x7aadc3d0)
+  # Check if f31 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f31, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x80, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x80_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=136
@@ -533,9 +533,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x80:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -136 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x88:
-  c.fldsp f26, 136(sp) # perform load (0x0cb0616f)
-  # Check if f26 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f26, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x88, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x88_str)
+  c.fldsp f28, 136(sp) # perform load (0x98027c0f)
+  # Check if f28 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x88, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x88_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=144
@@ -543,9 +543,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x88:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -144 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x90:
-  c.fldsp f17, 144(sp) # perform load (0x4eaa93e2)
-  # Check if f17 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f17, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x90, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x90_str)
+  c.fldsp f23, 144(sp) # perform load (0x6623b993)
+  # Check if f23 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f23, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x90, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x90_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=152
@@ -553,9 +553,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x90:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -152 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x98:
-  c.fldsp f24, 152(sp) # perform load (0x6623b993)
-  # Check if f24 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f24, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x98, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x98_str)
+  c.fldsp f2, 152(sp) # perform load (0xff6efe85)
+  # Check if f2 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f2, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x98, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x98_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=160
@@ -563,9 +563,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x98:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -160 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa0:
-  c.fldsp f3, 160(sp) # perform load (0xff6efe85)
-  # Check if f3 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f3, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa0_str)
+  c.fldsp f22, 160(sp) # perform load (0x4dca08cd)
+  # Check if f22 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f22, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=168
@@ -573,9 +573,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -168 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa8:
-  c.fldsp f23, 168(sp) # perform load (0x4dca08cd)
-  # Check if f23 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f23, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa8_str)
+  c.fldsp f29, 168(sp) # perform load (0xf8c45fea)
+  # Check if f29 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f29, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=176
@@ -583,9 +583,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -176 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb0:
-  c.fldsp f30, 176(sp) # perform load (0xf8c45fea)
-  # Check if f30 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f30, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb0_str)
+  c.fldsp f20, 176(sp) # perform load (0x2f35d4b2)
+  # Check if f20 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f20, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=184
@@ -593,9 +593,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -184 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb8:
-  c.fldsp f21, 184(sp) # perform load (0x2f35d4b2)
-  # Check if f21 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f21, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb8_str)
+  c.fldsp f26, 184(sp) # perform load (0x224d4141)
+  # Check if f26 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f26, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=192
@@ -603,9 +603,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -192 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc0:
-  c.fldsp f27, 192(sp) # perform load (0x224d4141)
-  # Check if f27 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f27, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc0_str)
+  c.fldsp f15, 192(sp) # perform load (0xb638ff67)
+  # Check if f15 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f15, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=200
@@ -613,9 +613,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -200 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc8:
-  c.fldsp f16, 200(sp) # perform load (0xb638ff67)
-  # Check if f16 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f16, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc8_str)
+  c.fldsp f30, 200(sp) # perform load (0x9878c087)
+  # Check if f30 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f30, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=208
@@ -623,9 +623,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -208 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd0:
-  c.fldsp f18, 208(sp) # perform load (0x9878c087)
-  # Check if f18 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f18, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd0_str)
+  c.fldsp f31, 208(sp) # perform load (0x19937464)
+  # Check if f31 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f31, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=216
@@ -633,9 +633,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -216 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd8:
-  c.fldsp f11, 216(sp) # perform load (0x19937464)
-  # Check if f11 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f11, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd8_str)
+  c.fldsp f17, 216(sp) # perform load (0x4ff6703b)
+  # Check if f17 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f17, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=224
@@ -643,9 +643,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -224 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe0:
-  c.fldsp f13, 224(sp) # perform load (0x0b124cba)
-  # Check if f13 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f13, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe0_str)
+  c.fldsp f26, 224(sp) # perform load (0x860c3036)
+  # Check if f26 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f26, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=232
@@ -653,9 +653,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -232 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe8:
-  c.fldsp f8, 232(sp) # perform load (0xbc9ee647)
-  # Check if f8 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe8_str)
+  c.fldsp f7, 232(sp) # perform load (0xbc9ee647)
+  # Check if f7 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f7, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=240
@@ -663,9 +663,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -240 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf0:
-  c.fldsp f10, 240(sp) # perform load (0x49412373)
-  # Check if f10 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf0_str)
+  c.fldsp f9, 240(sp) # perform load (0x49412373)
+  # Check if f9 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=248
@@ -673,9 +673,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -248 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf8:
-  c.fldsp f5, 248(sp) # perform load (0xea47949d)
-  # Check if f5 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f5, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf8_str)
+  c.fldsp f3, 248(sp) # perform load (0xea47949d)
+  # Check if f3 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f3, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=256
@@ -683,9 +683,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -256 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x100:
-  c.fldsp f13, 256(sp) # perform load (0x195694fd)
-  # Check if f13 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f13, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x100, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x100_str)
+  c.fldsp f31, 256(sp) # perform load (0x195694fd)
+  # Check if f31 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f31, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x100, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x100_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=264
@@ -693,9 +693,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x100:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -264 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x108:
-  c.fldsp f7, 264(sp) # perform load (0x67545e0f)
-  # Check if f7 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f7, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x108, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x108_str)
+  c.fldsp f16, 264(sp) # perform load (0xce3854b5)
+  # Check if f16 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f16, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x108, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x108_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=272
@@ -703,9 +703,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x108:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -272 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x110:
-  c.fldsp f22, 272(sp) # perform load (0x6dbcfda4)
-  # Check if f22 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f22, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x110, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x110_str)
+  c.fldsp f6, 272(sp) # perform load (0x2495eb4b)
+  # Check if f6 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f6, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x110, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x110_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=280
@@ -713,9 +713,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x110:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -280 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x118:
-  c.fldsp f2, 280(sp) # perform load (0x3c7d191c)
-  # Check if f2 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f2, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x118, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x118_str)
+  c.fldsp f1, 280(sp) # perform load (0x3c7d191c)
+  # Check if f1 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f1, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x118, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x118_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=288
@@ -723,9 +723,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x118:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -288 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x120:
-  c.fldsp f10, 288(sp) # perform load (0x323be219)
-  # Check if f10 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x120, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x120_str)
+  c.fldsp f9, 288(sp) # perform load (0x323be219)
+  # Check if f9 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x120, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x120_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=296
@@ -733,9 +733,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x120:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -296 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x128:
-  c.fldsp f16, 296(sp) # perform load (0xff5053aa)
-  # Check if f16 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f16, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x128, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x128_str)
+  c.fldsp f15, 296(sp) # perform load (0xff5053aa)
+  # Check if f15 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f15, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x128, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x128_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=304
@@ -743,9 +743,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x128:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -304 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x130:
-  c.fldsp f13, 304(sp) # perform load (0xad08ff8e)
-  # Check if f13 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f13, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x130, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x130_str)
+  c.fldsp f12, 304(sp) # perform load (0xad08ff8e)
+  # Check if f12 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f12, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x130, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x130_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=312
@@ -753,9 +753,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x130:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -312 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x138:
-  c.fldsp f19, 312(sp) # perform load (0x913639b6)
-  # Check if f19 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f19, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x138, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x138_str)
+  c.fldsp f30, 312(sp) # perform load (0x913639b6)
+  # Check if f30 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f30, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x138, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x138_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=320
@@ -763,9 +763,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x138:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -320 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x140:
-  c.fldsp f27, 320(sp) # perform load (0x1857472c)
-  # Check if f27 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f27, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x140, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x140_str)
+  c.fldsp f25, 320(sp) # perform load (0xb1dc698a)
+  # Check if f25 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f25, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x140, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x140_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=328
@@ -773,9 +773,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x140:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -328 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x148:
-  c.fldsp f21, 328(sp) # perform load (0x366e6886)
-  # Check if f21 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f21, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x148, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x148_str)
+  c.fldsp f12, 328(sp) # perform load (0x210a49e1)
+  # Check if f12 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f12, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x148, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x148_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=336
@@ -783,9 +783,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x148:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -336 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x150:
-  c.fldsp f6, 336(sp) # perform load (0xe6491b2e)
-  # Check if f6 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f6, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x150, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x150_str)
+  c.fldsp f16, 336(sp) # perform load (0x61b1a2a0)
+  # Check if f16 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f16, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x150, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x150_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=344
@@ -793,9 +793,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x150:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -344 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x158:
-  c.fldsp f30, 344(sp) # perform load (0xfdfa045d)
-  # Check if f30 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f30, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x158, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x158_str)
+  c.fldsp f15, 344(sp) # perform load (0x6712fdb6)
+  # Check if f15 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f15, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x158, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x158_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=352
@@ -803,9 +803,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x158:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -352 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x160:
-  c.fldsp f5, 352(sp) # perform load (0xf57a0ee1)
-  # Check if f5 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f5, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x160, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x160_str)
+  c.fldsp f19, 352(sp) # perform load (0x7616a8e4)
+  # Check if f19 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f19, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x160, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x160_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=360
@@ -813,9 +813,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x160:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -360 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x168:
-  c.fldsp f20, 360(sp) # perform load (0x6465ac89)
-  # Check if f20 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f20, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x168, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x168_str)
+  c.fldsp f21, 360(sp) # perform load (0x158ed768)
+  # Check if f21 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f21, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x168, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x168_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=368
@@ -823,9 +823,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x168:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -368 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x170:
-  c.fldsp f9, 368(sp) # perform load (0xdaaa77d8)
-  # Check if f9 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x170, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x170_str)
+  c.fldsp f8, 368(sp) # perform load (0xdaaa77d8)
+  # Check if f8 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x170, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x170_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=376
@@ -833,9 +833,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x170:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -376 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x178:
-  c.fldsp f26, 376(sp) # perform load (0xa5dd494d)
-  # Check if f26 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f26, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x178, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x178_str)
+  c.fldsp f25, 376(sp) # perform load (0xa5dd494d)
+  # Check if f25 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f25, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x178, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x178_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=384
@@ -843,9 +843,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x178:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -384 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x180:
-  c.fldsp f2, 384(sp) # perform load (0xfd56720d)
-  # Check if f2 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f2, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x180, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x180_str)
+  c.fldsp f1, 384(sp) # perform load (0xfd56720d)
+  # Check if f1 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f1, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x180, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x180_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=392
@@ -853,9 +853,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x180:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -392 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x188:
-  c.fldsp f28, 392(sp) # perform load (0x38b405d5)
-  # Check if f28 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x188, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x188_str)
+  c.fldsp f27, 392(sp) # perform load (0x38b405d5)
+  # Check if f27 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f27, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x188, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x188_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=400
@@ -863,9 +863,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x188:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -400 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x190:
-  c.fldsp f5, 400(sp) # perform load (0x1a7ccaed)
-  # Check if f5 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f5, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x190, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x190_str)
+  c.fldsp f3, 400(sp) # perform load (0x1a7ccaed)
+  # Check if f3 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f3, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x190, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x190_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=408
@@ -873,9 +873,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x190:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -408 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x198:
-  c.fldsp f22, 408(sp) # perform load (0x5a73004b)
-  # Check if f22 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f22, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x198, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x198_str)
+  c.fldsp f21, 408(sp) # perform load (0x5a73004b)
+  # Check if f21 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f21, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x198, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x198_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=416
@@ -883,9 +883,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x198:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -416 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a0:
-  c.fldsp f14, 416(sp) # perform load (0x04fdde3b)
-  # Check if f14 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f14, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a0_str)
+  c.fldsp f13, 416(sp) # perform load (0x04fdde3b)
+  # Check if f13 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f13, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=424
@@ -893,9 +893,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -424 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a8:
-  c.fldsp f9, 424(sp) # perform load (0x03f3fa7f)
-  # Check if f9 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a8_str)
+  c.fldsp f31, 424(sp) # perform load (0x03f3fa7f)
+  # Check if f31 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f31, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=432
@@ -903,9 +903,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -432 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b0:
-  c.fldsp f19, 432(sp) # perform load (0xc398918d)
-  # Check if f19 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f19, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b0_str)
+  c.fldsp f18, 432(sp) # perform load (0x35c7936d)
+  # Check if f18 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f18, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=440
@@ -913,9 +913,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -440 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b8:
-  c.fldsp f12, 440(sp) # perform load (0xe924a50f)
-  # Check if f12 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f12, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b8_str)
+  c.fldsp f6, 440(sp) # perform load (0x6e303937)
+  # Check if f6 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f6, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=448
@@ -923,9 +923,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -448 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c0:
-  c.fldsp f20, 448(sp) # perform load (0xfb05861b)
-  # Check if f20 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f20, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c0_str)
+  c.fldsp f12, 448(sp) # perform load (0xcacaea0b)
+  # Check if f12 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f12, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=456
@@ -933,9 +933,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -456 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c8:
-  c.fldsp f20, 456(sp) # perform load (0xb0388c05)
-  # Check if f20 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f20, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c8_str)
+  c.fldsp f10, 456(sp) # perform load (0xab8ecf28)
+  # Check if f10 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=464
@@ -943,9 +943,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -464 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d0:
-  c.fldsp f17, 464(sp) # perform load (0xc26a7440)
-  # Check if f17 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f17, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d0_str)
+  c.fldsp f1, 464(sp) # perform load (0x46f5f2c8)
+  # Check if f1 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f1, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=472
@@ -953,9 +953,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -472 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d8:
-  c.fldsp f8, 472(sp) # perform load (0x73925829)
-  # Check if f8 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d8_str)
+  c.fldsp f13, 472(sp) # perform load (0xc24aad74)
+  # Check if f13 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f13, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=480
@@ -963,9 +963,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -480 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e0:
-  c.fldsp f17, 480(sp) # perform load (0x74d7fb96)
-  # Check if f17 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f17, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e0_str)
+  c.fldsp f19, 480(sp) # perform load (0x79ad0f3b)
+  # Check if f19 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f19, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=488
@@ -973,9 +973,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -488 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e8:
-  c.fldsp f10, 488(sp) # perform load (0xd39890b8)
-  # Check if f10 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e8_str)
+  c.fldsp f19, 488(sp) # perform load (0x29b7f789)
+  # Check if f19 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f19, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=496
@@ -983,9 +983,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -496 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f0:
-  c.fldsp f22, 496(sp) # perform load (0x7f745ded)
-  # Check if f22 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f22, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f0_str)
+  c.fldsp f27, 496(sp) # perform load (0x6482a15d)
+  # Check if f27 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f27, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=504
@@ -993,9 +993,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -504 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f8:
-  c.fldsp f13, 504(sp) # perform load (0xfbde4b5d)
-  # Check if f13 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x26, x5, x4, f4, f13, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f8_str)
+  c.fldsp f9, 504(sp) # perform load (0xd39890b8)
+  # Check if f9 contains the expected result. Also checks fflags. x26 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x26, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
   mv x2, x26 # restore signature pointer to default register for teardown
@@ -1017,8 +1017,9 @@ RVTEST_DATA_BEGIN
 .dword 0x000000002c647dd0
 .dword 0x00000000518ae11a
 .dword 0x000000001191b685
-.dword 0xffffffffb715ae5a
-.dword 0xffffffffc06941be
+.dword 0x00000000736a03e6
+.dword 0x000000003d0d387c
+.dword 0x0000000005ac9a90
 .dword 0x0000000066709449
 .dword 0x00000000735cf69d
 .dword 0x000000001c4554ca
@@ -1038,7 +1039,6 @@ RVTEST_DATA_BEGIN
 .dword 0xffffffff9af151e1
 .dword 0x000000007d7d3dfe
 .dword 0x0000000010d1b178
-.dword 0x00000000360cdf80
 .dword 0x000000000511cc30
 .dword 0xffffffff803e3902
 .dword 0x000000004b53267a
@@ -1056,8 +1056,7 @@ RVTEST_DATA_BEGIN
 .dword 0x00000000646bb191
 .dword 0xffffffffc901a8ba
 .dword 0x000000007aadc3d0
-.dword 0x000000000cb0616f
-.dword 0x000000004eaa93e2
+.dword 0xffffffff98027c0f
 .dword 0x000000006623b993
 .dword 0xffffffffff6efe85
 .dword 0x000000004dca08cd
@@ -1067,24 +1066,25 @@ RVTEST_DATA_BEGIN
 .dword 0xffffffffb638ff67
 .dword 0xffffffff9878c087
 .dword 0x0000000019937464
-.dword 0x000000000b124cba
+.dword 0x000000004ff6703b
+.dword 0xffffffff860c3036
 .dword 0xffffffffbc9ee647
 .dword 0x0000000049412373
 .dword 0xffffffffea47949d
 .dword 0x00000000195694fd
-.dword 0x0000000067545e0f
-.dword 0x000000006dbcfda4
+.dword 0xffffffffce3854b5
+.dword 0x000000002495eb4b
 .dword 0x000000003c7d191c
 .dword 0x00000000323be219
 .dword 0xffffffffff5053aa
 .dword 0xffffffffad08ff8e
 .dword 0xffffffff913639b6
-.dword 0x000000001857472c
-.dword 0x00000000366e6886
-.dword 0xffffffffe6491b2e
-.dword 0xfffffffffdfa045d
-.dword 0xfffffffff57a0ee1
-.dword 0x000000006465ac89
+.dword 0xffffffffb1dc698a
+.dword 0x00000000210a49e1
+.dword 0x0000000061b1a2a0
+.dword 0x000000006712fdb6
+.dword 0x000000007616a8e4
+.dword 0x00000000158ed768
 .dword 0xffffffffdaaa77d8
 .dword 0xffffffffa5dd494d
 .dword 0xfffffffffd56720d
@@ -1093,16 +1093,16 @@ RVTEST_DATA_BEGIN
 .dword 0x000000005a73004b
 .dword 0x0000000004fdde3b
 .dword 0x0000000003f3fa7f
-.dword 0xffffffffc398918d
-.dword 0xffffffffe924a50f
-.dword 0xfffffffffb05861b
-.dword 0xffffffffb0388c05
-.dword 0xffffffffc26a7440
-.dword 0x0000000073925829
-.dword 0x0000000074d7fb96
+.dword 0x0000000035c7936d
+.dword 0x000000006e303937
+.dword 0xffffffffcacaea0b
+.dword 0xffffffffab8ecf28
+.dword 0x0000000046f5f2c8
+.dword 0xffffffffc24aad74
+.dword 0x0000000079ad0f3b
+.dword 0x0000000029b7f789
+.dword 0x000000006482a15d
 .dword 0xffffffffd39890b8
-.dword 0x000000007f745ded
-.dword 0xfffffffffbde4b5d
 
 // Testcase strings
 Zcd_c_fldsp_cg_cp_fd_b0_str: .string "\"test: 1; cg: Zcd_c.fldsp_cg; cp: cp_fd; bin: b0\""

--- a/tests/rv32i/Zcf/Zcf-c.flwsp-00.S
+++ b/tests/rv32i/Zcf/Zcf-c.flwsp-00.S
@@ -87,9 +87,9 @@ Zcf_c_flwsp_cg_cp_fd_b4:
 # Testcase cp_fd (Test destination fd = f5)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -208 # adjust base address for load
+  addi sp, sp, -60 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b5:
-  c.flwsp f5, 208(sp) # perform load (0xcf0c1771)
+  c.flwsp f5, 60(sp) # perform load (0x63b47019)
   # Check if f5 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f13 is a floating point temp reg.
   RVTEST_SIGUPD_F(x28, x5, x4, f13, f5, Zcf_c_flwsp_cg_cp_fd_b5, Zcf_c_flwsp_cg_cp_fd_b5_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -99,7 +99,7 @@ Zcf_c_flwsp_cg_cp_fd_b5:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -208 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b6:
-  c.flwsp f6, 208(sp) # perform load (0x9f49d42a)
+  c.flwsp f6, 208(sp) # perform load (0x183ee34a)
   # Check if f6 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f13 is a floating point temp reg.
   RVTEST_SIGUPD_F(x28, x5, x4, f13, f6, Zcf_c_flwsp_cg_cp_fd_b6, Zcf_c_flwsp_cg_cp_fd_b6_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -107,9 +107,9 @@ Zcf_c_flwsp_cg_cp_fd_b6:
 # Testcase cp_fd (Test destination fd = f7)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, 0 # adjust base address for load
+  addi sp, sp, -124 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b7:
-  c.flwsp f7, 0(sp) # perform load (0xd69b9428)
+  c.flwsp f7, 124(sp) # perform load (0x5030f7c5)
   # Check if f7 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f13 is a floating point temp reg.
   RVTEST_SIGUPD_F(x28, x5, x4, f13, f7, Zcf_c_flwsp_cg_cp_fd_b7, Zcf_c_flwsp_cg_cp_fd_b7_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -117,9 +117,9 @@ Zcf_c_flwsp_cg_cp_fd_b7:
 # Testcase cp_fd (Test destination fd = f8)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -56 # adjust base address for load
+  addi sp, sp, -164 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b8:
-  c.flwsp f8, 56(sp) # perform load (0xab4d3afe)
+  c.flwsp f8, 164(sp) # perform load (0x7793805e)
   # Check if f8 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f13 is a floating point temp reg.
   RVTEST_SIGUPD_F(x28, x5, x4, f13, f8, Zcf_c_flwsp_cg_cp_fd_b8, Zcf_c_flwsp_cg_cp_fd_b8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -127,9 +127,9 @@ Zcf_c_flwsp_cg_cp_fd_b8:
 # Testcase cp_fd (Test destination fd = f9)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -164 # adjust base address for load
+  addi sp, sp, -224 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b9:
-  c.flwsp f9, 164(sp) # perform load (0xd9efe4ca)
+  c.flwsp f9, 224(sp) # perform load (0x9a0e986e)
   # Check if f9 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f13 is a floating point temp reg.
   RVTEST_SIGUPD_F(x28, x5, x4, f13, f9, Zcf_c_flwsp_cg_cp_fd_b9, Zcf_c_flwsp_cg_cp_fd_b9_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -137,9 +137,9 @@ Zcf_c_flwsp_cg_cp_fd_b9:
 # Testcase cp_fd (Test destination fd = f10)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -116 # adjust base address for load
+  addi sp, sp, -248 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b10:
-  c.flwsp f10, 116(sp) # perform load (0xa1f3a00f)
+  c.flwsp f10, 248(sp) # perform load (0xdd76c122)
   # Check if f10 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f13 is a floating point temp reg.
   RVTEST_SIGUPD_F(x28, x5, x4, f13, f10, Zcf_c_flwsp_cg_cp_fd_b10, Zcf_c_flwsp_cg_cp_fd_b10_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -147,9 +147,9 @@ Zcf_c_flwsp_cg_cp_fd_b10:
 # Testcase cp_fd (Test destination fd = f11)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -240 # adjust base address for load
+  addi sp, sp, -148 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b11:
-  c.flwsp f11, 240(sp) # perform load (0xfc240c1b)
+  c.flwsp f11, 148(sp) # perform load (0x24ce3d0a)
   # Check if f11 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f13 is a floating point temp reg.
   RVTEST_SIGUPD_F(x28, x5, x4, f13, f11, Zcf_c_flwsp_cg_cp_fd_b11, Zcf_c_flwsp_cg_cp_fd_b11_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -157,9 +157,9 @@ Zcf_c_flwsp_cg_cp_fd_b11:
 # Testcase cp_fd (Test destination fd = f12)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -208 # adjust base address for load
+  addi sp, sp, -76 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b12:
-  c.flwsp f12, 208(sp) # perform load (0x19658f53)
+  c.flwsp f12, 76(sp) # perform load (0x07bbba2d)
   # Check if f12 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f13 is a floating point temp reg.
   RVTEST_SIGUPD_F(x28, x5, x4, f13, f12, Zcf_c_flwsp_cg_cp_fd_b12, Zcf_c_flwsp_cg_cp_fd_b12_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -169,129 +169,129 @@ Zcf_c_flwsp_cg_cp_fd_b12:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -240 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b13:
-  c.flwsp f13, 240(sp) # perform load (0x4aa6de84)
-  # Check if f13 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f13, Zcf_c_flwsp_cg_cp_fd_b13, Zcf_c_flwsp_cg_cp_fd_b13_str)
+  c.flwsp f13, 240(sp) # perform load (0xfc240c1b)
+  # Check if f13 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f13, Zcf_c_flwsp_cg_cp_fd_b13, Zcf_c_flwsp_cg_cp_fd_b13_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f14)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -164 # adjust base address for load
+  addi sp, sp, -208 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b14:
-  c.flwsp f14, 164(sp) # perform load (0xecceaa11)
-  # Check if f14 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f14, Zcf_c_flwsp_cg_cp_fd_b14, Zcf_c_flwsp_cg_cp_fd_b14_str)
+  c.flwsp f14, 208(sp) # perform load (0x19658f53)
+  # Check if f14 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f14, Zcf_c_flwsp_cg_cp_fd_b14, Zcf_c_flwsp_cg_cp_fd_b14_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f15)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -120 # adjust base address for load
+  addi sp, sp, -240 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b15:
-  c.flwsp f15, 120(sp) # perform load (0x0b89f94e)
-  # Check if f15 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f15, Zcf_c_flwsp_cg_cp_fd_b15, Zcf_c_flwsp_cg_cp_fd_b15_str)
+  c.flwsp f15, 240(sp) # perform load (0x4aa6de84)
+  # Check if f15 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f15, Zcf_c_flwsp_cg_cp_fd_b15, Zcf_c_flwsp_cg_cp_fd_b15_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f16)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -56 # adjust base address for load
+  addi sp, sp, -164 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b16:
-  c.flwsp f16, 56(sp) # perform load (0x3e01a8ff)
-  # Check if f16 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f16, Zcf_c_flwsp_cg_cp_fd_b16, Zcf_c_flwsp_cg_cp_fd_b16_str)
+  c.flwsp f16, 164(sp) # perform load (0xecceaa11)
+  # Check if f16 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f16, Zcf_c_flwsp_cg_cp_fd_b16, Zcf_c_flwsp_cg_cp_fd_b16_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f17)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -252 # adjust base address for load
+  addi sp, sp, -120 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b17:
-  c.flwsp f17, 252(sp) # perform load (0x21f6a4a0)
-  # Check if f17 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f17, Zcf_c_flwsp_cg_cp_fd_b17, Zcf_c_flwsp_cg_cp_fd_b17_str)
+  c.flwsp f17, 120(sp) # perform load (0x0b89f94e)
+  # Check if f17 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f17, Zcf_c_flwsp_cg_cp_fd_b17, Zcf_c_flwsp_cg_cp_fd_b17_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f18)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -232 # adjust base address for load
+  addi sp, sp, -56 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b18:
-  c.flwsp f18, 232(sp) # perform load (0x0ae63304)
-  # Check if f18 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f18, Zcf_c_flwsp_cg_cp_fd_b18, Zcf_c_flwsp_cg_cp_fd_b18_str)
+  c.flwsp f18, 56(sp) # perform load (0x3e01a8ff)
+  # Check if f18 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f18, Zcf_c_flwsp_cg_cp_fd_b18, Zcf_c_flwsp_cg_cp_fd_b18_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f19)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -48 # adjust base address for load
+  addi sp, sp, -252 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b19:
-  c.flwsp f19, 48(sp) # perform load (0xb5310240)
-  # Check if f19 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f19, Zcf_c_flwsp_cg_cp_fd_b19, Zcf_c_flwsp_cg_cp_fd_b19_str)
+  c.flwsp f19, 252(sp) # perform load (0x21f6a4a0)
+  # Check if f19 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f19, Zcf_c_flwsp_cg_cp_fd_b19, Zcf_c_flwsp_cg_cp_fd_b19_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f20)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -108 # adjust base address for load
+  addi sp, sp, -232 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b20:
-  c.flwsp f20, 108(sp) # perform load (0xc7fc732e)
-  # Check if f20 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f20, Zcf_c_flwsp_cg_cp_fd_b20, Zcf_c_flwsp_cg_cp_fd_b20_str)
+  c.flwsp f20, 232(sp) # perform load (0x0ae63304)
+  # Check if f20 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f20, Zcf_c_flwsp_cg_cp_fd_b20, Zcf_c_flwsp_cg_cp_fd_b20_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f21)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -124 # adjust base address for load
+  addi sp, sp, -48 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b21:
-  c.flwsp f21, 124(sp) # perform load (0x829f228d)
-  # Check if f21 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f21, Zcf_c_flwsp_cg_cp_fd_b21, Zcf_c_flwsp_cg_cp_fd_b21_str)
+  c.flwsp f21, 48(sp) # perform load (0xb5310240)
+  # Check if f21 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f21, Zcf_c_flwsp_cg_cp_fd_b21, Zcf_c_flwsp_cg_cp_fd_b21_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f22)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -100 # adjust base address for load
+  addi sp, sp, -108 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b22:
-  c.flwsp f22, 100(sp) # perform load (0xfbc8a76e)
-  # Check if f22 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f22, Zcf_c_flwsp_cg_cp_fd_b22, Zcf_c_flwsp_cg_cp_fd_b22_str)
+  c.flwsp f22, 108(sp) # perform load (0xc7fc732e)
+  # Check if f22 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f22, Zcf_c_flwsp_cg_cp_fd_b22, Zcf_c_flwsp_cg_cp_fd_b22_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f23)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -136 # adjust base address for load
+  addi sp, sp, -124 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b23:
-  c.flwsp f23, 136(sp) # perform load (0xe481d98b)
-  # Check if f23 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f23, Zcf_c_flwsp_cg_cp_fd_b23, Zcf_c_flwsp_cg_cp_fd_b23_str)
+  c.flwsp f23, 124(sp) # perform load (0x829f228d)
+  # Check if f23 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f23, Zcf_c_flwsp_cg_cp_fd_b23, Zcf_c_flwsp_cg_cp_fd_b23_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f24)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -104 # adjust base address for load
+  addi sp, sp, -100 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b24:
-  c.flwsp f24, 104(sp) # perform load (0x6fbe7406)
-  # Check if f24 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f24, Zcf_c_flwsp_cg_cp_fd_b24, Zcf_c_flwsp_cg_cp_fd_b24_str)
+  c.flwsp f24, 100(sp) # perform load (0xfbc8a76e)
+  # Check if f24 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f24, Zcf_c_flwsp_cg_cp_fd_b24, Zcf_c_flwsp_cg_cp_fd_b24_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f25)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -152 # adjust base address for load
+  addi sp, sp, -136 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b25:
-  c.flwsp f25, 152(sp) # perform load (0x3a1f7aa9)
-  # Check if f25 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f25, Zcf_c_flwsp_cg_cp_fd_b25, Zcf_c_flwsp_cg_cp_fd_b25_str)
+  c.flwsp f25, 136(sp) # perform load (0xe481d98b)
+  # Check if f25 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f25, Zcf_c_flwsp_cg_cp_fd_b25, Zcf_c_flwsp_cg_cp_fd_b25_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f26)
@@ -299,59 +299,59 @@ Zcf_c_flwsp_cg_cp_fd_b25:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -104 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b26:
-  c.flwsp f26, 104(sp) # perform load (0x5d14a6b7)
-  # Check if f26 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f26, Zcf_c_flwsp_cg_cp_fd_b26, Zcf_c_flwsp_cg_cp_fd_b26_str)
+  c.flwsp f26, 104(sp) # perform load (0x6fbe7406)
+  # Check if f26 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f26, Zcf_c_flwsp_cg_cp_fd_b26, Zcf_c_flwsp_cg_cp_fd_b26_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f27)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -140 # adjust base address for load
+  addi sp, sp, -152 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b27:
-  c.flwsp f27, 140(sp) # perform load (0x1850c597)
-  # Check if f27 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f27, Zcf_c_flwsp_cg_cp_fd_b27, Zcf_c_flwsp_cg_cp_fd_b27_str)
+  c.flwsp f27, 152(sp) # perform load (0x3a1f7aa9)
+  # Check if f27 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f27, Zcf_c_flwsp_cg_cp_fd_b27, Zcf_c_flwsp_cg_cp_fd_b27_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f28)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -216 # adjust base address for load
+  addi sp, sp, -104 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b28:
-  c.flwsp f28, 216(sp) # perform load (0xeaeb0858)
-  # Check if f28 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f28, Zcf_c_flwsp_cg_cp_fd_b28, Zcf_c_flwsp_cg_cp_fd_b28_str)
+  c.flwsp f28, 104(sp) # perform load (0x5d14a6b7)
+  # Check if f28 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f28, Zcf_c_flwsp_cg_cp_fd_b28, Zcf_c_flwsp_cg_cp_fd_b28_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f29)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -148 # adjust base address for load
+  addi sp, sp, -140 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b29:
-  c.flwsp f29, 148(sp) # perform load (0x3104fcd8)
-  # Check if f29 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f29, Zcf_c_flwsp_cg_cp_fd_b29, Zcf_c_flwsp_cg_cp_fd_b29_str)
+  c.flwsp f29, 140(sp) # perform load (0x1850c597)
+  # Check if f29 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f29, Zcf_c_flwsp_cg_cp_fd_b29, Zcf_c_flwsp_cg_cp_fd_b29_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f30)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -12 # adjust base address for load
+  addi sp, sp, -216 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b30:
-  c.flwsp f30, 12(sp) # perform load (0x0bc79936)
-  # Check if f30 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f30, Zcf_c_flwsp_cg_cp_fd_b30, Zcf_c_flwsp_cg_cp_fd_b30_str)
+  c.flwsp f30, 216(sp) # perform load (0xeaeb0858)
+  # Check if f30 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f30, Zcf_c_flwsp_cg_cp_fd_b30, Zcf_c_flwsp_cg_cp_fd_b30_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f31)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -104 # adjust base address for load
+  addi sp, sp, -148 # adjust base address for load
 Zcf_c_flwsp_cg_cp_fd_b31:
-  c.flwsp f31, 104(sp) # perform load (0x88656d90)
-  # Check if f31 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f31, Zcf_c_flwsp_cg_cp_fd_b31, Zcf_c_flwsp_cg_cp_fd_b31_str)
+  c.flwsp f31, 148(sp) # perform load (0x3104fcd8)
+  # Check if f31 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f31, Zcf_c_flwsp_cg_cp_fd_b31, Zcf_c_flwsp_cg_cp_fd_b31_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 /////////////////////////////////
@@ -363,9 +363,9 @@ Zcf_c_flwsp_cg_cp_fd_b31:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, 0 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x0:
-  c.flwsp f25, 0(sp) # perform load (0xe74f63ab)
-  # Check if f25 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f25, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x0, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x0_str)
+  c.flwsp f24, 0(sp) # perform load (0xe74f63ab)
+  # Check if f24 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f24, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x0, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=4
@@ -373,9 +373,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -4 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x4:
-  c.flwsp f23, 4(sp) # perform load (0xcedb34c8)
-  # Check if f23 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f23, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x4_str)
+  c.flwsp f22, 4(sp) # perform load (0xcedb34c8)
+  # Check if f22 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f22, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x4_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=8
@@ -383,9 +383,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x4:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -8 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x8:
-  c.flwsp f29, 8(sp) # perform load (0x32d901c7)
-  # Check if f29 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f29, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x8, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x8_str)
+  c.flwsp f28, 8(sp) # perform load (0x32d901c7)
+  # Check if f28 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f28, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x8, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=12
@@ -393,9 +393,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -12 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc:
-  c.flwsp f21, 12(sp) # perform load (0x0ecf6de2)
-  # Check if f21 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f21, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc_str)
+  c.flwsp f20, 12(sp) # perform load (0x0ecf6de2)
+  # Check if f20 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f20, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=16
@@ -403,9 +403,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -16 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x10:
-  c.flwsp f28, 16(sp) # perform load (0x6da0f326)
-  # Check if f28 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f28, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x10, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x10_str)
+  c.flwsp f30, 16(sp) # perform load (0x6da0f326)
+  # Check if f30 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f30, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x10, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x10_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=20
@@ -413,9 +413,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x10:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -20 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x14:
-  c.flwsp f19, 20(sp) # perform load (0x47068032)
-  # Check if f19 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f19, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x14, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x14_str)
+  c.flwsp f18, 20(sp) # perform load (0x47068032)
+  # Check if f18 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f18, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x14, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x14_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=24
@@ -423,9 +423,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x14:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -24 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x18:
-  c.flwsp f26, 24(sp) # perform load (0x157a725d)
-  # Check if f26 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f26, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x18, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x18_str)
+  c.flwsp f25, 24(sp) # perform load (0x157a725d)
+  # Check if f25 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f25, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x18, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x18_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=28
@@ -433,9 +433,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x18:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -28 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x1c:
-  c.flwsp f30, 28(sp) # perform load (0xdd980ea5)
-  # Check if f30 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f30, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x1c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x1c_str)
+  c.flwsp f29, 28(sp) # perform load (0xdd980ea5)
+  # Check if f29 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f29, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x1c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x1c_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=32
@@ -443,9 +443,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x1c:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -32 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x20:
-  c.flwsp f20, 32(sp) # perform load (0xe5d5be72)
-  # Check if f20 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f20, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x20, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x20_str)
+  c.flwsp f19, 32(sp) # perform load (0xe5d5be72)
+  # Check if f19 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f19, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x20, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x20_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=36
@@ -453,9 +453,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x20:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -36 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x24:
-  c.flwsp f29, 36(sp) # perform load (0xa89d0685)
-  # Check if f29 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f29, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x24, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x24_str)
+  c.flwsp f0, 36(sp) # perform load (0x66d93c03)
+  # Check if f0 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f0, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x24, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x24_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=40
@@ -463,9 +463,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x24:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -40 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x28:
-  c.flwsp f13, 40(sp) # perform load (0xd62a8a21)
-  # Check if f13 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f13, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x28, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x28_str)
+  c.flwsp f6, 40(sp) # perform load (0xa887a3e6)
+  # Check if f6 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f6, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x28, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x28_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=44
@@ -473,9 +473,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x28:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -44 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x2c:
-  c.flwsp f20, 44(sp) # perform load (0x1c58b8dc)
-  # Check if f20 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f20, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x2c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x2c_str)
+  c.flwsp f20, 44(sp) # perform load (0xcaadb16a)
+  # Check if f20 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f20, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x2c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x2c_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=48
@@ -483,9 +483,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x2c:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -48 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x30:
-  c.flwsp f23, 48(sp) # perform load (0xb1d7d0e3)
-  # Check if f23 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f23, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x30, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x30_str)
+  c.flwsp f4, 48(sp) # perform load (0x9c58a66b)
+  # Check if f4 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x30, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x30_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=52
@@ -493,9 +493,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x30:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -52 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x34:
-  c.flwsp f9, 52(sp) # perform load (0x8ffa55df)
-  # Check if f9 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f9, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x34, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x34_str)
+  c.flwsp f24, 52(sp) # perform load (0x74c1e129)
+  # Check if f24 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f24, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x34, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x34_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=56
@@ -503,9 +503,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x34:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -56 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x38:
-  c.flwsp f16, 56(sp) # perform load (0xe2428159)
-  # Check if f16 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f16, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x38, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x38_str)
+  c.flwsp f13, 56(sp) # perform load (0xb858d21f)
+  # Check if f13 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f13, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x38, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x38_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=60
@@ -513,9 +513,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x38:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -60 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x3c:
-  c.flwsp f13, 60(sp) # perform load (0x0d10b924)
-  # Check if f13 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f13, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x3c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x3c_str)
+  c.flwsp f18, 60(sp) # perform load (0xf38b634f)
+  # Check if f18 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f18, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x3c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x3c_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=64
@@ -523,9 +523,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x3c:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -64 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x40:
-  c.flwsp f25, 64(sp) # perform load (0x85f8d691)
-  # Check if f25 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f25, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x40, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x40_str)
+  c.flwsp f0, 64(sp) # perform load (0xde01e3eb)
+  # Check if f0 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f0, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x40, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x40_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=68
@@ -533,9 +533,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x40:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -68 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x44:
-  c.flwsp f12, 68(sp) # perform load (0x806cd5cb)
-  # Check if f12 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f12, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x44, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x44_str)
+  c.flwsp f18, 68(sp) # perform load (0x39bf9ff3)
+  # Check if f18 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f18, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x44, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x44_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=72
@@ -543,9 +543,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x44:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -72 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x48:
-  c.flwsp f25, 72(sp) # perform load (0x163340a1)
-  # Check if f25 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f25, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x48, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x48_str)
+  c.flwsp f3, 72(sp) # perform load (0x295cc235)
+  # Check if f3 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f3, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x48, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x48_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=76
@@ -553,9 +553,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x48:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -76 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x4c:
-  c.flwsp f17, 76(sp) # perform load (0xe6c9d738)
-  # Check if f17 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f17, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x4c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x4c_str)
+  c.flwsp f11, 76(sp) # perform load (0xd4caeb08)
+  # Check if f11 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f11, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x4c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x4c_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=80
@@ -563,9 +563,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x4c:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -80 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x50:
-  c.flwsp f19, 80(sp) # perform load (0x282c0fb1)
-  # Check if f19 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f19, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x50, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x50_str)
+  c.flwsp f21, 80(sp) # perform load (0xe57b6250)
+  # Check if f21 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f21, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x50, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x50_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=84
@@ -573,9 +573,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x50:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -84 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x54:
-  c.flwsp f10, 84(sp) # perform load (0xa88ecdf2)
-  # Check if f10 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f10, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x54, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x54_str)
+  c.flwsp f18, 84(sp) # perform load (0xf73f2e41)
+  # Check if f18 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f18, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x54, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x54_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=88
@@ -583,9 +583,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x54:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -88 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x58:
-  c.flwsp f16, 88(sp) # perform load (0xefe75778)
-  # Check if f16 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f16, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x58, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x58_str)
+  c.flwsp f14, 88(sp) # perform load (0xc2b6a7e1)
+  # Check if f14 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f14, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x58, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x58_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=92
@@ -593,9 +593,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x58:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -92 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x5c:
-  c.flwsp f28, 92(sp) # perform load (0xa7c9ed2a)
-  # Check if f28 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f28, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x5c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x5c_str)
+  c.flwsp f19, 92(sp) # perform load (0xf5f2325d)
+  # Check if f19 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f19, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x5c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x5c_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=96
@@ -603,9 +603,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x5c:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -96 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x60:
-  c.flwsp f30, 96(sp) # perform load (0xf6eb6015)
-  # Check if f30 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f30, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x60, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x60_str)
+  c.flwsp f1, 96(sp) # perform load (0xcdbe12cf)
+  # Check if f1 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f1, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x60, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x60_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=100
@@ -613,9 +613,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x60:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -100 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x64:
-  c.flwsp f6, 100(sp) # perform load (0xf62bdc3c)
-  # Check if f6 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f6, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x64, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x64_str)
+  c.flwsp f4, 100(sp) # perform load (0xf62bdc3c)
+  # Check if f4 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x64, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x64_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=104
@@ -623,9 +623,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x64:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -104 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x68:
-  c.flwsp f11, 104(sp) # perform load (0x63739c34)
-  # Check if f11 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f11, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x68, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x68_str)
+  c.flwsp f10, 104(sp) # perform load (0x63739c34)
+  # Check if f10 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f10, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x68, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x68_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=108
@@ -633,9 +633,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x68:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -108 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x6c:
-  c.flwsp f28, 108(sp) # perform load (0x9a581017)
-  # Check if f28 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f28, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x6c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x6c_str)
+  c.flwsp f27, 108(sp) # perform load (0x9a581017)
+  # Check if f27 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f27, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x6c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x6c_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=112
@@ -643,9 +643,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x6c:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -112 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x70:
-  c.flwsp f19, 112(sp) # perform load (0x14faa3be)
-  # Check if f19 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f19, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x70, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x70_str)
+  c.flwsp f18, 112(sp) # perform load (0x14faa3be)
+  # Check if f18 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f18, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x70, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x70_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=116
@@ -653,9 +653,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x70:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -116 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x74:
-  c.flwsp f23, 116(sp) # perform load (0x326526af)
-  # Check if f23 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f23, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x74, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x74_str)
+  c.flwsp f22, 116(sp) # perform load (0x326526af)
+  # Check if f22 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f22, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x74, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x74_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=120
@@ -663,9 +663,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x74:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -120 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x78:
-  c.flwsp f7, 120(sp) # perform load (0xd33b17b0)
-  # Check if f7 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f7, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x78, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x78_str)
+  c.flwsp f5, 120(sp) # perform load (0xd33b17b0)
+  # Check if f5 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f5, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x78, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x78_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=124
@@ -673,9 +673,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x78:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -124 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x7c:
-  c.flwsp f19, 124(sp) # perform load (0x38398c3f)
-  # Check if f19 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f19, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x7c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x7c_str)
+  c.flwsp f18, 124(sp) # perform load (0x38398c3f)
+  # Check if f18 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f18, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x7c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x7c_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=128
@@ -683,9 +683,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x7c:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -128 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x80:
-  c.flwsp f3, 128(sp) # perform load (0x4e68090f)
-  # Check if f3 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f3, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x80, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x80_str)
+  c.flwsp f2, 128(sp) # perform load (0x4e68090f)
+  # Check if f2 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f2, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x80, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x80_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=132
@@ -693,9 +693,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x80:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -132 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x84:
-  c.flwsp f22, 132(sp) # perform load (0xd0866aa1)
-  # Check if f22 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f22, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x84, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x84_str)
+  c.flwsp f16, 132(sp) # perform load (0xec038561)
+  # Check if f16 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f16, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x84, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x84_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=136
@@ -703,9 +703,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x84:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -136 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x88:
-  c.flwsp f21, 136(sp) # perform load (0xff1bbc2f)
-  # Check if f21 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f21, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x88, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x88_str)
+  c.flwsp f10, 136(sp) # perform load (0xc2a8e5e0)
+  # Check if f10 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f10, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x88, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x88_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=140
@@ -713,9 +713,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x88:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -140 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x8c:
-  c.flwsp f24, 140(sp) # perform load (0x8b2b8c32)
-  # Check if f24 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f24, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x8c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x8c_str)
+  c.flwsp f20, 140(sp) # perform load (0xff1bbc2f)
+  # Check if f20 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f20, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x8c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x8c_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=144
@@ -723,9 +723,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x8c:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -144 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x90:
-  c.flwsp f16, 144(sp) # perform load (0x3b69dbe1)
-  # Check if f16 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f16, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x90, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x90_str)
+  c.flwsp f23, 144(sp) # perform load (0x8b2b8c32)
+  # Check if f23 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f23, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x90, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x90_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=148
@@ -733,9 +733,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x90:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -148 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x94:
-  c.flwsp f27, 148(sp) # perform load (0x93056424)
-  # Check if f27 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f27, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x94, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x94_str)
+  c.flwsp f15, 148(sp) # perform load (0x3b69dbe1)
+  # Check if f15 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f15, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x94, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x94_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=152
@@ -743,9 +743,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x94:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -152 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x98:
-  c.flwsp f26, 152(sp) # perform load (0x9355d45f)
-  # Check if f26 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f26, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x98, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x98_str)
+  c.flwsp f26, 152(sp) # perform load (0x93056424)
+  # Check if f26 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f26, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x98, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x98_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=156
@@ -753,9 +753,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x98:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -156 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x9c:
-  c.flwsp f20, 156(sp) # perform load (0x5a2a5a65)
-  # Check if f20 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f20, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x9c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x9c_str)
+  c.flwsp f25, 156(sp) # perform load (0x9355d45f)
+  # Check if f25 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f25, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x9c, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x9c_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=160
@@ -763,9 +763,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0x9c:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -160 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa0:
-  c.flwsp f24, 160(sp) # perform load (0xab251ebb)
-  # Check if f24 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f24, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa0, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa0_str)
+  c.flwsp f19, 160(sp) # perform load (0x5a2a5a65)
+  # Check if f19 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f19, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa0, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=164
@@ -773,9 +773,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -164 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa4:
-  c.flwsp f3, 164(sp) # perform load (0xacab0830)
-  # Check if f3 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f3, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa4_str)
+  c.flwsp f23, 164(sp) # perform load (0xab251ebb)
+  # Check if f23 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f23, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa4_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=168
@@ -783,9 +783,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa4:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -168 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa8:
-  c.flwsp f19, 168(sp) # perform load (0x68a3f0b5)
-  # Check if f19 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f19, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa8, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa8_str)
+  c.flwsp f2, 168(sp) # perform load (0xacab0830)
+  # Check if f2 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f2, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa8, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=172
@@ -793,9 +793,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xa8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -172 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xac:
-  c.flwsp f16, 172(sp) # perform load (0xa0aa7fa9)
-  # Check if f16 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f16, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xac, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xac_str)
+  c.flwsp f18, 172(sp) # perform load (0x68a3f0b5)
+  # Check if f18 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f18, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xac, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xac_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=176
@@ -803,9 +803,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xac:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -176 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb0:
-  c.flwsp f24, 176(sp) # perform load (0x44528487)
-  # Check if f24 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f24, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb0, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb0_str)
+  c.flwsp f15, 176(sp) # perform load (0xa0aa7fa9)
+  # Check if f15 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f15, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb0, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=180
@@ -813,9 +813,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -180 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb4:
-  c.flwsp f3, 180(sp) # perform load (0x4597cc2d)
-  # Check if f3 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f3, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb4_str)
+  c.flwsp f23, 180(sp) # perform load (0x44528487)
+  # Check if f23 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f23, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb4_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=184
@@ -823,9 +823,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb4:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -184 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb8:
-  c.flwsp f17, 184(sp) # perform load (0x4663f5ac)
-  # Check if f17 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f17, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb8, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb8_str)
+  c.flwsp f31, 184(sp) # perform load (0x4597cc2d)
+  # Check if f31 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f31, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb8, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=188
@@ -833,9 +833,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xb8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -188 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xbc:
-  c.flwsp f13, 188(sp) # perform load (0x9cd6397e)
-  # Check if f13 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f13, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xbc, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xbc_str)
+  c.flwsp f21, 188(sp) # perform load (0x529dd061)
+  # Check if f21 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f21, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xbc, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xbc_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=192
@@ -843,9 +843,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xbc:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -192 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc0:
-  c.flwsp f25, 192(sp) # perform load (0x754cbd3d)
-  # Check if f25 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f25, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc0, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc0_str)
+  c.flwsp f30, 192(sp) # perform load (0x4663f5ac)
+  # Check if f30 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f30, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc0, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=196
@@ -853,9 +853,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -196 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc4:
-  c.flwsp f18, 196(sp) # perform load (0x7c747c28)
-  # Check if f18 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f18, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc4_str)
+  c.flwsp f4, 196(sp) # perform load (0xf3049119)
+  # Check if f4 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc4_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=200
@@ -863,9 +863,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc4:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -200 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc8:
-  c.flwsp f16, 200(sp) # perform load (0x10f6d822)
-  # Check if f16 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f16, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc8, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc8_str)
+  c.flwsp f31, 200(sp) # perform load (0x48e72455)
+  # Check if f31 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f31, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc8, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=204
@@ -873,9 +873,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xc8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -204 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xcc:
-  c.flwsp f27, 204(sp) # perform load (0x7ee9b202)
-  # Check if f27 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f27, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xcc, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xcc_str)
+  c.flwsp f14, 204(sp) # perform load (0x3e41b0b3)
+  # Check if f14 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f14, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xcc, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xcc_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=208
@@ -883,9 +883,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xcc:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -208 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd0:
-  c.flwsp f30, 208(sp) # perform load (0xb8fc1dd8)
-  # Check if f30 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f30, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd0, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd0_str)
+  c.flwsp f15, 208(sp) # perform load (0x10f6d822)
+  # Check if f15 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f15, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd0, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=212
@@ -893,9 +893,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -212 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd4:
-  c.flwsp f10, 212(sp) # perform load (0x4a06d135)
-  # Check if f10 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f10, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd4_str)
+  c.flwsp f26, 212(sp) # perform load (0x7ee9b202)
+  # Check if f26 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f26, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd4_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=216
@@ -903,9 +903,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd4:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -216 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd8:
-  c.flwsp f25, 216(sp) # perform load (0x581d6d8f)
-  # Check if f25 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f25, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd8, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd8_str)
+  c.flwsp f29, 216(sp) # perform load (0xb8fc1dd8)
+  # Check if f29 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f29, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd8, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=220
@@ -913,9 +913,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xd8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -220 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xdc:
-  c.flwsp f17, 220(sp) # perform load (0xc73655eb)
-  # Check if f17 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f17, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xdc, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xdc_str)
+  c.flwsp f9, 220(sp) # perform load (0x4a06d135)
+  # Check if f9 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f9, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xdc, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xdc_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=224
@@ -923,9 +923,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xdc:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -224 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe0:
-  c.flwsp f21, 224(sp) # perform load (0x418c1c82)
-  # Check if f21 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f21, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe0, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe0_str)
+  c.flwsp f24, 224(sp) # perform load (0x581d6d8f)
+  # Check if f24 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f24, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe0, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=228
@@ -933,9 +933,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -228 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe4:
-  c.flwsp f23, 228(sp) # perform load (0xdea72d85)
-  # Check if f23 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f23, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe4_str)
+  c.flwsp f16, 228(sp) # perform load (0xc73655eb)
+  # Check if f16 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f16, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe4_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=232
@@ -943,9 +943,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe4:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -232 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe8:
-  c.flwsp f2, 232(sp) # perform load (0xe2d513bf)
-  # Check if f2 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f2, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe8, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe8_str)
+  c.flwsp f31, 232(sp) # perform load (0x418c1c82)
+  # Check if f31 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f31, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe8, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=236
@@ -953,9 +953,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xe8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -236 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xec:
-  c.flwsp f29, 236(sp) # perform load (0xd45f1798)
-  # Check if f29 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f29, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xec, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xec_str)
+  c.flwsp f1, 236(sp) # perform load (0x8fa5dfe8)
+  # Check if f1 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f1, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xec, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xec_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=240
@@ -963,9 +963,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xec:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -240 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf0:
-  c.flwsp f5, 240(sp) # perform load (0x1182e14c)
-  # Check if f5 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f5, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf0, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf0_str)
+  c.flwsp f22, 240(sp) # perform load (0xdea72d85)
+  # Check if f22 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f22, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf0, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=244
@@ -973,9 +973,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -244 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf4:
-  c.flwsp f2, 244(sp) # perform load (0x03edd4ca)
-  # Check if f2 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f2, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf4_str)
+  c.flwsp f1, 244(sp) # perform load (0xe2d513bf)
+  # Check if f1 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f1, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf4, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf4_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=248
@@ -983,9 +983,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf4:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -248 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf8:
-  c.flwsp f23, 248(sp) # perform load (0xdbfc565d)
-  # Check if f23 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f23, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf8, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf8_str)
+  c.flwsp f28, 248(sp) # perform load (0xd45f1798)
+  # Check if f28 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f28, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf8, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=252
@@ -993,9 +993,9 @@ Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xf8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -252 # adjust base address for load
 Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xfc:
-  c.flwsp f7, 252(sp) # perform load (0xad7769c8)
-  # Check if f7 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x28, x5, x4, f4, f7, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xfc, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xfc_str)
+  c.flwsp f3, 252(sp) # perform load (0x1182e14c)
+  # Check if f3 contains the expected result. Also checks fflags. x28 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x28, x5, x4, f7, f3, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xfc, Zcf_c_flwsp_cg_cp_imm_mul_4sp_b0xfc_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
   mv x2, x28 # restore signature pointer to default register for teardown
@@ -1012,12 +1012,14 @@ RVTEST_DATA_BEGIN
 .word 0x95a045c0
 .word 0xa1fcc06a
 .word 0x71a2b096
-.word 0xcf0c1771
-.word 0x9f49d42a
-.word 0xd69b9428
-.word 0xab4d3afe
-.word 0xd9efe4ca
-.word 0xa1f3a00f
+.word 0x63b47019
+.word 0x183ee34a
+.word 0x5030f7c5
+.word 0x7793805e
+.word 0x9a0e986e
+.word 0xdd76c122
+.word 0x24ce3d0a
+.word 0x07bbba2d
 .word 0xfc240c1b
 .word 0x19658f53
 .word 0x4aa6de84
@@ -1037,8 +1039,6 @@ RVTEST_DATA_BEGIN
 .word 0x1850c597
 .word 0xeaeb0858
 .word 0x3104fcd8
-.word 0x0bc79936
-.word 0x88656d90
 .word 0xe74f63ab
 .word 0xcedb34c8
 .word 0x32d901c7
@@ -1048,22 +1048,22 @@ RVTEST_DATA_BEGIN
 .word 0x157a725d
 .word 0xdd980ea5
 .word 0xe5d5be72
-.word 0xa89d0685
-.word 0xd62a8a21
-.word 0x1c58b8dc
-.word 0xb1d7d0e3
-.word 0x8ffa55df
-.word 0xe2428159
-.word 0x0d10b924
-.word 0x85f8d691
-.word 0x806cd5cb
-.word 0x163340a1
-.word 0xe6c9d738
-.word 0x282c0fb1
-.word 0xa88ecdf2
-.word 0xefe75778
-.word 0xa7c9ed2a
-.word 0xf6eb6015
+.word 0x66d93c03
+.word 0xa887a3e6
+.word 0xcaadb16a
+.word 0x9c58a66b
+.word 0x74c1e129
+.word 0xb858d21f
+.word 0xf38b634f
+.word 0xde01e3eb
+.word 0x39bf9ff3
+.word 0x295cc235
+.word 0xd4caeb08
+.word 0xe57b6250
+.word 0xf73f2e41
+.word 0xc2b6a7e1
+.word 0xf5f2325d
+.word 0xcdbe12cf
 .word 0xf62bdc3c
 .word 0x63739c34
 .word 0x9a581017
@@ -1072,7 +1072,8 @@ RVTEST_DATA_BEGIN
 .word 0xd33b17b0
 .word 0x38398c3f
 .word 0x4e68090f
-.word 0xd0866aa1
+.word 0xec038561
+.word 0xc2a8e5e0
 .word 0xff1bbc2f
 .word 0x8b2b8c32
 .word 0x3b69dbe1
@@ -1085,10 +1086,11 @@ RVTEST_DATA_BEGIN
 .word 0xa0aa7fa9
 .word 0x44528487
 .word 0x4597cc2d
+.word 0x529dd061
 .word 0x4663f5ac
-.word 0x9cd6397e
-.word 0x754cbd3d
-.word 0x7c747c28
+.word 0xf3049119
+.word 0x48e72455
+.word 0x3e41b0b3
 .word 0x10f6d822
 .word 0x7ee9b202
 .word 0xb8fc1dd8
@@ -1096,13 +1098,11 @@ RVTEST_DATA_BEGIN
 .word 0x581d6d8f
 .word 0xc73655eb
 .word 0x418c1c82
+.word 0x8fa5dfe8
 .word 0xdea72d85
 .word 0xe2d513bf
 .word 0xd45f1798
 .word 0x1182e14c
-.word 0x03edd4ca
-.word 0xdbfc565d
-.word 0xad7769c8
 
 // Testcase strings
 Zcf_c_flwsp_cg_cp_fd_b0_str: .string "\"test: 1; cg: Zcf_c.flwsp_cg; cp: cp_fd; bin: b0\""

--- a/tests/rv64i/Zca/Zca-c.ldsp-00.S
+++ b/tests/rv64i/Zca/Zca-c.ldsp-00.S
@@ -187,9 +187,9 @@ Zca_c_ldsp_cg_cp_rd_nx0_b16:
 
 # Testcase cp_rd_nx0 (Test destination rd = x17)
   mv sp, x21 # move data_ptr to sp
-  addi sp, sp, -168 # adjust base address for load
+  addi sp, sp, -64 # adjust base address for load
 Zca_c_ldsp_cg_cp_rd_nx0_b17:
-  c.ldsp x17, 168(sp) # perform load (0x78162aba1098f066)
+  c.ldsp x17, 64(sp) # perform load (0x42b95e66af5aa287)
   # Check if x17 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x17, Zca_c_ldsp_cg_cp_rd_nx0_b17, Zca_c_ldsp_cg_cp_rd_nx0_b17_str)
   addi x21, x21, SIG_STRIDE # increment data_ptr
@@ -198,714 +198,711 @@ Zca_c_ldsp_cg_cp_rd_nx0_b17:
   mv sp, x21 # move data_ptr to sp
   addi sp, sp, -56 # adjust base address for load
 Zca_c_ldsp_cg_cp_rd_nx0_b18:
-  c.ldsp x18, 56(sp) # perform load (0x91b7498ee75d3bf3)
+  c.ldsp x18, 56(sp) # perform load (0x49c965d6d9446f0d)
   # Check if x18 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x18, Zca_c_ldsp_cg_cp_rd_nx0_b18, Zca_c_ldsp_cg_cp_rd_nx0_b18_str)
   addi x21, x21, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x19)
   mv sp, x21 # move data_ptr to sp
-  addi sp, sp, -424 # adjust base address for load
+  addi sp, sp, -400 # adjust base address for load
 Zca_c_ldsp_cg_cp_rd_nx0_b19:
-  c.ldsp x19, 424(sp) # perform load (0x822acb2789b3fbc0)
+  c.ldsp x19, 400(sp) # perform load (0x09b3fbc0cbf83952)
   # Check if x19 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x19, Zca_c_ldsp_cg_cp_rd_nx0_b19, Zca_c_ldsp_cg_cp_rd_nx0_b19_str)
   addi x21, x21, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x20)
   mv sp, x21 # move data_ptr to sp
-  addi sp, sp, -224 # adjust base address for load
+  addi sp, sp, -216 # adjust base address for load
 Zca_c_ldsp_cg_cp_rd_nx0_b20:
-  c.ldsp x20, 224(sp) # perform load (0xb6dde2453fd94159)
+  c.ldsp x20, 216(sp) # perform load (0x9743bcf26aebd22c)
   # Check if x20 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x20, Zca_c_ldsp_cg_cp_rd_nx0_b20, Zca_c_ldsp_cg_cp_rd_nx0_b20_str)
   addi x21, x21, SIG_STRIDE # increment data_ptr
 
-  mv x2, x21 # switch data pointer register to avoid conflict with test
+  mv x20, x21 # switch data pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x21)
-  mv x26, x2 # switch data pointer register to avoid conflict with test
-  mv sp, x26 # move data_ptr to sp
-  addi sp, sp, -472 # adjust base address for load
+  mv sp, x20 # move data_ptr to sp
+  addi sp, sp, -224 # adjust base address for load
 Zca_c_ldsp_cg_cp_rd_nx0_b21:
-  c.ldsp x21, 472(sp) # perform load (0x82b6aa74388258ba)
+  c.ldsp x21, 224(sp) # perform load (0x8a44f62a3994e7e2)
   # Check if x21 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x21, Zca_c_ldsp_cg_cp_rd_nx0_b21, Zca_c_ldsp_cg_cp_rd_nx0_b21_str)
-  addi x26, x26, SIG_STRIDE # increment data_ptr
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x22)
-  mv sp, x26 # move data_ptr to sp
-  addi sp, sp, -376 # adjust base address for load
+  mv sp, x20 # move data_ptr to sp
+  addi sp, sp, -368 # adjust base address for load
 Zca_c_ldsp_cg_cp_rd_nx0_b22:
-  c.ldsp x22, 376(sp) # perform load (0x1926ea0efd113cb8)
+  c.ldsp x22, 368(sp) # perform load (0xdeaa3432e9c8c43d)
   # Check if x22 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x22, Zca_c_ldsp_cg_cp_rd_nx0_b22, Zca_c_ldsp_cg_cp_rd_nx0_b22_str)
-  addi x26, x26, SIG_STRIDE # increment data_ptr
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x23)
-  mv sp, x26 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -368 # adjust base address for load
 Zca_c_ldsp_cg_cp_rd_nx0_b23:
-  c.ldsp x23, 368(sp) # perform load (0xd6d94102cbb1f40b)
+  c.ldsp x23, 368(sp) # perform load (0x4bb1f40bd8a47fbd)
   # Check if x23 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x23, Zca_c_ldsp_cg_cp_rd_nx0_b23, Zca_c_ldsp_cg_cp_rd_nx0_b23_str)
-  addi x26, x26, SIG_STRIDE # increment data_ptr
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x24)
-  mv sp, x26 # move data_ptr to sp
-  addi sp, sp, -232 # adjust base address for load
+  mv sp, x20 # move data_ptr to sp
+  addi sp, sp, -8 # adjust base address for load
 Zca_c_ldsp_cg_cp_rd_nx0_b24:
-  c.ldsp x24, 232(sp) # perform load (0xfa60101d51d719db)
+  c.ldsp x24, 8(sp) # perform load (0xd1d719db8f06f990)
   # Check if x24 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x24, Zca_c_ldsp_cg_cp_rd_nx0_b24, Zca_c_ldsp_cg_cp_rd_nx0_b24_str)
-  addi x26, x26, SIG_STRIDE # increment data_ptr
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x25)
-  mv sp, x26 # move data_ptr to sp
-  addi sp, sp, -336 # adjust base address for load
+  mv sp, x20 # move data_ptr to sp
+  addi sp, sp, -120 # adjust base address for load
 Zca_c_ldsp_cg_cp_rd_nx0_b25:
-  c.ldsp x25, 336(sp) # perform load (0x9ed0d5a599534c5d)
+  c.ldsp x25, 120(sp) # perform load (0x5c95a447c9046ef8)
   # Check if x25 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x25, Zca_c_ldsp_cg_cp_rd_nx0_b25, Zca_c_ldsp_cg_cp_rd_nx0_b25_str)
-  addi x26, x26, SIG_STRIDE # increment data_ptr
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
-  mv x30, x26 # switch data pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x26)
-  mv sp, x30 # move data_ptr to sp
-  addi sp, sp, -160 # adjust base address for load
+  mv sp, x20 # move data_ptr to sp
+  addi sp, sp, -376 # adjust base address for load
 Zca_c_ldsp_cg_cp_rd_nx0_b26:
-  c.ldsp x26, 160(sp) # perform load (0x7a3b55acbaeed86b)
+  c.ldsp x26, 376(sp) # perform load (0x285a66935514c9f2)
   # Check if x26 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x26, Zca_c_ldsp_cg_cp_rd_nx0_b26, Zca_c_ldsp_cg_cp_rd_nx0_b26_str)
-  addi x30, x30, SIG_STRIDE # increment data_ptr
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x27)
-  mv sp, x30 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -24 # adjust base address for load
 Zca_c_ldsp_cg_cp_rd_nx0_b27:
   c.ldsp x27, 24(sp) # perform load (0xe8c40dfbbeb35fa2)
   # Check if x27 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x27, Zca_c_ldsp_cg_cp_rd_nx0_b27, Zca_c_ldsp_cg_cp_rd_nx0_b27_str)
-  addi x30, x30, SIG_STRIDE # increment data_ptr
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x28)
-  mv sp, x30 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -384 # adjust base address for load
 Zca_c_ldsp_cg_cp_rd_nx0_b28:
   c.ldsp x28, 384(sp) # perform load (0xef25f959e2bd04e9)
   # Check if x28 contains the expected result. x29 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x29, x8, x7, x28, Zca_c_ldsp_cg_cp_rd_nx0_b28, Zca_c_ldsp_cg_cp_rd_nx0_b28_str)
-  addi x30, x30, SIG_STRIDE # increment data_ptr
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
-  mv x22, x29 # switch signature pointer register to avoid conflict with test
+  mv x23, x29 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x29)
-  mv sp, x30 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -176 # adjust base address for load
 Zca_c_ldsp_cg_cp_rd_nx0_b29:
   c.ldsp x29, 176(sp) # perform load (0x8542e6be11304844)
-  # Check if x29 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x29, Zca_c_ldsp_cg_cp_rd_nx0_b29, Zca_c_ldsp_cg_cp_rd_nx0_b29_str)
-  addi x30, x30, SIG_STRIDE # increment data_ptr
+  # Check if x29 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x29, Zca_c_ldsp_cg_cp_rd_nx0_b29, Zca_c_ldsp_cg_cp_rd_nx0_b29_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
-  mv x19, x30 # switch data pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x30)
-  mv sp, x19 # move data_ptr to sp
-  addi sp, sp, -392 # adjust base address for load
+  mv sp, x20 # move data_ptr to sp
+  addi sp, sp, 0 # adjust base address for load
 Zca_c_ldsp_cg_cp_rd_nx0_b30:
-  c.ldsp x30, 392(sp) # perform load (0x538516160037c940)
-  # Check if x30 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x30, Zca_c_ldsp_cg_cp_rd_nx0_b30, Zca_c_ldsp_cg_cp_rd_nx0_b30_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x30, 0(sp) # perform load (0x9a60c30cd1609483)
+  # Check if x30 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x30, Zca_c_ldsp_cg_cp_rd_nx0_b30, Zca_c_ldsp_cg_cp_rd_nx0_b30_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x31)
-  mv sp, x19 # move data_ptr to sp
-  addi sp, sp, -160 # adjust base address for load
+  mv sp, x20 # move data_ptr to sp
+  addi sp, sp, -168 # adjust base address for load
 Zca_c_ldsp_cg_cp_rd_nx0_b31:
-  c.ldsp x31, 160(sp) # perform load (0x3593dcc85c7a5275)
-  # Check if x31 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x31, Zca_c_ldsp_cg_cp_rd_nx0_b31, Zca_c_ldsp_cg_cp_rd_nx0_b31_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x31, 168(sp) # perform load (0xe3aaad61d7a3fade)
+  # Check if x31 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x31, Zca_c_ldsp_cg_cp_rd_nx0_b31, Zca_c_ldsp_cg_cp_rd_nx0_b31_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 /////////////////////////////////
 // cp_imm_mul_8sp
 /////////////////////////////////
 
 # Testcase cp_imm_mul_8sp: imm=0
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, 0 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x0:
   c.ldsp x28, 0(sp) # perform load (0xdac845a8f99476d7)
-  # Check if x28 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x28, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x0_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x28 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x28, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x0_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=8
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -8 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x8:
   c.ldsp x1, 8(sp) # perform load (0x160ae826f6d5ad62)
-  # Check if x1 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x1, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x8_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x1 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x1, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x8_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=16
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -16 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x10:
   c.ldsp x28, 16(sp) # perform load (0x8037569c259c0718)
-  # Check if x28 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x28, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x10, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x10_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x28 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x28, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x10, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x10_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=24
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -24 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x18:
   c.ldsp x2, 24(sp) # perform load (0x0401fe52e361f6c6)
-  # Check if x2 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x2, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x18, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x18_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x2 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x2, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x18, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x18_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=32
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -32 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x20:
   c.ldsp x2, 32(sp) # perform load (0x0a7031fd42a31e07)
-  # Check if x2 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x2, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x20, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x20_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x2 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x2, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x20, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x20_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=40
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -40 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x28:
   c.ldsp x6, 40(sp) # perform load (0xd277eb2095afcf3c)
-  # Check if x6 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x6, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x28, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x28_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x6 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x6, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x28, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x28_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=48
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -48 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x30:
   c.ldsp x17, 48(sp) # perform load (0xf691458e70f99dd4)
-  # Check if x17 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x17, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x30, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x30_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x17 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x17, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x30, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x30_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=56
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -56 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x38:
   c.ldsp x16, 56(sp) # perform load (0xff093d2f2598aa61)
-  # Check if x16 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x16, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x38, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x38_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x16 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x16, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x38, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x38_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=64
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -64 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x40:
   c.ldsp x5, 64(sp) # perform load (0x8beee0f78fb6e35a)
-  # Check if x5 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x5, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x40, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x40_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x5 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x5, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x40, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x40_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=72
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -72 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x48:
   c.ldsp x2, 72(sp) # perform load (0x8f0e8f557947e666)
-  # Check if x2 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x2, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x48, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x48_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x2 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x2, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x48, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x48_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=80
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -80 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x50:
   c.ldsp x18, 80(sp) # perform load (0x89dfd1804ddecb94)
-  # Check if x18 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x18, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x50, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x50_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x18 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x18, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x50, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x50_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=88
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -88 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x58:
   c.ldsp x2, 88(sp) # perform load (0xb4e0eb98bd7fa418)
-  # Check if x2 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x2, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x58, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x58_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x2 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x2, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x58, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x58_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=96
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -96 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x60:
   c.ldsp x9, 96(sp) # perform load (0xbaf279b82760e18c)
-  # Check if x9 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x9, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x60, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x60_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x9 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x9, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x60, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x60_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=104
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -104 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x68:
   c.ldsp x28, 104(sp) # perform load (0x38fc7343092e3cd1)
-  # Check if x28 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x28, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x68, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x68_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x28 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x28, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x68, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x68_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=112
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -112 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x70:
   c.ldsp x30, 112(sp) # perform load (0x60b21ecd2f722862)
-  # Check if x30 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x30, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x70, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x70_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x30 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x30, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x70, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x70_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=120
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -120 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x78:
   c.ldsp x28, 120(sp) # perform load (0x6b22a05c1ac4cb9b)
-  # Check if x28 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x28, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x78, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x78_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x28 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x28, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x78, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x78_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=128
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -128 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x80:
   c.ldsp x18, 128(sp) # perform load (0x1be13c7e8bdb5bdb)
-  # Check if x18 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x18, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x80, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x80_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x18 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x18, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x80, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x80_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=136
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -136 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x88:
   c.ldsp x11, 136(sp) # perform load (0xdf65db28ac5851f1)
-  # Check if x11 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x11, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x88, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x88_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x11 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x11, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x88, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x88_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=144
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -144 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x90:
   c.ldsp x4, 144(sp) # perform load (0x78349f1a3196c72d)
-  # Check if x4 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x4, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x90, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x90_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x4 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x4, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x90, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x90_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=152
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -152 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x98:
   c.ldsp x21, 152(sp) # perform load (0x9c13e347993e68b8)
-  # Check if x21 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x21, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x98, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x98_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x21 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x21, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x98, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x98_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=160
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -160 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xa0:
   c.ldsp x24, 160(sp) # perform load (0x56f3498d1e1103e2)
-  # Check if x24 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x24, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xa0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xa0_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  # Check if x24 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x24, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xa0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xa0_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=168
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -168 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xa8:
-  c.ldsp x29, 168(sp) # perform load (0x4ebaa860f85e28ee)
-  # Check if x29 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x29, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xa8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xa8_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x29, 168(sp) # perform load (0xfe4337f938e3a69f)
+  # Check if x29 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x29, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xa8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xa8_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=176
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -176 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xb0:
-  c.ldsp x25, 176(sp) # perform load (0xfcd7c308cc5ef55c)
-  # Check if x25 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x25, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xb0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xb0_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x22, 176(sp) # perform load (0xd533a5dd7cd7c308)
+  # Check if x22 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x22, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xb0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xb0_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=184
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -184 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xb8:
-  c.ldsp x18, 184(sp) # perform load (0x348a7c69918d3206)
-  # Check if x18 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x18, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xb8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xb8_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x15, 184(sp) # perform load (0xbe54ec8a3fc384e1)
+  # Check if x15 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x15, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xb8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xb8_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=192
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -192 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xc0:
-  c.ldsp x27, 192(sp) # perform load (0xdd586607c9075e05)
-  # Check if x27 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x27, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xc0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xc0_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x31, 192(sp) # perform load (0xc608a2050b4324e1)
+  # Check if x31 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x31, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xc0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xc0_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=200
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -200 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xc8:
-  c.ldsp x11, 200(sp) # perform load (0xef29c0827a94cccb)
-  # Check if x11 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x11, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xc8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xc8_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x18, 200(sp) # perform load (0x7131adc36dce3747)
+  # Check if x18 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x18, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xc8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xc8_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=208
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -208 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xd0:
-  c.ldsp x15, 208(sp) # perform load (0x3e79e9d3fb283c3b)
-  # Check if x15 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x15, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xd0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xd0_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x12, 208(sp) # perform load (0xb49578848118a204)
+  # Check if x12 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x12, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xd0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xd0_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=216
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -216 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xd8:
-  c.ldsp x28, 216(sp) # perform load (0xb49578848118a204)
-  # Check if x28 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x28, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xd8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xd8_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x15, 216(sp) # perform load (0xd90a957566540c7c)
+  # Check if x15 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x15, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xd8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xd8_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=224
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -224 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xe0:
-  c.ldsp x15, 224(sp) # perform load (0xd90a957566540c7c)
-  # Check if x15 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x15, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xe0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xe0_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x26, 224(sp) # perform load (0xb3e30479bef7d777)
+  # Check if x26 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x26, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xe0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xe0_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=232
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -232 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xe8:
-  c.ldsp x26, 232(sp) # perform load (0xb3e30479bef7d777)
-  # Check if x26 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x26, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xe8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xe8_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x30, 232(sp) # perform load (0xb675d3d402ef0f40)
+  # Check if x30 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x30, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xe8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xe8_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=240
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -240 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xf0:
-  c.ldsp x30, 240(sp) # perform load (0xb675d3d402ef0f40)
-  # Check if x30 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x30, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xf0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xf0_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x2, 240(sp) # perform load (0x77df6e8293d81a76)
+  # Check if x2 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x2, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xf0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xf0_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=248
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -248 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xf8:
-  c.ldsp x2, 248(sp) # perform load (0x77df6e8293d81a76)
-  # Check if x2 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x2, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xf8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xf8_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x1, 248(sp) # perform load (0xbf6bcb5d5a0e196c)
+  # Check if x1 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x1, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xf8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0xf8_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=256
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -256 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x100:
-  c.ldsp x1, 256(sp) # perform load (0xbf6bcb5d5a0e196c)
-  # Check if x1 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x1, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x100, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x100_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x15, 256(sp) # perform load (0x952e32aa5f828591)
+  # Check if x15 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x15, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x100, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x100_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=264
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -264 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x108:
-  c.ldsp x15, 264(sp) # perform load (0x952e32aa5f828591)
-  # Check if x15 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x15, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x108, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x108_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x6, 264(sp) # perform load (0xc092c7eb71d872e3)
+  # Check if x6 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x6, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x108, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x108_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=272
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -272 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x110:
-  c.ldsp x6, 272(sp) # perform load (0xc092c7eb71d872e3)
-  # Check if x6 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x6, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x110, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x110_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x17, 272(sp) # perform load (0x8f434e9584abc939)
+  # Check if x17 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x17, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x110, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x110_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=280
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -280 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x118:
-  c.ldsp x17, 280(sp) # perform load (0x8f434e9584abc939)
-  # Check if x17 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x17, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x118, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x118_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x26, 280(sp) # perform load (0xf720c52909892736)
+  # Check if x26 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x26, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x118, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x118_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=288
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -288 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x120:
-  c.ldsp x26, 288(sp) # perform load (0xf720c52909892736)
-  # Check if x26 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x26, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x120, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x120_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x5, 288(sp) # perform load (0x1ab9125ca018f29f)
+  # Check if x5 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x5, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x120, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x120_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=296
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -296 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x128:
-  c.ldsp x5, 296(sp) # perform load (0x1ab9125ca018f29f)
-  # Check if x5 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x5, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x128, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x128_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x5, 296(sp) # perform load (0x74b1e6b7ba60f32d)
+  # Check if x5 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x5, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x128, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x128_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=304
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -304 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x130:
-  c.ldsp x5, 304(sp) # perform load (0x74b1e6b7ba60f32d)
-  # Check if x5 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x5, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x130, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x130_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x10, 304(sp) # perform load (0x74a832c51705fefb)
+  # Check if x10 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x10, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x130, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x130_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=312
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -312 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x138:
-  c.ldsp x10, 312(sp) # perform load (0x4e34f00423efdaa3)
-  # Check if x10 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x10, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x138, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x138_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x30, 312(sp) # perform load (0xabe47d883482f4c1)
+  # Check if x30 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x30, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x138, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x138_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=320
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -320 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x140:
-  c.ldsp x16, 320(sp) # perform load (0x74a832c51705fefb)
-  # Check if x16 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x16, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x140, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x140_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x2, 320(sp) # perform load (0xf7df01481f882642)
+  # Check if x2 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x2, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x140, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x140_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=328
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -328 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x148:
-  c.ldsp x30, 328(sp) # perform load (0xabe47d883482f4c1)
-  # Check if x30 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x30, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x148, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x148_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x19, 328(sp) # perform load (0xcad62842cf21dfc5)
+  # Check if x19 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x19, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x148, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x148_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=336
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -336 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x150:
-  c.ldsp x2, 336(sp) # perform load (0xf7df01481f882642)
-  # Check if x2 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x2, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x150, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x150_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x10, 336(sp) # perform load (0xc7ee01804e983913)
+  # Check if x10 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x10, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x150, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x150_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=344
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -344 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x158:
-  c.ldsp x20, 344(sp) # perform load (0xbf0437275aa82c5d)
-  # Check if x20 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x20, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x158, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x158_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x19, 344(sp) # perform load (0x4b4fe302a4f0bfc6)
+  # Check if x19 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x19, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x158, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x158_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=352
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -352 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x160:
-  c.ldsp x12, 352(sp) # perform load (0x010169cb49edbd01)
-  # Check if x12 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x12, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x160, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x160_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x16, 352(sp) # perform load (0x6faccab385d7599c)
+  # Check if x16 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x16, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x160, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x160_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=360
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -360 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x168:
-  c.ldsp x25, 360(sp) # perform load (0x5cb2e35068ab3898)
-  # Check if x25 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x25, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x168, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x168_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x28, 360(sp) # perform load (0xb5a1e331f4f7fe24)
+  # Check if x28 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x28, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x168, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x168_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=368
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -368 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x170:
-  c.ldsp x14, 368(sp) # perform load (0x6faccab385d7599c)
-  # Check if x14 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x14, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x170, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x170_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x13, 368(sp) # perform load (0x65f86772607ceff8)
+  # Check if x13 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x13, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x170, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x170_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=376
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -376 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x178:
-  c.ldsp x28, 376(sp) # perform load (0xb5a1e331f4f7fe24)
-  # Check if x28 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x28, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x178, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x178_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x30, 376(sp) # perform load (0x5a8dadbc63b60373)
+  # Check if x30 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x30, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x178, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x178_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=384
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -384 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x180:
-  c.ldsp x13, 384(sp) # perform load (0x65f86772607ceff8)
-  # Check if x13 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x13, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x180, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x180_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x29, 384(sp) # perform load (0x9d669980a38efd06)
+  # Check if x29 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x29, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x180, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x180_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=392
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -392 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x188:
-  c.ldsp x30, 392(sp) # perform load (0x5a8dadbc63b60373)
-  # Check if x30 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x30, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x188, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x188_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x15, 392(sp) # perform load (0xefb4ee46718e2413)
+  # Check if x15 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x15, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x188, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x188_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=400
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -400 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x190:
-  c.ldsp x29, 400(sp) # perform load (0x9d669980a38efd06)
-  # Check if x29 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x29, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x190, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x190_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x1, 400(sp) # perform load (0xb39cc131269d80f8)
+  # Check if x1 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x1, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x190, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x190_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=408
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -408 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x198:
-  c.ldsp x15, 408(sp) # perform load (0xefb4ee46718e2413)
-  # Check if x15 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x15, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x198, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x198_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x10, 408(sp) # perform load (0xd48d3eb0420b3554)
+  # Check if x10 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x10, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x198, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x198_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=416
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -416 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1a0:
-  c.ldsp x1, 416(sp) # perform load (0xb39cc131269d80f8)
-  # Check if x1 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x1, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1a0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1a0_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x14, 416(sp) # perform load (0xc952e9dd9f29f294)
+  # Check if x14 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x14, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1a0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1a0_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=424
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -424 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1a8:
-  c.ldsp x10, 424(sp) # perform load (0xd48d3eb0420b3554)
-  # Check if x10 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x10, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1a8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1a8_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x10, 424(sp) # perform load (0x8776dd06041d3e7d)
+  # Check if x10 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x10, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1a8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1a8_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=432
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -432 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1b0:
-  c.ldsp x14, 432(sp) # perform load (0xc952e9dd9f29f294)
-  # Check if x14 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x14, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1b0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1b0_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x26, 432(sp) # perform load (0x48c6e775bfef3c2f)
+  # Check if x26 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x26, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1b0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1b0_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=440
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -440 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1b8:
-  c.ldsp x10, 440(sp) # perform load (0x8776dd06041d3e7d)
-  # Check if x10 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x10, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1b8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1b8_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x21, 440(sp) # perform load (0xea4787e23c6deb8e)
+  # Check if x21 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x21, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1b8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1b8_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=448
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -448 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1c0:
-  c.ldsp x26, 448(sp) # perform load (0x48c6e775bfef3c2f)
-  # Check if x26 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x26, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1c0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1c0_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x27, 448(sp) # perform load (0xdcc621952136349f)
+  # Check if x27 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x27, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1c0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1c0_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=456
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -456 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1c8:
-  c.ldsp x21, 456(sp) # perform load (0xea4787e23c6deb8e)
-  # Check if x21 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x21, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1c8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1c8_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x25, 456(sp) # perform load (0xefcf063834ed22ca)
+  # Check if x25 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x25, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1c8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1c8_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=464
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -464 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1d0:
-  c.ldsp x27, 464(sp) # perform load (0xdcc621952136349f)
-  # Check if x27 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x27, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1d0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1d0_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x2, 464(sp) # perform load (0xe3b8255e7d2a9228)
+  # Check if x2 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x2, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1d0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1d0_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=472
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -472 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1d8:
-  c.ldsp x25, 472(sp) # perform load (0xefcf063834ed22ca)
-  # Check if x25 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x25, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1d8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1d8_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x28, 472(sp) # perform load (0xa4c6d1cc8a4d9304)
+  # Check if x28 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x28, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1d8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1d8_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=480
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -480 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1e0:
-  c.ldsp x2, 480(sp) # perform load (0xe3b8255e7d2a9228)
-  # Check if x2 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x2, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1e0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1e0_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x12, 480(sp) # perform load (0x54f671eb6b43dd2f)
+  # Check if x12 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x12, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1e0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1e0_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=488
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -488 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1e8:
-  c.ldsp x28, 488(sp) # perform load (0xa4c6d1cc8a4d9304)
-  # Check if x28 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x28, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1e8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1e8_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x21, 488(sp) # perform load (0x4b669d090295250c)
+  # Check if x21 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x21, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1e8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1e8_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=496
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -496 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1f0:
-  c.ldsp x12, 496(sp) # perform load (0x54f671eb6b43dd2f)
-  # Check if x12 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x12, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1f0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1f0_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x31, 496(sp) # perform load (0x536cab0d518f6ea8)
+  # Check if x31 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x31, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1f0, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1f0_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=504
-  mv sp, x19 # move data_ptr to sp
+  mv sp, x20 # move data_ptr to sp
   addi sp, sp, -504 # adjust base address for load
 Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1f8:
-  c.ldsp x21, 504(sp) # perform load (0x4b669d090295250c)
-  # Check if x21 contains the expected result. x22 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x22, x8, x7, x21, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1f8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1f8_str)
-  addi x19, x19, SIG_STRIDE # increment data_ptr
+  c.ldsp x19, 504(sp) # perform load (0x5984ccb4ce444a2b)
+  # Check if x19 contains the expected result. x23 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x23, x8, x7, x19, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1f8, Zca_c_ldsp_cg_cp_imm_mul_8sp_b0x1f8_str)
+  addi x20, x20, SIG_STRIDE # increment data_ptr
 
-  mv x2, x22 # restore signature pointer to default register for teardown
+  mv x2, x23 # restore signature pointer to default register for teardown
 
 // Instantiate trap handlers and other epilog code, call RVMODEL_HALT at end of test
 RVTEST_CODE_END
@@ -930,21 +927,21 @@ RVTEST_DATA_BEGIN
 .dword 0x014c15fe474189b8
 .dword 0x03fc2bbb3ad88e54
 .dword 0x6445bfcc440e18f0
-.dword 0x78162aba1098f066
-.dword 0x91b7498ee75d3bf3
-.dword 0x822acb2789b3fbc0
-.dword 0xb6dde2453fd94159
-.dword 0x82b6aa74388258ba
-.dword 0x1926ea0efd113cb8
-.dword 0xd6d94102cbb1f40b
-.dword 0xfa60101d51d719db
-.dword 0x9ed0d5a599534c5d
-.dword 0x7a3b55acbaeed86b
+.dword 0x42b95e66af5aa287
+.dword 0x49c965d6d9446f0d
+.dword 0x09b3fbc0cbf83952
+.dword 0x9743bcf26aebd22c
+.dword 0x8a44f62a3994e7e2
+.dword 0xdeaa3432e9c8c43d
+.dword 0x4bb1f40bd8a47fbd
+.dword 0xd1d719db8f06f990
+.dword 0x5c95a447c9046ef8
+.dword 0x285a66935514c9f2
 .dword 0xe8c40dfbbeb35fa2
 .dword 0xef25f959e2bd04e9
 .dword 0x8542e6be11304844
-.dword 0x538516160037c940
-.dword 0x3593dcc85c7a5275
+.dword 0x9a60c30cd1609483
+.dword 0xe3aaad61d7a3fade
 .dword 0xdac845a8f99476d7
 .dword 0x160ae826f6d5ad62
 .dword 0x8037569c259c0718
@@ -966,12 +963,11 @@ RVTEST_DATA_BEGIN
 .dword 0x78349f1a3196c72d
 .dword 0x9c13e347993e68b8
 .dword 0x56f3498d1e1103e2
-.dword 0x4ebaa860f85e28ee
-.dword 0xfcd7c308cc5ef55c
-.dword 0x348a7c69918d3206
-.dword 0xdd586607c9075e05
-.dword 0xef29c0827a94cccb
-.dword 0x3e79e9d3fb283c3b
+.dword 0xfe4337f938e3a69f
+.dword 0xd533a5dd7cd7c308
+.dword 0xbe54ec8a3fc384e1
+.dword 0xc608a2050b4324e1
+.dword 0x7131adc36dce3747
 .dword 0xb49578848118a204
 .dword 0xd90a957566540c7c
 .dword 0xb3e30479bef7d777
@@ -984,13 +980,12 @@ RVTEST_DATA_BEGIN
 .dword 0xf720c52909892736
 .dword 0x1ab9125ca018f29f
 .dword 0x74b1e6b7ba60f32d
-.dword 0x4e34f00423efdaa3
 .dword 0x74a832c51705fefb
 .dword 0xabe47d883482f4c1
 .dword 0xf7df01481f882642
-.dword 0xbf0437275aa82c5d
-.dword 0x010169cb49edbd01
-.dword 0x5cb2e35068ab3898
+.dword 0xcad62842cf21dfc5
+.dword 0xc7ee01804e983913
+.dword 0x4b4fe302a4f0bfc6
 .dword 0x6faccab385d7599c
 .dword 0xb5a1e331f4f7fe24
 .dword 0x65f86772607ceff8
@@ -1009,6 +1004,8 @@ RVTEST_DATA_BEGIN
 .dword 0xa4c6d1cc8a4d9304
 .dword 0x54f671eb6b43dd2f
 .dword 0x4b669d090295250c
+.dword 0x536cab0d518f6ea8
+.dword 0x5984ccb4ce444a2b
 
 // Testcase strings
 Zca_c_ldsp_cg_cp_rd_nx0_b1_str: .string "\"test: 1; cg: Zca_c.ldsp_cg; cp: cp_rd_nx0; bin: b1\""

--- a/tests/rv64i/Zca/Zca-c.lwsp-00.S
+++ b/tests/rv64i/Zca/Zca-c.lwsp-00.S
@@ -159,36 +159,36 @@ Zca_c_lwsp_cg_cp_rd_nx0_b13:
 
 # Testcase cp_rd_nx0 (Test destination rd = x14)
   mv sp, x1 # move data_ptr to sp
-  addi sp, sp, -88 # adjust base address for load
+  addi sp, sp, -168 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b14:
-  c.lwsp x14, 88(sp) # perform load (0xbdce726a3f5a4211)
+  c.lwsp x14, 168(sp) # perform load (0xbf5a4211e90308d2)
   # Check if x14 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x14, Zca_c_lwsp_cg_cp_rd_nx0_b14, Zca_c_lwsp_cg_cp_rd_nx0_b14_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x15)
   mv sp, x1 # move data_ptr to sp
-  addi sp, sp, -52 # adjust base address for load
+  addi sp, sp, -188 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b15:
-  c.lwsp x15, 52(sp) # perform load (0xd3bc90c5c3a5f279)
+  c.lwsp x15, 188(sp) # perform load (0x8b2cfc2e53bc90c5)
   # Check if x15 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x15, Zca_c_lwsp_cg_cp_rd_nx0_b15, Zca_c_lwsp_cg_cp_rd_nx0_b15_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x16)
   mv sp, x1 # move data_ptr to sp
-  addi sp, sp, -28 # adjust base address for load
+  addi sp, sp, -224 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b16:
-  c.lwsp x16, 28(sp) # perform load (0xd1540c9c20add5c9)
+  c.lwsp x16, 224(sp) # perform load (0xe9780bd1cddd6d89)
   # Check if x16 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x16, Zca_c_lwsp_cg_cp_rd_nx0_b16, Zca_c_lwsp_cg_cp_rd_nx0_b16_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_rd_nx0 (Test destination rd = x17)
   mv sp, x1 # move data_ptr to sp
-  addi sp, sp, -248 # adjust base address for load
+  addi sp, sp, -124 # adjust base address for load
 Zca_c_lwsp_cg_cp_rd_nx0_b17:
-  c.lwsp x17, 248(sp) # perform load (0x4ddd6d89b79a9c43)
+  c.lwsp x17, 124(sp) # perform load (0x568ae350b1c1f574)
   # Check if x17 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x27, x5, x4, x17, Zca_c_lwsp_cg_cp_rd_nx0_b17, Zca_c_lwsp_cg_cp_rd_nx0_b17_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
@@ -400,27 +400,27 @@ Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x1c:
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -32 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x20:
-  c.lwsp x8, 32(sp) # perform load (0xaf1cae297ff3af14)
-  # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x20, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x20_str)
+  c.lwsp x31, 32(sp) # perform load (0xd3d7487bc4282201)
+  # Check if x31 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x31, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x20, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x20_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=36
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -36 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x24:
-  c.lwsp x9, 36(sp) # perform load (0xb168166ac907e937)
-  # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x24_str)
+  c.lwsp x21, 36(sp) # perform load (0xa8446cae2f1cae29)
+  # Check if x21 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x21, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x24_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=40
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -40 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x28:
-  c.lwsp x2, 40(sp) # perform load (0x98edb9d9e94d5b06)
-  # Check if x2 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x2, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x28_str)
+  c.lwsp x22, 40(sp) # perform load (0x98edb9d9e94d5b06)
+  # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x28_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=44
@@ -481,25 +481,25 @@ Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x40:
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -68 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x44:
-  c.lwsp x12, 68(sp) # perform load (0xf3fa74fdcedc76e8)
-  # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x12, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x44_str)
+  c.lwsp x31, 68(sp) # perform load (0x4edc76e862cedd7a)
+  # Check if x31 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x31, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x44_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=72
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -72 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x48:
-  c.lwsp x19, 72(sp) # perform load (0x15ca99d229305694)
-  # Check if x19 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x19, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x48_str)
+  c.lwsp x6, 72(sp) # perform load (0x298d676417ebd681)
+  # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x48_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=76
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -76 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x4c:
-  c.lwsp x21, 76(sp) # perform load (0xb6256a972da059a1)
+  c.lwsp x21, 76(sp) # perform load (0xada059a11cd81425)
   # Check if x21 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x21, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x4c_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
@@ -508,349 +508,349 @@ Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x4c:
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -80 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x50:
-  c.lwsp x14, 80(sp) # perform load (0xa96fd7c797640e6e)
-  # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x50_str)
+  c.lwsp x8, 80(sp) # perform load (0x17640e6e244c7a09)
+  # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x50_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=84
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -84 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x54:
-  c.lwsp x7, 84(sp) # perform load (0x31b431a1ae1395c4)
-  # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x54_str)
+  c.lwsp x16, 84(sp) # perform load (0xcbdc695aab09593d)
+  # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x54_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=88
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -88 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x58:
-  c.lwsp x15, 88(sp) # perform load (0x5ed32655db80f34b)
-  # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x58_str)
+  c.lwsp x26, 88(sp) # perform load (0x31b431a1ae1395c4)
+  # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x58_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=92
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -92 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x5c:
-  c.lwsp x9, 92(sp) # perform load (0x40049a50531b58c7)
-  # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x5c_str)
+  c.lwsp x15, 92(sp) # perform load (0x5ed32655db80f34b)
+  # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x5c_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=96
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -96 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x60:
-  c.lwsp x30, 96(sp) # perform load (0x25587ca8edaed40d)
-  # Check if x30 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x30, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x60_str)
+  c.lwsp x9, 96(sp) # perform load (0x40049a50531b58c7)
+  # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x60_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=100
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -100 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x64:
-  c.lwsp x27, 100(sp) # perform load (0x82eb3de44dbf254c)
-  # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x64_str)
+  c.lwsp x30, 100(sp) # perform load (0x25587ca8edaed40d)
+  # Check if x30 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x30, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x64_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=104
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -104 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x68:
-  c.lwsp x7, 104(sp) # perform load (0x3be4f34c9bc0db1b)
-  # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x68_str)
+  c.lwsp x27, 104(sp) # perform load (0x0e2a4020b70c3b5e)
+  # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x68_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=108
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -108 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x6c:
-  c.lwsp x2, 108(sp) # perform load (0x4a0a9926b25842ad)
-  # Check if x2 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x2, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x6c_str)
+  c.lwsp x30, 108(sp) # perform load (0x82eb3de44dbf254c)
+  # Check if x30 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x30, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x6c_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=112
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -112 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x70:
-  c.lwsp x10, 112(sp) # perform load (0x028f00d46d552934)
-  # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x70_str)
+  c.lwsp x7, 112(sp) # perform load (0x3be4f34c9bc0db1b)
+  # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x70_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=116
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -116 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x74:
-  c.lwsp x19, 116(sp) # perform load (0xb312c4a849c6d17a)
-  # Check if x19 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x19, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x74_str)
+  c.lwsp x2, 116(sp) # perform load (0x4a0a9926b25842ad)
+  # Check if x2 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x2, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x74_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=120
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -120 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x78:
-  c.lwsp x2, 120(sp) # perform load (0xd8c868d0e5ec5d87)
-  # Check if x2 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x2, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x78_str)
+  c.lwsp x10, 120(sp) # perform load (0x028f00d46d552934)
+  # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x78_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=124
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -124 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x7c:
-  c.lwsp x9, 124(sp) # perform load (0x301df2b7584f3ee0)
-  # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x7c_str)
+  c.lwsp x19, 124(sp) # perform load (0xb312c4a849c6d17a)
+  # Check if x19 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x19, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x7c_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=128
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -128 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x80:
-  c.lwsp x8, 128(sp) # perform load (0xe3f74b4f66169e43)
-  # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x80_str)
+  c.lwsp x2, 128(sp) # perform load (0xd8c868d0e5ec5d87)
+  # Check if x2 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x2, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x80_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=132
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -132 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x84:
-  c.lwsp x16, 132(sp) # perform load (0xbca95738eae63906)
-  # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x84_str)
+  c.lwsp x9, 132(sp) # perform load (0x301df2b7584f3ee0)
+  # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x84_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=136
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -136 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x88:
-  c.lwsp x23, 136(sp) # perform load (0x38d306b37e6dbfd4)
-  # Check if x23 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x23, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x88_str)
+  c.lwsp x31, 136(sp) # perform load (0xe6169e43b17fded6)
+  # Check if x31 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x31, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x88_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=140
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -140 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x8c:
-  c.lwsp x27, 140(sp) # perform load (0x1a836368feefdc23)
-  # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x8c_str)
+  c.lwsp x9, 140(sp) # perform load (0x6ae63906835d0912)
+  # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x8c_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=144
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -144 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x90:
-  c.lwsp x16, 144(sp) # perform load (0x5b84d59c9203aeaf)
-  # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x90_str)
+  c.lwsp x13, 144(sp) # perform load (0x32b5957c4ec5203f)
+  # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x13, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x90_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=148
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -148 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x94:
-  c.lwsp x8, 148(sp) # perform load (0xaea16e96fc613e25)
-  # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x94_str)
+  c.lwsp x24, 148(sp) # perform load (0xf2e18b3ddb84d59c)
+  # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x94_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=152
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -152 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x98:
-  c.lwsp x13, 152(sp) # perform load (0xcf77db427a720f62)
-  # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x13, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x98_str)
+  c.lwsp x31, 152(sp) # perform load (0xaea16e96fc613e25)
+  # Check if x31 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x31, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x98_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=156
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -156 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x9c:
-  c.lwsp x15, 156(sp) # perform load (0xf1929dbed33ae7be)
-  # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x9c_str)
+  c.lwsp x13, 156(sp) # perform load (0xcf77db427a720f62)
+  # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x13, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0x9c_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=160
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -160 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa0:
-  c.lwsp x8, 160(sp) # perform load (0xbca4b5ceacbd897a)
-  # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa0_str)
+  c.lwsp x15, 160(sp) # perform load (0xf1929dbed33ae7be)
+  # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa0_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=164
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -164 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa4:
-  c.lwsp x16, 164(sp) # perform load (0x8d50d3dbecc45c95)
-  # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa4_str)
+  c.lwsp x8, 164(sp) # perform load (0xbca4b5ceacbd897a)
+  # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa4_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=168
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -168 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa8:
-  c.lwsp x10, 168(sp) # perform load (0x35098311b94fe3a6)
-  # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa8_str)
+  c.lwsp x16, 168(sp) # perform load (0x8d50d3dbecc45c95)
+  # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xa8_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=172
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -172 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xac:
-  c.lwsp x15, 172(sp) # perform load (0x6652bfcca8cfcfda)
-  # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xac_str)
+  c.lwsp x10, 172(sp) # perform load (0x35098311b94fe3a6)
+  # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xac_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=176
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -176 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb0:
-  c.lwsp x21, 176(sp) # perform load (0x034154ff2c2b6adc)
-  # Check if x21 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x21, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb0_str)
+  c.lwsp x15, 176(sp) # perform load (0x6652bfcca8cfcfda)
+  # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb0_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=180
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -180 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb4:
-  c.lwsp x29, 180(sp) # perform load (0x58deb24bf05edc66)
-  # Check if x29 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x29, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb4_str)
+  c.lwsp x21, 180(sp) # perform load (0x034154ff2c2b6adc)
+  # Check if x21 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x21, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb4_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=184
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -184 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb8:
-  c.lwsp x7, 184(sp) # perform load (0x5e1096a88fe5f19b)
-  # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb8_str)
+  c.lwsp x29, 184(sp) # perform load (0x58deb24bf05edc66)
+  # Check if x29 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x29, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xb8_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=188
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -188 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xbc:
-  c.lwsp x8, 188(sp) # perform load (0x5e13a1c4f2eea947)
-  # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xbc_str)
+  c.lwsp x7, 188(sp) # perform load (0x5e1096a88fe5f19b)
+  # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xbc_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=192
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -192 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc0:
-  c.lwsp x27, 192(sp) # perform load (0xf8b1ab2467371470)
-  # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc0_str)
+  c.lwsp x8, 192(sp) # perform load (0x5e13a1c4f2eea947)
+  # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc0_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=196
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -196 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc4:
-  c.lwsp x3, 196(sp) # perform load (0x691dca865b5a1566)
-  # Check if x3 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x3, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc4_str)
+  c.lwsp x27, 196(sp) # perform load (0xf8b1ab2467371470)
+  # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc4_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=200
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -200 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc8:
-  c.lwsp x18, 200(sp) # perform load (0xfda9e83978551780)
-  # Check if x18 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x18, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc8_str)
+  c.lwsp x3, 200(sp) # perform load (0x691dca865b5a1566)
+  # Check if x3 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x3, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xc8_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=204
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -204 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xcc:
-  c.lwsp x12, 204(sp) # perform load (0x5e0db5f2494024df)
-  # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x12, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xcc_str)
+  c.lwsp x18, 204(sp) # perform load (0xfda9e83978551780)
+  # Check if x18 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x18, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xcc_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=208
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -208 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd0:
-  c.lwsp x10, 208(sp) # perform load (0x8d9cbe551af0a176)
-  # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd0_str)
+  c.lwsp x12, 208(sp) # perform load (0x5e0db5f2494024df)
+  # Check if x12 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x12, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd0_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=212
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -212 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd4:
-  c.lwsp x24, 212(sp) # perform load (0xddd9d46c6b3ba686)
-  # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd4_str)
+  c.lwsp x10, 212(sp) # perform load (0x8d9cbe551af0a176)
+  # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd4_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=216
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -216 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd8:
-  c.lwsp x28, 216(sp) # perform load (0x6cff05f4471f466e)
-  # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd8_str)
+  c.lwsp x24, 216(sp) # perform load (0xddd9d46c6b3ba686)
+  # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xd8_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=220
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -220 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xdc:
-  c.lwsp x8, 220(sp) # perform load (0x5c3285f1b465cfc7)
-  # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xdc_str)
+  c.lwsp x28, 220(sp) # perform load (0x6cff05f4471f466e)
+  # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xdc_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=224
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -224 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe0:
-  c.lwsp x13, 224(sp) # perform load (0x4e135a2dd1a9235d)
-  # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x13, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe0_str)
+  c.lwsp x8, 224(sp) # perform load (0x5c3285f1b465cfc7)
+  # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe0_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=228
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -228 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe4:
-  c.lwsp x21, 228(sp) # perform load (0x240d4654d7d49243)
-  # Check if x21 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x21, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe4_str)
+  c.lwsp x31, 228(sp) # perform load (0x9f1bd751cc3667f4)
+  # Check if x31 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x31, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe4_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=232
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -232 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe8:
-  c.lwsp x6, 232(sp) # perform load (0xd3a8220afbbd3470)
+  c.lwsp x6, 232(sp) # perform load (0x240d4654d7d49243)
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe8_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
@@ -859,45 +859,45 @@ Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xe8:
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -236 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xec:
-  c.lwsp x26, 236(sp) # perform load (0x8467edc6ad732d79)
-  # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xec_str)
+  c.lwsp x6, 236(sp) # perform load (0xd3a8220afbbd3470)
+  # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xec_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=240
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -240 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf0:
-  c.lwsp x20, 240(sp) # perform load (0xcb645ce00bd21d6e)
-  # Check if x20 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x20, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf0_str)
+  c.lwsp x26, 240(sp) # perform load (0x8467edc6ad732d79)
+  # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf0_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=244
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -244 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf4:
-  c.lwsp x18, 244(sp) # perform load (0x481805026f50a0f8)
-  # Check if x18 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x18, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf4_str)
+  c.lwsp x20, 244(sp) # perform load (0xcb645ce00bd21d6e)
+  # Check if x20 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x20, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf4_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=248
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -248 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf8:
-  c.lwsp x28, 248(sp) # perform load (0x8b0236541400a891)
-  # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf8_str)
+  c.lwsp x18, 248(sp) # perform load (0x481805026f50a0f8)
+  # Check if x18 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x18, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xf8_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_4sp: imm=252
   mv sp, x1 # move data_ptr to sp
   addi sp, sp, -252 # adjust base address for load
 Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xfc:
-  c.lwsp x15, 252(sp) # perform load (0x2313d8d6fd2f2c38)
-  # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xfc_str)
+  c.lwsp x28, 252(sp) # perform load (0x8b0236541400a891)
+  # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_lwsp_cg_cp_imm_mul_4sp_b0xfc_str)
   addi x1, x1, SIG_STRIDE # increment data_ptr
 
   mv x2, x11 # restore signature pointer to default register for teardown
@@ -922,10 +922,10 @@ RVTEST_DATA_BEGIN
 .dword 0x38c4c96ea863e883
 .dword 0xf55336015daf6e31
 .dword 0x34112b22b5496321
-.dword 0xbdce726a3f5a4211
-.dword 0xd3bc90c5c3a5f279
-.dword 0xd1540c9c20add5c9
-.dword 0x4ddd6d89b79a9c43
+.dword 0xbf5a4211e90308d2
+.dword 0x8b2cfc2e53bc90c5
+.dword 0xe9780bd1cddd6d89
+.dword 0x568ae350b1c1f574
 .dword 0xd03981d0301f80fd
 .dword 0x4c6bd35bf65174a4
 .dword 0xe6ff110947c416cb
@@ -948,8 +948,8 @@ RVTEST_DATA_BEGIN
 .dword 0x1e0e11fea3b11597
 .dword 0x6d7c5a1cea0b154c
 .dword 0x3624e24f3e4c6364
-.dword 0xaf1cae297ff3af14
-.dword 0xb168166ac907e937
+.dword 0xd3d7487bc4282201
+.dword 0xa8446cae2f1cae29
 .dword 0x98edb9d9e94d5b06
 .dword 0x8eca0a288ead11be
 .dword 0xb8c5a9641607e87c
@@ -957,14 +957,16 @@ RVTEST_DATA_BEGIN
 .dword 0x19bd346da9741118
 .dword 0xa2b70c8a09449a9b
 .dword 0x5e9819a017a564a9
-.dword 0xf3fa74fdcedc76e8
-.dword 0x15ca99d229305694
-.dword 0xb6256a972da059a1
-.dword 0xa96fd7c797640e6e
+.dword 0x4edc76e862cedd7a
+.dword 0x298d676417ebd681
+.dword 0xada059a11cd81425
+.dword 0x17640e6e244c7a09
+.dword 0xcbdc695aab09593d
 .dword 0x31b431a1ae1395c4
 .dword 0x5ed32655db80f34b
 .dword 0x40049a50531b58c7
 .dword 0x25587ca8edaed40d
+.dword 0x0e2a4020b70c3b5e
 .dword 0x82eb3de44dbf254c
 .dword 0x3be4f34c9bc0db1b
 .dword 0x4a0a9926b25842ad
@@ -972,11 +974,10 @@ RVTEST_DATA_BEGIN
 .dword 0xb312c4a849c6d17a
 .dword 0xd8c868d0e5ec5d87
 .dword 0x301df2b7584f3ee0
-.dword 0xe3f74b4f66169e43
-.dword 0xbca95738eae63906
-.dword 0x38d306b37e6dbfd4
-.dword 0x1a836368feefdc23
-.dword 0x5b84d59c9203aeaf
+.dword 0xe6169e43b17fded6
+.dword 0x6ae63906835d0912
+.dword 0x32b5957c4ec5203f
+.dword 0xf2e18b3ddb84d59c
 .dword 0xaea16e96fc613e25
 .dword 0xcf77db427a720f62
 .dword 0xf1929dbed33ae7be
@@ -996,14 +997,13 @@ RVTEST_DATA_BEGIN
 .dword 0xddd9d46c6b3ba686
 .dword 0x6cff05f4471f466e
 .dword 0x5c3285f1b465cfc7
-.dword 0x4e135a2dd1a9235d
+.dword 0x9f1bd751cc3667f4
 .dword 0x240d4654d7d49243
 .dword 0xd3a8220afbbd3470
 .dword 0x8467edc6ad732d79
 .dword 0xcb645ce00bd21d6e
 .dword 0x481805026f50a0f8
 .dword 0x8b0236541400a891
-.dword 0x2313d8d6fd2f2c38
 
 // Testcase strings
 Zca_c_lwsp_cg_cp_rd_nx0_b1_str: .string "\"test: 1; cg: Zca_c.lwsp_cg; cp: cp_rd_nx0; bin: b1\""

--- a/tests/rv64i/Zcd/Zcd-c.fldsp-00.S
+++ b/tests/rv64i/Zcd/Zcd-c.fldsp-00.S
@@ -67,9 +67,9 @@ Zcd_c_fldsp_cg_cp_fd_b2:
 # Testcase cp_fd (Test destination fd = f3)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -384 # adjust base address for load
+  addi sp, sp, -24 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b3:
-  c.fldsp f3, 384(sp) # perform load (0x8623b2b364225d27)
+  c.fldsp f3, 24(sp) # perform load (0x9efb8bb0dd3b149c)
   # Check if f3 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f3, Zcd_c_fldsp_cg_cp_fd_b3, Zcd_c_fldsp_cg_cp_fd_b3_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -77,9 +77,9 @@ Zcd_c_fldsp_cg_cp_fd_b3:
 # Testcase cp_fd (Test destination fd = f4)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -440 # adjust base address for load
+  addi sp, sp, -368 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b4:
-  c.fldsp f4, 440(sp) # perform load (0x8a9b56b93da1089d)
+  c.fldsp f4, 368(sp) # perform load (0x0d10769bf6e7f968)
   # Check if f4 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f7, f4, Zcd_c_fldsp_cg_cp_fd_b4, Zcd_c_fldsp_cg_cp_fd_b4_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -87,9 +87,9 @@ Zcd_c_fldsp_cg_cp_fd_b4:
 # Testcase cp_fd (Test destination fd = f5)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -504 # adjust base address for load
+  addi sp, sp, -280 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b5:
-  c.fldsp f5, 504(sp) # perform load (0x2c647dd06847b676)
+  c.fldsp f5, 280(sp) # perform load (0xfcec03ee0a9b56b9)
   # Check if f5 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f7, f5, Zcd_c_fldsp_cg_cp_fd_b5, Zcd_c_fldsp_cg_cp_fd_b5_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -97,9 +97,9 @@ Zcd_c_fldsp_cg_cp_fd_b5:
 # Testcase cp_fd (Test destination fd = f6)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -440 # adjust base address for load
+  addi sp, sp, -16 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b6:
-  c.fldsp f6, 440(sp) # perform load (0x518ae11a83937455)
+  c.fldsp f6, 16(sp) # perform load (0xff2dcc4ae10eaac4)
   # Check if f6 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f7 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f7, f6, Zcd_c_fldsp_cg_cp_fd_b6, Zcd_c_fldsp_cg_cp_fd_b6_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -107,11 +107,11 @@ Zcd_c_fldsp_cg_cp_fd_b6:
 # Testcase cp_fd (Test destination fd = f7)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -464 # adjust base address for load
+  addi sp, sp, -416 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b7:
-  c.fldsp f7, 464(sp) # perform load (0x3d0d387c681edbb6)
-  # Check if f7 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f7, Zcd_c_fldsp_cg_cp_fd_b7, Zcd_c_fldsp_cg_cp_fd_b7_str)
+  c.fldsp f7, 416(sp) # perform load (0xb715ae5af36a03e6)
+  # Check if f7 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f13 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f13, f7, Zcd_c_fldsp_cg_cp_fd_b7, Zcd_c_fldsp_cg_cp_fd_b7_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f8)
@@ -120,8 +120,8 @@ Zcd_c_fldsp_cg_cp_fd_b7:
   addi sp, sp, -224 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b8:
   c.fldsp f8, 224(sp) # perform load (0x1c4554caa41ca44f)
-  # Check if f8 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f8, Zcd_c_fldsp_cg_cp_fd_b8, Zcd_c_fldsp_cg_cp_fd_b8_str)
+  # Check if f8 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f13 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f13, f8, Zcd_c_fldsp_cg_cp_fd_b8, Zcd_c_fldsp_cg_cp_fd_b8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f9)
@@ -130,8 +130,8 @@ Zcd_c_fldsp_cg_cp_fd_b8:
   addi sp, sp, -48 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b9:
   c.fldsp f9, 48(sp) # perform load (0x08a61cad1f002307)
-  # Check if f9 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_fd_b9, Zcd_c_fldsp_cg_cp_fd_b9_str)
+  # Check if f9 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f13 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f13, f9, Zcd_c_fldsp_cg_cp_fd_b9, Zcd_c_fldsp_cg_cp_fd_b9_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f10)
@@ -140,8 +140,8 @@ Zcd_c_fldsp_cg_cp_fd_b9:
   addi sp, sp, -176 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b10:
   c.fldsp f10, 176(sp) # perform load (0xa60535fa3d35d68c)
-  # Check if f10 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f10, Zcd_c_fldsp_cg_cp_fd_b10, Zcd_c_fldsp_cg_cp_fd_b10_str)
+  # Check if f10 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f13 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f13, f10, Zcd_c_fldsp_cg_cp_fd_b10, Zcd_c_fldsp_cg_cp_fd_b10_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f11)
@@ -150,8 +150,8 @@ Zcd_c_fldsp_cg_cp_fd_b10:
   addi sp, sp, 0 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b11:
   c.fldsp f11, 0(sp) # perform load (0x561f1e4014cc7e7e)
-  # Check if f11 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f11, Zcd_c_fldsp_cg_cp_fd_b11, Zcd_c_fldsp_cg_cp_fd_b11_str)
+  # Check if f11 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f13 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f13, f11, Zcd_c_fldsp_cg_cp_fd_b11, Zcd_c_fldsp_cg_cp_fd_b11_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f12)
@@ -160,16 +160,16 @@ Zcd_c_fldsp_cg_cp_fd_b11:
   addi sp, sp, -160 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b12:
   c.fldsp f12, 160(sp) # perform load (0xb9c580bdf288a013)
-  # Check if f12 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f12, Zcd_c_fldsp_cg_cp_fd_b12, Zcd_c_fldsp_cg_cp_fd_b12_str)
+  # Check if f12 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f13 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f13, f12, Zcd_c_fldsp_cg_cp_fd_b12, Zcd_c_fldsp_cg_cp_fd_b12_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_fd (Test destination fd = f13)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -376 # adjust base address for load
+  addi sp, sp, -16 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b13:
-  c.fldsp f13, 376(sp) # perform load (0x8533572499c66843)
+  c.fldsp f13, 16(sp) # perform load (0x154c3fb0b0e9a818)
   # Check if f13 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f13, Zcd_c_fldsp_cg_cp_fd_b13, Zcd_c_fldsp_cg_cp_fd_b13_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -177,9 +177,9 @@ Zcd_c_fldsp_cg_cp_fd_b13:
 # Testcase cp_fd (Test destination fd = f14)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -96 # adjust base address for load
+  addi sp, sp, -72 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b14:
-  c.fldsp f14, 96(sp) # perform load (0xdc8b3fd8132870b8)
+  c.fldsp f14, 72(sp) # perform load (0x3047b44bbe4ff324)
   # Check if f14 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f14, Zcd_c_fldsp_cg_cp_fd_b14, Zcd_c_fldsp_cg_cp_fd_b14_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -187,9 +187,9 @@ Zcd_c_fldsp_cg_cp_fd_b14:
 # Testcase cp_fd (Test destination fd = f15)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -488 # adjust base address for load
+  addi sp, sp, -440 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b15:
-  c.fldsp f15, 488(sp) # perform load (0xa3fcbb7f5962da28)
+  c.fldsp f15, 440(sp) # perform load (0x980db6081b8488a7)
   # Check if f15 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f15, Zcd_c_fldsp_cg_cp_fd_b15, Zcd_c_fldsp_cg_cp_fd_b15_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -197,9 +197,9 @@ Zcd_c_fldsp_cg_cp_fd_b15:
 # Testcase cp_fd (Test destination fd = f16)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -208 # adjust base address for load
+  addi sp, sp, -264 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b16:
-  c.fldsp f16, 208(sp) # perform load (0x3e8519587d41c4c4)
+  c.fldsp f16, 264(sp) # perform load (0xf547255c23fcbb7f)
   # Check if f16 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f16, Zcd_c_fldsp_cg_cp_fd_b16, Zcd_c_fldsp_cg_cp_fd_b16_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -207,9 +207,9 @@ Zcd_c_fldsp_cg_cp_fd_b16:
 # Testcase cp_fd (Test destination fd = f17)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -112 # adjust base address for load
+  addi sp, sp, -464 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b17:
-  c.fldsp f17, 112(sp) # perform load (0xf269cff632810e78)
+  c.fldsp f17, 464(sp) # perform load (0x04fa9bc1354733e3)
   # Check if f17 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f17, Zcd_c_fldsp_cg_cp_fd_b17, Zcd_c_fldsp_cg_cp_fd_b17_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -217,9 +217,9 @@ Zcd_c_fldsp_cg_cp_fd_b17:
 # Testcase cp_fd (Test destination fd = f18)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -104 # adjust base address for load
+  addi sp, sp, -112 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b18:
-  c.fldsp f18, 104(sp) # perform load (0x451c73527a2fb114)
+  c.fldsp f18, 112(sp) # perform load (0xf269cff632810e78)
   # Check if f18 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f18, Zcd_c_fldsp_cg_cp_fd_b18, Zcd_c_fldsp_cg_cp_fd_b18_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -227,9 +227,9 @@ Zcd_c_fldsp_cg_cp_fd_b18:
 # Testcase cp_fd (Test destination fd = f19)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -168 # adjust base address for load
+  addi sp, sp, -104 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b19:
-  c.fldsp f19, 168(sp) # perform load (0x7d7d3dfe7979a0f3)
+  c.fldsp f19, 104(sp) # perform load (0x451c73527a2fb114)
   # Check if f19 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f19, Zcd_c_fldsp_cg_cp_fd_b19, Zcd_c_fldsp_cg_cp_fd_b19_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -237,9 +237,9 @@ Zcd_c_fldsp_cg_cp_fd_b19:
 # Testcase cp_fd (Test destination fd = f20)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -360 # adjust base address for load
+  addi sp, sp, -168 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b20:
-  c.fldsp f20, 360(sp) # perform load (0xda826e7324827b37)
+  c.fldsp f20, 168(sp) # perform load (0x7d7d3dfe7979a0f3)
   # Check if f20 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f20, Zcd_c_fldsp_cg_cp_fd_b20, Zcd_c_fldsp_cg_cp_fd_b20_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -247,9 +247,9 @@ Zcd_c_fldsp_cg_cp_fd_b20:
 # Testcase cp_fd (Test destination fd = f21)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -416 # adjust base address for load
+  addi sp, sp, -360 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b21:
-  c.fldsp f21, 416(sp) # perform load (0x2ea9e51b14b21f57)
+  c.fldsp f21, 360(sp) # perform load (0xda826e7324827b37)
   # Check if f21 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f21, Zcd_c_fldsp_cg_cp_fd_b21, Zcd_c_fldsp_cg_cp_fd_b21_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -257,9 +257,9 @@ Zcd_c_fldsp_cg_cp_fd_b21:
 # Testcase cp_fd (Test destination fd = f22)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -200 # adjust base address for load
+  addi sp, sp, -416 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b22:
-  c.fldsp f22, 200(sp) # perform load (0xccf60058673d9d2f)
+  c.fldsp f22, 416(sp) # perform load (0x2ea9e51b14b21f57)
   # Check if f22 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f22, Zcd_c_fldsp_cg_cp_fd_b22, Zcd_c_fldsp_cg_cp_fd_b22_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -267,9 +267,9 @@ Zcd_c_fldsp_cg_cp_fd_b22:
 # Testcase cp_fd (Test destination fd = f23)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -8 # adjust base address for load
+  addi sp, sp, -200 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b23:
-  c.fldsp f23, 8(sp) # perform load (0x86697cd88720ef90)
+  c.fldsp f23, 200(sp) # perform load (0xccf60058673d9d2f)
   # Check if f23 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f23, Zcd_c_fldsp_cg_cp_fd_b23, Zcd_c_fldsp_cg_cp_fd_b23_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -277,9 +277,9 @@ Zcd_c_fldsp_cg_cp_fd_b23:
 # Testcase cp_fd (Test destination fd = f24)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -296 # adjust base address for load
+  addi sp, sp, -8 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b24:
-  c.fldsp f24, 296(sp) # perform load (0x13ec57051f85d841)
+  c.fldsp f24, 8(sp) # perform load (0x86697cd88720ef90)
   # Check if f24 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f24, Zcd_c_fldsp_cg_cp_fd_b24, Zcd_c_fldsp_cg_cp_fd_b24_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -287,9 +287,9 @@ Zcd_c_fldsp_cg_cp_fd_b24:
 # Testcase cp_fd (Test destination fd = f25)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -104 # adjust base address for load
+  addi sp, sp, -296 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b25:
-  c.fldsp f25, 104(sp) # perform load (0x623083aef02c440f)
+  c.fldsp f25, 296(sp) # perform load (0x13ec57051f85d841)
   # Check if f25 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f25, Zcd_c_fldsp_cg_cp_fd_b25, Zcd_c_fldsp_cg_cp_fd_b25_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -297,9 +297,9 @@ Zcd_c_fldsp_cg_cp_fd_b25:
 # Testcase cp_fd (Test destination fd = f26)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -136 # adjust base address for load
+  addi sp, sp, -104 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b26:
-  c.fldsp f26, 136(sp) # perform load (0xd1325e279163edbf)
+  c.fldsp f26, 104(sp) # perform load (0x623083aef02c440f)
   # Check if f26 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f26, Zcd_c_fldsp_cg_cp_fd_b26, Zcd_c_fldsp_cg_cp_fd_b26_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -307,9 +307,9 @@ Zcd_c_fldsp_cg_cp_fd_b26:
 # Testcase cp_fd (Test destination fd = f27)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -248 # adjust base address for load
+  addi sp, sp, -136 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b27:
-  c.fldsp f27, 248(sp) # perform load (0xb9a6cd6a43b251ba)
+  c.fldsp f27, 136(sp) # perform load (0xd1325e279163edbf)
   # Check if f27 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f27, Zcd_c_fldsp_cg_cp_fd_b27, Zcd_c_fldsp_cg_cp_fd_b27_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -317,9 +317,9 @@ Zcd_c_fldsp_cg_cp_fd_b27:
 # Testcase cp_fd (Test destination fd = f28)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -184 # adjust base address for load
+  addi sp, sp, -248 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b28:
-  c.fldsp f28, 184(sp) # perform load (0x7df195c9552031a0)
+  c.fldsp f28, 248(sp) # perform load (0xb9a6cd6a43b251ba)
   # Check if f28 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f28, Zcd_c_fldsp_cg_cp_fd_b28, Zcd_c_fldsp_cg_cp_fd_b28_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -327,9 +327,9 @@ Zcd_c_fldsp_cg_cp_fd_b28:
 # Testcase cp_fd (Test destination fd = f29)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -200 # adjust base address for load
+  addi sp, sp, -184 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b29:
-  c.fldsp f29, 200(sp) # perform load (0xc8aa1bd7966bc272)
+  c.fldsp f29, 184(sp) # perform load (0x7df195c9552031a0)
   # Check if f29 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f29, Zcd_c_fldsp_cg_cp_fd_b29, Zcd_c_fldsp_cg_cp_fd_b29_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -337,9 +337,9 @@ Zcd_c_fldsp_cg_cp_fd_b29:
 # Testcase cp_fd (Test destination fd = f30)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -56 # adjust base address for load
+  addi sp, sp, -200 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b30:
-  c.fldsp f30, 56(sp) # perform load (0x0f6d98386b25ae2a)
+  c.fldsp f30, 200(sp) # perform load (0xc8aa1bd7966bc272)
   # Check if f30 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f30, Zcd_c_fldsp_cg_cp_fd_b30, Zcd_c_fldsp_cg_cp_fd_b30_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -347,9 +347,9 @@ Zcd_c_fldsp_cg_cp_fd_b30:
 # Testcase cp_fd (Test destination fd = f31)
   fsflagsi 0b00000 # clear all fflags
   mv sp, x3 # move data_ptr to sp
-  addi sp, sp, -248 # adjust base address for load
+  addi sp, sp, -56 # adjust base address for load
 Zcd_c_fldsp_cg_cp_fd_b31:
-  c.fldsp f31, 248(sp) # perform load (0x168b6abb4768941d)
+  c.fldsp f31, 56(sp) # perform load (0x0f6d98386b25ae2a)
   # Check if f31 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f31, Zcd_c_fldsp_cg_cp_fd_b31, Zcd_c_fldsp_cg_cp_fd_b31_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -373,9 +373,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -8 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x8:
-  c.fldsp f1, 8(sp) # perform load (0xba5045f7cb53267a)
-  # Check if f1 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f1, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x8_str)
+  c.fldsp f0, 8(sp) # perform load (0xba5045f7cb53267a)
+  # Check if f0 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=16
@@ -383,9 +383,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -16 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x10:
-  c.fldsp f29, 16(sp) # perform load (0x498e6290e853ac0b)
-  # Check if f29 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f29, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x10_str)
+  c.fldsp f28, 16(sp) # perform load (0x498e6290e853ac0b)
+  # Check if f28 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x10_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=24
@@ -393,9 +393,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x10:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -24 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x18:
-  c.fldsp f14, 24(sp) # perform load (0xc2ad4c91a43c8bb1)
-  # Check if f14 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f14, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x18, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x18_str)
+  c.fldsp f13, 24(sp) # perform load (0xc2ad4c91a43c8bb1)
+  # Check if f13 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f13, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x18, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x18_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=32
@@ -403,9 +403,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x18:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -32 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x20:
-  c.fldsp f3, 32(sp) # perform load (0xbe653780c5cebb4a)
-  # Check if f3 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f3, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x20, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x20_str)
+  c.fldsp f2, 32(sp) # perform load (0xbe653780c5cebb4a)
+  # Check if f2 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f2, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x20, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x20_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=40
@@ -413,9 +413,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x20:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -40 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x28:
-  c.fldsp f28, 40(sp) # perform load (0x66aba3cdf5a05ab8)
-  # Check if f28 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x28_str)
+  c.fldsp f27, 40(sp) # perform load (0x66aba3cdf5a05ab8)
+  # Check if f27 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f27, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x28_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=48
@@ -423,9 +423,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x28:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -48 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x30:
-  c.fldsp f28, 48(sp) # perform load (0x3438b12d890b6870)
-  # Check if f28 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x30, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x30_str)
+  c.fldsp f27, 48(sp) # perform load (0x3438b12d890b6870)
+  # Check if f27 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f27, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x30, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x30_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=56
@@ -433,9 +433,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x30:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -56 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x38:
-  c.fldsp f5, 56(sp) # perform load (0xa50b632e2678132b)
-  # Check if f5 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f5, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x38, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x38_str)
+  c.fldsp f3, 56(sp) # perform load (0xa50b632e2678132b)
+  # Check if f3 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f3, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x38, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x38_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=64
@@ -443,9 +443,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x38:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -64 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x40:
-  c.fldsp f27, 64(sp) # perform load (0x85be2c20f447ab80)
-  # Check if f27 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f27, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x40, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x40_str)
+  c.fldsp f26, 64(sp) # perform load (0x85be2c20f447ab80)
+  # Check if f26 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f26, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x40, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x40_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=72
@@ -453,9 +453,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x40:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -72 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x48:
-  c.fldsp f25, 72(sp) # perform load (0x511aa18321750613)
-  # Check if f25 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f25, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x48, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x48_str)
+  c.fldsp f24, 72(sp) # perform load (0x511aa18321750613)
+  # Check if f24 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f24, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x48, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x48_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=80
@@ -463,9 +463,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x48:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -80 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x50:
-  c.fldsp f10, 80(sp) # perform load (0xf66f6dffe7c5f63d)
-  # Check if f10 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x50, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x50_str)
+  c.fldsp f9, 80(sp) # perform load (0xf66f6dffe7c5f63d)
+  # Check if f9 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x50, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x50_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=88
@@ -473,9 +473,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x50:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -88 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x58:
-  c.fldsp f11, 88(sp) # perform load (0x6934e85a839f7dd0)
-  # Check if f11 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f11, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x58, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x58_str)
+  c.fldsp f10, 88(sp) # perform load (0x6934e85a839f7dd0)
+  # Check if f10 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x58, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x58_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=96
@@ -483,9 +483,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x58:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -96 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x60:
-  c.fldsp f11, 96(sp) # perform load (0xe6c0c5d717cc8f68)
-  # Check if f11 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f11, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x60, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x60_str)
+  c.fldsp f10, 96(sp) # perform load (0xe6c0c5d717cc8f68)
+  # Check if f10 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x60, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x60_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=104
@@ -493,9 +493,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x60:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -104 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x68:
-  c.fldsp f26, 104(sp) # perform load (0x0cb0616ff1ba431d)
-  # Check if f26 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f26, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x68, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x68_str)
+  c.fldsp f25, 104(sp) # perform load (0x0cb0616ff1ba431d)
+  # Check if f25 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f25, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x68, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x68_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=112
@@ -503,9 +503,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x68:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -112 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x70:
-  c.fldsp f29, 112(sp) # perform load (0x98027c0fceaa93e2)
-  # Check if f29 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f29, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x70, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x70_str)
+  c.fldsp f28, 112(sp) # perform load (0x98027c0fceaa93e2)
+  # Check if f28 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x70, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x70_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=120
@@ -513,9 +513,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x70:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -120 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x78:
-  c.fldsp f24, 120(sp) # perform load (0x92da32e17f6efe85)
-  # Check if f24 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f24, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x78, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x78_str)
+  c.fldsp f23, 120(sp) # perform load (0x92da32e17f6efe85)
+  # Check if f23 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f23, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x78, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x78_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=128
@@ -523,9 +523,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x78:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -128 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x80:
-  c.fldsp f9, 128(sp) # perform load (0x07a779b6be947e6d)
-  # Check if f9 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x80, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x80_str)
+  c.fldsp f30, 128(sp) # perform load (0x2ac10a59452134df)
+  # Check if f30 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f30, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x80, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x80_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=136
@@ -533,9 +533,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x80:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -136 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x88:
-  c.fldsp f9, 136(sp) # perform load (0x19d86a6672fe3e90)
-  # Check if f9 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x88, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x88_str)
+  c.fldsp f6, 136(sp) # perform load (0x8f036558fae1ed7b)
+  # Check if f6 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f6, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x88, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x88_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=144
@@ -543,9 +543,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x88:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -144 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x90:
-  c.fldsp f7, 144(sp) # perform load (0x8f036558fae1ed7b)
-  # Check if f7 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f7, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x90, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x90_str)
+  c.fldsp f23, 144(sp) # perform load (0x5bbf750c58c25ca1)
+  # Check if f23 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f23, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x90, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x90_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=152
@@ -553,7 +553,7 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x90:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -152 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x98:
-  c.fldsp f24, 152(sp) # perform load (0x5bbf750c58c25ca1)
+  c.fldsp f24, 152(sp) # perform load (0x7689355d3e0d4dee)
   # Check if f24 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f24, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x98, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x98_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -563,9 +563,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x98:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -160 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa0:
-  c.fldsp f25, 160(sp) # perform load (0x7689355d3e0d4dee)
-  # Check if f25 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f25, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa0_str)
+  c.fldsp f26, 160(sp) # perform load (0x860c30368b124cba)
+  # Check if f26 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f26, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=168
@@ -573,9 +573,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -168 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa8:
-  c.fldsp f27, 168(sp) # perform load (0x860c30368b124cba)
-  # Check if f27 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f27, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa8_str)
+  c.fldsp f3, 168(sp) # perform load (0x2d5277d9ff00687b)
+  # Check if f3 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f3, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=176
@@ -583,9 +583,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xa8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -176 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb0:
-  c.fldsp f5, 176(sp) # perform load (0x2d5277d9ff00687b)
-  # Check if f5 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f5, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb0_str)
+  c.fldsp f9, 176(sp) # perform load (0x494123738fc39857)
+  # Check if f9 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=184
@@ -593,9 +593,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -184 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb8:
-  c.fldsp f10, 184(sp) # perform load (0x494123738fc39857)
-  # Check if f10 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb8_str)
+  c.fldsp f23, 184(sp) # perform load (0x74d36aa8eceb1aab)
+  # Check if f23 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f23, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=192
@@ -603,9 +603,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xb8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -192 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc0:
-  c.fldsp f24, 192(sp) # perform load (0x74d36aa8eceb1aab)
-  # Check if f24 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f24, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc0_str)
+  c.fldsp f30, 192(sp) # perform load (0xa9df029f4e3854b5)
+  # Check if f30 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f30, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=200
@@ -613,9 +613,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -200 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc8:
-  c.fldsp f10, 200(sp) # perform load (0xa9df029f4e3854b5)
-  # Check if f10 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc8_str)
+  c.fldsp f26, 200(sp) # perform load (0xef43d8d6a495eb4b)
+  # Check if f26 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f26, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=208
@@ -623,9 +623,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xc8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -208 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd0:
-  c.fldsp f30, 208(sp) # perform load (0x7f755960216e180d)
-  # Check if f30 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f30, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd0_str)
+  c.fldsp f9, 208(sp) # perform load (0x323be21952a56745)
+  # Check if f9 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=216
@@ -633,9 +633,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -216 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd8:
-  c.fldsp f2, 216(sp) # perform load (0x3c7d191c99adaac4)
-  # Check if f2 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f2, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd8_str)
+  c.fldsp f9, 216(sp) # perform load (0x2bd37e9ea6ecc7b3)
+  # Check if f9 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=224
@@ -643,9 +643,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xd8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -224 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe0:
-  c.fldsp f30, 224(sp) # perform load (0xb3e2993bb23be219)
-  # Check if f30 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f30, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe0_str)
+  c.fldsp f12, 224(sp) # perform load (0xad08ff8e7e9d03aa)
+  # Check if f12 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f12, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=232
@@ -653,9 +653,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -232 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe8:
-  c.fldsp f10, 232(sp) # perform load (0x2bd37e9ea6ecc7b3)
-  # Check if f10 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe8_str)
+  c.fldsp f27, 232(sp) # perform load (0x2aa117d628e6e541)
+  # Check if f27 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f27, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=240
@@ -663,7 +663,7 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xe8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -240 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf0:
-  c.fldsp f13, 240(sp) # perform load (0xad08ff8e7e9d03aa)
+  c.fldsp f13, 240(sp) # perform load (0x2ddc2d5f9d1af773)
   # Check if f13 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f13, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -673,9 +673,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -248 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf8:
-  c.fldsp f28, 248(sp) # perform load (0x2aa117d628e6e541)
-  # Check if f28 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf8_str)
+  c.fldsp f26, 248(sp) # perform load (0x1857472cd0dd8f6a)
+  # Check if f26 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f26, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=256
@@ -683,9 +683,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0xf8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -256 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x100:
-  c.fldsp f14, 256(sp) # perform load (0x2ddc2d5f9d1af773)
-  # Check if f14 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f14, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x100, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x100_str)
+  c.fldsp f21, 256(sp) # perform load (0x40e0c647267c8fa9)
+  # Check if f21 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f21, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x100, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x100_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=264
@@ -693,9 +693,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x100:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -264 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x108:
-  c.fldsp f27, 264(sp) # perform load (0x1857472cd0dd8f6a)
-  # Check if f27 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f27, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x108, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x108_str)
+  c.fldsp f23, 264(sp) # perform load (0x19a700f009f68038)
+  # Check if f23 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f23, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x108, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x108_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=272
@@ -703,9 +703,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x108:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -272 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x110:
-  c.fldsp f22, 272(sp) # perform load (0x40e0c647267c8fa9)
-  # Check if f22 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f22, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x110, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x110_str)
+  c.fldsp f29, 272(sp) # perform load (0xdb9e150466491b2e)
+  # Check if f29 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f29, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x110, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x110_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=280
@@ -713,9 +713,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x110:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -280 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x118:
-  c.fldsp f24, 280(sp) # perform load (0x19a700f009f68038)
-  # Check if f24 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f24, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x118, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x118_str)
+  c.fldsp f3, 280(sp) # perform load (0xf57a0ee178ca746b)
+  # Check if f3 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f3, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x118, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x118_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=288
@@ -723,9 +723,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x118:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -288 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x120:
-  c.fldsp f30, 288(sp) # perform load (0xdb9e150466491b2e)
-  # Check if f30 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f30, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x120, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x120_str)
+  c.fldsp f19, 288(sp) # perform load (0x7616a8e4ae71b083)
+  # Check if f19 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f19, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x120, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x120_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=296
@@ -733,9 +733,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x120:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -296 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x128:
-  c.fldsp f5, 296(sp) # perform load (0xf57a0ee178ca746b)
-  # Check if f5 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f5, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x128, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x128_str)
+  c.fldsp f8, 296(sp) # perform load (0xdaaa77d899d126f2)
+  # Check if f8 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x128, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x128_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=304
@@ -743,9 +743,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x128:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -304 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x130:
-  c.fldsp f20, 304(sp) # perform load (0x7616a8e4ae71b083)
-  # Check if f20 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f20, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x130, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x130_str)
+  c.fldsp f19, 304(sp) # perform load (0x33b5ac409a4129a4)
+  # Check if f19 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f19, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x130, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x130_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=312
@@ -753,9 +753,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x130:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -312 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x138:
-  c.fldsp f9, 312(sp) # perform load (0xdaaa77d899d126f2)
-  # Check if f9 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x138, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x138_str)
+  c.fldsp f16, 312(sp) # perform load (0x40b820f40cce48b5)
+  # Check if f16 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f16, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x138, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x138_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=320
@@ -763,9 +763,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x138:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -320 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x140:
-  c.fldsp f20, 320(sp) # perform load (0x33b5ac409a4129a4)
-  # Check if f20 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f20, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x140, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x140_str)
+  c.fldsp f22, 320(sp) # perform load (0x1952d16a0e351218)
+  # Check if f22 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f22, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x140, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x140_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=328
@@ -773,9 +773,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x140:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -328 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x148:
-  c.fldsp f17, 328(sp) # perform load (0x40b820f40cce48b5)
-  # Check if f17 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f17, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x148, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x148_str)
+  c.fldsp f3, 328(sp) # perform load (0x1a7ccaed78716c01)
+  # Check if f3 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f3, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x148, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x148_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=336
@@ -783,7 +783,7 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x148:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -336 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x150:
-  c.fldsp f23, 336(sp) # perform load (0x1952d16a0e351218)
+  c.fldsp f23, 336(sp) # perform load (0x59cfaa758bf60fa8)
   # Check if f23 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
   RVTEST_SIGUPD_F(x10, x5, x4, f4, f23, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x150, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x150_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
@@ -793,9 +793,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x150:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -344 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x158:
-  c.fldsp f5, 344(sp) # perform load (0x1a7ccaed78716c01)
-  # Check if f5 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f5, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x158, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x158_str)
+  c.fldsp f21, 344(sp) # perform load (0x5a73004be455e34f)
+  # Check if f21 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f21, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x158, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x158_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=352
@@ -803,9 +803,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x158:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -352 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x160:
-  c.fldsp f24, 352(sp) # perform load (0x59cfaa758bf60fa8)
-  # Check if f24 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f24, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x160, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x160_str)
+  c.fldsp f23, 352(sp) # perform load (0xca7f5ca484fdde3b)
+  # Check if f23 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f23, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x160, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x160_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=360
@@ -813,9 +813,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x160:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -360 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x168:
-  c.fldsp f22, 360(sp) # perform load (0x5a73004be455e34f)
-  # Check if f22 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f22, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x168, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x168_str)
+  c.fldsp f18, 360(sp) # perform load (0x35c7936d3e3a13ec)
+  # Check if f18 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f18, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x168, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x168_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=368
@@ -823,9 +823,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x168:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -368 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x170:
-  c.fldsp f24, 368(sp) # perform load (0xca7f5ca484fdde3b)
-  # Check if f24 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f24, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x170, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x170_str)
+  c.fldsp f18, 368(sp) # perform load (0xc398918dee303937)
+  # Check if f18 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f18, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x170, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x170_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=376
@@ -833,9 +833,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x170:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -376 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x178:
-  c.fldsp f19, 376(sp) # perform load (0x35c7936d3e3a13ec)
-  # Check if f19 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f19, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x178, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x178_str)
+  c.fldsp f6, 376(sp) # perform load (0xdef584366924a50f)
+  # Check if f6 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f6, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x178, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x178_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=384
@@ -843,9 +843,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x178:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -384 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x180:
-  c.fldsp f19, 384(sp) # perform load (0xc398918dee303937)
-  # Check if f19 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f19, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x180, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x180_str)
+  c.fldsp f1, 384(sp) # perform load (0x46f5f2c8f5d01258)
+  # Check if f1 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f1, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x180, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x180_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=392
@@ -853,9 +853,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x180:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -392 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x188:
-  c.fldsp f7, 392(sp) # perform load (0xdef584366924a50f)
-  # Check if f7 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f7, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x188, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x188_str)
+  c.fldsp f16, 392(sp) # perform load (0xc26a7440424aad74)
+  # Check if f16 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f16, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x188, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x188_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=400
@@ -863,9 +863,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x188:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -400 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x190:
-  c.fldsp f2, 400(sp) # perform load (0x46f5f2c8f5d01258)
-  # Check if f2 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f2, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x190, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x190_str)
+  c.fldsp f28, 400(sp) # perform load (0xd1a24a1cf4d7fb96)
+  # Check if f28 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x190, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x190_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=408
@@ -873,9 +873,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x190:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -408 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x198:
-  c.fldsp f17, 408(sp) # perform load (0xc26a7440424aad74)
-  # Check if f17 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f17, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x198, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x198_str)
+  c.fldsp f9, 408(sp) # perform load (0xd39890b899348b32)
+  # Check if f9 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x198, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x198_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=416
@@ -883,9 +883,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x198:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -416 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a0:
-  c.fldsp f29, 416(sp) # perform load (0xd1a24a1cf4d7fb96)
-  # Check if f29 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f29, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a0_str)
+  c.fldsp f21, 416(sp) # perform load (0x1dfae0815518c01e)
+  # Check if f21 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f21, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=424
@@ -893,9 +893,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -424 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a8:
-  c.fldsp f10, 424(sp) # perform load (0xd39890b899348b32)
-  # Check if f10 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a8_str)
+  c.fldsp f12, 424(sp) # perform load (0xfbde4b5d57a6779b)
+  # Check if f12 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f12, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=432
@@ -903,9 +903,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1a8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -432 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b0:
-  c.fldsp f22, 432(sp) # perform load (0x1dfae0815518c01e)
-  # Check if f22 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f22, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b0_str)
+  c.fldsp f1, 432(sp) # perform load (0x9e526144517dcaa7)
+  # Check if f1 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f1, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=440
@@ -913,9 +913,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -440 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b8:
-  c.fldsp f13, 440(sp) # perform load (0xfbde4b5d57a6779b)
-  # Check if f13 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f13, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b8_str)
+  c.fldsp f21, 440(sp) # perform load (0x1078cff537186b25)
+  # Check if f21 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f21, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=448
@@ -923,9 +923,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1b8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -448 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c0:
-  c.fldsp f2, 448(sp) # perform load (0x9e526144517dcaa7)
-  # Check if f2 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f2, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c0_str)
+  c.fldsp f23, 448(sp) # perform load (0x29c809e5e28475b1)
+  # Check if f23 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f23, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=456
@@ -933,9 +933,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -456 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c8:
-  c.fldsp f22, 456(sp) # perform load (0x1078cff537186b25)
-  # Check if f22 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f22, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c8_str)
+  c.fldsp f9, 456(sp) # perform load (0x7deb83155b754332)
+  # Check if f9 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=464
@@ -943,9 +943,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1c8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -464 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d0:
-  c.fldsp f24, 464(sp) # perform load (0x29c809e5e28475b1)
-  # Check if f24 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f24, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d0_str)
+  c.fldsp f31, 464(sp) # perform load (0xf077a4de3aa90a42)
+  # Check if f31 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f31, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=472
@@ -953,9 +953,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -472 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d8:
-  c.fldsp f10, 472(sp) # perform load (0x7deb83155b754332)
-  # Check if f10 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d8_str)
+  c.fldsp f17, 472(sp) # perform load (0xcabc0b3eff682062)
+  # Check if f17 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f17, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=480
@@ -963,9 +963,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1d8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -480 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e0:
-  c.fldsp f25, 480(sp) # perform load (0xf077a4de3aa90a42)
-  # Check if f25 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f25, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e0_str)
+  c.fldsp f6, 480(sp) # perform load (0x58ec48158fdb6870)
+  # Check if f6 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f6, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=488
@@ -973,9 +973,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -488 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e8:
-  c.fldsp f28, 488(sp) # perform load (0xad6bfeb177e37d72)
-  # Check if f28 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f28, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e8_str)
+  c.fldsp f23, 488(sp) # perform load (0x416fd514d6a46038)
+  # Check if f23 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f23, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=496
@@ -983,9 +983,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1e8:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -496 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f0:
-  c.fldsp f18, 496(sp) # perform load (0x36ca574e3b07a099)
-  # Check if f18 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f18, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f0_str)
+  c.fldsp f9, 496(sp) # perform load (0x38f1a8156aa9af1c)
+  # Check if f9 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f9, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f0, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f0_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
 # Testcase cp_imm_mul_8sp: imm=504
@@ -993,9 +993,9 @@ Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f0:
   mv sp, x3 # move data_ptr to sp
   addi sp, sp, -504 # adjust base address for load
 Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f8:
-  c.fldsp f10, 504(sp) # perform load (0x38f1a8156aa9af1c)
-  # Check if f10 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x10, x5, x4, f4, f10, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f8_str)
+  c.fldsp f2, 504(sp) # perform load (0x93a110ad53ee84ca)
+  # Check if f2 contains the expected result. Also checks fflags. x10 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x10, x5, x4, f4, f2, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f8, Zcd_c_fldsp_cg_cp_imm_mul_8sp_b0x1f8_str)
   addi x3, x3, SIG_STRIDE # increment data_ptr
 
   mv x2, x10 # restore signature pointer to default register for teardown
@@ -1010,20 +1010,21 @@ RVTEST_DATA_BEGIN
 .dword 0xe5bf1b7a345e6b03
 .dword 0xd22ebbf21c8a5531
 .dword 0x340a96fbd37f81b6
-.dword 0x8623b2b364225d27
-.dword 0x8a9b56b93da1089d
-.dword 0x2c647dd06847b676
-.dword 0x518ae11a83937455
-.dword 0x3d0d387c681edbb6
+.dword 0x9efb8bb0dd3b149c
+.dword 0x0d10769bf6e7f968
+.dword 0xfcec03ee0a9b56b9
+.dword 0xff2dcc4ae10eaac4
+.dword 0xb715ae5af36a03e6
 .dword 0x1c4554caa41ca44f
 .dword 0x08a61cad1f002307
 .dword 0xa60535fa3d35d68c
 .dword 0x561f1e4014cc7e7e
 .dword 0xb9c580bdf288a013
-.dword 0x8533572499c66843
-.dword 0xdc8b3fd8132870b8
-.dword 0xa3fcbb7f5962da28
-.dword 0x3e8519587d41c4c4
+.dword 0x154c3fb0b0e9a818
+.dword 0x3047b44bbe4ff324
+.dword 0x980db6081b8488a7
+.dword 0xf547255c23fcbb7f
+.dword 0x04fa9bc1354733e3
 .dword 0xf269cff632810e78
 .dword 0x451c73527a2fb114
 .dword 0x7d7d3dfe7979a0f3
@@ -1038,7 +1039,6 @@ RVTEST_DATA_BEGIN
 .dword 0x7df195c9552031a0
 .dword 0xc8aa1bd7966bc272
 .dword 0x0f6d98386b25ae2a
-.dword 0x168b6abb4768941d
 .dword 0xdd89a1e8003e3902
 .dword 0xba5045f7cb53267a
 .dword 0x498e6290e853ac0b
@@ -1055,8 +1055,7 @@ RVTEST_DATA_BEGIN
 .dword 0x0cb0616ff1ba431d
 .dword 0x98027c0fceaa93e2
 .dword 0x92da32e17f6efe85
-.dword 0x07a779b6be947e6d
-.dword 0x19d86a6672fe3e90
+.dword 0x2ac10a59452134df
 .dword 0x8f036558fae1ed7b
 .dword 0x5bbf750c58c25ca1
 .dword 0x7689355d3e0d4dee
@@ -1065,9 +1064,8 @@ RVTEST_DATA_BEGIN
 .dword 0x494123738fc39857
 .dword 0x74d36aa8eceb1aab
 .dword 0xa9df029f4e3854b5
-.dword 0x7f755960216e180d
-.dword 0x3c7d191c99adaac4
-.dword 0xb3e2993bb23be219
+.dword 0xef43d8d6a495eb4b
+.dword 0x323be21952a56745
 .dword 0x2bd37e9ea6ecc7b3
 .dword 0xad08ff8e7e9d03aa
 .dword 0x2aa117d628e6e541
@@ -1100,9 +1098,11 @@ RVTEST_DATA_BEGIN
 .dword 0x29c809e5e28475b1
 .dword 0x7deb83155b754332
 .dword 0xf077a4de3aa90a42
-.dword 0xad6bfeb177e37d72
-.dword 0x36ca574e3b07a099
+.dword 0xcabc0b3eff682062
+.dword 0x58ec48158fdb6870
+.dword 0x416fd514d6a46038
 .dword 0x38f1a8156aa9af1c
+.dword 0x93a110ad53ee84ca
 
 // Testcase strings
 Zcd_c_fldsp_cg_cp_fd_b0_str: .string "\"test: 1; cg: Zcd_c.fldsp_cg; cp: cp_fd; bin: b0\""


### PR DESCRIPTION
Issue #2147 item 24.

`cils_type.py` and `cfls_type.py` both had `reg_range=range(1, 31)` (1..30) with a comment claiming only that the register cannot be x0, so x31/f31 were never drawn for `c.lwsp`, `c.ldsp`, `c.flwsp`, `c.fldsp`. `cjalr_type.py` and `cjr_type.py` write the same intent correctly as `range(1, 32)`.

- CILS → `range(1, 32)` (rd cannot be x0)
- CFLS → `range(32)` (f0 is a legal float destination)
