### PR TITLE
Compare amocas rd against its own pre-instruction value

### DIFF
--- a/coverpoints/unpriv/Zacas_coverage.svh
+++ b/coverpoints/unpriv/Zacas_coverage.svh
@@ -24,18 +24,18 @@ covergroup Zacas_amocas_w_cg with function sample(ins_t ins);
         ignore_bins x0 = {x0};
     }
 
-    cmp_rd_rs1_val_eq : coverpoint (ins.current.rd_val == ins.prev.rd_val) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_eq : coverpoint (ins.current.rd_val == ins.current.rd_val_pre) iff (ins.trap == 0) {
         // Compare rd current to rd previous value (which is the same as rs1 value for the current instruction)
     }
 
-    cmp_rd_rs1_val_hw : coverpoint (ins.current.rd_val[15:0] == ins.prev.rd_val[15:0]) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_hw : coverpoint (ins.current.rd_val[15:0] == ins.current.rd_val_pre[15:0]) iff (ins.trap == 0) {
         // Compare the lowest 16 bits of current rd value to
-        // lowest 16 bits of previous rd value (which is the same as rs1 value for the current instruction)
+        // lowest 16 bits of the value rd held before this instruction, which is the comparand
     }
 
-    cmp_rd_rs1_val_lsb : coverpoint (ins.current.rd_val[7:0] == ins.prev.rd_val[7:0]) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_lsb : coverpoint (ins.current.rd_val[7:0] == ins.current.rd_val_pre[7:0]) iff (ins.trap == 0) {
         // Compare the least significant byte of current rd value to the
-        // least significant byte of previous rd value (which is the same as rs1 value for the current instruction)
+        // least significant byte of the value rd held before this instruction, which is the comparand
     }
 
     cmp_rd_rs2 : coverpoint ins.get_gpr_reg(ins.current.rd)  iff (ins.current.rd == ins.current.rs2 & ins.trap == 0 )  {
@@ -118,8 +118,8 @@ covergroup Zacas_amocas_d_cg with function sample(ins_t ins);
     }
 
     cmp_rd_rs1_pair_partial_val : coverpoint (
-            (ins.current.rd_val == ins.prev.rd_val) ^
-            (ins.current.rd_upper_pair_val == ins.prev.rd_upper_pair_val)
+            (ins.current.rd_val == ins.current.rd_val_pre) ^
+            (ins.current.rd_upper_pair_val == ins.current.rd_upper_pair_val_pre)
         ) iff (ins.trap == 0)
         {
         // Cases where rd and rs1 have matching high or low halves but not both
@@ -133,23 +133,23 @@ covergroup Zacas_amocas_d_cg with function sample(ins_t ins);
         bins reg_pair[] = {[$:$]} with (item % 2 == 0);
     }
 
-    cmp_rd_rs1_val_eq : coverpoint (ins.current.rd_val == ins.prev.rd_val) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_eq : coverpoint (ins.current.rd_val == ins.current.rd_val_pre) iff (ins.trap == 0) {
         // Compare rd current to rd previous value (which is the same as rs1 value for the current instruction)
     }
 
-    cmp_rd_rs1_val_hw : coverpoint (ins.current.rd_val[15:0] == ins.prev.rd_val[15:0]) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_hw : coverpoint (ins.current.rd_val[15:0] == ins.current.rd_val_pre[15:0]) iff (ins.trap == 0) {
         // Compare the lowest 16 bits of current rd value to
-        // lowest 16 bits of previous rd value (which is the same as rs1 value for the current instruction)
+        // lowest 16 bits of the value rd held before this instruction, which is the comparand
     }
 
-    cmp_rd_rs1_val_lsb : coverpoint (ins.current.rd_val[7:0] == ins.prev.rd_val[7:0]) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_lsb : coverpoint (ins.current.rd_val[7:0] == ins.current.rd_val_pre[7:0]) iff (ins.trap == 0) {
         // Compare the least significant byte of current rd value to the
-        // least significant byte of previous rd value (which is the same as rs1 value for the current instruction)
+        // least significant byte of the value rd held before this instruction, which is the comparand
     }
 
-    cmp_rd_rs1_val_w : coverpoint (ins.current.rd_val[31:0] == ins.prev.rd_val[31:0]) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_w : coverpoint (ins.current.rd_val[31:0] == ins.current.rd_val_pre[31:0]) iff (ins.trap == 0) {
         // Compare the lowest 32 bits of current rd value to the
-        // lowest 32 bits of previous rd value (which is the same as rs1 value for the current instruction)
+        // lowest 32 bits of the value rd held before this instruction, which is the comparand
         bins rd_equal_val_w_rs1  = {1}; // Cases where the lowest 32 bits of rd and rs1 are equal
         bins rd_not_equal_val_w_rs1  = {0}; // Cases where the lowest 32 bits of rd and rs1 are not equal
     }
@@ -235,23 +235,23 @@ covergroup Zacas_amocas_d_cg with function sample(ins_t ins);
         ignore_bins x0 = {x0};
     }
 
-    cmp_rd_rs1_val_eq : coverpoint (ins.current.rd_val == ins.prev.rd_val) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_eq : coverpoint (ins.current.rd_val == ins.current.rd_val_pre) iff (ins.trap == 0) {
         // Compare rd current to rd previous value (which is the same as rs1 value for the current instruction)
     }
 
-    cmp_rd_rs1_val_hw : coverpoint (ins.current.rd_val[15:0] == ins.prev.rd_val[15:0]) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_hw : coverpoint (ins.current.rd_val[15:0] == ins.current.rd_val_pre[15:0]) iff (ins.trap == 0) {
         // Compare the lowest 16 bits of current rd value to
-        // lowest 16 bits of previous rd value (which is the same as rs1 value for the current instruction)
+        // lowest 16 bits of the value rd held before this instruction, which is the comparand
     }
 
-    cmp_rd_rs1_val_lsb : coverpoint (ins.current.rd_val[7:0] == ins.prev.rd_val[7:0]) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_lsb : coverpoint (ins.current.rd_val[7:0] == ins.current.rd_val_pre[7:0]) iff (ins.trap == 0) {
         // Compare the least significant byte of current rd value to the
-        // least significant byte of previous rd value (which is the same as rs1 value for the current instruction)
+        // least significant byte of the value rd held before this instruction, which is the comparand
     }
 
-    cmp_rd_rs1_val_w : coverpoint (ins.current.rd_val[31:0] == ins.prev.rd_val[31:0]) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_w : coverpoint (ins.current.rd_val[31:0] == ins.current.rd_val_pre[31:0]) iff (ins.trap == 0) {
         // Compare the lowest 32 bits of current rd value to the
-        // lowest 32 bits of previous rd value (which is the same as rs1 value for the current instruction)
+        // lowest 32 bits of the value rd held before this instruction, which is the comparand
         bins rd_equal_val_w_rs1  = {1}; // Cases where the lowest 32 bits of rd and rs1 are equal
         bins rd_not_equal_val_w_rs1  = {0}; // Cases where the lowest 32 bits of rd and rs1 are not equal
     }
@@ -328,8 +328,8 @@ covergroup Zacas_amocas_q_cg with function sample(ins_t ins);
     }
 
     cmp_rd_rs1_pair_partial_val : coverpoint (
-            (ins.current.rd_val == ins.prev.rd_val) ^
-            (ins.current.rd_upper_pair_val == ins.prev.rd_upper_pair_val)
+            (ins.current.rd_val == ins.current.rd_val_pre) ^
+            (ins.current.rd_upper_pair_val == ins.current.rd_upper_pair_val_pre)
         ) iff (ins.trap == 0)
         {
         // Cases where rd and rs1 have matching high or low halves but not both
@@ -343,23 +343,23 @@ covergroup Zacas_amocas_q_cg with function sample(ins_t ins);
         bins reg_pair[] = {[$:$]} with (item % 2 == 0);
     }
 
-    cmp_rd_rs1_val_eq : coverpoint (ins.current.rd_val == ins.prev.rd_val) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_eq : coverpoint (ins.current.rd_val == ins.current.rd_val_pre) iff (ins.trap == 0) {
         // Compare rd current to rd previous value (which is the same as rs1 value for the current instruction)
     }
 
-    cmp_rd_rs1_val_hw : coverpoint (ins.current.rd_val[15:0] == ins.prev.rd_val[15:0]) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_hw : coverpoint (ins.current.rd_val[15:0] == ins.current.rd_val_pre[15:0]) iff (ins.trap == 0) {
         // Compare the lowest 16 bits of current rd value to
-        // lowest 16 bits of previous rd value (which is the same as rs1 value for the current instruction)
+        // lowest 16 bits of the value rd held before this instruction, which is the comparand
     }
 
-    cmp_rd_rs1_val_lsb : coverpoint (ins.current.rd_val[7:0] == ins.prev.rd_val[7:0]) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_lsb : coverpoint (ins.current.rd_val[7:0] == ins.current.rd_val_pre[7:0]) iff (ins.trap == 0) {
         // Compare the least significant byte of current rd value to the
-        // least significant byte of previous rd value (which is the same as rs1 value for the current instruction)
+        // least significant byte of the value rd held before this instruction, which is the comparand
     }
 
-    cmp_rd_rs1_val_w : coverpoint (ins.current.rd_val[31:0] == ins.prev.rd_val[31:0]) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_w : coverpoint (ins.current.rd_val[31:0] == ins.current.rd_val_pre[31:0]) iff (ins.trap == 0) {
         // Compare the lowest 32 bits of current rd value to the
-        // lowest 32 bits of previous rd value (which is the same as rs1 value for the current instruction)
+        // lowest 32 bits of the value rd held before this instruction, which is the comparand
         bins rd_equal_val_w_rs1  = {1}; // Cases where the lowest 32 bits of rd and rs1 are equal
         bins rd_not_equal_val_w_rs1  = {0}; // Cases where the lowest 32 bits of rd and rs1 are not equal
     }

--- a/generators/coverage/src/covergroupgen/templates/cmp_rd_rs1_pair_partial_val.sv
+++ b/generators/coverage/src/covergroupgen/templates/cmp_rd_rs1_pair_partial_val.sv
@@ -1,6 +1,6 @@
     cmp_rd_rs1_pair_partial_val : coverpoint (
-            (ins.current.rd_val == ins.prev.rd_val) ^
-            (ins.current.rd_upper_pair_val == ins.prev.rd_upper_pair_val)
+            (ins.current.rd_val == ins.current.rd_val_pre) ^
+            (ins.current.rd_upper_pair_val == ins.current.rd_upper_pair_val_pre)
         ) iff (ins.trap == 0)
         {
         // Cases where rd and rs1 have matching high or low halves but not both

--- a/generators/coverage/src/covergroupgen/templates/cmp_rd_rs1_val_eq.sv
+++ b/generators/coverage/src/covergroupgen/templates/cmp_rd_rs1_val_eq.sv
@@ -1,3 +1,3 @@
-    cmp_rd_rs1_val_eq : coverpoint (ins.current.rd_val == ins.prev.rd_val) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_eq : coverpoint (ins.current.rd_val == ins.current.rd_val_pre) iff (ins.trap == 0) {
         // Compare rd current to rd previous value (which is the same as rs1 value for the current instruction)
     }

--- a/generators/coverage/src/covergroupgen/templates/cmp_rd_rs1_val_hw.sv
+++ b/generators/coverage/src/covergroupgen/templates/cmp_rd_rs1_val_hw.sv
@@ -1,4 +1,4 @@
-    cmp_rd_rs1_val_hw : coverpoint (ins.current.rd_val[15:0] == ins.prev.rd_val[15:0]) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_hw : coverpoint (ins.current.rd_val[15:0] == ins.current.rd_val_pre[15:0]) iff (ins.trap == 0) {
         // Compare the lowest 16 bits of current rd value to
-        // lowest 16 bits of previous rd value (which is the same as rs1 value for the current instruction)
+        // lowest 16 bits of the value rd held before this instruction, which is the comparand
     }

--- a/generators/coverage/src/covergroupgen/templates/cmp_rd_rs1_val_lsb.sv
+++ b/generators/coverage/src/covergroupgen/templates/cmp_rd_rs1_val_lsb.sv
@@ -1,4 +1,4 @@
-    cmp_rd_rs1_val_lsb : coverpoint (ins.current.rd_val[7:0] == ins.prev.rd_val[7:0]) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_lsb : coverpoint (ins.current.rd_val[7:0] == ins.current.rd_val_pre[7:0]) iff (ins.trap == 0) {
         // Compare the least significant byte of current rd value to the
-        // least significant byte of previous rd value (which is the same as rs1 value for the current instruction)
+        // least significant byte of the value rd held before this instruction, which is the comparand
     }

--- a/generators/coverage/src/covergroupgen/templates/cmp_rd_rs1_val_w.sv
+++ b/generators/coverage/src/covergroupgen/templates/cmp_rd_rs1_val_w.sv
@@ -1,6 +1,6 @@
-    cmp_rd_rs1_val_w : coverpoint (ins.current.rd_val[31:0] == ins.prev.rd_val[31:0]) iff (ins.trap == 0) {
+    cmp_rd_rs1_val_w : coverpoint (ins.current.rd_val[31:0] == ins.current.rd_val_pre[31:0]) iff (ins.trap == 0) {
         // Compare the lowest 32 bits of current rd value to the
-        // lowest 32 bits of previous rd value (which is the same as rs1 value for the current instruction)
+        // lowest 32 bits of the value rd held before this instruction, which is the comparand
         bins rd_equal_val_w_rs1  = {1}; // Cases where the lowest 32 bits of rd and rs1 are equal
         bins rd_not_equal_val_w_rs1  = {0}; // Cases where the lowest 32 bits of rd and rs1 are not equal
     }


### PR DESCRIPTION
Issue #2147 item 29.

The Zacas value-comparison coverpoints sampled `ins.prev.rd_val` — the destination value of the
*previous* instruction. In every generated amocas test the previous instruction is the store that
seeds memory, which has no `rd`, so the field is 0 and the coverpoints compared `rd` against zero
instead of against the comparand.

`RISCV_trace_data.svh` already carries `current.rd_val_pre` and `current.rd_upper_pair_val_pre`,
populated with the value the destination held before the instruction ran. For amocas that is the
comparand.

17 occurrences change across the four Zacas covergroups; no tests regenerate. Zacas and ZacasZabha
stay at 100% on both sail configs — expected, since each coverpoint is a boolean whose two bins were
reachable either way, which is exactly why comparing the wrong field went unnoticed.

`coverpoints/priv/ExceptionsZalrsc_coverage.svh` is left alone: it pairs `sc.x` with the preceding
`lr.x` and genuinely wants the previous instruction's value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTjX9BBLNAQkWwTTq6vfxq
