### PR TITLE
Exclude x2 from randomly chosen rs2 in CSS-type stores

### DIFF
--- a/generators/testgen/src/testgen/formatters/types/css_type.py
+++ b/generators/testgen/src/testgen/formatters/types/css_type.py
@@ -15,6 +15,8 @@ css_config = InstructionTypeConfig(
     required_params={"rs2", "rs2val", "immval", "temp_reg"},
     imm_bits=9,
     imm_signed=False,
+    # sp holds the store base address, so a randomly chosen rs2 must not be x2
+    excluded_regs={"rs2": {2}},
 )
 
 

--- a/tests/rv32e/Zca/Zca-c.swsp-00.S
+++ b/tests/rv32e/Zca/Zca-c.swsp-00.S
@@ -211,768 +211,768 @@ Zca_c_swsp_cg_cp_rs2_b15:
 /////////////////////////////////
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000)
-  RVTEST_TESTDATA_LOAD_INT(x1, x4) # load rs2: x4 = 0x00000000
+  RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x00000000
   addi sp, x9, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x0:
-  c.swsp x4, 16(sp) # perform store
+  c.swsp x5, 16(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_rs2_edges_0x0, Zca_c_swsp_cg_cp_rs2_edges_0x0_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x00000001
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x00000001
   addi sp, x9, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x1:
-  c.swsp x14, 144(sp) # perform store
+  c.swsp x15, 144(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0x1, Zca_c_swsp_cg_cp_rs2_edges_0x1_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
-  RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x00000002
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x00000002
   addi sp, x9, -44  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x2:
-  c.swsp x5, 44(sp) # perform store
+  c.swsp x6, 44(sp) # perform store
   LREG x13, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x13, Zca_c_swsp_cg_cp_rs2_edges_0x2, Zca_c_swsp_cg_cp_rs2_edges_0x2_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x80000000
-  addi sp, x9, -236  # copy sig_reg to sp and adjust for offset
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x80000000
+  addi sp, x9, -212  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x80000000:
-  c.swsp x15, 236(sp) # perform store
-  LREG x11, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_edges_0x80000000, Zca_c_swsp_cg_cp_rs2_edges_0x80000000_str)
-
-# Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x80000001
-  addi sp, x9, -4  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_rs2_edges_0x80000001:
-  c.swsp x14, 4(sp) # perform store
-  LREG x13, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x13 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x13, Zca_c_swsp_cg_cp_rs2_edges_0x80000001, Zca_c_swsp_cg_cp_rs2_edges_0x80000001_str)
-
-# Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x7fffffff
-  addi sp, x9, -52  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff:
-  c.swsp x6, 52(sp) # perform store
-  LREG x11, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff_str)
-
-# Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
-  RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x7ffffffe
-  addi sp, x9, -204  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe:
-  c.swsp x5, 204(sp) # perform store
-  LREG x10, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe_str)
-
-# Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xffffffff
-  addi sp, x9, -144  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
-  c.swsp x11, 144(sp) # perform store
-  LREG x14, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff_str)
-
-# Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xfffffffe
-  addi sp, x9, -240  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
-  c.swsp x15, 240(sp) # perform store
+  c.swsp x11, 212(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe_str)
+  RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_rs2_edges_0x80000000, Zca_c_swsp_cg_cp_rs2_edges_0x80000000_str)
 
-# Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x5bbc8872
-  addi sp, x9, -144  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872:
-  c.swsp x13, 144(sp) # perform store
-  LREG x12, 0(x9) # load stored value for checking
+# Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x80000001
+  addi sp, x9, -28  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_rs2_edges_0x80000001:
+  c.swsp x10, 28(sp) # perform store
+  LREG x11, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872_str)
+  # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_edges_0x80000001, Zca_c_swsp_cg_cp_rs2_edges_0x80000001_str)
 
-# Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xaaaaaaaa
-  addi sp, x9, -252  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa:
-  c.swsp x11, 252(sp) # perform store
+# Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x7fffffff
+  addi sp, x9, -240  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff:
+  c.swsp x15, 240(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa_str)
+  RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff_str)
+
+# Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x7ffffffe
+  addi sp, x9, -128  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe:
+  c.swsp x6, 128(sp) # perform store
+  LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe_str)
+
+# Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xffffffff
+  addi sp, x9, -196  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
+  c.swsp x13, 196(sp) # perform store
+  LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff_str)
+
+# Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xfffffffe
+  addi sp, x9, -172  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
+  c.swsp x13, 172(sp) # perform store
+  LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe_str)
+
+# Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
+  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x5bbc8872
+  addi sp, x9, -32  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872:
+  c.swsp x12, 32(sp) # perform store
+  LREG x13, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x13 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x13, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872_str)
+
+# Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xaaaaaaaa
+  addi sp, x9, -196  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa:
+  c.swsp x6, 196(sp) # perform store
+  LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x55555555
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x55555555
   addi sp, x9, -228  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x55555555:
-  c.swsp x3, 228(sp) # perform store
-  LREG x10, 0(x9) # load stored value for checking
+  c.swsp x14, 228(sp) # perform store
+  LREG x15, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_rs2_edges_0x55555555, Zca_c_swsp_cg_cp_rs2_edges_0x55555555_str)
+  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_rs2_edges_0x55555555, Zca_c_swsp_cg_cp_rs2_edges_0x55555555_str)
 
 /////////////////////////////////
 // cp_imm_mul_4sp
 /////////////////////////////////
 
 # Testcase cp_imm_mul_4sp: imm=0
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x3748c810
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x3748c810
   addi sp, x9, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0:
-  c.swsp x6, 0(sp) # perform store
+  c.swsp x10, 0(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0_str)
 
 # Testcase cp_imm_mul_4sp: imm=4
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x212852d1
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x212852d1
   addi sp, x9, -4  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4:
-  c.swsp x12, 4(sp) # perform store
+  c.swsp x13, 4(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4_str)
 
 # Testcase cp_imm_mul_4sp: imm=8
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xde9d49fb
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xde9d49fb
   addi sp, x9, -8  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8:
-  c.swsp x6, 8(sp) # perform store
+  c.swsp x10, 8(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8_str)
 
 # Testcase cp_imm_mul_4sp: imm=12
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x63ff9a0d
+  RVTEST_TESTDATA_LOAD_INT(x1, x4) # load rs2: x4 = 0x63ff9a0d
   addi sp, x9, -12  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc:
-  c.swsp x3, 12(sp) # perform store
+  c.swsp x4, 12(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc_str)
 
 # Testcase cp_imm_mul_4sp: imm=16
-  RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0xbe081e73
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xbe081e73
   addi sp, x9, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10:
-  c.swsp x5, 16(sp) # perform store
-  LREG x6, 0(x9) # load stored value for checking
+  c.swsp x6, 16(sp) # perform store
+  LREG x5, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10_str)
+  # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10_str)
 
 # Testcase cp_imm_mul_4sp: imm=20
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xf630d861
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xf630d861
   addi sp, x9, -20  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14:
-  c.swsp x10, 20(sp) # perform store
+  c.swsp x11, 20(sp) # perform store
   LREG x4, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14_str)
 
 # Testcase cp_imm_mul_4sp: imm=24
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xb3a35dad
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xb3a35dad
   addi sp, x9, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18:
-  c.swsp x10, 24(sp) # perform store
+  c.swsp x11, 24(sp) # perform store
   LREG x4, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18_str)
 
 # Testcase cp_imm_mul_4sp: imm=28
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xf7c9a307
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xf7c9a307
   addi sp, x9, -28  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c:
-  c.swsp x12, 28(sp) # perform store
+  c.swsp x13, 28(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c_str)
 
 # Testcase cp_imm_mul_4sp: imm=32
-  RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x2dc2d097
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x2dc2d097
   addi sp, x9, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20:
-  c.swsp x5, 32(sp) # perform store
+  c.swsp x6, 32(sp) # perform store
   LREG x4, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20_str)
 
 # Testcase cp_imm_mul_4sp: imm=36
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x6e9d4158
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x6e9d4158
   addi sp, x9, -36  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24:
-  c.swsp x10, 36(sp) # perform store
+  c.swsp x11, 36(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24_str)
 
 # Testcase cp_imm_mul_4sp: imm=40
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x926d86de
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x926d86de
   addi sp, x9, -40  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28:
-  c.swsp x13, 40(sp) # perform store
+  c.swsp x14, 40(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28_str)
 
 # Testcase cp_imm_mul_4sp: imm=44
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x0402a4fe
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x0402a4fe
   addi sp, x9, -44  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
-  c.swsp x6, 44(sp) # perform store
-  LREG x10, 0(x9) # load stored value for checking
+  c.swsp x10, 44(sp) # perform store
+  LREG x6, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c_str)
+  # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c_str)
 
 # Testcase cp_imm_mul_4sp: imm=48
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xb78a0b4b
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xb78a0b4b
   addi sp, x9, -48  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
-  c.swsp x6, 48(sp) # perform store
+  c.swsp x10, 48(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30_str)
 
 # Testcase cp_imm_mul_4sp: imm=52
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x419d87b9
+  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x419d87b9
   addi sp, x9, -52  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
-  c.swsp x11, 52(sp) # perform store
+  c.swsp x12, 52(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34_str)
 
 # Testcase cp_imm_mul_4sp: imm=56
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xdf3eea06
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xbb6c6c9f
   addi sp, x9, -56  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
-  c.swsp x15, 56(sp) # perform store
-  LREG x3, 0(x9) # load stored value for checking
+  c.swsp x10, 56(sp) # perform store
+  LREG x12, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38_str)
+  # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38_str)
 
 # Testcase cp_imm_mul_4sp: imm=60
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x2db624b0
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xe03fe2d8
   addi sp, x9, -60  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
   c.swsp x15, 60(sp) # perform store
-  LREG x10, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c_str)
-
-# Testcase cp_imm_mul_4sp: imm=64
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xccf3cd83
-  addi sp, x9, -64  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
-  c.swsp x12, 64(sp) # perform store
-  LREG x3, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40_str)
-
-# Testcase cp_imm_mul_4sp: imm=68
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x688d5237
-  addi sp, x9, -68  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
-  c.swsp x11, 68(sp) # perform store
-  LREG x4, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44_str)
-
-# Testcase cp_imm_mul_4sp: imm=72
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x1b13aa7d
-  addi sp, x9, -72  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
-  c.swsp x15, 72(sp) # perform store
-  LREG x12, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48_str)
-
-# Testcase cp_imm_mul_4sp: imm=76
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x64c46502
-  addi sp, x9, -76  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
-  c.swsp x15, 76(sp) # perform store
-  LREG x6, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c_str)
-
-# Testcase cp_imm_mul_4sp: imm=80
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x2ef80023
-  addi sp, x9, -80  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
-  c.swsp x6, 80(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50_str)
-
-# Testcase cp_imm_mul_4sp: imm=84
-  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x1a9509f6
-  addi sp, x9, -84  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
-  c.swsp x0, 84(sp) # perform store
-  LREG x5, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54_str)
-
-# Testcase cp_imm_mul_4sp: imm=88
-  RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xc18c3264
-  addi sp, x9, -88  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
-  c.swsp x2, 88(sp) # perform store
-  LREG x3, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58_str)
-
-# Testcase cp_imm_mul_4sp: imm=92
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x80283a47
-  addi sp, x9, -92  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
-  c.swsp x6, 92(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c_str)
-
-# Testcase cp_imm_mul_4sp: imm=96
-  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x068e9e00
-  addi sp, x9, -96  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
-  c.swsp x0, 96(sp) # perform store
-  LREG x4, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60_str)
-
-# Testcase cp_imm_mul_4sp: imm=100
-  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0xe87a0869
-  addi sp, x9, -100  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
-  c.swsp x0, 100(sp) # perform store
-  LREG x6, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64_str)
-
-# Testcase cp_imm_mul_4sp: imm=104
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x25bff6fb
-  addi sp, x9, -104  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
-  c.swsp x12, 104(sp) # perform store
-  LREG x5, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68_str)
-
-# Testcase cp_imm_mul_4sp: imm=108
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x7e22c6d5
-  addi sp, x9, -108  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
-  c.swsp x14, 108(sp) # perform store
-  LREG x12, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c_str)
-
-# Testcase cp_imm_mul_4sp: imm=112
-  RVTEST_TESTDATA_LOAD_INT(x1, x4) # load rs2: x4 = 0x030293c6
-  addi sp, x9, -112  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
-  c.swsp x4, 112(sp) # perform store
-  LREG x3, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70_str)
-
-# Testcase cp_imm_mul_4sp: imm=116
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xb4461515
-  addi sp, x9, -116  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
-  c.swsp x13, 116(sp) # perform store
-  LREG x4, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74_str)
-
-# Testcase cp_imm_mul_4sp: imm=120
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x2a4c1092
-  addi sp, x9, -120  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
-  c.swsp x6, 120(sp) # perform store
-  LREG x5, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78_str)
-
-# Testcase cp_imm_mul_4sp: imm=124
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x28842345
-  addi sp, x9, -124  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
-  c.swsp x12, 124(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c_str)
-
-# Testcase cp_imm_mul_4sp: imm=128
-  RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x1442f570
-  addi sp, x9, -128  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
-  c.swsp x5, 128(sp) # perform store
-  LREG x4, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80_str)
-
-# Testcase cp_imm_mul_4sp: imm=132
-  RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x24a65a68
-  addi sp, x9, -132  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
-  c.swsp x5, 132(sp) # perform store
-  LREG x3, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84_str)
-
-# Testcase cp_imm_mul_4sp: imm=136
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x6eefa15a
-  addi sp, x9, -136  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
-  c.swsp x14, 136(sp) # perform store
-  LREG x5, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88_str)
-
-# Testcase cp_imm_mul_4sp: imm=140
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x12412a8a
-  addi sp, x9, -140  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
-  c.swsp x15, 140(sp) # perform store
-  LREG x13, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x13 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c_str)
-
-# Testcase cp_imm_mul_4sp: imm=144
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x1719b70c
-  addi sp, x9, -144  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
-  c.swsp x10, 144(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90_str)
+  RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c_str)
+
+# Testcase cp_imm_mul_4sp: imm=64
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x1ccb9251
+  addi sp, x9, -64  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
+  c.swsp x15, 64(sp) # perform store
+  LREG x13, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x13 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40_str)
+
+# Testcase cp_imm_mul_4sp: imm=68
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0xd7b73193
+  addi sp, x9, -68  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
+  c.swsp x0, 68(sp) # perform store
+  LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44_str)
+
+# Testcase cp_imm_mul_4sp: imm=72
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0xb7a2726d
+  addi sp, x9, -72  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
+  c.swsp x0, 72(sp) # perform store
+  LREG x13, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x13 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48_str)
+
+# Testcase cp_imm_mul_4sp: imm=76
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x007aeb44
+  addi sp, x9, -76  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
+  c.swsp x15, 76(sp) # perform store
+  LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c_str)
+
+# Testcase cp_imm_mul_4sp: imm=80
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x1a9509f6
+  addi sp, x9, -80  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
+  c.swsp x13, 80(sp) # perform store
+  LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50_str)
+
+# Testcase cp_imm_mul_4sp: imm=84
+  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xc18c3264
+  addi sp, x9, -84  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
+  c.swsp x3, 84(sp) # perform store
+  LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54_str)
+
+# Testcase cp_imm_mul_4sp: imm=88
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x80283a47
+  addi sp, x9, -88  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
+  c.swsp x10, 88(sp) # perform store
+  LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58_str)
+
+# Testcase cp_imm_mul_4sp: imm=92
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x068e9e00
+  addi sp, x9, -92  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
+  c.swsp x0, 92(sp) # perform store
+  LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c_str)
+
+# Testcase cp_imm_mul_4sp: imm=96
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0xe87a0869
+  addi sp, x9, -96  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
+  c.swsp x0, 96(sp) # perform store
+  LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60_str)
+
+# Testcase cp_imm_mul_4sp: imm=100
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x25bff6fb
+  addi sp, x9, -100  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
+  c.swsp x13, 100(sp) # perform store
+  LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64_str)
+
+# Testcase cp_imm_mul_4sp: imm=104
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x7e22c6d5
+  addi sp, x9, -104  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
+  c.swsp x15, 104(sp) # perform store
+  LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68_str)
+
+# Testcase cp_imm_mul_4sp: imm=108
+  RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x030293c6
+  addi sp, x9, -108  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
+  c.swsp x5, 108(sp) # perform store
+  LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c_str)
+
+# Testcase cp_imm_mul_4sp: imm=112
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xb4461515
+  addi sp, x9, -112  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
+  c.swsp x14, 112(sp) # perform store
+  LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70_str)
+
+# Testcase cp_imm_mul_4sp: imm=116
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x2a4c1092
+  addi sp, x9, -116  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
+  c.swsp x10, 116(sp) # perform store
+  LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74_str)
+
+# Testcase cp_imm_mul_4sp: imm=120
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x28842345
+  addi sp, x9, -120  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
+  c.swsp x13, 120(sp) # perform store
+  LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78_str)
+
+# Testcase cp_imm_mul_4sp: imm=124
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x1442f570
+  addi sp, x9, -124  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
+  c.swsp x6, 124(sp) # perform store
+  LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c_str)
+
+# Testcase cp_imm_mul_4sp: imm=128
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x24a65a68
+  addi sp, x9, -128  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
+  c.swsp x6, 128(sp) # perform store
+  LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80_str)
+
+# Testcase cp_imm_mul_4sp: imm=132
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x6eefa15a
+  addi sp, x9, -132  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
+  c.swsp x15, 132(sp) # perform store
+  LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84_str)
+
+# Testcase cp_imm_mul_4sp: imm=136
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xae04c112
+  addi sp, x9, -136  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
+  c.swsp x11, 136(sp) # perform store
+  LREG x13, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x13 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88_str)
+
+# Testcase cp_imm_mul_4sp: imm=140
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xaf6fdcc0
+  addi sp, x9, -140  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
+  c.swsp x14, 140(sp) # perform store
+  LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c_str)
+
+# Testcase cp_imm_mul_4sp: imm=144
+  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x72762c57
+  addi sp, x9, -144  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
+  c.swsp x3, 144(sp) # perform store
+  LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90_str)
 
 # Testcase cp_imm_mul_4sp: imm=148
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x5e38ff0e
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x912f8b40
   addi sp, x9, -148  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
-  c.swsp x3, 148(sp) # perform store
+  c.swsp x0, 148(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94_str)
 
 # Testcase cp_imm_mul_4sp: imm=152
-  RVTEST_TESTDATA_LOAD_INT(x1, x4) # load rs2: x4 = 0x9b99e043
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xbe6fd0d3
   addi sp, x9, -152  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
-  c.swsp x4, 152(sp) # perform store
+  c.swsp x6, 152(sp) # perform store
+  LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98_str)
+
+# Testcase cp_imm_mul_4sp: imm=156
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xc76e4eac
+  addi sp, x9, -156  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
+  c.swsp x6, 156(sp) # perform store
+  LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c_str)
+
+# Testcase cp_imm_mul_4sp: imm=160
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xfe6286b1
+  addi sp, x9, -160  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
+  c.swsp x6, 160(sp) # perform store
+  LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0_str)
+
+# Testcase cp_imm_mul_4sp: imm=164
+  RVTEST_TESTDATA_LOAD_INT(x1, x4) # load rs2: x4 = 0xe7279c63
+  addi sp, x9, -164  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
+  c.swsp x4, 164(sp) # perform store
+  LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4_str)
+
+# Testcase cp_imm_mul_4sp: imm=168
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0xf2f89694
+  addi sp, x9, -168  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
+  c.swsp x0, 168(sp) # perform store
+  LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8_str)
+
+# Testcase cp_imm_mul_4sp: imm=172
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xbbddc34d
+  addi sp, x9, -172  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
+  c.swsp x10, 172(sp) # perform store
+  LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac_str)
+
+# Testcase cp_imm_mul_4sp: imm=176
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xff34c182
+  addi sp, x9, -176  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
+  c.swsp x11, 176(sp) # perform store
+  LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0_str)
+
+# Testcase cp_imm_mul_4sp: imm=180
+  RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x3dd4f217
+  addi sp, x9, -180  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
+  c.swsp x5, 180(sp) # perform store
+  LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4_str)
+
+# Testcase cp_imm_mul_4sp: imm=184
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xfe3a31b4
+  addi sp, x9, -184  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
+  c.swsp x14, 184(sp) # perform store
+  LREG x13, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x13 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8_str)
+
+# Testcase cp_imm_mul_4sp: imm=188
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x1a38a42b
+  addi sp, x9, -188  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
+  c.swsp x11, 188(sp) # perform store
+  LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc_str)
+
+# Testcase cp_imm_mul_4sp: imm=192
+  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xf4ac6d36
+  addi sp, x9, -192  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
+  c.swsp x12, 192(sp) # perform store
+  LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0_str)
+
+# Testcase cp_imm_mul_4sp: imm=196
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x67a37c7e
+  addi sp, x9, -196  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
+  c.swsp x6, 196(sp) # perform store
+  LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4_str)
+
+# Testcase cp_imm_mul_4sp: imm=200
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x5c00883f
+  addi sp, x9, -200  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
+  c.swsp x14, 200(sp) # perform store
+  LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8_str)
+
+# Testcase cp_imm_mul_4sp: imm=204
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xce57c134
+  addi sp, x9, -204  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
+  c.swsp x13, 204(sp) # perform store
+  LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc_str)
+
+# Testcase cp_imm_mul_4sp: imm=208
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xd74f79ef
+  addi sp, x9, -208  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
+  c.swsp x10, 208(sp) # perform store
+  LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0_str)
+
+# Testcase cp_imm_mul_4sp: imm=212
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x6b889049
+  addi sp, x9, -212  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
+  c.swsp x10, 212(sp) # perform store
+  LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4_str)
+
+# Testcase cp_imm_mul_4sp: imm=216
+  RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x54a09b6b
+  addi sp, x9, -216  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
+  c.swsp x5, 216(sp) # perform store
+  LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8_str)
+
+# Testcase cp_imm_mul_4sp: imm=220
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x196dee6f
+  addi sp, x9, -220  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
+  c.swsp x13, 220(sp) # perform store
+  LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc_str)
+
+# Testcase cp_imm_mul_4sp: imm=224
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xcccf5ac6
+  addi sp, x9, -224  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
+  c.swsp x14, 224(sp) # perform store
+  LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0_str)
+
+# Testcase cp_imm_mul_4sp: imm=228
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x0a25908f
+  addi sp, x9, -228  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
+  c.swsp x15, 228(sp) # perform store
+  LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4_str)
+
+# Testcase cp_imm_mul_4sp: imm=232
+  RVTEST_TESTDATA_LOAD_INT(x1, x4) # load rs2: x4 = 0x90229d22
+  addi sp, x9, -232  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
+  c.swsp x4, 232(sp) # perform store
+  LREG x5, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8_str)
+
+# Testcase cp_imm_mul_4sp: imm=236
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x770bf921
+  addi sp, x9, -236  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
+  c.swsp x0, 236(sp) # perform store
+  LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec_str)
+
+# Testcase cp_imm_mul_4sp: imm=240
+  RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x6e70fb89
+  addi sp, x9, -240  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
+  c.swsp x5, 240(sp) # perform store
+  LREG x4, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0_str)
+
+# Testcase cp_imm_mul_4sp: imm=244
+  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xc368e283
+  addi sp, x9, -244  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
+  c.swsp x12, 244(sp) # perform store
+  LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4_str)
+
+# Testcase cp_imm_mul_4sp: imm=248
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x5fcdd39f
+  addi sp, x9, -248  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
+  c.swsp x6, 248(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98_str)
-
-# Testcase cp_imm_mul_4sp: imm=156
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x912f8b40
-  addi sp, x9, -156  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
-  c.swsp x14, 156(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c_str)
-
-# Testcase cp_imm_mul_4sp: imm=160
-  RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0xbe6fd0d3
-  addi sp, x9, -160  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
-  c.swsp x5, 160(sp) # perform store
-  LREG x3, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0_str)
-
-# Testcase cp_imm_mul_4sp: imm=164
-  RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0xc76e4eac
-  addi sp, x9, -164  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
-  c.swsp x5, 164(sp) # perform store
-  LREG x4, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4_str)
-
-# Testcase cp_imm_mul_4sp: imm=168
-  RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0xfe6286b1
-  addi sp, x9, -168  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
-  c.swsp x5, 168(sp) # perform store
-  LREG x6, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8_str)
-
-# Testcase cp_imm_mul_4sp: imm=172
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xe7279c63
-  addi sp, x9, -172  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
-  c.swsp x3, 172(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac_str)
-
-# Testcase cp_imm_mul_4sp: imm=176
-  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0xf2f89694
-  addi sp, x9, -176  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
-  c.swsp x0, 176(sp) # perform store
-  LREG x4, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0_str)
-
-# Testcase cp_imm_mul_4sp: imm=180
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xbbddc34d
-  addi sp, x9, -180  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
-  c.swsp x6, 180(sp) # perform store
-  LREG x14, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4_str)
-
-# Testcase cp_imm_mul_4sp: imm=184
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xff34c182
-  addi sp, x9, -184  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
-  c.swsp x10, 184(sp) # perform store
-  LREG x3, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x3 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8_str)
-
-# Testcase cp_imm_mul_4sp: imm=188
-  RVTEST_TESTDATA_LOAD_INT(x1, x4) # load rs2: x4 = 0x3dd4f217
-  addi sp, x9, -188  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
-  c.swsp x4, 188(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc_str)
-
-# Testcase cp_imm_mul_4sp: imm=192
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xfe3a31b4
-  addi sp, x9, -192  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
-  c.swsp x13, 192(sp) # perform store
-  LREG x14, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0_str)
-
-# Testcase cp_imm_mul_4sp: imm=196
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x1a38a42b
-  addi sp, x9, -196  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
-  c.swsp x10, 196(sp) # perform store
-  LREG x5, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4_str)
-
-# Testcase cp_imm_mul_4sp: imm=200
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xf4ac6d36
-  addi sp, x9, -200  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
-  c.swsp x11, 200(sp) # perform store
-  LREG x12, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8_str)
-
-# Testcase cp_imm_mul_4sp: imm=204
-  RVTEST_TESTDATA_LOAD_INT(x1, x5) # load rs2: x5 = 0x67a37c7e
-  addi sp, x9, -204  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
-  c.swsp x5, 204(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc_str)
-
-# Testcase cp_imm_mul_4sp: imm=208
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x5c00883f
-  addi sp, x9, -208  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
-  c.swsp x13, 208(sp) # perform store
-  LREG x4, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0_str)
-
-# Testcase cp_imm_mul_4sp: imm=212
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xce57c134
-  addi sp, x9, -212  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
-  c.swsp x12, 212(sp) # perform store
-  LREG x4, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4_str)
-
-# Testcase cp_imm_mul_4sp: imm=216
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xd74f79ef
-  addi sp, x9, -216  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
-  c.swsp x6, 216(sp) # perform store
-  LREG x11, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8_str)
-
-# Testcase cp_imm_mul_4sp: imm=220
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x6b889049
-  addi sp, x9, -220  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
-  c.swsp x6, 220(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc_str)
-
-# Testcase cp_imm_mul_4sp: imm=224
-  RVTEST_TESTDATA_LOAD_INT(x1, x4) # load rs2: x4 = 0x54a09b6b
-  addi sp, x9, -224  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
-  c.swsp x4, 224(sp) # perform store
-  LREG x12, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0_str)
-
-# Testcase cp_imm_mul_4sp: imm=228
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x196dee6f
-  addi sp, x9, -228  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
-  c.swsp x12, 228(sp) # perform store
-  LREG x14, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x14 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4_str)
-
-# Testcase cp_imm_mul_4sp: imm=232
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xcccf5ac6
-  addi sp, x9, -232  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
-  c.swsp x13, 232(sp) # perform store
-  LREG x11, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8_str)
-
-# Testcase cp_imm_mul_4sp: imm=236
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x0a25908f
-  addi sp, x9, -236  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
-  c.swsp x14, 236(sp) # perform store
-  LREG x6, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x6 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec_str)
-
-# Testcase cp_imm_mul_4sp: imm=240
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x90229d22
-  addi sp, x9, -240  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
-  c.swsp x3, 240(sp) # perform store
-  LREG x5, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x5 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0_str)
-
-# Testcase cp_imm_mul_4sp: imm=244
-  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x770bf921
-  addi sp, x9, -244  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
-  c.swsp x0, 244(sp) # perform store
-  LREG x11, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4_str)
-
-# Testcase cp_imm_mul_4sp: imm=248
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xb44a4f10
-  addi sp, x9, -248  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
-  c.swsp x15, 248(sp) # perform store
-  LREG x11, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8_str)
+  RVTEST_SIGUPD(x9, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8_str)
 
 # Testcase cp_imm_mul_4sp: imm=252
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x6e70fb89
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x672ed623
   addi sp, x9, -252  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc:
   c.swsp x14, 252(sp) # perform store
-  LREG x4, 0(x9) # load stored value for checking
+  LREG x12, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x4 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x9, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc_str)
+  # Check if x12 contains the expected result. x9 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x9, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc_str)
 
   mv x2, x9 # restore signature pointer to default register for teardown
 
@@ -1025,13 +1025,12 @@ RVTEST_DATA_BEGIN
 .word 0x0402a4fe
 .word 0xb78a0b4b
 .word 0x419d87b9
-.word 0xdf3eea06
-.word 0x2db624b0
-.word 0xccf3cd83
-.word 0x688d5237
-.word 0x1b13aa7d
-.word 0x64c46502
-.word 0x2ef80023
+.word 0xbb6c6c9f
+.word 0xe03fe2d8
+.word 0x1ccb9251
+.word 0xd7b73193
+.word 0xb7a2726d
+.word 0x007aeb44
 .word 0x1a9509f6
 .word 0xc18c3264
 .word 0x80283a47
@@ -1046,10 +1045,9 @@ RVTEST_DATA_BEGIN
 .word 0x1442f570
 .word 0x24a65a68
 .word 0x6eefa15a
-.word 0x12412a8a
-.word 0x1719b70c
-.word 0x5e38ff0e
-.word 0x9b99e043
+.word 0xae04c112
+.word 0xaf6fdcc0
+.word 0x72762c57
 .word 0x912f8b40
 .word 0xbe6fd0d3
 .word 0xc76e4eac
@@ -1073,8 +1071,10 @@ RVTEST_DATA_BEGIN
 .word 0x0a25908f
 .word 0x90229d22
 .word 0x770bf921
-.word 0xb44a4f10
 .word 0x6e70fb89
+.word 0xc368e283
+.word 0x5fcdd39f
+.word 0x672ed623
 
 // Testcase strings
 Zca_c_swsp_cg_cp_rs2_b0_str: .string "\"test: 1; cg: Zca_c.swsp_cg; cp: cp_rs2; bin: b0\""

--- a/tests/rv32i/Zca/Zca-c.swsp-00.S
+++ b/tests/rv32i/Zca/Zca-c.swsp-00.S
@@ -368,120 +368,120 @@ Zca_c_swsp_cg_cp_rs2_b31:
 /////////////////////////////////
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000)
-  RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x00000000
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x00000000
   addi sp, x18, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x0:
-  c.swsp x9, 16(sp) # perform store
+  c.swsp x10, 16(sp) # perform store
   LREG x6, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x6, Zca_c_swsp_cg_cp_rs2_edges_0x0, Zca_c_swsp_cg_cp_rs2_edges_0x0_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000001)
-  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x00000001
+  RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0x00000001
   addi sp, x18, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x1:
-  c.swsp x23, 144(sp) # perform store
+  c.swsp x24, 144(sp) # perform store
   LREG x19, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_edges_0x1, Zca_c_swsp_cg_cp_rs2_edges_0x1_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000002)
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x00000002
+  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x00000002
   addi sp, x18, -44  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x2:
-  c.swsp x11, 44(sp) # perform store
+  c.swsp x12, 44(sp) # perform store
   LREG x20, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x20 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x20, Zca_c_swsp_cg_cp_rs2_edges_0x2, Zca_c_swsp_cg_cp_rs2_edges_0x2_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000000)
-  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x80000000
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x80000000
   addi sp, x18, -112  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x80000000:
-  c.swsp x25, 112(sp) # perform store
+  c.swsp x26, 112(sp) # perform store
   LREG x27, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, Zca_c_swsp_cg_cp_rs2_edges_0x80000000, Zca_c_swsp_cg_cp_rs2_edges_0x80000000_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x80000001)
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x80000001
+  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x80000001
   addi sp, x18, -212  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x80000001:
-  c.swsp x11, 212(sp) # perform store
+  c.swsp x12, 212(sp) # perform store
   LREG x26, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x26, Zca_c_swsp_cg_cp_rs2_edges_0x80000001, Zca_c_swsp_cg_cp_rs2_edges_0x80000001_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffff)
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x7fffffff
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x7fffffff
   addi sp, x18, -28  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff:
-  c.swsp x12, 28(sp) # perform store
+  c.swsp x13, 28(sp) # perform store
   LREG x15, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffff_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffe)
-  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x7ffffffe
+  RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0x7ffffffe
   addi sp, x18, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe:
-  c.swsp x23, 240(sp) # perform store
+  c.swsp x24, 240(sp) # perform store
   LREG x6, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x6, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffe_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffff)
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xffffffff
+  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xffffffff
   addi sp, x18, -128  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
-  c.swsp x11, 128(sp) # perform store
+  c.swsp x12, 128(sp) # perform store
   LREG x21, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x21, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffe)
-  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0xfffffffe
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0xfffffffe
   addi sp, x18, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
-  c.swsp x20, 144(sp) # perform store
+  c.swsp x21, 144(sp) # perform store
   LREG x28, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc8872)
-  RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x5bbc8872
+  RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x5bbc8872
   addi sp, x18, -196  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872:
-  c.swsp x29, 196(sp) # perform store
+  c.swsp x30, 196(sp) # perform store
   LREG x26, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x26, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc8872_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaa)
-  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0xaaaaaaaa
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0xaaaaaaaa
   addi sp, x18, -172  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa:
-  c.swsp x20, 172(sp) # perform store
+  c.swsp x21, 172(sp) # perform store
   LREG x23, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaa_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x55555555)
-  RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x55555555
+  RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0x55555555
   addi sp, x18, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x55555555:
-  c.swsp x16, 32(sp) # perform store
+  c.swsp x17, 32(sp) # perform store
   LREG x19, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -492,640 +492,640 @@ Zca_c_swsp_cg_cp_rs2_edges_0x55555555:
 /////////////////////////////////
 
 # Testcase cp_imm_mul_4sp: imm=0
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x3748c810
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x3748c810
   addi sp, x18, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0:
-  c.swsp x14, 0(sp) # perform store
+  c.swsp x15, 0(sp) # perform store
   LREG x24, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x24 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0_str)
 
 # Testcase cp_imm_mul_4sp: imm=4
-  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x212852d1
+  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0x212852d1
   addi sp, x18, -4  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4:
-  c.swsp x21, 4(sp) # perform store
+  c.swsp x22, 4(sp) # perform store
   LREG x12, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4_str)
 
 # Testcase cp_imm_mul_4sp: imm=8
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xde9d49fb
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xde9d49fb
   addi sp, x18, -8  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8:
-  c.swsp x14, 8(sp) # perform store
+  c.swsp x15, 8(sp) # perform store
   LREG x27, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8_str)
 
 # Testcase cp_imm_mul_4sp: imm=12
-  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0xd63152f0
+  RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0xd63152f0
   addi sp, x18, -12  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc:
-  c.swsp x26, 12(sp) # perform store
+  c.swsp x27, 12(sp) # perform store
   LREG x31, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc_str)
 
 # Testcase cp_imm_mul_4sp: imm=16
-  RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0xc38312ff
+  RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0xc38312ff
   addi sp, x18, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10:
-  c.swsp x16, 16(sp) # perform store
+  c.swsp x17, 16(sp) # perform store
   LREG x14, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10_str)
 
 # Testcase cp_imm_mul_4sp: imm=20
-  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0xbe081e73
+  RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0xbe081e73
   addi sp, x18, -20  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14:
-  c.swsp x23, 20(sp) # perform store
+  c.swsp x24, 20(sp) # perform store
   LREG x30, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x30 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14_str)
 
 # Testcase cp_imm_mul_4sp: imm=24
-  RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0xeaf691d2
+  RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0xeaf691d2
   addi sp, x18, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18:
-  c.swsp x29, 24(sp) # perform store
+  c.swsp x30, 24(sp) # perform store
   LREG x17, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18_str)
 
 # Testcase cp_imm_mul_4sp: imm=28
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x68bd767c
+  RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x68bd767c
   addi sp, x18, -28  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c:
-  c.swsp x6, 28(sp) # perform store
+  c.swsp x7, 28(sp) # perform store
   LREG x3, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c_str)
 
 # Testcase cp_imm_mul_4sp: imm=32
-  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0xb3a35dad
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0xb3a35dad
   addi sp, x18, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20:
-  c.swsp x25, 32(sp) # perform store
+  c.swsp x26, 32(sp) # perform store
   LREG x7, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20_str)
 
 # Testcase cp_imm_mul_4sp: imm=36
-  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0xf7c9a307
+  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0xf7c9a307
   addi sp, x18, -36  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24:
-  c.swsp x21, 36(sp) # perform store
-  LREG x22, 0(x18) # load stored value for checking
+  c.swsp x22, 36(sp) # perform store
+  LREG x21, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
-  # Check if x22 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24_str)
+  # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x18, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24_str)
 
 # Testcase cp_imm_mul_4sp: imm=40
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x2dc2d097
+  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x2dc2d097
   addi sp, x18, -40  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28:
-  c.swsp x11, 40(sp) # perform store
+  c.swsp x12, 40(sp) # perform store
   LREG x8, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28_str)
 
 # Testcase cp_imm_mul_4sp: imm=44
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x6e9d4158
+  RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x6e9d4158
   addi sp, x18, -44  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
-  c.swsp x15, 44(sp) # perform store
+  c.swsp x16, 44(sp) # perform store
   LREG x28, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c_str)
 
 # Testcase cp_imm_mul_4sp: imm=48
-  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x025588f2
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x025588f2
   addi sp, x18, -48  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
-  c.swsp x20, 48(sp) # perform store
+  c.swsp x21, 48(sp) # perform store
   LREG x22, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30_str)
 
 # Testcase cp_imm_mul_4sp: imm=52
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xd6d5ceed
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xd6d5ceed
   addi sp, x18, -52  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
-  c.swsp x12, 52(sp) # perform store
+  c.swsp x13, 52(sp) # perform store
   LREG x23, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34_str)
 
 # Testcase cp_imm_mul_4sp: imm=56
-  RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0xbcc0102f
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xbcc0102f
   addi sp, x18, -56  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
-  c.swsp x9, 56(sp) # perform store
+  c.swsp x10, 56(sp) # perform store
   LREG x28, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38_str)
 
 # Testcase cp_imm_mul_4sp: imm=60
-  RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0xdf3eea06
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xdf3eea06
   addi sp, x18, -60  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
-  c.swsp x9, 60(sp) # perform store
+  c.swsp x10, 60(sp) # perform store
   LREG x6, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c_str)
 
 # Testcase cp_imm_mul_4sp: imm=64
-  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x2db624b0
+  RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x2db624b0
   addi sp, x18, -64  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
-  c.swsp x26, 64(sp) # perform store
+  c.swsp x27, 64(sp) # perform store
   LREG x13, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40_str)
 
 # Testcase cp_imm_mul_4sp: imm=68
-  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0xccf3cd83
+  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0xccf3cd83
   addi sp, x18, -68  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
-  c.swsp x21, 68(sp) # perform store
+  c.swsp x22, 68(sp) # perform store
   LREG x3, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44_str)
 
 # Testcase cp_imm_mul_4sp: imm=72
-  RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0x688d5237
+  RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0x688d5237
   addi sp, x18, -72  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
-  c.swsp x17, 72(sp) # perform store
+  c.swsp x19, 72(sp) # perform store
   LREG x8, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48_str)
 
 # Testcase cp_imm_mul_4sp: imm=76
-  RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x1b13aa7d
+  RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x1b13aa7d
   addi sp, x18, -76  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
-  c.swsp x27, 76(sp) # perform store
+  c.swsp x28, 76(sp) # perform store
   LREG x17, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x17, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c_str)
 
 # Testcase cp_imm_mul_4sp: imm=80
-  RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x64c46502
+  RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x64c46502
   addi sp, x18, -80  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
-  c.swsp x27, 80(sp) # perform store
+  c.swsp x28, 80(sp) # perform store
   LREG x31, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50_str)
 
 # Testcase cp_imm_mul_4sp: imm=84
-  RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0xd0d5a125
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xd0d5a125
   addi sp, x18, -84  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
-  c.swsp x9, 84(sp) # perform store
+  c.swsp x10, 84(sp) # perform store
   LREG x27, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54_str)
 
 # Testcase cp_imm_mul_4sp: imm=88
-  RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x2ef80023
+  RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x2ef80023
   addi sp, x18, -88  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
-  c.swsp x30, 88(sp) # perform store
+  c.swsp x31, 88(sp) # perform store
   LREG x29, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58_str)
 
 # Testcase cp_imm_mul_4sp: imm=92
-  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x007aeb44
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x007aeb44
   addi sp, x18, -92  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
-  c.swsp x25, 92(sp) # perform store
+  c.swsp x26, 92(sp) # perform store
   LREG x23, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c_str)
 
 # Testcase cp_imm_mul_4sp: imm=96
-  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x1a9509f6
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x1a9509f6
   addi sp, x18, -96  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
-  c.swsp x20, 96(sp) # perform store
+  c.swsp x21, 96(sp) # perform store
   LREG x10, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60_str)
 
 # Testcase cp_imm_mul_4sp: imm=100
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xc18c3264
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xc18c3264
   addi sp, x18, -100  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
-  c.swsp x3, 100(sp) # perform store
-  LREG x6, 0(x18) # load stored value for checking
+  c.swsp x6, 100(sp) # perform store
+  LREG x3, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
-  # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64_str)
+  # Check if x3 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x18, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64_str)
 
 # Testcase cp_imm_mul_4sp: imm=104
-  RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0xd7d19c00
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x80283a47
   addi sp, x18, -104  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
-  c.swsp x31, 104(sp) # perform store
-  LREG x11, 0(x18) # load stored value for checking
+  c.swsp x14, 104(sp) # perform store
+  LREG x25, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68_str)
+  # Check if x25 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x18, x5, x4, x25, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68_str)
 
 # Testcase cp_imm_mul_4sp: imm=108
-  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0x087a85ad
+  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0x8d1f80d2
   addi sp, x18, -108  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
   c.swsp x22, 108(sp) # perform store
-  LREG x6, 0(x18) # load stored value for checking
+  LREG x24, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
-  # Check if x6 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c_str)
+  # Check if x24 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x18, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c_str)
 
 # Testcase cp_imm_mul_4sp: imm=112
-  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x068e9e00
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x9f15dcb8
   addi sp, x18, -112  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
   c.swsp x21, 112(sp) # perform store
-  LREG x8, 0(x18) # load stored value for checking
+  LREG x19, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
-  # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70_str)
+  # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70_str)
 
 # Testcase cp_imm_mul_4sp: imm=116
-  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0xe87a0869
+  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x25bff6fb
   addi sp, x18, -116  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
-  c.swsp x0, 116(sp) # perform store
-  LREG x12, 0(x18) # load stored value for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # Check if x12 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74_str)
-
-# Testcase cp_imm_mul_4sp: imm=120
-  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x25bff6fb
-  addi sp, x18, -120  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
-  c.swsp x21, 120(sp) # perform store
+  c.swsp x20, 116(sp) # perform store
   LREG x9, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78_str)
+  RVTEST_SIGUPD(x18, x5, x4, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74_str)
+
+# Testcase cp_imm_mul_4sp: imm=120
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x7e22c6d5
+  addi sp, x18, -120  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
+  c.swsp x26, 120(sp) # perform store
+  LREG x19, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
+  # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78_str)
 
 # Testcase cp_imm_mul_4sp: imm=124
-  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x7e22c6d5
+  RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x06c2ea11
   addi sp, x18, -124  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
-  c.swsp x25, 124(sp) # perform store
+  c.swsp x31, 124(sp) # perform store
   LREG x19, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c_str)
 
 # Testcase cp_imm_mul_4sp: imm=128
-  RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x06c2ea11
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x030293c6
   addi sp, x18, -128  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
-  c.swsp x30, 128(sp) # perform store
-  LREG x19, 0(x18) # load stored value for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80_str)
-
-# Testcase cp_imm_mul_4sp: imm=132
-  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x030293c6
-  addi sp, x18, -132  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
-  c.swsp x20, 132(sp) # perform store
+  c.swsp x21, 128(sp) # perform store
   LREG x26, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84_str)
+  RVTEST_SIGUPD(x18, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80_str)
 
-# Testcase cp_imm_mul_4sp: imm=136
+# Testcase cp_imm_mul_4sp: imm=132
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x12be5c00
-  addi sp, x18, -136  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
-  c.swsp x0, 136(sp) # perform store
+  addi sp, x18, -132  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
+  c.swsp x0, 132(sp) # perform store
   LREG x25, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x25, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88_str)
+  RVTEST_SIGUPD(x18, x5, x4, x25, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84_str)
 
-# Testcase cp_imm_mul_4sp: imm=140
-  RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0xd0f0cbd2
-  addi sp, x18, -140  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
-  c.swsp x9, 140(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=136
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xd0f0cbd2
+  addi sp, x18, -136  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
+  c.swsp x10, 136(sp) # perform store
   LREG x17, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x17, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c_str)
+  RVTEST_SIGUPD(x18, x5, x4, x17, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88_str)
 
-# Testcase cp_imm_mul_4sp: imm=144
-  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x2a4c1092
-  addi sp, x18, -144  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
-  c.swsp x20, 144(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=140
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x2a4c1092
+  addi sp, x18, -140  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
+  c.swsp x21, 140(sp) # perform store
   LREG x9, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90_str)
+  RVTEST_SIGUPD(x18, x5, x4, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c_str)
+
+# Testcase cp_imm_mul_4sp: imm=144
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x28842345
+  addi sp, x18, -144  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
+  c.swsp x21, 144(sp) # perform store
+  LREG x26, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
+  # Check if x26 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x18, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90_str)
 
 # Testcase cp_imm_mul_4sp: imm=148
-  RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x01d0e558
+  RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x0ade41e0
   addi sp, x18, -148  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
-  c.swsp x31, 148(sp) # perform store
-  LREG x28, 0(x18) # load stored value for checking
+  c.swsp x29, 148(sp) # perform store
+  LREG x24, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
-  # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94_str)
+  # Check if x24 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x18, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94_str)
 
 # Testcase cp_imm_mul_4sp: imm=152
-  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x9147f96e
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x40814800
   addi sp, x18, -152  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
-  c.swsp x25, 152(sp) # perform store
+  c.swsp x11, 152(sp) # perform store
+  LREG x14, 0(x18) # load stored value for checking
+  addi x18, x18, SIG_STRIDE # increment signature pointer
+  # Check if x14 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x18, x5, x4, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98_str)
+
+# Testcase cp_imm_mul_4sp: imm=156
+  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0xa1cad1b2
+  addi sp, x18, -156  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
+  c.swsp x25, 156(sp) # perform store
   LREG x27, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98_str)
-
-# Testcase cp_imm_mul_4sp: imm=156
-  RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x6eefa15a
-  addi sp, x18, -156  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
-  c.swsp x7, 156(sp) # perform store
-  LREG x11, 0(x18) # load stored value for checking
-  addi x18, x18, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c_str)
+  RVTEST_SIGUPD(x18, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c_str)
 
 # Testcase cp_imm_mul_4sp: imm=160
-  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x12412a8a
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xc7e9464d
   addi sp, x18, -160  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
-  c.swsp x26, 160(sp) # perform store
-  LREG x21, 0(x18) # load stored value for checking
+  c.swsp x14, 160(sp) # perform store
+  LREG x29, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
-  # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0_str)
+  # Check if x29 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x18, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0_str)
 
 # Testcase cp_imm_mul_4sp: imm=164
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x1719b70c
+  RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0xae04c112
   addi sp, x18, -164  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
-  c.swsp x15, 164(sp) # perform store
-  LREG x21, 0(x18) # load stored value for checking
+  c.swsp x16, 164(sp) # perform store
+  LREG x19, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
-  # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x18, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4_str)
+  # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4_str)
 
 # Testcase cp_imm_mul_4sp: imm=168
-  RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0xaf6fdcc0
+  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0xaf6fdcc0
   addi sp, x18, -168  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
-  c.swsp x30, 168(sp) # perform store
+  c.swsp x23, 168(sp) # perform store
   LREG x12, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8_str)
 
 # Testcase cp_imm_mul_4sp: imm=172
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x72762c57
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x72762c57
   addi sp, x18, -172  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
-  c.swsp x3, 172(sp) # perform store
+  c.swsp x6, 172(sp) # perform store
   LREG x27, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac_str)
 
 # Testcase cp_imm_mul_4sp: imm=176
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x81c76166
+  RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x81c76166
   addi sp, x18, -176  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
-  c.swsp x6, 176(sp) # perform store
+  c.swsp x7, 176(sp) # perform store
   LREG x28, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0_str)
 
 # Testcase cp_imm_mul_4sp: imm=180
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xccacd523
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xccacd523
   addi sp, x18, -180  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
-  c.swsp x3, 180(sp) # perform store
+  c.swsp x6, 180(sp) # perform store
   LREG x23, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4_str)
 
 # Testcase cp_imm_mul_4sp: imm=184
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x9f2e744b
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x9f2e744b
   addi sp, x18, -184  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
-  c.swsp x10, 184(sp) # perform store
+  c.swsp x11, 184(sp) # perform store
   LREG x15, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8_str)
 
 # Testcase cp_imm_mul_4sp: imm=188
-  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x0b5a9947
+  RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x0b5a9947
   addi sp, x18, -188  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
-  c.swsp x26, 188(sp) # perform store
+  c.swsp x27, 188(sp) # perform store
   LREG x19, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x19, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc_str)
 
 # Testcase cp_imm_mul_4sp: imm=192
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xcdaf39df
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xcdaf39df
   addi sp, x18, -192  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
-  c.swsp x3, 192(sp) # perform store
+  c.swsp x6, 192(sp) # perform store
   LREG x11, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0_str)
 
 # Testcase cp_imm_mul_4sp: imm=196
-  RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0xa5fdc85b
+  RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0xa5fdc85b
   addi sp, x18, -196  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
-  c.swsp x27, 196(sp) # perform store
+  c.swsp x28, 196(sp) # perform store
   LREG x8, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4_str)
 
 # Testcase cp_imm_mul_4sp: imm=200
-  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x0ace2b10
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x0ace2b10
   addi sp, x18, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
-  c.swsp x25, 200(sp) # perform store
+  c.swsp x26, 200(sp) # perform store
   LREG x31, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8_str)
 
 # Testcase cp_imm_mul_4sp: imm=204
-  RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0xec4e4dbb
+  RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0xec4e4dbb
   addi sp, x18, -204  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
-  c.swsp x17, 204(sp) # perform store
+  c.swsp x19, 204(sp) # perform store
   LREG x16, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x16 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x16, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc_str)
 
 # Testcase cp_imm_mul_4sp: imm=208
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xfe63f0d7
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xfe63f0d7
   addi sp, x18, -208  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
-  c.swsp x10, 208(sp) # perform store
+  c.swsp x11, 208(sp) # perform store
   LREG x22, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0_str)
 
 # Testcase cp_imm_mul_4sp: imm=212
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x4d0e9cdf
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x4d0e9cdf
   addi sp, x18, -212  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
-  c.swsp x3, 212(sp) # perform store
+  c.swsp x6, 212(sp) # perform store
   LREG x30, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x30 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4_str)
 
 # Testcase cp_imm_mul_4sp: imm=216
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xfe3a31b4
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xfe3a31b4
   addi sp, x18, -216  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
-  c.swsp x14, 216(sp) # perform store
+  c.swsp x15, 216(sp) # perform store
   LREG x21, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8_str)
 
 # Testcase cp_imm_mul_4sp: imm=220
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x1a38a42b
+  RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x1a38a42b
   addi sp, x18, -220  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
-  c.swsp x15, 220(sp) # perform store
+  c.swsp x16, 220(sp) # perform store
   LREG x29, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc_str)
 
 # Testcase cp_imm_mul_4sp: imm=224
-  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x50912704
+  RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x50912704
   addi sp, x18, -224  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
-  c.swsp x8, 224(sp) # perform store
+  c.swsp x9, 224(sp) # perform store
   LREG x21, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0_str)
 
 # Testcase cp_imm_mul_4sp: imm=228
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xdb21878d
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xdb21878d
   addi sp, x18, -228  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
-  c.swsp x14, 228(sp) # perform store
+  c.swsp x15, 228(sp) # perform store
   LREG x3, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4_str)
 
 # Testcase cp_imm_mul_4sp: imm=232
-  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0xbcc1dfe0
+  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0xbcc1dfe0
   addi sp, x18, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
-  c.swsp x21, 232(sp) # perform store
+  c.swsp x22, 232(sp) # perform store
   LREG x23, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8_str)
 
 # Testcase cp_imm_mul_4sp: imm=236
-  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x6cf3621e
+  RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x6cf3621e
   addi sp, x18, -236  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
-  c.swsp x8, 236(sp) # perform store
+  c.swsp x9, 236(sp) # perform store
   LREG x15, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec_str)
 
 # Testcase cp_imm_mul_4sp: imm=240
-  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0xdfc67ab8
+  RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0xdfc67ab8
   addi sp, x18, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
-  c.swsp x23, 240(sp) # perform store
+  c.swsp x24, 240(sp) # perform store
   LREG x22, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0_str)
 
 # Testcase cp_imm_mul_4sp: imm=244
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x1e17df6a
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x1e17df6a
   addi sp, x18, -244  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
-  c.swsp x10, 244(sp) # perform store
+  c.swsp x11, 244(sp) # perform store
   LREG x15, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4_str)
 
 # Testcase cp_imm_mul_4sp: imm=248
-  RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0xc611b086
+  RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0xc611b086
   addi sp, x18, -248  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
-  c.swsp x30, 248(sp) # perform store
+  c.swsp x31, 248(sp) # perform store
   LREG x12, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x18, x5, x4, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8_str)
 
 # Testcase cp_imm_mul_4sp: imm=252
-  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x6b889049
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x6b889049
   addi sp, x18, -252  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc:
-  c.swsp x20, 252(sp) # perform store
+  c.swsp x21, 252(sp) # perform store
   LREG x24, 0(x18) # load stored value for checking
   addi x18, x18, SIG_STRIDE # increment signature pointer
   # Check if x24 contains the expected result. x18 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -1210,10 +1210,9 @@ RVTEST_DATA_BEGIN
 .word 0x007aeb44
 .word 0x1a9509f6
 .word 0xc18c3264
-.word 0xd7d19c00
-.word 0x087a85ad
-.word 0x068e9e00
-.word 0xe87a0869
+.word 0x80283a47
+.word 0x8d1f80d2
+.word 0x9f15dcb8
 .word 0x25bff6fb
 .word 0x7e22c6d5
 .word 0x06c2ea11
@@ -1221,11 +1220,12 @@ RVTEST_DATA_BEGIN
 .word 0x12be5c00
 .word 0xd0f0cbd2
 .word 0x2a4c1092
-.word 0x01d0e558
-.word 0x9147f96e
-.word 0x6eefa15a
-.word 0x12412a8a
-.word 0x1719b70c
+.word 0x28842345
+.word 0x0ade41e0
+.word 0x40814800
+.word 0xa1cad1b2
+.word 0xc7e9464d
+.word 0xae04c112
 .word 0xaf6fdcc0
 .word 0x72762c57
 .word 0x81c76166

--- a/tests/rv64e/Zca/Zca-c.sdsp-00.S
+++ b/tests/rv64e/Zca/Zca-c.sdsp-00.S
@@ -209,150 +209,150 @@ Zca_c_sdsp_cg_cp_rs2_b15:
 /////////////////////////////////
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000000)
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x0000000000000000
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x0000000000000000
   addi sp, x9, -368  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x0:
-  c.sdsp x13, 368(sp) # perform store
+  c.sdsp x14, 368(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_rs2_edges_0x0, Zca_c_sdsp_cg_cp_rs2_edges_0x0_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x0000000000000001
+  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x0000000000000001
   addi sp, x9, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x1:
-  c.sdsp x11, 24(sp) # perform store
+  c.sdsp x12, 24(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_rs2_edges_0x1, Zca_c_sdsp_cg_cp_rs2_edges_0x1_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x0000000000000002
+  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x0000000000000002
   addi sp, x9, -392  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x2:
-  c.sdsp x11, 392(sp) # perform store
+  c.sdsp x12, 392(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_rs2_edges_0x2, Zca_c_sdsp_cg_cp_rs2_edges_0x2_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x8000000000000000
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x8000000000000000
   addi sp, x9, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000:
-  c.sdsp x14, 16(sp) # perform store
+  c.sdsp x15, 16(sp) # perform store
   LREG x3, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x8000000000000001
+  RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x8000000000000001
   addi sp, x9, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001:
-  c.sdsp x6, 240(sp) # perform store
+  c.sdsp x7, 240(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x7fffffffffffffff
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x7fffffffffffffff
   addi sp, x9, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff:
-  c.sdsp x13, 24(sp) # perform store
+  c.sdsp x14, 24(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
-  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x7ffffffffffffffe
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x7ffffffffffffffe
   addi sp, x9, -48  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
-  c.sdsp x8, 48(sp) # perform store
+  c.sdsp x10, 48(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xffffffffffffffff
-  addi sp, x9, -368  # copy sig_reg to sp and adjust for offset
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xffffffffffffffff
+  addi sp, x9, -168  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff:
-  c.sdsp x15, 368(sp) # perform store
-  LREG x11, 0(x9) # load stored value for checking
+  c.sdsp x11, 168(sp) # perform store
+  LREG x12, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff_str)
+  # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xfffffffffffffffe
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xfffffffffffffffe
   addi sp, x9, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe:
-  c.sdsp x6, 232(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
+  c.sdsp x15, 232(sp) # perform store
+  LREG x14, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe_str)
+  # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x5bbc887763ae86f2
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x5bbc887763ae86f2
   addi sp, x9, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
-  c.sdsp x3, 0(sp) # perform store
+  c.sdsp x6, 0(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xaaaaaaaaaaaaaaaa
+  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xaaaaaaaaaaaaaaaa
   addi sp, x9, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
-  c.sdsp x11, 200(sp) # perform store
+  c.sdsp x12, 200(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
-  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x5555555555555555
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x5555555555555555
   addi sp, x9, -480  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555:
-  c.sdsp x8, 480(sp) # perform store
+  c.sdsp x10, 480(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555, Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
-  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x00000000ffffffff
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x00000000ffffffff
   addi sp, x9, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff:
-  c.sdsp x8, 240(sp) # perform store
+  c.sdsp x10, 240(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x00000000fffffffe
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x00000000fffffffe
   addi sp, x9, -280  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe:
-  c.sdsp x13, 280(sp) # perform store
+  c.sdsp x14, 280(sp) # perform store
   LREG x10, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x0000000100000000
+  RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x0000000100000000
   addi sp, x9, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x100000000:
-  c.sdsp x6, 0(sp) # perform store
+  c.sdsp x7, 0(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -373,644 +373,644 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x100000001:
 /////////////////////////////////
 
 # Testcase cp_imm_mul_8sp: imm=0
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xe7843756bb2856f6
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xe7843756bb2856f6
   addi sp, x9, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0:
-  c.sdsp x13, 0(sp) # perform store
+  c.sdsp x14, 0(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0_str)
 
 # Testcase cp_imm_mul_8sp: imm=8
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x67dec3de031accb0
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x67dec3de031accb0
   addi sp, x9, -8  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8:
-  c.sdsp x12, 8(sp) # perform store
-  LREG x13, 0(x9) # load stored value for checking
+  c.sdsp x13, 8(sp) # perform store
+  LREG x12, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8_str)
+  # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8_str)
 
 # Testcase cp_imm_mul_8sp: imm=16
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xe39a83545d97493f
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xe39a83545d97493f
   addi sp, x9, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10:
-  c.sdsp x14, 16(sp) # perform store
+  c.sdsp x15, 16(sp) # perform store
   LREG x8, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10_str)
 
 # Testcase cp_imm_mul_8sp: imm=24
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x2e327176756d4ebe
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x2e327176756d4ebe
   addi sp, x9, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18:
-  c.sdsp x10, 24(sp) # perform store
+  c.sdsp x11, 24(sp) # perform store
   LREG x8, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18_str)
 
 # Testcase cp_imm_mul_8sp: imm=32
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x4168dcc8d4012311
+  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xe3c5129528f9e5fd
   addi sp, x9, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20:
-  c.sdsp x15, 32(sp) # perform store
-  LREG x13, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20_str)
-
-# Testcase cp_imm_mul_8sp: imm=40
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x489a4340dbdf2615
-  addi sp, x9, -40  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28:
-  c.sdsp x11, 40(sp) # perform store
-  LREG x7, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28_str)
-
-# Testcase cp_imm_mul_8sp: imm=48
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xdefd37874d7a166c
-  addi sp, x9, -48  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30:
-  c.sdsp x10, 48(sp) # perform store
-  LREG x6, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30_str)
-
-# Testcase cp_imm_mul_8sp: imm=56
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x311f512377729429
-  addi sp, x9, -56  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38:
-  c.sdsp x14, 56(sp) # perform store
-  LREG x11, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38_str)
-
-# Testcase cp_imm_mul_8sp: imm=64
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x42a631e63f18b79c
-  addi sp, x9, -64  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40:
-  c.sdsp x14, 64(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40_str)
-
-# Testcase cp_imm_mul_8sp: imm=72
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x333c9b6b28a78fbb
-  addi sp, x9, -72  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48:
-  c.sdsp x10, 72(sp) # perform store
-  LREG x11, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48_str)
-
-# Testcase cp_imm_mul_8sp: imm=80
-  RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0x232143be4eaaf506
-  addi sp, x9, -80  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50:
-  c.sdsp x2, 80(sp) # perform store
-  LREG x11, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50_str)
-
-# Testcase cp_imm_mul_8sp: imm=88
-  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xa770099d80f721f1
-  addi sp, x9, -88  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58:
-  c.sdsp x8, 88(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58_str)
-
-# Testcase cp_imm_mul_8sp: imm=96
-  RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xdf6920cd16583c5a
-  addi sp, x9, -96  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60:
-  c.sdsp x7, 96(sp) # perform store
-  LREG x11, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60_str)
-
-# Testcase cp_imm_mul_8sp: imm=104
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x5d9b066998e4bf86
-  addi sp, x9, -104  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68:
-  c.sdsp x3, 104(sp) # perform store
-  LREG x14, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68_str)
-
-# Testcase cp_imm_mul_8sp: imm=112
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x0eb58b177691c3e5
-  addi sp, x9, -112  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70:
-  c.sdsp x10, 112(sp) # perform store
-  LREG x3, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70_str)
-
-# Testcase cp_imm_mul_8sp: imm=120
-  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x07617a39ce4dc4b9
-  addi sp, x9, -120  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78:
-  c.sdsp x0, 120(sp) # perform store
-  LREG x3, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78_str)
-
-# Testcase cp_imm_mul_8sp: imm=128
-  RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xcbccb4ad19434aba
-  addi sp, x9, -128  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80:
-  c.sdsp x2, 128(sp) # perform store
+  c.sdsp x12, 32(sp) # perform store
   LREG x8, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80_str)
+  RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20_str)
 
-# Testcase cp_imm_mul_8sp: imm=136
-  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x66f82a9b2160346f
-  addi sp, x9, -136  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88:
-  c.sdsp x0, 136(sp) # perform store
-  LREG x14, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88_str)
-
-# Testcase cp_imm_mul_8sp: imm=144
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x40708a82cd1e787f
-  addi sp, x9, -144  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90:
-  c.sdsp x3, 144(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90_str)
-
-# Testcase cp_imm_mul_8sp: imm=152
-  RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0x8bd07a7b6f7fa90f
-  addi sp, x9, -152  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98:
-  c.sdsp x2, 152(sp) # perform store
+# Testcase cp_imm_mul_8sp: imm=40
+  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x1585b3191e4e1db7
+  addi sp, x9, -40  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28:
+  c.sdsp x8, 40(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98_str)
+  RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28_str)
+
+# Testcase cp_imm_mul_8sp: imm=48
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x26872efce1224e5f
+  addi sp, x9, -48  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30:
+  c.sdsp x10, 48(sp) # perform store
+  LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30_str)
+
+# Testcase cp_imm_mul_8sp: imm=56
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xe1d8baabdd554c6c
+  addi sp, x9, -56  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38:
+  c.sdsp x13, 56(sp) # perform store
+  LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38_str)
+
+# Testcase cp_imm_mul_8sp: imm=64
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x963e51c3446d7a7d
+  addi sp, x9, -64  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40:
+  c.sdsp x14, 64(sp) # perform store
+  LREG x8, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40_str)
+
+# Testcase cp_imm_mul_8sp: imm=72
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x96583c5a4cd19791
+  addi sp, x9, -72  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48:
+  c.sdsp x10, 72(sp) # perform store
+  LREG x7, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48_str)
+
+# Testcase cp_imm_mul_8sp: imm=80
+  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x5099acee99b9956b
+  addi sp, x9, -80  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50:
+  c.sdsp x8, 80(sp) # perform store
+  LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50_str)
+
+# Testcase cp_imm_mul_8sp: imm=88
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xea20320fdd9b0669
+  addi sp, x9, -88  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58:
+  c.sdsp x14, 88(sp) # perform store
+  LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58_str)
+
+# Testcase cp_imm_mul_8sp: imm=96
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x9d3c740c0f2e82ea
+  addi sp, x9, -96  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60:
+  c.sdsp x0, 96(sp) # perform store
+  LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60_str)
+
+# Testcase cp_imm_mul_8sp: imm=104
+  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x579316aab65ce178
+  addi sp, x9, -104  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68:
+  c.sdsp x3, 104(sp) # perform store
+  LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68_str)
+
+# Testcase cp_imm_mul_8sp: imm=112
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x5533b3b8e5199b49
+  addi sp, x9, -112  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70:
+  c.sdsp x6, 112(sp) # perform store
+  LREG x13, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70_str)
+
+# Testcase cp_imm_mul_8sp: imm=120
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x43e26d557c07ac67
+  addi sp, x9, -120  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78:
+  c.sdsp x0, 120(sp) # perform store
+  LREG x13, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78_str)
+
+# Testcase cp_imm_mul_8sp: imm=128
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x936367ad51b7f0d2
+  addi sp, x9, -128  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80:
+  c.sdsp x11, 128(sp) # perform store
+  LREG x6, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80_str)
+
+# Testcase cp_imm_mul_8sp: imm=136
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x54becd06dfcea75b
+  addi sp, x9, -136  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88:
+  c.sdsp x14, 136(sp) # perform store
+  LREG x7, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88_str)
+
+# Testcase cp_imm_mul_8sp: imm=144
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xc4c3dd45bffa094b
+  addi sp, x9, -144  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90:
+  c.sdsp x6, 144(sp) # perform store
+  LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90_str)
+
+# Testcase cp_imm_mul_8sp: imm=152
+  RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xa780478f2afafa33
+  addi sp, x9, -152  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98:
+  c.sdsp x7, 152(sp) # perform store
+  LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98_str)
 
 # Testcase cp_imm_mul_8sp: imm=160
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x71eb79a68484acb6
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xa2750e708238bbd2
   addi sp, x9, -160  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0:
-  c.sdsp x11, 160(sp) # perform store
+  c.sdsp x15, 160(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0_str)
 
 # Testcase cp_imm_mul_8sp: imm=168
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x43dc93fe909e693f
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x6a625f4c69814353
   addi sp, x9, -168  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8:
-  c.sdsp x6, 168(sp) # perform store
-  LREG x8, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8_str)
-
-# Testcase cp_imm_mul_8sp: imm=176
-  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xbb09c16e136367ad
-  addi sp, x9, -176  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0:
-  c.sdsp x8, 176(sp) # perform store
-  LREG x3, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0_str)
-
-# Testcase cp_imm_mul_8sp: imm=184
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x54becd06dfcea75b
-  addi sp, x9, -184  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8:
-  c.sdsp x14, 184(sp) # perform store
-  LREG x7, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8_str)
-
-# Testcase cp_imm_mul_8sp: imm=192
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xc4c3dd45bffa094b
-  addi sp, x9, -192  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0:
-  c.sdsp x3, 192(sp) # perform store
+  c.sdsp x11, 168(sp) # perform store
   LREG x12, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0_str)
+  RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8_str)
+
+# Testcase cp_imm_mul_8sp: imm=176
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xc9298bb990d75b42
+  addi sp, x9, -176  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0:
+  c.sdsp x11, 176(sp) # perform store
+  LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0_str)
+
+# Testcase cp_imm_mul_8sp: imm=184
+  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xbe86c7acf7dd8daa
+  addi sp, x9, -184  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8:
+  c.sdsp x3, 184(sp) # perform store
+  LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8_str)
+
+# Testcase cp_imm_mul_8sp: imm=192
+  RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x844daf8a0fcf8d39
+  addi sp, x9, -192  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0:
+  c.sdsp x7, 192(sp) # perform store
+  LREG x14, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0_str)
 
 # Testcase cp_imm_mul_8sp: imm=200
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xa780478f2afafa33
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x5773c2c65f0945af
   addi sp, x9, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8:
-  c.sdsp x6, 200(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8_str)
-
-# Testcase cp_imm_mul_8sp: imm=208
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xa2750e708238bbd2
-  addi sp, x9, -208  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0:
-  c.sdsp x14, 208(sp) # perform store
+  c.sdsp x14, 200(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0_str)
+  RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8_str)
+
+# Testcase cp_imm_mul_8sp: imm=208
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xa6489b7449318d41
+  addi sp, x9, -208  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0:
+  c.sdsp x6, 208(sp) # perform store
+  LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0_str)
 
 # Testcase cp_imm_mul_8sp: imm=216
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x6a625f4c69814353
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x39e4b525d668b965
   addi sp, x9, -216  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8:
-  c.sdsp x10, 216(sp) # perform store
-  LREG x12, 0(x9) # load stored value for checking
+  c.sdsp x0, 216(sp) # perform store
+  LREG x14, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8_str)
+  # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8_str)
 
 # Testcase cp_imm_mul_8sp: imm=224
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xc9298bb990d75b42
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xbcfd25131039b9b4
   addi sp, x9, -224  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0:
-  c.sdsp x10, 224(sp) # perform store
-  LREG x12, 0(x9) # load stored value for checking
+  c.sdsp x15, 224(sp) # perform store
+  LREG x14, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0_str)
+  # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0_str)
 
 # Testcase cp_imm_mul_8sp: imm=232
-  RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xbe86c7acf7dd8daa
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x6b83664e78cedd7d
   addi sp, x9, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8:
-  c.sdsp x2, 232(sp) # perform store
+  c.sdsp x10, 232(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8_str)
 
 # Testcase cp_imm_mul_8sp: imm=240
-  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x8fcf8d3933dfa4fa
+  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x2c425ae64196dff7
   addi sp, x9, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0:
   c.sdsp x8, 240(sp) # perform store
-  LREG x7, 0(x9) # load stored value for checking
+  LREG x10, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0_str)
+  # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0_str)
 
 # Testcase cp_imm_mul_8sp: imm=248
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x43e8b457481285cb
+  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x1bfa1eb08948dd23
   addi sp, x9, -248  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8:
-  c.sdsp x11, 248(sp) # perform store
-  LREG x7, 0(x9) # load stored value for checking
+  c.sdsp x3, 248(sp) # perform store
+  LREG x10, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8_str)
+  # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8_str)
 
 # Testcase cp_imm_mul_8sp: imm=256
-  RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x83adbd6cd922a4a7
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x12090e83c930ed5a
   addi sp, x9, -256  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100:
-  c.sdsp x7, 256(sp) # perform store
+  c.sdsp x0, 256(sp) # perform store
   LREG x11, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100_str)
 
 # Testcase cp_imm_mul_8sp: imm=264
-  RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xbcfd25131039b9b4
+  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x3e16aa45e923c3f9
   addi sp, x9, -264  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108:
-  c.sdsp x7, 264(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
+  c.sdsp x8, 264(sp) # perform store
+  LREG x12, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108_str)
+  # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108_str)
 
 # Testcase cp_imm_mul_8sp: imm=272
-  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x6b83664e78cedd7d
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x0e2cdb50d93eb680
   addi sp, x9, -272  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110:
-  c.sdsp x8, 272(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
+  c.sdsp x11, 272(sp) # perform store
+  LREG x3, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110_str)
+  # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110_str)
 
 # Testcase cp_imm_mul_8sp: imm=280
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x7c1250bdd773b3b4
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xfd897652701a53d4
   addi sp, x9, -280  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118:
-  c.sdsp x15, 280(sp) # perform store
+  c.sdsp x14, 280(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118_str)
 
 # Testcase cp_imm_mul_8sp: imm=288
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x24e7e2edab5fefb7
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x1e7806e61e43fc7a
   addi sp, x9, -288  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120:
-  c.sdsp x6, 288(sp) # perform store
-  LREG x8, 0(x9) # load stored value for checking
+  c.sdsp x11, 288(sp) # perform store
+  LREG x15, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120_str)
+  # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120_str)
 
 # Testcase cp_imm_mul_8sp: imm=296
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xb14be2d69bfa1eb0
+  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xc9479168666b4861
   addi sp, x9, -296  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128:
-  c.sdsp x6, 296(sp) # perform store
-  LREG x3, 0(x9) # load stored value for checking
+  c.sdsp x12, 296(sp) # perform store
+  LREG x13, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128_str)
+  # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128_str)
 
 # Testcase cp_imm_mul_8sp: imm=304
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x3be7969e5f134560
+  RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x39155319516f9cb5
   addi sp, x9, -304  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130:
-  c.sdsp x13, 304(sp) # perform store
-  LREG x10, 0(x9) # load stored value for checking
+  c.sdsp x7, 304(sp) # perform store
+  LREG x13, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130_str)
+  # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130_str)
 
 # Testcase cp_imm_mul_8sp: imm=312
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x5c4c533f712fdb1c
+  RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xefa48ec47be81dda
   addi sp, x9, -312  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138:
-  c.sdsp x15, 312(sp) # perform store
-  LREG x12, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138_str)
-
-# Testcase cp_imm_mul_8sp: imm=320
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x1cb6d0b40a9f66c7
-  addi sp, x9, -320  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140:
-  c.sdsp x6, 320(sp) # perform store
-  LREG x14, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140_str)
-
-# Testcase cp_imm_mul_8sp: imm=328
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xb2cf3e88608bbe9f
-  addi sp, x9, -328  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148:
-  c.sdsp x10, 328(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148_str)
-
-# Testcase cp_imm_mul_8sp: imm=336
-  RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xffdc4787dffa9f28
-  addi sp, x9, -336  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150:
-  c.sdsp x2, 336(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150_str)
-
-# Testcase cp_imm_mul_8sp: imm=344
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xbeb9843accce868d
-  addi sp, x9, -344  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158:
-  c.sdsp x10, 344(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158_str)
-
-# Testcase cp_imm_mul_8sp: imm=352
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xe429acbb65619efe
-  addi sp, x9, -352  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160:
-  c.sdsp x14, 352(sp) # perform store
-  LREG x3, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160_str)
-
-# Testcase cp_imm_mul_8sp: imm=360
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xfbe81ddac1840952
-  addi sp, x9, -360  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168:
-  c.sdsp x3, 360(sp) # perform store
-  LREG x10, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168_str)
-
-# Testcase cp_imm_mul_8sp: imm=368
-  RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xbb16ad134fc321f1
-  addi sp, x9, -368  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170:
-  c.sdsp x2, 368(sp) # perform store
+  c.sdsp x7, 312(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170_str)
+  RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138_str)
 
-# Testcase cp_imm_mul_8sp: imm=376
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x6cf5e2123634e21b
-  addi sp, x9, -376  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178:
-  c.sdsp x14, 376(sp) # perform store
-  LREG x13, 0(x9) # load stored value for checking
+# Testcase cp_imm_mul_8sp: imm=320
+  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xe4b923143b16ad13
+  addi sp, x9, -320  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140:
+  c.sdsp x8, 320(sp) # perform store
+  LREG x10, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178_str)
+  # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140_str)
 
-# Testcase cp_imm_mul_8sp: imm=384
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xd9b35d062ff04b89
-  addi sp, x9, -384  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180:
-  c.sdsp x11, 384(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
+# Testcase cp_imm_mul_8sp: imm=328
+  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xf56378fc732c51a3
+  addi sp, x9, -328  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148:
+  c.sdsp x3, 328(sp) # perform store
+  LREG x12, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180_str)
+  # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148_str)
 
-# Testcase cp_imm_mul_8sp: imm=392
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x45ecee9bcab93ac0
-  addi sp, x9, -392  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188:
-  c.sdsp x10, 392(sp) # perform store
-  LREG x15, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188_str)
-
-# Testcase cp_imm_mul_8sp: imm=400
-  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xcee9d6eb418a2ed7
-  addi sp, x9, -400  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190:
-  c.sdsp x11, 400(sp) # perform store
+# Testcase cp_imm_mul_8sp: imm=336
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x062ee05cefb767e6
+  addi sp, x9, -336  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150:
+  c.sdsp x11, 336(sp) # perform store
   LREG x7, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190_str)
+  RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150_str)
 
-# Testcase cp_imm_mul_8sp: imm=408
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x48d33b6a60c0fc0e
-  addi sp, x9, -408  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198:
-  c.sdsp x6, 408(sp) # perform store
+# Testcase cp_imm_mul_8sp: imm=344
+  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xf352f88e87154a59
+  addi sp, x9, -344  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158:
+  c.sdsp x3, 344(sp) # perform store
+  LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158_str)
+
+# Testcase cp_imm_mul_8sp: imm=352
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xb0ec0a1b20b0ed65
+  addi sp, x9, -352  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160:
+  c.sdsp x11, 352(sp) # perform store
   LREG x14, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198_str)
+  RVTEST_SIGUPD(x9, x5, x4, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160_str)
 
-# Testcase cp_imm_mul_8sp: imm=416
-  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xcfeffd6dfc6579f8
-  addi sp, x9, -416  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0:
-  c.sdsp x8, 416(sp) # perform store
-  LREG x13, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0_str)
-
-# Testcase cp_imm_mul_8sp: imm=424
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x40ec2a7f005e2c7f
-  addi sp, x9, -424  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8:
-  c.sdsp x14, 424(sp) # perform store
+# Testcase cp_imm_mul_8sp: imm=360
+  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x7c6579f852c4f5ff
+  addi sp, x9, -360  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168:
+  c.sdsp x12, 360(sp) # perform store
   LREG x8, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8_str)
+  RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168_str)
 
-# Testcase cp_imm_mul_8sp: imm=432
-  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0xe5c64717a541dd19
-  addi sp, x9, -432  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0:
-  c.sdsp x0, 432(sp) # perform store
-  LREG x7, 0(x9) # load stored value for checking
+# Testcase cp_imm_mul_8sp: imm=368
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x18018b9845bfa117
+  addi sp, x9, -368  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170:
+  c.sdsp x11, 368(sp) # perform store
+  LREG x3, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0_str)
+  # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170_str)
 
-# Testcase cp_imm_mul_8sp: imm=440
-  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x7ca683507aa3f794
-  addi sp, x9, -440  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8:
-  c.sdsp x6, 440(sp) # perform store
+# Testcase cp_imm_mul_8sp: imm=376
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xa996105fc7ab094d
+  addi sp, x9, -376  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178:
+  c.sdsp x10, 376(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8_str)
+  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178_str)
+
+# Testcase cp_imm_mul_8sp: imm=384
+  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x40e8ab2b8766b985
+  addi sp, x9, -384  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180:
+  c.sdsp x12, 384(sp) # perform store
+  LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180_str)
+
+# Testcase cp_imm_mul_8sp: imm=392
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xdb785df4817f88ab
+  addi sp, x9, -392  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188:
+  c.sdsp x15, 392(sp) # perform store
+  LREG x11, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188_str)
+
+# Testcase cp_imm_mul_8sp: imm=400
+  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xa99b23d29f38afe7
+  addi sp, x9, -400  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190:
+  c.sdsp x8, 400(sp) # perform store
+  LREG x15, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190_str)
+
+# Testcase cp_imm_mul_8sp: imm=408
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x2863ec8f0a9eaf38
+  addi sp, x9, -408  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198:
+  c.sdsp x10, 408(sp) # perform store
+  LREG x7, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198_str)
+
+# Testcase cp_imm_mul_8sp: imm=416
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xbe9f8d619688a066
+  addi sp, x9, -416  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0:
+  c.sdsp x15, 416(sp) # perform store
+  LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0_str)
+
+# Testcase cp_imm_mul_8sp: imm=424
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xe46fe00895d55ff0
+  addi sp, x9, -424  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8:
+  c.sdsp x6, 424(sp) # perform store
+  LREG x7, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8_str)
+
+# Testcase cp_imm_mul_8sp: imm=432
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x9a5400bbd95a9ab6
+  addi sp, x9, -432  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0:
+  c.sdsp x13, 432(sp) # perform store
+  LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0_str)
+
+# Testcase cp_imm_mul_8sp: imm=440
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xa19a95fb8df5a97f
+  addi sp, x9, -440  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8:
+  c.sdsp x10, 440(sp) # perform store
+  LREG x13, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8_str)
 
 # Testcase cp_imm_mul_8sp: imm=448
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xd9a36e80b18412ee
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x8df39988123c4140
   addi sp, x9, -448  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0:
-  c.sdsp x12, 448(sp) # perform store
+  c.sdsp x6, 448(sp) # perform store
   LREG x8, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x9, x5, x4, x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0_str)
 
 # Testcase cp_imm_mul_8sp: imm=456
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x4d38fb1f8bd439a8
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x1b2630b16def7171
   addi sp, x9, -456  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8:
-  c.sdsp x13, 456(sp) # perform store
-  LREG x10, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8_str)
-
-# Testcase cp_imm_mul_8sp: imm=464
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x4843cfefb8627336
-  addi sp, x9, -464  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0:
-  c.sdsp x10, 464(sp) # perform store
+  c.sdsp x11, 456(sp) # perform store
   LREG x15, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0_str)
+  RVTEST_SIGUPD(x9, x5, x4, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8_str)
 
-# Testcase cp_imm_mul_8sp: imm=472
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x52d08efc52ffdf73
-  addi sp, x9, -472  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8:
-  c.sdsp x15, 472(sp) # perform store
-  LREG x7, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8_str)
-
-# Testcase cp_imm_mul_8sp: imm=480
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xe41a120a3e9f8d61
-  addi sp, x9, -480  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0:
-  c.sdsp x13, 480(sp) # perform store
-  LREG x7, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x7 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x7, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0_str)
-
-# Testcase cp_imm_mul_8sp: imm=488
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x267c2ac16b65c89b
-  addi sp, x9, -488  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8:
-  c.sdsp x3, 488(sp) # perform store
-  LREG x11, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x11, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8_str)
-
-# Testcase cp_imm_mul_8sp: imm=496
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x9a5400bbd95a9ab6
-  addi sp, x9, -496  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0:
-  c.sdsp x13, 496(sp) # perform store
-  LREG x12, 0(x9) # load stored value for checking
-  addi x9, x9, SIG_STRIDE # increment signature pointer
-  # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0_str)
-
-# Testcase cp_imm_mul_8sp: imm=504
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x7e354eb1e8d863a7
-  addi sp, x9, -504  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8:
-  c.sdsp x15, 504(sp) # perform store
+# Testcase cp_imm_mul_8sp: imm=464
+  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x4aa841d2e2521005
+  addi sp, x9, -464  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0:
+  c.sdsp x3, 464(sp) # perform store
   LREG x6, 0(x9) # load stored value for checking
   addi x9, x9, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8_str)
+  RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0_str)
+
+# Testcase cp_imm_mul_8sp: imm=472
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x67e6171dc58dfda4
+  addi sp, x9, -472  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8:
+  c.sdsp x15, 472(sp) # perform store
+  LREG x13, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8_str)
+
+# Testcase cp_imm_mul_8sp: imm=480
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0xb44919d799621656
+  addi sp, x9, -480  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0:
+  c.sdsp x11, 480(sp) # perform store
+  LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0_str)
+
+# Testcase cp_imm_mul_8sp: imm=488
+  RVTEST_TESTDATA_LOAD_INT(x1, x11) # load rs2: x11 = 0x67ffd03d37156bae
+  addi sp, x9, -488  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8:
+  c.sdsp x11, 488(sp) # perform store
+  LREG x12, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x12 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8_str)
+
+# Testcase cp_imm_mul_8sp: imm=496
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x11f01cfa3b13eba7
+  addi sp, x9, -496  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0:
+  c.sdsp x13, 496(sp) # perform store
+  LREG x10, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x10 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0_str)
+
+# Testcase cp_imm_mul_8sp: imm=504
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xfc1d2177821836f6
+  addi sp, x9, -504  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8:
+  c.sdsp x10, 504(sp) # perform store
+  LREG x3, 0(x9) # load stored value for checking
+  addi x9, x9, SIG_STRIDE # increment signature pointer
+  # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8_str)
 
   mv x2, x9 # restore signature pointer to default register for teardown
 
@@ -1057,25 +1057,19 @@ RVTEST_DATA_BEGIN
 .dword 0x67dec3de031accb0
 .dword 0xe39a83545d97493f
 .dword 0x2e327176756d4ebe
-.dword 0x4168dcc8d4012311
-.dword 0x489a4340dbdf2615
-.dword 0xdefd37874d7a166c
-.dword 0x311f512377729429
-.dword 0x42a631e63f18b79c
-.dword 0x333c9b6b28a78fbb
-.dword 0x232143be4eaaf506
-.dword 0xa770099d80f721f1
-.dword 0xdf6920cd16583c5a
-.dword 0x5d9b066998e4bf86
-.dword 0x0eb58b177691c3e5
-.dword 0x07617a39ce4dc4b9
-.dword 0xcbccb4ad19434aba
-.dword 0x66f82a9b2160346f
-.dword 0x40708a82cd1e787f
-.dword 0x8bd07a7b6f7fa90f
-.dword 0x71eb79a68484acb6
-.dword 0x43dc93fe909e693f
-.dword 0xbb09c16e136367ad
+.dword 0xe3c5129528f9e5fd
+.dword 0x1585b3191e4e1db7
+.dword 0x26872efce1224e5f
+.dword 0xe1d8baabdd554c6c
+.dword 0x963e51c3446d7a7d
+.dword 0x96583c5a4cd19791
+.dword 0x5099acee99b9956b
+.dword 0xea20320fdd9b0669
+.dword 0x9d3c740c0f2e82ea
+.dword 0x579316aab65ce178
+.dword 0x5533b3b8e5199b49
+.dword 0x43e26d557c07ac67
+.dword 0x936367ad51b7f0d2
 .dword 0x54becd06dfcea75b
 .dword 0xc4c3dd45bffa094b
 .dword 0xa780478f2afafa33
@@ -1083,40 +1077,46 @@ RVTEST_DATA_BEGIN
 .dword 0x6a625f4c69814353
 .dword 0xc9298bb990d75b42
 .dword 0xbe86c7acf7dd8daa
-.dword 0x8fcf8d3933dfa4fa
-.dword 0x43e8b457481285cb
-.dword 0x83adbd6cd922a4a7
+.dword 0x844daf8a0fcf8d39
+.dword 0x5773c2c65f0945af
+.dword 0xa6489b7449318d41
+.dword 0x39e4b525d668b965
 .dword 0xbcfd25131039b9b4
 .dword 0x6b83664e78cedd7d
-.dword 0x7c1250bdd773b3b4
-.dword 0x24e7e2edab5fefb7
-.dword 0xb14be2d69bfa1eb0
-.dword 0x3be7969e5f134560
-.dword 0x5c4c533f712fdb1c
-.dword 0x1cb6d0b40a9f66c7
-.dword 0xb2cf3e88608bbe9f
-.dword 0xffdc4787dffa9f28
-.dword 0xbeb9843accce868d
-.dword 0xe429acbb65619efe
-.dword 0xfbe81ddac1840952
-.dword 0xbb16ad134fc321f1
-.dword 0x6cf5e2123634e21b
-.dword 0xd9b35d062ff04b89
-.dword 0x45ecee9bcab93ac0
-.dword 0xcee9d6eb418a2ed7
-.dword 0x48d33b6a60c0fc0e
-.dword 0xcfeffd6dfc6579f8
-.dword 0x40ec2a7f005e2c7f
-.dword 0xe5c64717a541dd19
-.dword 0x7ca683507aa3f794
-.dword 0xd9a36e80b18412ee
-.dword 0x4d38fb1f8bd439a8
-.dword 0x4843cfefb8627336
-.dword 0x52d08efc52ffdf73
-.dword 0xe41a120a3e9f8d61
-.dword 0x267c2ac16b65c89b
+.dword 0x2c425ae64196dff7
+.dword 0x1bfa1eb08948dd23
+.dword 0x12090e83c930ed5a
+.dword 0x3e16aa45e923c3f9
+.dword 0x0e2cdb50d93eb680
+.dword 0xfd897652701a53d4
+.dword 0x1e7806e61e43fc7a
+.dword 0xc9479168666b4861
+.dword 0x39155319516f9cb5
+.dword 0xefa48ec47be81dda
+.dword 0xe4b923143b16ad13
+.dword 0xf56378fc732c51a3
+.dword 0x062ee05cefb767e6
+.dword 0xf352f88e87154a59
+.dword 0xb0ec0a1b20b0ed65
+.dword 0x7c6579f852c4f5ff
+.dword 0x18018b9845bfa117
+.dword 0xa996105fc7ab094d
+.dword 0x40e8ab2b8766b985
+.dword 0xdb785df4817f88ab
+.dword 0xa99b23d29f38afe7
+.dword 0x2863ec8f0a9eaf38
+.dword 0xbe9f8d619688a066
+.dword 0xe46fe00895d55ff0
 .dword 0x9a5400bbd95a9ab6
-.dword 0x7e354eb1e8d863a7
+.dword 0xa19a95fb8df5a97f
+.dword 0x8df39988123c4140
+.dword 0x1b2630b16def7171
+.dword 0x4aa841d2e2521005
+.dword 0x67e6171dc58dfda4
+.dword 0xb44919d799621656
+.dword 0x67ffd03d37156bae
+.dword 0x11f01cfa3b13eba7
+.dword 0xfc1d2177821836f6
 
 // Testcase strings
 Zca_c_sdsp_cg_cp_rs2_b0_str: .string "\"test: 1; cg: Zca_c.sdsp_cg; cp: cp_rs2; bin: b0\""

--- a/tests/rv64e/Zca/Zca-c.swsp-00.S
+++ b/tests/rv64e/Zca/Zca-c.swsp-00.S
@@ -206,451 +206,451 @@ Zca_c_swsp_cg_cp_rs2_b15:
 /////////////////////////////////
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000000)
-  RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x0000000000000000
+  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0x0000000000000000
   addi sp, x1, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x0:
-  c.swsp x5, 16(sp) # perform store
+  c.swsp x6, 16(sp) # perform store
   LREG x4, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_rs2_edges_0x0, Zca_c_swsp_cg_cp_rs2_edges_0x0_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
-  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x0000000000000001
+  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x0000000000000001
   addi sp, x1, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x1:
-  c.swsp x14, 144(sp) # perform store
+  c.swsp x15, 144(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0x1, Zca_c_swsp_cg_cp_rs2_edges_0x1_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
-  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0x0000000000000002
+  RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x0000000000000002
   addi sp, x1, -44  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x2:
-  c.swsp x6, 44(sp) # perform store
+  c.swsp x9, 44(sp) # perform store
   LREG x13, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_rs2_edges_0x2, Zca_c_swsp_cg_cp_rs2_edges_0x2_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
-  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x8000000000000000
-  addi sp, x1, -236  # copy sig_reg to sp and adjust for offset
+  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x8000000000000000
+  addi sp, x1, -212  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000:
-  c.swsp x15, 236(sp) # perform store
-  LREG x11, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000_str)
-
-# Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
-  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x8000000000000001
-  addi sp, x1, -4  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001:
-  c.swsp x14, 4(sp) # perform store
-  LREG x13, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001_str)
-
-# Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
-  RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x7fffffffffffffff
-  addi sp, x1, -52  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff:
-  c.swsp x9, 52(sp) # perform store
-  LREG x11, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff_str)
-
-# Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
-  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0x7ffffffffffffffe
-  addi sp, x1, -204  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
-  c.swsp x6, 204(sp) # perform store
-  LREG x10, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
-
-# Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
-  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xffffffffffffffff
-  addi sp, x1, -144  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff:
-  c.swsp x11, 144(sp) # perform store
-  LREG x14, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff_str)
-
-# Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
-  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xfffffffffffffffe
-  addi sp, x1, -240  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe:
-  c.swsp x15, 240(sp) # perform store
+  c.swsp x11, 212(sp) # perform store
   LREG x9, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe_str)
+  RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000_str)
 
-# Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
-  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x5bbc887763ae86f2
-  addi sp, x1, -144  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
-  c.swsp x13, 144(sp) # perform store
-  LREG x12, 0(x1) # load stored value for checking
+# Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
+  RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x8000000000000001
+  addi sp, x1, -28  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001:
+  c.swsp x10, 28(sp) # perform store
+  LREG x11, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
+  # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001_str)
 
-# Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
-  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xaaaaaaaaaaaaaaaa
-  addi sp, x1, -252  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
-  c.swsp x11, 252(sp) # perform store
+# Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
+  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x7fffffffffffffff
+  addi sp, x1, -240  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff:
+  c.swsp x15, 240(sp) # perform store
   LREG x4, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
+  RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff_str)
+
+# Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
+  RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x7ffffffffffffffe
+  addi sp, x1, -128  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
+  c.swsp x9, 128(sp) # perform store
+  LREG x14, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
+
+# Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
+  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xffffffffffffffff
+  addi sp, x1, -196  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff:
+  c.swsp x13, 196(sp) # perform store
+  LREG x12, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff_str)
+
+# Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
+  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xfffffffffffffffe
+  addi sp, x1, -172  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe:
+  c.swsp x13, 172(sp) # perform store
+  LREG x15, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe_str)
+
+# Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
+  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x5bbc887763ae86f2
+  addi sp, x1, -32  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
+  c.swsp x12, 32(sp) # perform store
+  LREG x13, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
+
+# Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
+  RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xaaaaaaaaaaaaaaaa
+  addi sp, x1, -196  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
+  c.swsp x9, 196(sp) # perform store
+  LREG x5, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
-  RVTEST_TESTDATA_LOAD_INT(x3, x4) # load rs2: x4 = 0x5555555555555555
+  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x5555555555555555
   addi sp, x1, -228  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555:
-  c.swsp x4, 228(sp) # perform store
-  LREG x10, 0(x1) # load stored value for checking
+  c.swsp x14, 228(sp) # perform store
+  LREG x15, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555, Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555_str)
+  # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555, Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
-  RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x00000000ffffffff
+  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x00000000ffffffff
   addi sp, x1, -212  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
-  c.swsp x10, 212(sp) # perform store
+  c.swsp x11, 212(sp) # perform store
   LREG x4, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
-  RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x00000000fffffffe
+  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0x00000000fffffffe
   addi sp, x1, -72  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
-  c.swsp x5, 72(sp) # perform store
+  c.swsp x6, 72(sp) # perform store
   LREG x4, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
-  RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x0000000100000000
+  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0x0000000100000000
   addi sp, x1, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x100000000:
-  c.swsp x5, 232(sp) # perform store
+  c.swsp x6, 232(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_rs2_edges_0x100000000, Zca_c_swsp_cg_cp_rs2_edges_0x100000000_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
-  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0x0000000100000001
+  RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x0000000100000001
   addi sp, x1, -104  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x100000001:
-  c.swsp x6, 104(sp) # perform store
-  LREG x9, 0(x1) # load stored value for checking
+  c.swsp x9, 104(sp) # perform store
+  LREG x6, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_rs2_edges_0x100000001, Zca_c_swsp_cg_cp_rs2_edges_0x100000001_str)
+  # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_rs2_edges_0x100000001, Zca_c_swsp_cg_cp_rs2_edges_0x100000001_str)
 
 /////////////////////////////////
 // cp_imm_mul_4sp
 /////////////////////////////////
 
 # Testcase cp_imm_mul_4sp: imm=0
-  RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xbf910318653dabd8
+  RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xbf910318653dabd8
   addi sp, x1, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0:
-  c.swsp x9, 0(sp) # perform store
+  c.swsp x10, 0(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0_str)
 
 # Testcase cp_imm_mul_4sp: imm=4
-  RVTEST_TESTDATA_LOAD_INT(x3, x4) # load rs2: x4 = 0xce44699c438312ff
+  RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0xce44699c438312ff
   addi sp, x1, -4  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4:
-  c.swsp x4, 4(sp) # perform store
+  c.swsp x5, 4(sp) # perform store
   LREG x9, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4_str)
 
 # Testcase cp_imm_mul_4sp: imm=8
-  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x4bebb042bb6b7680
+  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x4bebb042bb6b7680
   addi sp, x1, -8  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8:
-  c.swsp x14, 8(sp) # perform store
+  c.swsp x15, 8(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8_str)
 
 # Testcase cp_imm_mul_4sp: imm=12
-  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xb3a35dad89a83669
+  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xb3a35dad89a83669
   addi sp, x1, -12  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc:
-  c.swsp x11, 12(sp) # perform store
+  c.swsp x12, 12(sp) # perform store
   LREG x5, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc_str)
 
 # Testcase cp_imm_mul_4sp: imm=16
-  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xe8b95d8f77c9a307
+  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xe8b95d8f77c9a307
   addi sp, x1, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10:
-  c.swsp x12, 16(sp) # perform store
+  c.swsp x13, 16(sp) # perform store
   LREG x10, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10_str)
 
 # Testcase cp_imm_mul_4sp: imm=20
-  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x9c1fee450f68029b
+  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x9c1fee450f68029b
   addi sp, x1, -20  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14:
-  c.swsp x14, 20(sp) # perform store
+  c.swsp x15, 20(sp) # perform store
   LREG x4, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14_str)
 
 # Testcase cp_imm_mul_4sp: imm=24
-  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x6e9d4158bf1d20c7
+  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x6e9d4158bf1d20c7
   addi sp, x1, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18:
-  c.swsp x13, 24(sp) # perform store
+  c.swsp x14, 24(sp) # perform store
   LREG x15, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18_str)
 
 # Testcase cp_imm_mul_4sp: imm=28
-  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x025588f2e21db2f1
+  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x025588f2e21db2f1
   addi sp, x1, -28  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c:
-  c.swsp x13, 28(sp) # perform store
-  LREG x14, 0(x1) # load stored value for checking
+  c.swsp x14, 28(sp) # perform store
+  LREG x13, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c_str)
+  # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c_str)
 
 # Testcase cp_imm_mul_4sp: imm=32
-  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0xb18ad02d8402a4fe
+  RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xb18ad02d8402a4fe
   addi sp, x1, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20:
-  c.swsp x6, 32(sp) # perform store
+  c.swsp x9, 32(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20_str)
 
 # Testcase cp_imm_mul_4sp: imm=36
-  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xdf3eea06bccafcad
+  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xdf3eea06bccafcad
   addi sp, x1, -36  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24:
-  c.swsp x14, 36(sp) # perform store
+  c.swsp x15, 36(sp) # perform store
   LREG x4, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24_str)
 
 # Testcase cp_imm_mul_4sp: imm=40
-  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x2db624b0b45b2c8b
+  RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xe03fe2d8adb624b0
   addi sp, x1, -40  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28:
-  c.swsp x15, 40(sp) # perform store
-  LREG x10, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28_str)
-
-# Testcase cp_imm_mul_4sp: imm=44
-  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x688d523781f6d56d
-  addi sp, x1, -44  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
-  c.swsp x12, 44(sp) # perform store
-  LREG x5, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c_str)
-
-# Testcase cp_imm_mul_4sp: imm=48
-  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x80dc5f589b13aa7d
-  addi sp, x1, -48  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
-  c.swsp x15, 48(sp) # perform store
-  LREG x4, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30_str)
-
-# Testcase cp_imm_mul_4sp: imm=52
-  RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x007aeb44a84065b0
-  addi sp, x1, -52  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
-  c.swsp x5, 52(sp) # perform store
+  c.swsp x10, 40(sp) # perform store
   LREG x15, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34_str)
+  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28_str)
 
-# Testcase cp_imm_mul_4sp: imm=56
-  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xbfcd51149a9509f6
-  addi sp, x1, -56  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
-  c.swsp x12, 56(sp) # perform store
-  LREG x5, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38_str)
-
-# Testcase cp_imm_mul_4sp: imm=60
-  RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0xfc4e095f418c3264
-  addi sp, x1, -60  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
-  c.swsp x0, 60(sp) # perform store
-  LREG x11, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c_str)
-
-# Testcase cp_imm_mul_4sp: imm=64
-  RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0x823bf5eb1f15dcb8
-  addi sp, x1, -64  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
-  c.swsp x0, 64(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=44
+  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x1ccb9251b206b9c6
+  addi sp, x1, -44  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
+  c.swsp x15, 44(sp) # perform store
   LREG x13, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40_str)
+  RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c_str)
 
-# Testcase cp_imm_mul_4sp: imm=68
-  RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0xb5b23d03a5bff6fb
-  addi sp, x1, -68  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
-  c.swsp x5, 68(sp) # perform store
-  LREG x11, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44_str)
-
-# Testcase cp_imm_mul_4sp: imm=72
-  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x77ecf227f0d53ddd
-  addi sp, x1, -72  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
-  c.swsp x11, 72(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=48
+  RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0xd7b73193e88d5237
+  addi sp, x1, -48  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
+  c.swsp x0, 48(sp) # perform store
   LREG x15, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48_str)
+  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30_str)
 
-# Testcase cp_imm_mul_4sp: imm=76
-  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x1a324e134deab75c
-  addi sp, x1, -76  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
-  c.swsp x12, 76(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=52
+  RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0xd0d5a12537a2726d
+  addi sp, x1, -52  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
+  c.swsp x0, 52(sp) # perform store
+  LREG x6, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34_str)
+
+# Testcase cp_imm_mul_4sp: imm=56
+  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x1a9509f68513dcf1
+  addi sp, x1, -56  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
+  c.swsp x15, 56(sp) # perform store
+  LREG x6, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38_str)
+
+# Testcase cp_imm_mul_4sp: imm=60
+  RVTEST_TESTDATA_LOAD_INT(x3, x4) # load rs2: x4 = 0xc18c3264dcc27e4f
+  addi sp, x1, -60  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
+  c.swsp x4, 60(sp) # perform store
+  LREG x5, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c_str)
+
+# Testcase cp_imm_mul_4sp: imm=64
+  RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x8d1f80d2887a85ad
+  addi sp, x1, -64  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
+  c.swsp x10, 64(sp) # perform store
+  LREG x15, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40_str)
+
+# Testcase cp_imm_mul_4sp: imm=68
+  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x5db7f1313025852f
+  addi sp, x1, -68  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
+  c.swsp x13, 68(sp) # perform store
   LREG x4, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c_str)
+  RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44_str)
+
+# Testcase cp_imm_mul_4sp: imm=72
+  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x7e22c6d5dad9c9b3
+  addi sp, x1, -72  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
+  c.swsp x11, 72(sp) # perform store
+  LREG x13, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48_str)
+
+# Testcase cp_imm_mul_4sp: imm=76
+  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0x06c2ea11810eba9c
+  addi sp, x1, -76  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
+  c.swsp x6, 76(sp) # perform store
+  LREG x13, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c_str)
 
 # Testcase cp_imm_mul_4sp: imm=80
-  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xd0f0cbd234461515
+  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x12be5c00004a3fed
   addi sp, x1, -80  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
   c.swsp x13, 80(sp) # perform store
-  LREG x11, 0(x1) # load stored value for checking
+  LREG x9, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50_str)
+  # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50_str)
 
 # Testcase cp_imm_mul_4sp: imm=84
-  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x408148003ab1aa06
+  RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x786212eb1798103f
   addi sp, x1, -84  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
-  c.swsp x12, 84(sp) # perform store
-  LREG x10, 0(x1) # load stored value for checking
+  c.swsp x10, 84(sp) # perform store
+  LREG x15, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54_str)
+  # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54_str)
 
 # Testcase cp_imm_mul_4sp: imm=88
-  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xfd7e6a452e04c112
+  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x2a4c1092fe04b34d
   addi sp, x1, -88  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
-  c.swsp x14, 88(sp) # perform store
-  LREG x10, 0(x1) # load stored value for checking
+  c.swsp x15, 88(sp) # perform store
+  LREG x6, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58_str)
+  # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58_str)
 
 # Testcase cp_imm_mul_4sp: imm=92
-  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x5e38ff0ec964c067
+  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x1442f5704e6a577e
   addi sp, x1, -92  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
-  c.swsp x11, 92(sp) # perform store
-  LREG x14, 0(x1) # load stored value for checking
+  c.swsp x13, 92(sp) # perform store
+  LREG x5, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c_str)
+  # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c_str)
 
 # Testcase cp_imm_mul_4sp: imm=96
-  RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x72762c5712aecb88
+  RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xa1cad1b2a4a65a68
   addi sp, x1, -96  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
-  c.swsp x5, 96(sp) # perform store
-  LREG x6, 0(x1) # load stored value for checking
+  c.swsp x9, 96(sp) # perform store
+  LREG x12, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60_str)
+  # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60_str)
 
 # Testcase cp_imm_mul_4sp: imm=100
-  RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0x29602071330b5c12
+  RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x36cf981d2c3969a4
   addi sp, x1, -100  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
-  c.swsp x0, 100(sp) # perform store
-  LREG x6, 0(x1) # load stored value for checking
+  c.swsp x9, 100(sp) # perform store
+  LREG x15, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64_str)
+  # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64_str)
 
 # Testcase cp_imm_mul_4sp: imm=104
-  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x9f2e744b3e6fd0d3
+  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xfd7e6a452e04c112
   addi sp, x1, -104  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
-  c.swsp x12, 104(sp) # perform store
+  c.swsp x14, 104(sp) # perform store
   LREG x10, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68_str)
 
 # Testcase cp_imm_mul_4sp: imm=108
-  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xc76e4eac8b5a9947
+  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x5e38ff0ec964c067
   addi sp, x1, -108  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
-  c.swsp x15, 108(sp) # perform store
-  LREG x5, 0(x1) # load stored value for checking
+  c.swsp x12, 108(sp) # perform store
+  LREG x14, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c_str)
+  # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c_str)
 
 # Testcase cp_imm_mul_4sp: imm=112
-  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0xa5fdc85bc94a6e3a
+  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0x72762c5712aecb88
   addi sp, x1, -112  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
   c.swsp x6, 112(sp) # perform store
@@ -660,47 +660,47 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
   RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70_str)
 
 # Testcase cp_imm_mul_4sp: imm=116
-  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xec4e4dbb72f89694
+  RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0x29602071330b5c12
   addi sp, x1, -116  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
-  c.swsp x14, 116(sp) # perform store
-  LREG x11, 0(x1) # load stored value for checking
+  c.swsp x0, 116(sp) # perform store
+  LREG x6, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74_str)
+  # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74_str)
 
 # Testcase cp_imm_mul_4sp: imm=120
-  RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0xfe63f0d7c5845e44
+  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x9f2e744b3e6fd0d3
   addi sp, x1, -120  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
-  c.swsp x5, 120(sp) # perform store
-  LREG x14, 0(x1) # load stored value for checking
+  c.swsp x13, 120(sp) # perform store
+  LREG x10, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78_str)
+  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78_str)
 
 # Testcase cp_imm_mul_4sp: imm=124
-  RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0x350cf49aa81afa8d
+  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xebe5ef53476e4eac
   addi sp, x1, -124  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
-  c.swsp x2, 124(sp) # perform store
-  LREG x9, 0(x1) # load stored value for checking
+  c.swsp x13, 124(sp) # perform store
+  LREG x10, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c_str)
+  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c_str)
 
 # Testcase cp_imm_mul_4sp: imm=128
-  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x3e20939298556e72
+  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x3e4a4c562cd58959
   addi sp, x1, -128  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
-  c.swsp x15, 128(sp) # perform store
-  LREG x9, 0(x1) # load stored value for checking
+  c.swsp x12, 128(sp) # perform store
+  LREG x6, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80_str)
+  # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80_str)
 
 # Testcase cp_imm_mul_4sp: imm=132
-  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x5091270428a81959
+  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x0ace2b10eef2ff2b
   addi sp, x1, -132  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
   c.swsp x11, 132(sp) # perform store
@@ -710,304 +710,304 @@ Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84_str)
 
 # Testcase cp_imm_mul_4sp: imm=136
-  RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0xbcc1dfe0dc00883f
+  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xdc2b707d1aaef612
   addi sp, x1, -136  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
-  c.swsp x9, 136(sp) # perform store
-  LREG x15, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88_str)
-
-# Testcase cp_imm_mul_4sp: imm=140
-  RVTEST_TESTDATA_LOAD_INT(x3, x4) # load rs2: x4 = 0xce57c134ecf3621e
-  addi sp, x1, -140  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
-  c.swsp x4, 140(sp) # perform store
-  LREG x6, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c_str)
-
-# Testcase cp_imm_mul_4sp: imm=144
-  RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x009a13a349731787
-  addi sp, x1, -144  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
-  c.swsp x9, 144(sp) # perform store
-  LREG x12, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90_str)
-
-# Testcase cp_imm_mul_4sp: imm=148
-  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0xc611b086d3bafe55
-  addi sp, x1, -148  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
-  c.swsp x6, 148(sp) # perform store
-  LREG x10, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94_str)
-
-# Testcase cp_imm_mul_4sp: imm=152
-  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x588e3e6ad1a5621b
-  addi sp, x1, -152  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
-  c.swsp x12, 152(sp) # perform store
-  LREG x4, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98_str)
-
-# Testcase cp_imm_mul_4sp: imm=156
-  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xd5c2575b996dee6f
-  addi sp, x1, -156  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
-  c.swsp x14, 156(sp) # perform store
-  LREG x10, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c_str)
-
-# Testcase cp_imm_mul_4sp: imm=160
-  RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0x27cdf098599b04ff
-  addi sp, x1, -160  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
-  c.swsp x2, 160(sp) # perform store
-  LREG x14, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0_str)
-
-# Testcase cp_imm_mul_4sp: imm=164
-  RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0xa5b58e75380c8b13
-  addi sp, x1, -164  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
-  c.swsp x5, 164(sp) # perform store
-  LREG x12, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4_str)
-
-# Testcase cp_imm_mul_4sp: imm=168
-  RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0x770bf9210f2853d0
-  addi sp, x1, -168  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
-  c.swsp x2, 168(sp) # perform store
-  LREG x11, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8_str)
-
-# Testcase cp_imm_mul_4sp: imm=172
-  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x6d820e62ea9d99e5
-  addi sp, x1, -172  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
-  c.swsp x15, 172(sp) # perform store
+  c.swsp x11, 136(sp) # perform store
   LREG x13, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac_str)
+  RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88_str)
 
-# Testcase cp_imm_mul_4sp: imm=176
-  RVTEST_TESTDATA_LOAD_INT(x3, x2) # load rs2: x2 = 0x5544a03f53edc834
-  addi sp, x1, -176  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
-  c.swsp x2, 176(sp) # perform store
-  LREG x10, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0_str)
-
-# Testcase cp_imm_mul_4sp: imm=180
-  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x5fcdd39f891356e9
-  addi sp, x1, -180  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
-  c.swsp x11, 180(sp) # perform store
-  LREG x9, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4_str)
-
-# Testcase cp_imm_mul_4sp: imm=184
-  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x672ed62396b2c907
-  addi sp, x1, -184  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
-  c.swsp x15, 184(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=140
+  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x45845e44da746279
+  addi sp, x1, -140  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
+  c.swsp x15, 140(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8_str)
+  RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c_str)
 
-# Testcase cp_imm_mul_4sp: imm=188
-  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0xf578d9a8accea683
-  addi sp, x1, -188  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
-  c.swsp x11, 188(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=144
+  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x3dd4f2173af5f404
+  addi sp, x1, -144  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
+  c.swsp x12, 144(sp) # perform store
+  LREG x15, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90_str)
+
+# Testcase cp_imm_mul_4sp: imm=148
+  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xfe3a31b4be209392
+  addi sp, x1, -148  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
+  c.swsp x14, 148(sp) # perform store
+  LREG x13, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94_str)
+
+# Testcase cp_imm_mul_4sp: imm=152
+  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x3230458330514957
+  addi sp, x1, -152  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
+  c.swsp x11, 152(sp) # perform store
   LREG x14, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc_str)
+  RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98_str)
+
+# Testcase cp_imm_mul_4sp: imm=156
+  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xdb21878dfbc268c2
+  addi sp, x1, -156  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
+  c.swsp x12, 156(sp) # perform store
+  LREG x4, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c_str)
+
+# Testcase cp_imm_mul_4sp: imm=160
+  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x5c00883f90918b43
+  addi sp, x1, -160  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
+  c.swsp x13, 160(sp) # perform store
+  LREG x5, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x5 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x5, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0_str)
+
+# Testcase cp_imm_mul_4sp: imm=164
+  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x6cf3621e2909825c
+  addi sp, x1, -164  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
+  c.swsp x13, 164(sp) # perform store
+  LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4_str)
+
+# Testcase cp_imm_mul_4sp: imm=168
+  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x4c5429651a4f0a20
+  addi sp, x1, -168  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
+  c.swsp x14, 168(sp) # perform store
+  LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8_str)
+
+# Testcase cp_imm_mul_4sp: imm=172
+  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x1e17df6a3a92f564
+  addi sp, x1, -172  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
+  c.swsp x13, 172(sp) # perform store
+  LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac_str)
+
+# Testcase cp_imm_mul_4sp: imm=176
+  RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x588e3e6ad1a5621b
+  addi sp, x1, -176  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
+  c.swsp x9, 176(sp) # perform store
+  LREG x4, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x4 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0_str)
+
+# Testcase cp_imm_mul_4sp: imm=180
+  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xd5c2575b996dee6f
+  addi sp, x1, -180  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
+  c.swsp x15, 180(sp) # perform store
+  LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4_str)
+
+# Testcase cp_imm_mul_4sp: imm=184
+  RVTEST_TESTDATA_LOAD_INT(x3, x4) # load rs2: x4 = 0x27cdf098599b04ff
+  addi sp, x1, -184  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
+  c.swsp x4, 184(sp) # perform store
+  LREG x15, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8_str)
+
+# Testcase cp_imm_mul_4sp: imm=188
+  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0xa5b58e75380c8b13
+  addi sp, x1, -188  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
+  c.swsp x6, 188(sp) # perform store
+  LREG x12, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc_str)
 
 # Testcase cp_imm_mul_4sp: imm=192
-  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xc16b5051cd5bde9a
+  RVTEST_TESTDATA_LOAD_INT(x3, x4) # load rs2: x4 = 0x770bf9210f2853d0
   addi sp, x1, -192  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
-  c.swsp x13, 192(sp) # perform store
+  c.swsp x4, 192(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0_str)
 
 # Testcase cp_imm_mul_4sp: imm=196
-  RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x5e4fac3fa312586c
+  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0xf13039f7ee70fb89
   addi sp, x1, -196  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
-  c.swsp x5, 196(sp) # perform store
+  c.swsp x6, 196(sp) # perform store
   LREG x14, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4_str)
 
 # Testcase cp_imm_mul_4sp: imm=200
-  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x90a91e295406c510
+  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xc3497ffb4368e283
   addi sp, x1, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
-  c.swsp x13, 200(sp) # perform store
+  c.swsp x15, 200(sp) # perform store
   LREG x10, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8_str)
 
 # Testcase cp_imm_mul_4sp: imm=204
-  RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0x438cec2bceb3bcf7
+  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x5fcdd39f891356e9
   addi sp, x1, -204  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
-  c.swsp x0, 204(sp) # perform store
-  LREG x15, 0(x1) # load stored value for checking
+  c.swsp x15, 204(sp) # perform store
+  LREG x9, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc_str)
+  # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc_str)
 
 # Testcase cp_imm_mul_4sp: imm=208
-  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x731acb3086434034
+  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xf1bc5dd064d42cac
   addi sp, x1, -208  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
-  c.swsp x15, 208(sp) # perform store
+  c.swsp x14, 208(sp) # perform store
   LREG x6, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0_str)
 
 # Testcase cp_imm_mul_4sp: imm=212
-  RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0x3eb07ddda64eaff7
+  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0xf578d9a8accea683
   addi sp, x1, -212  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
-  c.swsp x10, 212(sp) # perform store
+  c.swsp x15, 212(sp) # perform store
+  LREG x13, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4_str)
+
+# Testcase cp_imm_mul_4sp: imm=216
+  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xc16b5051cd5bde9a
+  addi sp, x1, -216  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
+  c.swsp x14, 216(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4_str)
-
-# Testcase cp_imm_mul_4sp: imm=216
-  RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x0b83aa5c2014e92e
-  addi sp, x1, -216  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
-  c.swsp x5, 216(sp) # perform store
-  LREG x9, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8_str)
+  RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8_str)
 
 # Testcase cp_imm_mul_4sp: imm=220
-  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xf5322a13b5cf94f1
+  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0x5e4fac3fa312586c
   addi sp, x1, -220  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
-  c.swsp x12, 220(sp) # perform store
-  LREG x11, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc_str)
-
-# Testcase cp_imm_mul_4sp: imm=224
-  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x8cc550d17707262c
-  addi sp, x1, -224  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
-  c.swsp x11, 224(sp) # perform store
+  c.swsp x6, 220(sp) # perform store
   LREG x14, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0_str)
+  RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc_str)
+
+# Testcase cp_imm_mul_4sp: imm=224
+  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0x90a91e295406c510
+  addi sp, x1, -224  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
+  c.swsp x14, 224(sp) # perform store
+  LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0_str)
 
 # Testcase cp_imm_mul_4sp: imm=228
-  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x9b4d49e88fb35ff3
+  RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0x438cec2bceb3bcf7
   addi sp, x1, -228  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
-  c.swsp x15, 228(sp) # perform store
-  LREG x6, 0(x1) # load stored value for checking
+  c.swsp x0, 228(sp) # perform store
+  LREG x15, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x6 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4_str)
+  # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4_str)
 
 # Testcase cp_imm_mul_4sp: imm=232
-  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xeaaa04cc1ff917c8
+  RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x11f41e16768d503e
   addi sp, x1, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
-  c.swsp x12, 232(sp) # perform store
-  LREG x9, 0(x1) # load stored value for checking
+  c.swsp x9, 232(sp) # perform store
+  LREG x13, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x9 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8_str)
+  # Check if x13 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8_str)
 
 # Testcase cp_imm_mul_4sp: imm=236
-  RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xccafbae94bf0b9aa
+  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0xbd789a4d5f9c0192
   addi sp, x1, -236  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
-  c.swsp x10, 236(sp) # perform store
-  LREG x11, 0(x1) # load stored value for checking
+  c.swsp x12, 236(sp) # perform store
+  LREG x15, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x11 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x11, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec_str)
+  # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec_str)
 
 # Testcase cp_imm_mul_4sp: imm=240
-  RVTEST_TESTDATA_LOAD_INT(x3, x4) # load rs2: x4 = 0x40a8d8d0b51d61bd
+  RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0xf5322a13b5cf94f1
   addi sp, x1, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
-  c.swsp x4, 240(sp) # perform store
+  c.swsp x5, 240(sp) # perform store
   LREG x12, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x1, x8, x7, x12, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0_str)
 
 # Testcase cp_imm_mul_4sp: imm=244
-  RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x2966e1f9ea039ecc
+  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x8cc550d17707262c
   addi sp, x1, -244  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
-  c.swsp x5, 244(sp) # perform store
-  LREG x15, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4_str)
-
-# Testcase cp_imm_mul_4sp: imm=248
-  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x797ae270376a5013
-  addi sp, x1, -248  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
-  c.swsp x11, 248(sp) # perform store
-  LREG x10, 0(x1) # load stored value for checking
-  addi x1, x1, SIG_STRIDE # increment signature pointer
-  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8_str)
-
-# Testcase cp_imm_mul_4sp: imm=252
-  RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x49a50d91c8761ab8
-  addi sp, x1, -252  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc:
-  c.swsp x9, 252(sp) # perform store
+  c.swsp x12, 244(sp) # perform store
   LREG x14, 0(x1) # load stored value for checking
   addi x1, x1, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc_str)
+  RVTEST_SIGUPD(x1, x8, x7, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4_str)
+
+# Testcase cp_imm_mul_4sp: imm=248
+  RVTEST_TESTDATA_LOAD_INT(x3, x5) # load rs2: x5 = 0x64f6201bb5edac5c
+  addi sp, x1, -248  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
+  c.swsp x5, 248(sp) # perform store
+  LREG x15, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8_str)
+
+# Testcase cp_imm_mul_4sp: imm=252
+  RVTEST_TESTDATA_LOAD_INT(x3, x4) # load rs2: x4 = 0x9ff917c8c2c28fd7
+  addi sp, x1, -252  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc:
+  c.swsp x4, 252(sp) # perform store
+  LREG x10, 0(x1) # load stored value for checking
+  addi x1, x1, SIG_STRIDE # increment signature pointer
+  # Check if x10 contains the expected result. x1 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x1, x8, x7, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc_str)
 
   mv x2, x1 # restore signature pointer to default register for teardown
 
@@ -1060,60 +1060,60 @@ RVTEST_DATA_BEGIN
 .dword 0x025588f2e21db2f1
 .dword 0xb18ad02d8402a4fe
 .dword 0xdf3eea06bccafcad
-.dword 0x2db624b0b45b2c8b
-.dword 0x688d523781f6d56d
-.dword 0x80dc5f589b13aa7d
-.dword 0x007aeb44a84065b0
-.dword 0xbfcd51149a9509f6
-.dword 0xfc4e095f418c3264
-.dword 0x823bf5eb1f15dcb8
-.dword 0xb5b23d03a5bff6fb
-.dword 0x77ecf227f0d53ddd
-.dword 0x1a324e134deab75c
-.dword 0xd0f0cbd234461515
-.dword 0x408148003ab1aa06
+.dword 0xe03fe2d8adb624b0
+.dword 0x1ccb9251b206b9c6
+.dword 0xd7b73193e88d5237
+.dword 0xd0d5a12537a2726d
+.dword 0x1a9509f68513dcf1
+.dword 0xc18c3264dcc27e4f
+.dword 0x8d1f80d2887a85ad
+.dword 0x5db7f1313025852f
+.dword 0x7e22c6d5dad9c9b3
+.dword 0x06c2ea11810eba9c
+.dword 0x12be5c00004a3fed
+.dword 0x786212eb1798103f
+.dword 0x2a4c1092fe04b34d
+.dword 0x1442f5704e6a577e
+.dword 0xa1cad1b2a4a65a68
+.dword 0x36cf981d2c3969a4
 .dword 0xfd7e6a452e04c112
 .dword 0x5e38ff0ec964c067
 .dword 0x72762c5712aecb88
 .dword 0x29602071330b5c12
 .dword 0x9f2e744b3e6fd0d3
-.dword 0xc76e4eac8b5a9947
-.dword 0xa5fdc85bc94a6e3a
-.dword 0xec4e4dbb72f89694
-.dword 0xfe63f0d7c5845e44
-.dword 0x350cf49aa81afa8d
-.dword 0x3e20939298556e72
-.dword 0x5091270428a81959
-.dword 0xbcc1dfe0dc00883f
-.dword 0xce57c134ecf3621e
-.dword 0x009a13a349731787
-.dword 0xc611b086d3bafe55
+.dword 0xebe5ef53476e4eac
+.dword 0x3e4a4c562cd58959
+.dword 0x0ace2b10eef2ff2b
+.dword 0xdc2b707d1aaef612
+.dword 0x45845e44da746279
+.dword 0x3dd4f2173af5f404
+.dword 0xfe3a31b4be209392
+.dword 0x3230458330514957
+.dword 0xdb21878dfbc268c2
+.dword 0x5c00883f90918b43
+.dword 0x6cf3621e2909825c
+.dword 0x4c5429651a4f0a20
+.dword 0x1e17df6a3a92f564
 .dword 0x588e3e6ad1a5621b
 .dword 0xd5c2575b996dee6f
 .dword 0x27cdf098599b04ff
 .dword 0xa5b58e75380c8b13
 .dword 0x770bf9210f2853d0
-.dword 0x6d820e62ea9d99e5
-.dword 0x5544a03f53edc834
+.dword 0xf13039f7ee70fb89
+.dword 0xc3497ffb4368e283
 .dword 0x5fcdd39f891356e9
-.dword 0x672ed62396b2c907
+.dword 0xf1bc5dd064d42cac
 .dword 0xf578d9a8accea683
 .dword 0xc16b5051cd5bde9a
 .dword 0x5e4fac3fa312586c
 .dword 0x90a91e295406c510
 .dword 0x438cec2bceb3bcf7
-.dword 0x731acb3086434034
-.dword 0x3eb07ddda64eaff7
-.dword 0x0b83aa5c2014e92e
+.dword 0x11f41e16768d503e
+.dword 0xbd789a4d5f9c0192
 .dword 0xf5322a13b5cf94f1
 .dword 0x8cc550d17707262c
-.dword 0x9b4d49e88fb35ff3
-.dword 0xeaaa04cc1ff917c8
-.dword 0xccafbae94bf0b9aa
-.dword 0x40a8d8d0b51d61bd
-.dword 0x2966e1f9ea039ecc
-.dword 0x797ae270376a5013
-.dword 0x49a50d91c8761ab8
+.dword 0x64f6201bb5edac5c
+.dword 0x9ff917c8c2c28fd7
 
 // Testcase strings
 Zca_c_swsp_cg_cp_rs2_b0_str: .string "\"test: 1; cg: Zca_c.swsp_cg; cp: cp_rs2; bin: b0\""

--- a/tests/rv64i/Zca/Zca-c.sdsp-00.S
+++ b/tests/rv64i/Zca/Zca-c.sdsp-00.S
@@ -369,160 +369,160 @@ Zca_c_sdsp_cg_cp_rs2_b31:
 /////////////////////////////////
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000000)
-  RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0x0000000000000000
+  RVTEST_TESTDATA_LOAD_INT(x11, x23) # load rs2: x23 = 0x0000000000000000
   addi sp, x6, -312  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x0:
-  c.sdsp x31, 312(sp) # perform store
-  LREG x23, 0(x6) # load stored value for checking
+  c.sdsp x23, 312(sp) # perform store
+  LREG x29, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_rs2_edges_0x0, Zca_c_sdsp_cg_cp_rs2_edges_0x0_str)
+  # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_rs2_edges_0x0, Zca_c_sdsp_cg_cp_rs2_edges_0x0_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
-  RVTEST_TESTDATA_LOAD_INT(x11, x16) # load rs2: x16 = 0x0000000000000001
+  RVTEST_TESTDATA_LOAD_INT(x11, x17) # load rs2: x17 = 0x0000000000000001
   addi sp, x6, -40  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x1:
-  c.sdsp x16, 40(sp) # perform store
+  c.sdsp x17, 40(sp) # perform store
   LREG x20, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x20 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x20, Zca_c_sdsp_cg_cp_rs2_edges_0x1, Zca_c_sdsp_cg_cp_rs2_edges_0x1_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
-  RVTEST_TESTDATA_LOAD_INT(x11, x22) # load rs2: x22 = 0x0000000000000002
+  RVTEST_TESTDATA_LOAD_INT(x11, x23) # load rs2: x23 = 0x0000000000000002
   addi sp, x6, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x2:
-  c.sdsp x22, 24(sp) # perform store
+  c.sdsp x23, 24(sp) # perform store
   LREG x26, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x26, Zca_c_sdsp_cg_cp_rs2_edges_0x2, Zca_c_sdsp_cg_cp_rs2_edges_0x2_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
-  RVTEST_TESTDATA_LOAD_INT(x11, x18) # load rs2: x18 = 0x8000000000000000
+  RVTEST_TESTDATA_LOAD_INT(x11, x19) # load rs2: x19 = 0x8000000000000000
   addi sp, x6, -392  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000:
-  c.sdsp x18, 392(sp) # perform store
+  c.sdsp x19, 392(sp) # perform store
   LREG x22, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x22, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000000_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
-  RVTEST_TESTDATA_LOAD_INT(x11, x23) # load rs2: x23 = 0x8000000000000001
+  RVTEST_TESTDATA_LOAD_INT(x11, x24) # load rs2: x24 = 0x8000000000000001
   addi sp, x6, -8  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001:
-  c.sdsp x23, 8(sp) # perform store
+  c.sdsp x24, 8(sp) # perform store
   LREG x28, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x28, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001, Zca_c_sdsp_cg_cp_rs2_edges_0x8000000000000001_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
-  RVTEST_TESTDATA_LOAD_INT(x11, x27) # load rs2: x27 = 0x7fffffffffffffff
+  RVTEST_TESTDATA_LOAD_INT(x11, x28) # load rs2: x28 = 0x7fffffffffffffff
   addi sp, x6, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff:
-  c.sdsp x27, 16(sp) # perform store
+  c.sdsp x28, 16(sp) # perform store
   LREG x31, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0x7fffffffffffffff_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
-  RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0x7ffffffffffffffe
+  RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0x7ffffffffffffffe
   addi sp, x6, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
-  c.sdsp x5, 240(sp) # perform store
+  c.sdsp x9, 240(sp) # perform store
   LREG x22, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x22, Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
-  RVTEST_TESTDATA_LOAD_INT(x11, x27) # load rs2: x27 = 0xffffffffffffffff
+  RVTEST_TESTDATA_LOAD_INT(x11, x28) # load rs2: x28 = 0xffffffffffffffff
   addi sp, x6, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff:
-  c.sdsp x27, 24(sp) # perform store
+  c.sdsp x28, 24(sp) # perform store
   LREG x22, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x22, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffffffffffff_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
-  RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0xfffffffffffffffe
+  RVTEST_TESTDATA_LOAD_INT(x11, x15) # load rs2: x15 = 0xfffffffffffffffe
   addi sp, x6, -48  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe:
-  c.sdsp x14, 48(sp) # perform store
+  c.sdsp x15, 48(sp) # perform store
   LREG x29, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffffffffffe_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
-  RVTEST_TESTDATA_LOAD_INT(x11, x25) # load rs2: x25 = 0x5bbc887763ae86f2
+  RVTEST_TESTDATA_LOAD_INT(x11, x26) # load rs2: x26 = 0x5bbc887763ae86f2
   addi sp, x6, -336  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
-  c.sdsp x25, 336(sp) # perform store
+  c.sdsp x26, 336(sp) # perform store
   LREG x31, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_sdsp_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
-  RVTEST_TESTDATA_LOAD_INT(x11, x16) # load rs2: x16 = 0xaaaaaaaaaaaaaaaa
+  RVTEST_TESTDATA_LOAD_INT(x11, x17) # load rs2: x17 = 0xaaaaaaaaaaaaaaaa
   addi sp, x6, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
-  c.sdsp x16, 232(sp) # perform store
+  c.sdsp x17, 232(sp) # perform store
   LREG x10, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x10, Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_sdsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
-  RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0x5555555555555555
+  RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0x5555555555555555
   addi sp, x6, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555:
-  c.sdsp x4, 0(sp) # perform store
+  c.sdsp x5, 0(sp) # perform store
   LREG x21, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x21, Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555, Zca_c_sdsp_cg_cp_rs2_edges_0x5555555555555555_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
-  RVTEST_TESTDATA_LOAD_INT(x11, x17) # load rs2: x17 = 0x00000000ffffffff
+  RVTEST_TESTDATA_LOAD_INT(x11, x18) # load rs2: x18 = 0x00000000ffffffff
   addi sp, x6, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff:
-  c.sdsp x17, 200(sp) # perform store
+  c.sdsp x18, 200(sp) # perform store
   LREG x23, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff, Zca_c_sdsp_cg_cp_rs2_edges_0xffffffff_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
-  RVTEST_TESTDATA_LOAD_INT(x11, x13) # load rs2: x13 = 0x00000000fffffffe
+  RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0x00000000fffffffe
   addi sp, x6, -480  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe:
-  c.sdsp x13, 480(sp) # perform store
+  c.sdsp x14, 480(sp) # perform store
   LREG x18, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x18 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x18, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_sdsp_cg_cp_rs2_edges_0xfffffffe_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
-  RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0x0000000100000000
+  RVTEST_TESTDATA_LOAD_INT(x11, x15) # load rs2: x15 = 0x0000000100000000
   addi sp, x6, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x100000000:
-  c.sdsp x14, 240(sp) # perform store
+  c.sdsp x15, 240(sp) # perform store
   LREG x23, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_rs2_edges_0x100000000, Zca_c_sdsp_cg_cp_rs2_edges_0x100000000_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
-  RVTEST_TESTDATA_LOAD_INT(x11, x22) # load rs2: x22 = 0x0000000100000001
+  RVTEST_TESTDATA_LOAD_INT(x11, x23) # load rs2: x23 = 0x0000000100000001
   addi sp, x6, -280  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_rs2_edges_0x100000001:
-  c.sdsp x22, 280(sp) # perform store
+  c.sdsp x23, 280(sp) # perform store
   LREG x14, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -533,10 +533,10 @@ Zca_c_sdsp_cg_cp_rs2_edges_0x100000001:
 /////////////////////////////////
 
 # Testcase cp_imm_mul_8sp: imm=0
-  RVTEST_TESTDATA_LOAD_INT(x11, x29) # load rs2: x29 = 0xf3d86e9c8220235a
+  RVTEST_TESTDATA_LOAD_INT(x11, x30) # load rs2: x30 = 0xf3d86e9c8220235a
   addi sp, x6, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x0:
-  c.sdsp x29, 0(sp) # perform store
+  c.sdsp x30, 0(sp) # perform store
   LREG x22, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -553,170 +553,170 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8:
   RVTEST_SIGUPD(x6, x8, x7, x26, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x8_str)
 
 # Testcase cp_imm_mul_8sp: imm=16
-  RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0xe1b7fc19322c31c2
+  RVTEST_TESTDATA_LOAD_INT(x11, x10) # load rs2: x10 = 0x5b95a675fd10eacd
   addi sp, x6, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10:
-  c.sdsp x31, 16(sp) # perform store
-  LREG x12, 0(x6) # load stored value for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x12 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10_str)
-
-# Testcase cp_imm_mul_8sp: imm=24
-  RVTEST_TESTDATA_LOAD_INT(x11, x20) # load rs2: x20 = 0x22f38d7a63f41bf5
-  addi sp, x6, -24  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18:
-  c.sdsp x20, 24(sp) # perform store
-  LREG x18, 0(x6) # load stored value for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x18 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18_str)
-
-# Testcase cp_imm_mul_8sp: imm=32
-  RVTEST_TESTDATA_LOAD_INT(x11, x30) # load rs2: x30 = 0x2e327176756d4ebe
-  addi sp, x6, -32  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20:
-  c.sdsp x30, 32(sp) # perform store
-  LREG x31, 0(x6) # load stored value for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20_str)
-
-# Testcase cp_imm_mul_8sp: imm=40
-  RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0xfb0ca41c715a9eb6
-  addi sp, x6, -40  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28:
-  c.sdsp x9, 40(sp) # perform store
-  LREG x21, 0(x6) # load stored value for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x21 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x21, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28_str)
-
-# Testcase cp_imm_mul_8sp: imm=48
-  RVTEST_TESTDATA_LOAD_INT(x11, x25) # load rs2: x25 = 0xe3c5129528f9e5fd
-  addi sp, x6, -48  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30:
-  c.sdsp x25, 48(sp) # perform store
-  LREG x12, 0(x6) # load stored value for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x12 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30_str)
-
-# Testcase cp_imm_mul_8sp: imm=56
-  RVTEST_TESTDATA_LOAD_INT(x11, x13) # load rs2: x13 = 0x1585b3191e4e1db7
-  addi sp, x6, -56  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38:
-  c.sdsp x13, 56(sp) # perform store
-  LREG x29, 0(x6) # load stored value for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38_str)
-
-# Testcase cp_imm_mul_8sp: imm=64
-  RVTEST_TESTDATA_LOAD_INT(x11, x13) # load rs2: x13 = 0x42a631e63f18b79c
-  addi sp, x6, -64  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40:
-  c.sdsp x13, 64(sp) # perform store
-  LREG x24, 0(x6) # load stored value for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x24 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x24, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40_str)
-
-# Testcase cp_imm_mul_8sp: imm=72
-  RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0x148154ef0ad135b6
-  addi sp, x6, -72  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48:
-  c.sdsp x31, 72(sp) # perform store
-  LREG x4, 0(x6) # load stored value for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x4 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x4, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48_str)
-
-# Testcase cp_imm_mul_8sp: imm=80
-  RVTEST_TESTDATA_LOAD_INT(x11, x13) # load rs2: x13 = 0xbe119d7fa32143be
-  addi sp, x6, -80  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50:
-  c.sdsp x13, 80(sp) # perform store
-  LREG x18, 0(x6) # load stored value for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x18 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50_str)
-
-# Testcase cp_imm_mul_8sp: imm=88
-  RVTEST_TESTDATA_LOAD_INT(x11, x20) # load rs2: x20 = 0x96583c5a4cd19791
-  addi sp, x6, -88  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58:
-  c.sdsp x20, 88(sp) # perform store
-  LREG x9, 0(x6) # load stored value for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x9 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x9, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58_str)
-
-# Testcase cp_imm_mul_8sp: imm=96
-  RVTEST_TESTDATA_LOAD_INT(x11, x12) # load rs2: x12 = 0x5099acee99b9956b
-  addi sp, x6, -96  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60:
-  c.sdsp x12, 96(sp) # perform store
-  LREG x31, 0(x6) # load stored value for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60_str)
-
-# Testcase cp_imm_mul_8sp: imm=104
-  RVTEST_TESTDATA_LOAD_INT(x11, x26) # load rs2: x26 = 0xea20320fdd9b0669
-  addi sp, x6, -104  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68:
-  c.sdsp x26, 104(sp) # perform store
-  LREG x19, 0(x6) # load stored value for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x19 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x19, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68_str)
-
-# Testcase cp_imm_mul_8sp: imm=112
-  RVTEST_TESTDATA_LOAD_INT(x11, x28) # load rs2: x28 = 0x04cc8ebd088a04db
-  addi sp, x6, -112  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70:
-  c.sdsp x28, 112(sp) # perform store
+  c.sdsp x10, 16(sp) # perform store
   LREG x23, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70_str)
+  RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x10_str)
+
+# Testcase cp_imm_mul_8sp: imm=24
+  RVTEST_TESTDATA_LOAD_INT(x11, x17) # load rs2: x17 = 0xf3345acba2f38d7a
+  addi sp, x6, -24  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18:
+  c.sdsp x17, 24(sp) # perform store
+  LREG x5, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
+  # Check if x5 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x5, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x18_str)
+
+# Testcase cp_imm_mul_8sp: imm=32
+  RVTEST_TESTDATA_LOAD_INT(x11, x21) # load rs2: x21 = 0x44381886524504fd
+  addi sp, x6, -32  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20:
+  c.sdsp x21, 32(sp) # perform store
+  LREG x30, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
+  # Check if x30 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x20_str)
+
+# Testcase cp_imm_mul_8sp: imm=40
+  RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0xf15a9eb6c168dcc8
+  addi sp, x6, -40  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28:
+  c.sdsp x31, 40(sp) # perform store
+  LREG x20, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
+  # Check if x20 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x20, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x28_str)
+
+# Testcase cp_imm_mul_8sp: imm=48
+  RVTEST_TESTDATA_LOAD_INT(x11, x30) # load rs2: x30 = 0x2a8ee9c37777cd3f
+  addi sp, x6, -48  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30:
+  c.sdsp x30, 48(sp) # perform store
+  LREG x18, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
+  # Check if x18 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x30_str)
+
+# Testcase cp_imm_mul_8sp: imm=56
+  RVTEST_TESTDATA_LOAD_INT(x11, x0) # load rs2: x0 = 0x7a00915737e10357
+  addi sp, x6, -56  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38:
+  c.sdsp x0, 56(sp) # perform store
+  LREG x17, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
+  # Check if x17 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x17, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x38_str)
+
+# Testcase cp_imm_mul_8sp: imm=64
+  RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0x311f512377729429
+  addi sp, x6, -64  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40:
+  c.sdsp x14, 64(sp) # perform store
+  LREG x18, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
+  # Check if x18 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x40_str)
+
+# Testcase cp_imm_mul_8sp: imm=72
+  RVTEST_TESTDATA_LOAD_INT(x11, x25) # load rs2: x25 = 0x42a631e63f18b79c
+  addi sp, x6, -72  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48:
+  c.sdsp x25, 72(sp) # perform store
+  LREG x23, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
+  # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x48_str)
+
+# Testcase cp_imm_mul_8sp: imm=80
+  RVTEST_TESTDATA_LOAD_INT(x11, x17) # load rs2: x17 = 0x333c9b6b28a78fbb
+  addi sp, x6, -80  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50:
+  c.sdsp x17, 80(sp) # perform store
+  LREG x25, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
+  # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x25, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x50_str)
+
+# Testcase cp_imm_mul_8sp: imm=88
+  RVTEST_TESTDATA_LOAD_INT(x11, x13) # load rs2: x13 = 0x00f721f15b6ea0d3
+  addi sp, x6, -88  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58:
+  c.sdsp x13, 88(sp) # perform store
+  LREG x10, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
+  # Check if x10 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x58_str)
+
+# Testcase cp_imm_mul_8sp: imm=96
+  RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0x04aec7d5a41ca4bb
+  addi sp, x6, -96  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60:
+  c.sdsp x31, 96(sp) # perform store
+  LREG x4, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
+  # Check if x4 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x4, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x60_str)
+
+# Testcase cp_imm_mul_8sp: imm=104
+  RVTEST_TESTDATA_LOAD_INT(x11, x16) # load rs2: x16 = 0xc647867e2500cd3c
+  addi sp, x6, -104  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68:
+  c.sdsp x16, 104(sp) # perform store
+  LREG x28, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
+  # Check if x28 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x28, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x68_str)
+
+# Testcase cp_imm_mul_8sp: imm=112
+  RVTEST_TESTDATA_LOAD_INT(x11, x25) # load rs2: x25 = 0x5d9b066998e4bf86
+  addi sp, x6, -112  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70:
+  c.sdsp x25, 112(sp) # perform store
+  LREG x20, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
+  # Check if x20 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x20, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x70_str)
 
 # Testcase cp_imm_mul_8sp: imm=120
-  RVTEST_TESTDATA_LOAD_INT(x11, x0) # load rs2: x0 = 0x2e29e2f2b117c584
+  RVTEST_TESTDATA_LOAD_INT(x11, x18) # load rs2: x18 = 0x0eb58b177691c3e5
   addi sp, x6, -120  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78:
-  c.sdsp x0, 120(sp) # perform store
-  LREG x1, 0(x6) # load stored value for checking
+  c.sdsp x18, 120(sp) # perform store
+  LREG x29, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x1 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x1, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78_str)
+  # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x78_str)
 
 # Testcase cp_imm_mul_8sp: imm=128
-  RVTEST_TESTDATA_LOAD_INT(x11, x29) # load rs2: x29 = 0x9d3c740c0f2e82ea
+  RVTEST_TESTDATA_LOAD_INT(x11, x26) # load rs2: x26 = 0x9d3c740c0f2e82ea
   addi sp, x6, -128  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80:
-  c.sdsp x29, 128(sp) # perform store
+  c.sdsp x26, 128(sp) # perform store
   LREG x15, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x80_str)
 
 # Testcase cp_imm_mul_8sp: imm=136
-  RVTEST_TESTDATA_LOAD_INT(x11, x3) # load rs2: x3 = 0x579316aab65ce178
+  RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0x579316aab65ce178
   addi sp, x6, -136  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88:
-  c.sdsp x3, 136(sp) # perform store
+  c.sdsp x4, 136(sp) # perform store
   LREG x1, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x1 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x1, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x88_str)
 
 # Testcase cp_imm_mul_8sp: imm=144
-  RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0x5533b3b8e5199b49
+  RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0x5533b3b8e5199b49
   addi sp, x6, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x90:
-  c.sdsp x4, 144(sp) # perform store
+  c.sdsp x5, 144(sp) # perform store
   LREG x20, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x20 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -733,100 +733,100 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98:
   RVTEST_SIGUPD(x6, x8, x7, x22, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x98_str)
 
 # Testcase cp_imm_mul_8sp: imm=160
-  RVTEST_TESTDATA_LOAD_INT(x11, x17) # load rs2: x17 = 0x936367ad51b7f0d2
+  RVTEST_TESTDATA_LOAD_INT(x11, x18) # load rs2: x18 = 0x936367ad51b7f0d2
   addi sp, x6, -160  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0:
-  c.sdsp x17, 160(sp) # perform store
+  c.sdsp x18, 160(sp) # perform store
   LREG x4, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x4, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa0_str)
 
 # Testcase cp_imm_mul_8sp: imm=168
-  RVTEST_TESTDATA_LOAD_INT(x11, x23) # load rs2: x23 = 0x54becd06dfcea75b
+  RVTEST_TESTDATA_LOAD_INT(x11, x24) # load rs2: x24 = 0x54becd06dfcea75b
   addi sp, x6, -168  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8:
-  c.sdsp x23, 168(sp) # perform store
+  c.sdsp x24, 168(sp) # perform store
   LREG x9, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x9, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xa8_str)
 
 # Testcase cp_imm_mul_8sp: imm=176
-  RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0xc4c3dd45bffa094b
+  RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0xc4c3dd45bffa094b
   addi sp, x6, -176  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0:
-  c.sdsp x4, 176(sp) # perform store
+  c.sdsp x5, 176(sp) # perform store
   LREG x18, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x18 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x18, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb0_str)
 
 # Testcase cp_imm_mul_8sp: imm=184
-  RVTEST_TESTDATA_LOAD_INT(x11, x28) # load rs2: x28 = 0xaafafa333c526044
+  RVTEST_TESTDATA_LOAD_INT(x11, x29) # load rs2: x29 = 0xaafafa333c526044
   addi sp, x6, -184  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8:
-  c.sdsp x28, 184(sp) # perform store
+  c.sdsp x29, 184(sp) # perform store
   LREG x3, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x3, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xb8_str)
 
 # Testcase cp_imm_mul_8sp: imm=192
-  RVTEST_TESTDATA_LOAD_INT(x11, x28) # load rs2: x28 = 0xa2750e708238bbd2
+  RVTEST_TESTDATA_LOAD_INT(x11, x29) # load rs2: x29 = 0xa2750e708238bbd2
   addi sp, x6, -192  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0:
-  c.sdsp x28, 192(sp) # perform store
+  c.sdsp x29, 192(sp) # perform store
   LREG x31, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc0_str)
 
 # Testcase cp_imm_mul_8sp: imm=200
-  RVTEST_TESTDATA_LOAD_INT(x11, x3) # load rs2: x3 = 0x37d886f56ee2044a
+  RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0x37d886f56ee2044a
   addi sp, x6, -200  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8:
-  c.sdsp x3, 200(sp) # perform store
+  c.sdsp x4, 200(sp) # perform store
   LREG x14, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xc8_str)
 
 # Testcase cp_imm_mul_8sp: imm=208
-  RVTEST_TESTDATA_LOAD_INT(x11, x2) # load rs2: x2 = 0xdbfb793d1da20688
+  RVTEST_TESTDATA_LOAD_INT(x11, x3) # load rs2: x3 = 0xdbfb793d1da20688
   addi sp, x6, -208  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0:
-  c.sdsp x2, 208(sp) # perform store
-  LREG x15, 0(x6) # load stored value for checking
+  c.sdsp x3, 208(sp) # perform store
+  LREG x16, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0_str)
+  # Check if x16 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x16, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd0_str)
 
 # Testcase cp_imm_mul_8sp: imm=216
-  RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0x65bebc61e949888d
+  RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0x65bebc61e949888d
   addi sp, x6, -216  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8:
-  c.sdsp x4, 216(sp) # perform store
+  c.sdsp x5, 216(sp) # perform store
   LREG x25, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x25, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xd8_str)
 
 # Testcase cp_imm_mul_8sp: imm=224
-  RVTEST_TESTDATA_LOAD_INT(x11, x13) # load rs2: x13 = 0xd9fc207d018c7feb
+  RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0xd9fc207d018c7feb
   addi sp, x6, -224  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0:
-  c.sdsp x13, 224(sp) # perform store
-  LREG x14, 0(x6) # load stored value for checking
+  c.sdsp x14, 224(sp) # perform store
+  LREG x13, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x14 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x14, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0_str)
+  # Check if x13 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe0_str)
 
 # Testcase cp_imm_mul_8sp: imm=232
-  RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0xd20179d3f7b54a14
+  RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0xd20179d3f7b54a14
   addi sp, x6, -232  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xe8:
-  c.sdsp x4, 232(sp) # perform store
+  c.sdsp x5, 232(sp) # perform store
   LREG x3, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
@@ -843,334 +843,334 @@ Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0:
   RVTEST_SIGUPD(x6, x8, x7, x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf0_str)
 
 # Testcase cp_imm_mul_8sp: imm=248
-  RVTEST_TESTDATA_LOAD_INT(x11, x3) # load rs2: x3 = 0xa9857e9dc90ae2ab
+  RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0xa9857e9dc90ae2ab
   addi sp, x6, -248  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8:
-  c.sdsp x3, 248(sp) # perform store
+  c.sdsp x4, 248(sp) # perform store
   LREG x10, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x10 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x10, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0xf8_str)
 
 # Testcase cp_imm_mul_8sp: imm=256
-  RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0x5922a4a7f842cd06
+  RVTEST_TESTDATA_LOAD_INT(x11, x15) # load rs2: x15 = 0x5922a4a7f842cd06
   addi sp, x6, -256  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100:
-  c.sdsp x14, 256(sp) # perform store
+  c.sdsp x15, 256(sp) # perform store
   LREG x1, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x1 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x1, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x100_str)
 
 # Testcase cp_imm_mul_8sp: imm=264
-  RVTEST_TESTDATA_LOAD_INT(x11, x12) # load rs2: x12 = 0x9039b9b4a2c1310d
+  RVTEST_TESTDATA_LOAD_INT(x11, x13) # load rs2: x13 = 0x9039b9b4a2c1310d
   addi sp, x6, -264  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108:
-  c.sdsp x12, 264(sp) # perform store
+  c.sdsp x13, 264(sp) # perform store
   LREG x9, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x9, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x108_str)
 
 # Testcase cp_imm_mul_8sp: imm=272
-  RVTEST_TESTDATA_LOAD_INT(x11, x21) # load rs2: x21 = 0x510ccf70fe1d0e78
+  RVTEST_TESTDATA_LOAD_INT(x11, x22) # load rs2: x22 = 0x510ccf70fe1d0e78
   addi sp, x6, -272  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110:
-  c.sdsp x21, 272(sp) # perform store
+  c.sdsp x22, 272(sp) # perform store
   LREG x16, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x16 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x16, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x110_str)
 
 # Testcase cp_imm_mul_8sp: imm=280
-  RVTEST_TESTDATA_LOAD_INT(x11, x19) # load rs2: x19 = 0x3053ebc7a656231f
+  RVTEST_TESTDATA_LOAD_INT(x11, x20) # load rs2: x20 = 0x3053ebc7a656231f
   addi sp, x6, -280  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118:
-  c.sdsp x19, 280(sp) # perform store
+  c.sdsp x20, 280(sp) # perform store
   LREG x23, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x118_str)
 
 # Testcase cp_imm_mul_8sp: imm=288
-  RVTEST_TESTDATA_LOAD_INT(x11, x19) # load rs2: x19 = 0x7c1250bdd773b3b4
+  RVTEST_TESTDATA_LOAD_INT(x11, x20) # load rs2: x20 = 0x7c1250bdd773b3b4
   addi sp, x6, -288  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120:
-  c.sdsp x19, 288(sp) # perform store
+  c.sdsp x20, 288(sp) # perform store
   LREG x4, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x4, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x120_str)
 
 # Testcase cp_imm_mul_8sp: imm=296
-  RVTEST_TESTDATA_LOAD_INT(x11, x30) # load rs2: x30 = 0x6cc39520154c8834
+  RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0x6cc39520154c8834
   addi sp, x6, -296  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128:
-  c.sdsp x30, 296(sp) # perform store
+  c.sdsp x31, 296(sp) # perform store
   LREG x23, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x23, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x128_str)
 
 # Testcase cp_imm_mul_8sp: imm=304
-  RVTEST_TESTDATA_LOAD_INT(x11, x23) # load rs2: x23 = 0xb0c97748314be2d6
+  RVTEST_TESTDATA_LOAD_INT(x11, x24) # load rs2: x24 = 0xb0c97748314be2d6
   addi sp, x6, -304  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130:
-  c.sdsp x23, 304(sp) # perform store
+  c.sdsp x24, 304(sp) # perform store
   LREG x25, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x25, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x130_str)
 
 # Testcase cp_imm_mul_8sp: imm=312
-  RVTEST_TESTDATA_LOAD_INT(x11, x15) # load rs2: x15 = 0xde957692bbe7969e
+  RVTEST_TESTDATA_LOAD_INT(x11, x16) # load rs2: x16 = 0xde957692bbe7969e
   addi sp, x6, -312  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138:
-  c.sdsp x15, 312(sp) # perform store
+  c.sdsp x16, 312(sp) # perform store
   LREG x30, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x30 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x138_str)
 
 # Testcase cp_imm_mul_8sp: imm=320
-  RVTEST_TESTDATA_LOAD_INT(x11, x18) # load rs2: x18 = 0xd9921c6ddc4c533f
+  RVTEST_TESTDATA_LOAD_INT(x11, x19) # load rs2: x19 = 0xd9921c6ddc4c533f
   addi sp, x6, -320  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140:
-  c.sdsp x18, 320(sp) # perform store
+  c.sdsp x19, 320(sp) # perform store
   LREG x13, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x140_str)
 
 # Testcase cp_imm_mul_8sp: imm=328
-  RVTEST_TESTDATA_LOAD_INT(x11, x12) # load rs2: x12 = 0x569d184d5cb9fdcc
+  RVTEST_TESTDATA_LOAD_INT(x11, x13) # load rs2: x13 = 0x569d184d5cb9fdcc
   addi sp, x6, -328  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148:
-  c.sdsp x12, 328(sp) # perform store
+  c.sdsp x13, 328(sp) # perform store
   LREG x26, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x26, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x148_str)
 
 # Testcase cp_imm_mul_8sp: imm=336
-  RVTEST_TESTDATA_LOAD_INT(x11, x18) # load rs2: x18 = 0x6e9d7a6317eddacb
+  RVTEST_TESTDATA_LOAD_INT(x11, x19) # load rs2: x19 = 0x6e9d7a6317eddacb
   addi sp, x6, -336  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150:
-  c.sdsp x18, 336(sp) # perform store
+  c.sdsp x19, 336(sp) # perform store
   LREG x12, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x12 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x12, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x150_str)
 
 # Testcase cp_imm_mul_8sp: imm=344
-  RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0xe66b486193f2af0e
+  RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0xe66b486193f2af0e
   addi sp, x6, -344  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158:
-  c.sdsp x5, 344(sp) # perform store
+  c.sdsp x9, 344(sp) # perform store
   LREG x17, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x17 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x17, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x158_str)
 
 # Testcase cp_imm_mul_8sp: imm=352
-  RVTEST_TESTDATA_LOAD_INT(x11, x29) # load rs2: x29 = 0xbeb9843accce868d
+  RVTEST_TESTDATA_LOAD_INT(x11, x30) # load rs2: x30 = 0xbeb9843accce868d
   addi sp, x6, -352  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160:
-  c.sdsp x29, 352(sp) # perform store
+  c.sdsp x30, 352(sp) # perform store
   LREG x25, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x25, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x160_str)
 
 # Testcase cp_imm_mul_8sp: imm=360
-  RVTEST_TESTDATA_LOAD_INT(x11, x21) # load rs2: x21 = 0x39f2fbe1ae168133
+  RVTEST_TESTDATA_LOAD_INT(x11, x22) # load rs2: x22 = 0x39f2fbe1ae168133
   addi sp, x6, -360  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168:
-  c.sdsp x21, 360(sp) # perform store
+  c.sdsp x22, 360(sp) # perform store
   LREG x30, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x30 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x168_str)
 
 # Testcase cp_imm_mul_8sp: imm=368
-  RVTEST_TESTDATA_LOAD_INT(x11, x16) # load rs2: x16 = 0xb2bf245e6429acbb
+  RVTEST_TESTDATA_LOAD_INT(x11, x17) # load rs2: x17 = 0xb2bf245e6429acbb
   addi sp, x6, -368  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170:
-  c.sdsp x16, 368(sp) # perform store
+  c.sdsp x17, 368(sp) # perform store
   LREG x9, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x9, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x170_str)
 
 # Testcase cp_imm_mul_8sp: imm=376
-  RVTEST_TESTDATA_LOAD_INT(x11, x28) # load rs2: x28 = 0xefa48ec47be81dda
+  RVTEST_TESTDATA_LOAD_INT(x11, x29) # load rs2: x29 = 0xefa48ec47be81dda
   addi sp, x6, -376  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178:
-  c.sdsp x28, 376(sp) # perform store
+  c.sdsp x29, 376(sp) # perform store
   LREG x4, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x4 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x4, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x178_str)
 
 # Testcase cp_imm_mul_8sp: imm=384
-  RVTEST_TESTDATA_LOAD_INT(x11, x13) # load rs2: x13 = 0xe4b923143b16ad13
+  RVTEST_TESTDATA_LOAD_INT(x11, x14) # load rs2: x14 = 0xe4b923143b16ad13
   addi sp, x6, -384  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180:
-  c.sdsp x13, 384(sp) # perform store
+  c.sdsp x14, 384(sp) # perform store
   LREG x28, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x28, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x180_str)
 
 # Testcase cp_imm_mul_8sp: imm=392
-  RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0x93b38e5decf5e212
+  RVTEST_TESTDATA_LOAD_INT(x11, x10) # load rs2: x10 = 0x93b38e5decf5e212
   addi sp, x6, -392  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188:
-  c.sdsp x9, 392(sp) # perform store
+  c.sdsp x10, 392(sp) # perform store
   LREG x21, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x21, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x188_str)
 
 # Testcase cp_imm_mul_8sp: imm=400
-  RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0xc18a2ed77352f88e
+  RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0xc18a2ed77352f88e
   addi sp, x6, -400  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190:
-  c.sdsp x5, 400(sp) # perform store
+  c.sdsp x9, 400(sp) # perform store
   LREG x19, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x19, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x190_str)
 
 # Testcase cp_imm_mul_8sp: imm=408
-  RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0xfa1a9de47fd6e2dc
+  RVTEST_TESTDATA_LOAD_INT(x11, x5) # load rs2: x5 = 0xfa1a9de47fd6e2dc
   addi sp, x6, -408  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198:
-  c.sdsp x4, 408(sp) # perform store
+  c.sdsp x5, 408(sp) # perform store
   LREG x16, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x16 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x16, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x198_str)
 
 # Testcase cp_imm_mul_8sp: imm=416
-  RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0x2264cb8d638f1709
+  RVTEST_TESTDATA_LOAD_INT(x11, x10) # load rs2: x10 = 0x2264cb8d638f1709
   addi sp, x6, -416  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0:
-  c.sdsp x9, 416(sp) # perform store
+  c.sdsp x10, 416(sp) # perform store
   LREG x31, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x31, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a0_str)
 
 # Testcase cp_imm_mul_8sp: imm=424
-  RVTEST_TESTDATA_LOAD_INT(x11, x30) # load rs2: x30 = 0x40ec2a7f005e2c7f
+  RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0x40ec2a7f005e2c7f
   addi sp, x6, -424  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8:
-  c.sdsp x30, 424(sp) # perform store
+  c.sdsp x31, 424(sp) # perform store
   LREG x25, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x25, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1a8_str)
 
 # Testcase cp_imm_mul_8sp: imm=432
-  RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0xd59fb792e9382239
+  RVTEST_TESTDATA_LOAD_INT(x11, x10) # load rs2: x10 = 0xd59fb792e9382239
   addi sp, x6, -432  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0:
-  c.sdsp x9, 432(sp) # perform store
+  c.sdsp x10, 432(sp) # perform store
   LREG x27, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x27, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b0_str)
 
 # Testcase cp_imm_mul_8sp: imm=440
-  RVTEST_TESTDATA_LOAD_INT(x11, x16) # load rs2: x16 = 0x4b6d5b67caa4c348
+  RVTEST_TESTDATA_LOAD_INT(x11, x17) # load rs2: x17 = 0x4b6d5b67caa4c348
   addi sp, x6, -440  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8:
-  c.sdsp x16, 440(sp) # perform store
+  c.sdsp x17, 440(sp) # perform store
   LREG x29, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1b8_str)
 
 # Testcase cp_imm_mul_8sp: imm=448
-  RVTEST_TESTDATA_LOAD_INT(x11, x20) # load rs2: x20 = 0xd9a36e80b18412ee
+  RVTEST_TESTDATA_LOAD_INT(x11, x21) # load rs2: x21 = 0xd9a36e80b18412ee
   addi sp, x6, -448  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0:
-  c.sdsp x20, 448(sp) # perform store
+  c.sdsp x21, 448(sp) # perform store
   LREG x13, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x13 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x6, x8, x7, x13, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c0_str)
 
 # Testcase cp_imm_mul_8sp: imm=456
-  RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0xa99b23d29f38afe7
+  RVTEST_TESTDATA_LOAD_INT(x11, x24) # load rs2: x24 = 0x4d38fb1f8bd439a8
   addi sp, x6, -456  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8:
-  c.sdsp x31, 456(sp) # perform store
-  LREG x27, 0(x6) # load stored value for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x27 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x27, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8_str)
-
-# Testcase cp_imm_mul_8sp: imm=464
-  RVTEST_TESTDATA_LOAD_INT(x11, x21) # load rs2: x21 = 0xd883a246cd38fb1f
-  addi sp, x6, -464  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0:
-  c.sdsp x21, 464(sp) # perform store
-  LREG x19, 0(x6) # load stored value for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x19 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x19, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0_str)
-
-# Testcase cp_imm_mul_8sp: imm=472
-  RVTEST_TESTDATA_LOAD_INT(x11, x20) # load rs2: x20 = 0x2863ec8f0a9eaf38
-  addi sp, x6, -472  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8:
-  c.sdsp x20, 472(sp) # perform store
-  LREG x27, 0(x6) # load stored value for checking
-  addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x27 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x27, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8_str)
-
-# Testcase cp_imm_mul_8sp: imm=480
-  RVTEST_TESTDATA_LOAD_INT(x11, x27) # load rs2: x27 = 0xbe9f8d619688a066
-  addi sp, x6, -480  # copy sig_reg to sp and adjust for offset
-Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0:
-  c.sdsp x27, 480(sp) # perform store
+  c.sdsp x24, 456(sp) # perform store
   LREG x15, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0_str)
+  RVTEST_SIGUPD(x6, x8, x7, x15, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1c8_str)
+
+# Testcase cp_imm_mul_8sp: imm=464
+  RVTEST_TESTDATA_LOAD_INT(x11, x18) # load rs2: x18 = 0x4843cfefb8627336
+  addi sp, x6, -464  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0:
+  c.sdsp x18, 464(sp) # perform store
+  LREG x27, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
+  # Check if x27 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x27, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d0_str)
+
+# Testcase cp_imm_mul_8sp: imm=472
+  RVTEST_TESTDATA_LOAD_INT(x11, x25) # load rs2: x25 = 0x52d08efc52ffdf73
+  addi sp, x6, -472  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8:
+  c.sdsp x25, 472(sp) # perform store
+  LREG x9, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
+  # Check if x9 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x9, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1d8_str)
+
+# Testcase cp_imm_mul_8sp: imm=480
+  RVTEST_TESTDATA_LOAD_INT(x11, x23) # load rs2: x23 = 0xe41a120a3e9f8d61
+  addi sp, x6, -480  # copy sig_reg to sp and adjust for offset
+Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0:
+  c.sdsp x23, 480(sp) # perform store
+  LREG x9, 0(x6) # load stored value for checking
+  addi x6, x6, SIG_STRIDE # increment signature pointer
+  # Check if x9 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x9, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e0_str)
 
 # Testcase cp_imm_mul_8sp: imm=488
-  RVTEST_TESTDATA_LOAD_INT(x11, x4) # load rs2: x4 = 0xe46fe00895d55ff0
+  RVTEST_TESTDATA_LOAD_INT(x11, x9) # load rs2: x9 = 0x267c2ac16b65c89b
   addi sp, x6, -488  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8:
-  c.sdsp x4, 488(sp) # perform store
-  LREG x29, 0(x6) # load stored value for checking
+  c.sdsp x9, 488(sp) # perform store
+  LREG x16, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8_str)
+  # Check if x16 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x16, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1e8_str)
 
 # Testcase cp_imm_mul_8sp: imm=496
-  RVTEST_TESTDATA_LOAD_INT(x11, x2) # load rs2: x2 = 0xf00713851a5400bb
+  RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0xe46fe00895d55ff0
   addi sp, x6, -496  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0:
-  c.sdsp x2, 496(sp) # perform store
-  LREG x29, 0(x6) # load stored value for checking
+  c.sdsp x31, 496(sp) # perform store
+  LREG x28, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x29 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x29, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0_str)
+  # Check if x28 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x28, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f0_str)
 
 # Testcase cp_imm_mul_8sp: imm=504
-  RVTEST_TESTDATA_LOAD_INT(x11, x31) # load rs2: x31 = 0x661a0547f97f9aa4
+  RVTEST_TESTDATA_LOAD_INT(x11, x3) # load rs2: x3 = 0xf00713851a5400bb
   addi sp, x6, -504  # copy sig_reg to sp and adjust for offset
 Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8:
-  c.sdsp x31, 504(sp) # perform store
-  LREG x25, 0(x6) # load stored value for checking
+  c.sdsp x3, 504(sp) # perform store
+  LREG x30, 0(x6) # load stored value for checking
   addi x6, x6, SIG_STRIDE # increment signature pointer
-  # Check if x25 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x6, x8, x7, x25, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8_str)
+  # Check if x30 contains the expected result. x6 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x6, x8, x7, x30, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8, Zca_c_sdsp_cg_cp_imm_mul_8sp_b0x1f8_str)
 
   mv x2, x6 # restore signature pointer to default register for teardown
 
@@ -1231,20 +1231,20 @@ RVTEST_DATA_BEGIN
 .dword 0x0000000100000001
 .dword 0xf3d86e9c8220235a
 .dword 0xe39a83545d97493f
-.dword 0xe1b7fc19322c31c2
-.dword 0x22f38d7a63f41bf5
-.dword 0x2e327176756d4ebe
-.dword 0xfb0ca41c715a9eb6
-.dword 0xe3c5129528f9e5fd
-.dword 0x1585b3191e4e1db7
+.dword 0x5b95a675fd10eacd
+.dword 0xf3345acba2f38d7a
+.dword 0x44381886524504fd
+.dword 0xf15a9eb6c168dcc8
+.dword 0x2a8ee9c37777cd3f
+.dword 0x7a00915737e10357
+.dword 0x311f512377729429
 .dword 0x42a631e63f18b79c
-.dword 0x148154ef0ad135b6
-.dword 0xbe119d7fa32143be
-.dword 0x96583c5a4cd19791
-.dword 0x5099acee99b9956b
-.dword 0xea20320fdd9b0669
-.dword 0x04cc8ebd088a04db
-.dword 0x2e29e2f2b117c584
+.dword 0x333c9b6b28a78fbb
+.dword 0x00f721f15b6ea0d3
+.dword 0x04aec7d5a41ca4bb
+.dword 0xc647867e2500cd3c
+.dword 0x5d9b066998e4bf86
+.dword 0x0eb58b177691c3e5
 .dword 0x9d3c740c0f2e82ea
 .dword 0x579316aab65ce178
 .dword 0x5533b3b8e5199b49
@@ -1286,13 +1286,13 @@ RVTEST_DATA_BEGIN
 .dword 0xd59fb792e9382239
 .dword 0x4b6d5b67caa4c348
 .dword 0xd9a36e80b18412ee
-.dword 0xa99b23d29f38afe7
-.dword 0xd883a246cd38fb1f
-.dword 0x2863ec8f0a9eaf38
-.dword 0xbe9f8d619688a066
+.dword 0x4d38fb1f8bd439a8
+.dword 0x4843cfefb8627336
+.dword 0x52d08efc52ffdf73
+.dword 0xe41a120a3e9f8d61
+.dword 0x267c2ac16b65c89b
 .dword 0xe46fe00895d55ff0
 .dword 0xf00713851a5400bb
-.dword 0x661a0547f97f9aa4
 
 // Testcase strings
 Zca_c_sdsp_cg_cp_rs2_b0_str: .string "\"test: 1; cg: Zca_c.sdsp_cg; cp: cp_rs2; bin: b0\""

--- a/tests/rv64i/Zca/Zca-c.swsp-00.S
+++ b/tests/rv64i/Zca/Zca-c.swsp-00.S
@@ -366,160 +366,160 @@ Zca_c_swsp_cg_cp_rs2_b31:
 /////////////////////////////////
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000000)
-  RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x0000000000000000
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x0000000000000000
   addi sp, x11, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x0:
-  c.swsp x9, 16(sp) # perform store
+  c.swsp x10, 16(sp) # perform store
   LREG x6, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_swsp_cg_cp_rs2_edges_0x0, Zca_c_swsp_cg_cp_rs2_edges_0x0_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000001)
-  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x0000000000000001
+  RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0x0000000000000001
   addi sp, x11, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x1:
-  c.swsp x23, 144(sp) # perform store
+  c.swsp x24, 144(sp) # perform store
   LREG x19, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_edges_0x1, Zca_c_swsp_cg_cp_rs2_edges_0x1_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000000000002)
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x0000000000000002
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x0000000000000002
   addi sp, x11, -44  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x2:
-  c.swsp x12, 44(sp) # perform store
+  c.swsp x13, 44(sp) # perform store
   LREG x20, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x20 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x20, Zca_c_swsp_cg_cp_rs2_edges_0x2, Zca_c_swsp_cg_cp_rs2_edges_0x2_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000000)
-  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x8000000000000000
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x8000000000000000
   addi sp, x11, -112  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000:
-  c.swsp x25, 112(sp) # perform store
+  c.swsp x26, 112(sp) # perform store
   LREG x27, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000000_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x8000000000000001)
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x8000000000000001
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x8000000000000001
   addi sp, x11, -212  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001:
-  c.swsp x12, 212(sp) # perform store
+  c.swsp x13, 212(sp) # perform store
   LREG x26, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001, Zca_c_swsp_cg_cp_rs2_edges_0x8000000000000001_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7fffffffffffffff)
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x7fffffffffffffff
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x7fffffffffffffff
   addi sp, x11, -28  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff:
-  c.swsp x13, 28(sp) # perform store
+  c.swsp x14, 28(sp) # perform store
   LREG x16, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff, Zca_c_swsp_cg_cp_rs2_edges_0x7fffffffffffffff_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x7ffffffffffffffe)
-  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x7ffffffffffffffe
+  RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0x7ffffffffffffffe
   addi sp, x11, -240  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe:
-  c.swsp x23, 240(sp) # perform store
+  c.swsp x24, 240(sp) # perform store
   LREG x6, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe, Zca_c_swsp_cg_cp_rs2_edges_0x7ffffffffffffffe_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xffffffffffffffff)
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xffffffffffffffff
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xffffffffffffffff
   addi sp, x11, -128  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff:
-  c.swsp x12, 128(sp) # perform store
+  c.swsp x13, 128(sp) # perform store
   LREG x21, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x21 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x21, Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffffffffffff_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xfffffffffffffffe)
-  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0xfffffffffffffffe
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0xfffffffffffffffe
   addi sp, x11, -144  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe:
-  c.swsp x20, 144(sp) # perform store
+  c.swsp x21, 144(sp) # perform store
   LREG x28, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffffffffffe_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5bbc887763ae86f2)
-  RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x5bbc887763ae86f2
+  RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x5bbc887763ae86f2
   addi sp, x11, -196  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2:
-  c.swsp x29, 196(sp) # perform store
+  c.swsp x30, 196(sp) # perform store
   LREG x26, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2, Zca_c_swsp_cg_cp_rs2_edges_0x5bbc887763ae86f2_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0xaaaaaaaaaaaaaaaa)
-  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0xaaaaaaaaaaaaaaaa
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0xaaaaaaaaaaaaaaaa
   addi sp, x11, -172  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa:
-  c.swsp x20, 172(sp) # perform store
+  c.swsp x21, 172(sp) # perform store
   LREG x23, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x23, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa, Zca_c_swsp_cg_cp_rs2_edges_0xaaaaaaaaaaaaaaaa_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x5555555555555555)
-  RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0x5555555555555555
+  RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rs2: x18 = 0x5555555555555555
   addi sp, x11, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555:
-  c.swsp x17, 32(sp) # perform store
+  c.swsp x18, 32(sp) # perform store
   LREG x19, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x19 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x19, Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555, Zca_c_swsp_cg_cp_rs2_edges_0x5555555555555555_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000ffffffff)
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x00000000ffffffff
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x00000000ffffffff
   addi sp, x11, -196  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xffffffff:
-  c.swsp x12, 196(sp) # perform store
+  c.swsp x13, 196(sp) # perform store
   LREG x7, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff, Zca_c_swsp_cg_cp_rs2_edges_0xffffffff_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x00000000fffffffe)
-  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x00000000fffffffe
+  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0x00000000fffffffe
   addi sp, x11, -228  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe:
-  c.swsp x21, 228(sp) # perform store
+  c.swsp x22, 228(sp) # perform store
   LREG x24, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe, Zca_c_swsp_cg_cp_rs2_edges_0xfffffffe_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000000)
-  RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x0000000100000000
+  RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0x0000000100000000
   addi sp, x11, -12  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x100000000:
-  c.swsp x16, 12(sp) # perform store
+  c.swsp x17, 12(sp) # perform store
   LREG x27, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_swsp_cg_cp_rs2_edges_0x100000000, Zca_c_swsp_cg_cp_rs2_edges_0x100000000_str)
 
 # Testcase cp_rs2_edges (Test source rs2 value = 0x0000000100000001)
-  RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0x0000000100000001
+  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x0000000100000001
   addi sp, x11, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_rs2_edges_0x100000001:
-  c.swsp x19, 32(sp) # perform store
+  c.swsp x20, 32(sp) # perform store
   LREG x9, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
@@ -530,644 +530,644 @@ Zca_c_swsp_cg_cp_rs2_edges_0x100000001:
 /////////////////////////////////
 
 # Testcase cp_imm_mul_4sp: imm=0
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xbf910318653dabd8
+  RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0xbf910318653dabd8
   addi sp, x11, 0  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0:
-  c.swsp x15, 0(sp) # perform store
+  c.swsp x16, 0(sp) # perform store
   LREG x18, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x18 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x0_str)
 
 # Testcase cp_imm_mul_4sp: imm=4
-  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xce44699c438312ff
+  RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0xce44699c438312ff
   addi sp, x11, -4  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4:
-  c.swsp x8, 4(sp) # perform store
+  c.swsp x9, 4(sp) # perform store
   LREG x26, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4_str)
 
 # Testcase cp_imm_mul_4sp: imm=8
-  RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xbe081e73ad1eb060
+  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xbe081e73ad1eb060
   addi sp, x11, -8  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8:
-  c.swsp x7, 8(sp) # perform store
+  c.swsp x8, 8(sp) # perform store
   LREG x30, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x30 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8_str)
 
 # Testcase cp_imm_mul_4sp: imm=12
-  RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x6b21e26621cd47bd
+  RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x6b21e26621cd47bd
   addi sp, x11, -12  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc:
-  c.swsp x29, 12(sp) # perform store
+  c.swsp x30, 12(sp) # perform store
   LREG x20, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x20 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc_str)
 
 # Testcase cp_imm_mul_4sp: imm=16
-  RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x68bd767c1ef803ee
+  RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0x68bd767c1ef803ee
   addi sp, x11, -16  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10:
-  c.swsp x16, 16(sp) # perform store
+  c.swsp x17, 16(sp) # perform store
   LREG x3, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x3 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x10_str)
 
 # Testcase cp_imm_mul_4sp: imm=20
-  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x09a836698e0b9668
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x09a836698e0b9668
   addi sp, x11, -20  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14:
-  c.swsp x25, 20(sp) # perform store
+  c.swsp x26, 20(sp) # perform store
   LREG x7, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x14_str)
 
 # Testcase cp_imm_mul_4sp: imm=24
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xf7c9a3078d2115c3
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xf7c9a3078d2115c3
   addi sp, x11, -24  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18:
-  c.swsp x3, 24(sp) # perform store
+  c.swsp x6, 24(sp) # perform store
   LREG x22, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x18_str)
 
 # Testcase cp_imm_mul_4sp: imm=28
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x2dc2d097d9b73684
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x2dc2d097d9b73684
   addi sp, x11, -28  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c:
-  c.swsp x12, 28(sp) # perform store
+  c.swsp x13, 28(sp) # perform store
   LREG x8, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x1c_str)
 
 # Testcase cp_imm_mul_4sp: imm=32
-  RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x45c79713e475d3b4
+  RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0x45c79713e475d3b4
   addi sp, x11, -32  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20:
-  c.swsp x16, 32(sp) # perform store
+  c.swsp x17, 32(sp) # perform store
   LREG x26, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x20_str)
 
 # Testcase cp_imm_mul_4sp: imm=36
-  RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x926d86de825588f2
+  RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x926d86de825588f2
   addi sp, x11, -36  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24:
-  c.swsp x27, 36(sp) # perform store
+  c.swsp x28, 36(sp) # perform store
   LREG x15, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x24_str)
 
 # Testcase cp_imm_mul_4sp: imm=40
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xbcc0102f318ad02d
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xbcc0102f318ad02d
   addi sp, x11, -40  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28:
-  c.swsp x14, 40(sp) # perform store
+  c.swsp x15, 40(sp) # perform store
   LREG x28, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x28_str)
 
 # Testcase cp_imm_mul_4sp: imm=44
-  RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x419d87b97e3eb16c
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x419d87b97e3eb16c
   addi sp, x11, -44  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c:
-  c.swsp x9, 44(sp) # perform store
+  c.swsp x10, 44(sp) # perform store
   LREG x23, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x23 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x2c_str)
 
 # Testcase cp_imm_mul_4sp: imm=48
-  RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0xdf3eea06bccafcad
+  RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0xdf3eea06bccafcad
   addi sp, x11, -48  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30:
-  c.swsp x28, 48(sp) # perform store
+  c.swsp x29, 48(sp) # perform store
   LREG x6, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x30_str)
 
 # Testcase cp_imm_mul_4sp: imm=52
-  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x2db624b0b45b2c8b
+  RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x2db624b0b45b2c8b
   addi sp, x11, -52  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34:
-  c.swsp x26, 52(sp) # perform store
+  c.swsp x27, 52(sp) # perform store
   LREG x14, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x34_str)
 
 # Testcase cp_imm_mul_4sp: imm=56
-  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x688d523781f6d56d
+  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0x688d523781f6d56d
   addi sp, x11, -56  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38:
-  c.swsp x21, 56(sp) # perform store
+  c.swsp x22, 56(sp) # perform store
   LREG x8, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x38_str)
 
 # Testcase cp_imm_mul_4sp: imm=60
-  RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x80dc5f589b13aa7d
+  RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x80dc5f589b13aa7d
   addi sp, x11, -60  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c:
-  c.swsp x27, 60(sp) # perform store
+  c.swsp x28, 60(sp) # perform store
   LREG x30, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x30 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x3c_str)
 
 # Testcase cp_imm_mul_4sp: imm=64
-  RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xb7a2726dc175b476
+  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0xb7a2726dc175b476
   addi sp, x11, -64  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40:
-  c.swsp x2, 64(sp) # perform store
-  LREG x21, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x21 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40_str)
-
-# Testcase cp_imm_mul_4sp: imm=68
-  RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x007aeb44a84065b0
-  addi sp, x11, -68  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
-  c.swsp x31, 68(sp) # perform store
-  LREG x23, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x23 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44_str)
-
-# Testcase cp_imm_mul_4sp: imm=72
-  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0xbfcd51149a9509f6
-  addi sp, x11, -72  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
-  c.swsp x20, 72(sp) # perform store
-  LREG x7, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48_str)
-
-# Testcase cp_imm_mul_4sp: imm=76
-  RVTEST_TESTDATA_LOAD_INT(x1, x2) # load rs2: x2 = 0xfc4e095f418c3264
-  addi sp, x11, -76  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
-  c.swsp x2, 76(sp) # perform store
-  LREG x16, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c_str)
-
-# Testcase cp_imm_mul_4sp: imm=80
-  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x823bf5eb1f15dcb8
-  addi sp, x11, -80  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
-  c.swsp x0, 80(sp) # perform store
-  LREG x21, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x21 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x21, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50_str)
-
-# Testcase cp_imm_mul_4sp: imm=84
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xb5b23d03a5bff6fb
-  addi sp, x11, -84  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
-  c.swsp x10, 84(sp) # perform store
-  LREG x28, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54_str)
-
-# Testcase cp_imm_mul_4sp: imm=88
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x12be5c00004a3fed
-  addi sp, x11, -88  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
-  c.swsp x12, 88(sp) # perform store
-  LREG x26, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58_str)
-
-# Testcase cp_imm_mul_4sp: imm=92
-  RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x408148003ab1aa06
-  addi sp, x11, -92  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
-  c.swsp x9, 92(sp) # perform store
-  LREG x15, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c_str)
-
-# Testcase cp_imm_mul_4sp: imm=96
-  RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0xfd7e6a452e04c112
-  addi sp, x11, -96  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
-  c.swsp x24, 96(sp) # perform store
-  LREG x25, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x25 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x25, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60_str)
-
-# Testcase cp_imm_mul_4sp: imm=100
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xaf6fdcc0de38ff0e
-  addi sp, x11, -100  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
-  c.swsp x13, 100(sp) # perform store
-  LREG x14, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64_str)
-
-# Testcase cp_imm_mul_4sp: imm=104
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x81c761661b99e043
-  addi sp, x11, -104  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
-  c.swsp x3, 104(sp) # perform store
-  LREG x28, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68_str)
-
-# Testcase cp_imm_mul_4sp: imm=108
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x0c1f86852445601b
-  addi sp, x11, -108  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
-  c.swsp x3, 108(sp) # perform store
-  LREG x9, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c_str)
-
-# Testcase cp_imm_mul_4sp: imm=112
-  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x9f2e744b3e6fd0d3
-  addi sp, x11, -112  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
-  c.swsp x20, 112(sp) # perform store
-  LREG x15, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70_str)
-
-# Testcase cp_imm_mul_4sp: imm=116
-  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0xc76e4eac8b5a9947
-  addi sp, x11, -116  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
-  c.swsp x26, 116(sp) # perform store
-  LREG x7, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74_str)
-
-# Testcase cp_imm_mul_4sp: imm=120
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xa5fdc85bc94a6e3a
-  addi sp, x11, -120  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
-  c.swsp x13, 120(sp) # perform store
-  LREG x8, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78_str)
-
-# Testcase cp_imm_mul_4sp: imm=124
-  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0xec4e4dbb72f89694
-  addi sp, x11, -124  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
-  c.swsp x25, 124(sp) # perform store
-  LREG x17, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x17 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x17, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c_str)
-
-# Testcase cp_imm_mul_4sp: imm=128
-  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0xfe63f0d7c5845e44
-  addi sp, x11, -128  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
-  c.swsp x10, 128(sp) # perform store
+  c.swsp x3, 64(sp) # perform store
   LREG x22, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80_str)
+  RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x40_str)
+
+# Testcase cp_imm_mul_4sp: imm=68
+  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x2ef80023d7f2dc92
+  addi sp, x11, -68  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44:
+  c.swsp x25, 68(sp) # perform store
+  LREG x30, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x30 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x44_str)
+
+# Testcase cp_imm_mul_4sp: imm=72
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x1a9509f68513dcf1
+  addi sp, x11, -72  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48:
+  c.swsp x26, 72(sp) # perform store
+  LREG x10, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x10 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x10, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x48_str)
+
+# Testcase cp_imm_mul_4sp: imm=76
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xc18c3264dcc27e4f
+  addi sp, x11, -76  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c:
+  c.swsp x6, 76(sp) # perform store
+  LREG x3, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x3 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x4c_str)
+
+# Testcase cp_imm_mul_4sp: imm=80
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x8d1f80d2887a85ad
+  addi sp, x11, -80  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50:
+  c.swsp x15, 80(sp) # perform store
+  LREG x24, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x50_str)
+
+# Testcase cp_imm_mul_4sp: imm=84
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x5db7f1313025852f
+  addi sp, x11, -84  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54:
+  c.swsp x21, 84(sp) # perform store
+  LREG x3, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x3 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x54_str)
+
+# Testcase cp_imm_mul_4sp: imm=88
+  RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rs2: x18 = 0x7e22c6d5dad9c9b3
+  addi sp, x11, -88  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58:
+  c.swsp x18, 88(sp) # perform store
+  LREG x20, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x20 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x58_str)
+
+# Testcase cp_imm_mul_4sp: imm=92
+  RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x12be5c00004a3fed
+  addi sp, x11, -92  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c:
+  c.swsp x31, 92(sp) # perform store
+  LREG x25, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x25 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x25, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x5c_str)
+
+# Testcase cp_imm_mul_4sp: imm=96
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x408148003ab1aa06
+  addi sp, x11, -96  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60:
+  c.swsp x10, 96(sp) # perform store
+  LREG x15, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x60_str)
+
+# Testcase cp_imm_mul_4sp: imm=100
+  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0xfd7e6a452e04c112
+  addi sp, x11, -100  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64:
+  c.swsp x25, 100(sp) # perform store
+  LREG x24, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x64_str)
+
+# Testcase cp_imm_mul_4sp: imm=104
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xaf6fdcc0de38ff0e
+  addi sp, x11, -104  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68:
+  c.swsp x14, 104(sp) # perform store
+  LREG x13, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x13 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x13, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x68_str)
+
+# Testcase cp_imm_mul_4sp: imm=108
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x81c761661b99e043
+  addi sp, x11, -108  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c:
+  c.swsp x6, 108(sp) # perform store
+  LREG x28, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x28 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x28, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x6c_str)
+
+# Testcase cp_imm_mul_4sp: imm=112
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x0c1f86852445601b
+  addi sp, x11, -112  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70:
+  c.swsp x6, 112(sp) # perform store
+  LREG x9, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x70_str)
+
+# Testcase cp_imm_mul_4sp: imm=116
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x9f2e744b3e6fd0d3
+  addi sp, x11, -116  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74:
+  c.swsp x21, 116(sp) # perform store
+  LREG x15, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x74_str)
+
+# Testcase cp_imm_mul_4sp: imm=120
+  RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0xc76e4eac8b5a9947
+  addi sp, x11, -120  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78:
+  c.swsp x27, 120(sp) # perform store
+  LREG x7, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x78_str)
+
+# Testcase cp_imm_mul_4sp: imm=124
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xa5fdc85bc94a6e3a
+  addi sp, x11, -124  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c:
+  c.swsp x14, 124(sp) # perform store
+  LREG x8, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x8 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x7c_str)
+
+# Testcase cp_imm_mul_4sp: imm=128
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0xec4e4dbb72f89694
+  addi sp, x11, -128  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80:
+  c.swsp x26, 128(sp) # perform store
+  LREG x17, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x17 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x17, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x80_str)
 
 # Testcase cp_imm_mul_4sp: imm=132
-  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x350cf49aa81afa8d
+  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xfe63f0d7c5845e44
   addi sp, x11, -132  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84:
-  c.swsp x3, 132(sp) # perform store
-  LREG x31, 0(x11) # load stored value for checking
+  c.swsp x12, 132(sp) # perform store
+  LREG x22, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x31 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84_str)
+  # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x84_str)
 
 # Testcase cp_imm_mul_4sp: imm=136
-  RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x3dd4f2173af5f404
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x350cf49aa81afa8d
   addi sp, x11, -136  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88:
-  c.swsp x29, 136(sp) # perform store
+  c.swsp x6, 136(sp) # perform store
   LREG x31, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x88_str)
 
 # Testcase cp_imm_mul_4sp: imm=140
-  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x1403baf187eef96a
+  RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x3dd4f2173af5f404
   addi sp, x11, -140  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c:
-  c.swsp x23, 140(sp) # perform store
+  c.swsp x30, 140(sp) # perform store
+  LREG x31, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x31 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c_str)
+
+# Testcase cp_imm_mul_4sp: imm=144
+  RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0x1403baf187eef96a
+  addi sp, x11, -144  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
+  c.swsp x24, 144(sp) # perform store
   LREG x26, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x8c_str)
+  RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90_str)
 
-# Testcase cp_imm_mul_4sp: imm=144
-  RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x1a38a42b877ef27e
-  addi sp, x11, -144  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90:
-  c.swsp x27, 144(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=148
+  RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x1a38a42b877ef27e
+  addi sp, x11, -148  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
+  c.swsp x28, 148(sp) # perform store
   LREG x29, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x90_str)
+  RVTEST_SIGUPD(x11, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94_str)
 
-# Testcase cp_imm_mul_4sp: imm=148
-  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xf4ac6d36d084e406
-  addi sp, x11, -148  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94:
-  c.swsp x8, 148(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=152
+  RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0xf4ac6d36d084e406
+  addi sp, x11, -152  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
+  c.swsp x9, 152(sp) # perform store
   LREG x25, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x25 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x25, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x94_str)
-
-# Testcase cp_imm_mul_4sp: imm=152
-  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x7bc268c2a7be4141
-  addi sp, x11, -152  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98:
-  c.swsp x25, 152(sp) # perform store
-  LREG x15, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98_str)
+  RVTEST_SIGUPD(x11, x5, x4, x25, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x98_str)
 
 # Testcase cp_imm_mul_4sp: imm=156
-  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x4c5429651a4f0a20
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x7bc268c2a7be4141
   addi sp, x11, -156  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c:
-  c.swsp x0, 156(sp) # perform store
+  c.swsp x26, 156(sp) # perform store
   LREG x15, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c, Zca_c_swsp_cg_cp_imm_mul_4sp_b0x9c_str)
 
 # Testcase cp_imm_mul_4sp: imm=160
-  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x1e17df6a3a92f564
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x4c5429651a4f0a20
   addi sp, x11, -160  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0:
-  c.swsp x20, 160(sp) # perform store
+  c.swsp x0, 160(sp) # perform store
   LREG x15, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa0_str)
 
 # Testcase cp_imm_mul_4sp: imm=164
-  RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0xdbdc8cbc4611b086
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x1e17df6a3a92f564
   addi sp, x11, -164  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4:
-  c.swsp x30, 164(sp) # perform store
+  c.swsp x21, 164(sp) # perform store
+  LREG x15, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4_str)
+
+# Testcase cp_imm_mul_4sp: imm=168
+  RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0xdbdc8cbc4611b086
+  addi sp, x11, -168  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
+  c.swsp x31, 168(sp) # perform store
   LREG x22, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa4_str)
+  RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8_str)
 
-# Testcase cp_imm_mul_4sp: imm=168
-  RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x14f57c1e7730ae14
-  addi sp, x11, -168  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8:
-  c.swsp x9, 168(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=172
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x14f57c1e7730ae14
+  addi sp, x11, -172  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
+  c.swsp x10, 172(sp) # perform store
   LREG x24, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xa8_str)
+  RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac_str)
 
-# Testcase cp_imm_mul_4sp: imm=172
-  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x95b90a8d4ccf5ac6
-  addi sp, x11, -172  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac:
-  c.swsp x23, 172(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=176
+  RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0x95b90a8d4ccf5ac6
+  addi sp, x11, -176  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
+  c.swsp x24, 176(sp) # perform store
   LREG x27, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xac_str)
+  RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0_str)
 
-# Testcase cp_imm_mul_4sp: imm=176
-  RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x0a25908fa6593dcc
-  addi sp, x11, -176  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0:
-  c.swsp x7, 176(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=180
+  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x0a25908fa6593dcc
+  addi sp, x11, -180  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
+  c.swsp x8, 180(sp) # perform store
   LREG x30, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x30 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb0_str)
+  RVTEST_SIGUPD(x11, x5, x4, x30, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4_str)
 
-# Testcase cp_imm_mul_4sp: imm=180
-  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0xb80c8b139f02dfca
-  addi sp, x11, -180  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4:
-  c.swsp x22, 180(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=184
+  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0xb80c8b139f02dfca
+  addi sp, x11, -184  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
+  c.swsp x23, 184(sp) # perform store
   LREG x7, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb4_str)
+  RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8_str)
 
-# Testcase cp_imm_mul_4sp: imm=184
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x96b5673af5cd4ac4
-  addi sp, x11, -184  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8:
-  c.swsp x15, 184(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=188
+  RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x96b5673af5cd4ac4
+  addi sp, x11, -188  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
+  c.swsp x16, 188(sp) # perform store
   LREG x6, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x6 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xb8_str)
+  RVTEST_SIGUPD(x11, x5, x4, x6, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc_str)
 
-# Testcase cp_imm_mul_4sp: imm=188
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xb44a4f10b81f94c9
-  addi sp, x11, -188  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc:
-  c.swsp x14, 188(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=192
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xb44a4f10b81f94c9
+  addi sp, x11, -192  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
+  c.swsp x15, 192(sp) # perform store
   LREG x31, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x31 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xbc_str)
+  RVTEST_SIGUPD(x11, x5, x4, x31, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0_str)
 
-# Testcase cp_imm_mul_4sp: imm=192
-  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x6e70fb89a7f55807
-  addi sp, x11, -192  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0:
-  c.swsp x14, 192(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=196
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x6e70fb89a7f55807
+  addi sp, x11, -196  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
+  c.swsp x15, 196(sp) # perform store
   LREG x7, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc0_str)
+  RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4_str)
 
-# Testcase cp_imm_mul_4sp: imm=196
-  RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rs2: x18 = 0x0668109ea5789853
-  addi sp, x11, -196  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4:
-  c.swsp x18, 196(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=200
+  RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0x0668109ea5789853
+  addi sp, x11, -200  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
+  c.swsp x19, 200(sp) # perform store
   LREG x14, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x14 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc4_str)
+  RVTEST_SIGUPD(x11, x5, x4, x14, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8_str)
 
-# Testcase cp_imm_mul_4sp: imm=200
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x52bdd3617f8b6d8c
-  addi sp, x11, -200  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8:
-  c.swsp x12, 200(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=204
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x52bdd3617f8b6d8c
+  addi sp, x11, -204  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
+  c.swsp x13, 204(sp) # perform store
   LREG x27, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x27 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xc8_str)
+  RVTEST_SIGUPD(x11, x5, x4, x27, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc_str)
 
-# Testcase cp_imm_mul_4sp: imm=204
-  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0xf1bc5dd064d42cac
-  addi sp, x11, -204  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc:
-  c.swsp x21, 204(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=208
+  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0xf1bc5dd064d42cac
+  addi sp, x11, -208  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
+  c.swsp x22, 208(sp) # perform store
   LREG x9, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x9 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xcc_str)
+  RVTEST_SIGUPD(x11, x5, x4, x9, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0_str)
 
-# Testcase cp_imm_mul_4sp: imm=208
-  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0xf578d9a8accea683
-  addi sp, x11, -208  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0:
-  c.swsp x25, 208(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=212
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0xf578d9a8accea683
+  addi sp, x11, -212  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
+  c.swsp x26, 212(sp) # perform store
   LREG x20, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x20 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd0_str)
-
-# Testcase cp_imm_mul_4sp: imm=212
-  RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x4d5bde9a9003b69b
-  addi sp, x11, -212  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4:
-  c.swsp x31, 212(sp) # perform store
-  LREG x16, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4_str)
+  RVTEST_SIGUPD(x11, x5, x4, x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd4_str)
 
 # Testcase cp_imm_mul_4sp: imm=216
-  RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x127ee9b1f2aeccd0
+  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0xc16b5051cd5bde9a
   addi sp, x11, -216  # copy sig_reg to sp and adjust for offset
 Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8:
-  c.swsp x16, 216(sp) # perform store
-  LREG x29, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x29 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8_str)
-
-# Testcase cp_imm_mul_4sp: imm=220
-  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x90a91e295406c510
-  addi sp, x11, -220  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
-  c.swsp x15, 220(sp) # perform store
-  LREG x26, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc_str)
-
-# Testcase cp_imm_mul_4sp: imm=224
-  RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0xea87f67205d085b3
-  addi sp, x11, -224  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
-  c.swsp x12, 224(sp) # perform store
-  LREG x3, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x3 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0_str)
-
-# Testcase cp_imm_mul_4sp: imm=228
-  RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x427582f2bcc6b099
-  addi sp, x11, -228  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
-  c.swsp x30, 228(sp) # perform store
-  LREG x22, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4_str)
-
-# Testcase cp_imm_mul_4sp: imm=232
-  RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rs2: x18 = 0xfef588226e40e4d3
-  addi sp, x11, -232  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
-  c.swsp x18, 232(sp) # perform store
-  LREG x24, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8_str)
-
-# Testcase cp_imm_mul_4sp: imm=236
-  RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0xbd789a4d5f9c0192
-  addi sp, x11, -236  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
-  c.swsp x24, 236(sp) # perform store
-  LREG x23, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x23 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec_str)
-
-# Testcase cp_imm_mul_4sp: imm=240
-  RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xf5322a13b5cf94f1
-  addi sp, x11, -240  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
-  c.swsp x7, 240(sp) # perform store
+  c.swsp x23, 216(sp) # perform store
   LREG x18, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x18 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0_str)
+  RVTEST_SIGUPD(x11, x5, x4, x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xd8_str)
 
-# Testcase cp_imm_mul_4sp: imm=244
-  RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0xf707262c7db9241d
-  addi sp, x11, -244  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
-  c.swsp x31, 244(sp) # perform store
-  LREG x16, 0(x11) # load stored value for checking
-  addi x11, x11, SIG_STRIDE # increment signature pointer
-  # Check if x16 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x16, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4_str)
-
-# Testcase cp_imm_mul_4sp: imm=248
-  RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0x320353d8e46ad67b
-  addi sp, x11, -248  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
-  c.swsp x19, 248(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=220
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x5e4fac3fa312586c
+  addi sp, x11, -220  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc:
+  c.swsp x10, 220(sp) # perform store
   LREG x29, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x29 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8_str)
+  RVTEST_SIGUPD(x11, x5, x4, x29, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xdc_str)
 
-# Testcase cp_imm_mul_4sp: imm=252
-  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xe219fe6f1b4d49e8
-  addi sp, x11, -252  # copy sig_reg to sp and adjust for offset
-Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc:
-  c.swsp x13, 252(sp) # perform store
+# Testcase cp_imm_mul_4sp: imm=224
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x1487edaa78190573
+  addi sp, x11, -224  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0:
+  c.swsp x26, 224(sp) # perform store
+  LREG x20, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x20 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x20, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe0_str)
+
+# Testcase cp_imm_mul_4sp: imm=228
+  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0x90a91e295406c510
+  addi sp, x11, -228  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4:
+  c.swsp x22, 228(sp) # perform store
+  LREG x26, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x26 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x26, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe4_str)
+
+# Testcase cp_imm_mul_4sp: imm=232
+  RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xea87f67205d085b3
+  addi sp, x11, -232  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8:
+  c.swsp x13, 232(sp) # perform store
+  LREG x3, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x3 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x3, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xe8_str)
+
+# Testcase cp_imm_mul_4sp: imm=236
+  RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x427582f2bcc6b099
+  addi sp, x11, -236  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec:
+  c.swsp x31, 236(sp) # perform store
+  LREG x22, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xec_str)
+
+# Testcase cp_imm_mul_4sp: imm=240
+  RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0xfef588226e40e4d3
+  addi sp, x11, -240  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0:
+  c.swsp x19, 240(sp) # perform store
   LREG x24, 0(x11) # load stored value for checking
   addi x11, x11, SIG_STRIDE # increment signature pointer
   # Check if x24 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc_str)
+  RVTEST_SIGUPD(x11, x5, x4, x24, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf0_str)
+
+# Testcase cp_imm_mul_4sp: imm=244
+  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0xbd789a4d5f9c0192
+  addi sp, x11, -244  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4:
+  c.swsp x25, 244(sp) # perform store
+  LREG x23, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x23 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x23, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf4_str)
+
+# Testcase cp_imm_mul_4sp: imm=248
+  RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xf5322a13b5cf94f1
+  addi sp, x11, -248  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8:
+  c.swsp x8, 248(sp) # perform store
+  LREG x18, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x18 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x18, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xf8_str)
+
+# Testcase cp_imm_mul_4sp: imm=252
+  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rs2: x20 = 0x8cc550d17707262c
+  addi sp, x11, -252  # copy sig_reg to sp and adjust for offset
+Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc:
+  c.swsp x20, 252(sp) # perform store
+  LREG x22, 0(x11) # load stored value for checking
+  addi x11, x11, SIG_STRIDE # increment signature pointer
+  # Check if x22 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x22, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc, Zca_c_swsp_cg_cp_imm_mul_4sp_b0xfc_str)
 
   mv x2, x11 # restore signature pointer to default register for teardown
 
@@ -1243,11 +1243,12 @@ RVTEST_DATA_BEGIN
 .dword 0x688d523781f6d56d
 .dword 0x80dc5f589b13aa7d
 .dword 0xb7a2726dc175b476
-.dword 0x007aeb44a84065b0
-.dword 0xbfcd51149a9509f6
-.dword 0xfc4e095f418c3264
-.dword 0x823bf5eb1f15dcb8
-.dword 0xb5b23d03a5bff6fb
+.dword 0x2ef80023d7f2dc92
+.dword 0x1a9509f68513dcf1
+.dword 0xc18c3264dcc27e4f
+.dword 0x8d1f80d2887a85ad
+.dword 0x5db7f1313025852f
+.dword 0x7e22c6d5dad9c9b3
 .dword 0x12be5c00004a3fed
 .dword 0x408148003ab1aa06
 .dword 0xfd7e6a452e04c112
@@ -1279,17 +1280,16 @@ RVTEST_DATA_BEGIN
 .dword 0x52bdd3617f8b6d8c
 .dword 0xf1bc5dd064d42cac
 .dword 0xf578d9a8accea683
-.dword 0x4d5bde9a9003b69b
-.dword 0x127ee9b1f2aeccd0
+.dword 0xc16b5051cd5bde9a
+.dword 0x5e4fac3fa312586c
+.dword 0x1487edaa78190573
 .dword 0x90a91e295406c510
 .dword 0xea87f67205d085b3
 .dword 0x427582f2bcc6b099
 .dword 0xfef588226e40e4d3
 .dword 0xbd789a4d5f9c0192
 .dword 0xf5322a13b5cf94f1
-.dword 0xf707262c7db9241d
-.dword 0x320353d8e46ad67b
-.dword 0xe219fe6f1b4d49e8
+.dword 0x8cc550d17707262c
 
 // Testcase strings
 Zca_c_swsp_cg_cp_rs2_b0_str: .string "\"test: 1; cg: Zca_c.swsp_cg; cp: cp_rs2; bin: b0\""


### PR DESCRIPTION
Issue #2147 item 25.

`css_type.py` loads `rs2val` into `x{rs2}` and then clobbers x2 with the store base address (`addi sp, x{sig_reg}, -imm`). If `rs2 == 2` the value is discarded and the store writes the address, so the testcase checks the wrong thing.

Fix: `excluded_regs={"rs2": {2}}`. `params.py` applies operand exclusions only when the operand is unset, so the `cp_rs2` sweep keeps its explicit `rs2=2` bin (where the aliasing is inherent) while random and edge-value picks stop landing on x2.

Regenerated: 6 files. Before, 15 testcases across 5 files stored x2 outside `cp_rs2` — all under `cp_imm_mul_4sp`/`cp_imm_mul_8sp` — and were silently dead; now 0. The `cp_rs2` x2 bin survives in all six files, and no `cp_rs2_edges` testcase uses x2.

`a_type.py` and `ap_type.py` are intentionally untouched: the issue flags the same shape, but there the aliasing is architecturally required (`cmp_rs1_rs2_nx0` forces rs1 == rs2), so only the redundant `load_int_reg` line is cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTjX9BBLNAQkWwTTq6vfxq
