### PR TITLE
Skip the destination register check when rd is x0 for c.j and c.jr

### DIFF
--- a/generators/testgen/src/testgen/coverpoints/cp_imm_edges_jal.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_imm_edges_jal.py
@@ -74,8 +74,12 @@ def make_cp_imm_edges_jal(instr_name: str, instr_type: str, coverpoint: str, tes
                 write_sigupd(params.temp_reg, test_data)
                 if not skip_check
                 else f"{INDENT}# offset too small, skipping self-check",
-                f"{INDENT}# Check destination register",
-                write_sigupd(params.rd, test_data),
+                # c.j hardwires rd to x0, so its link check would sign a constant 0
+                *(
+                    [f"{INDENT}# Check destination register", write_sigupd(params.rd, test_data)]
+                    if params.rd != 0
+                    else []
+                ),
                 "",
             ]
         )
@@ -140,8 +144,12 @@ def make_cp_imm_edges_jal(instr_name: str, instr_type: str, coverpoint: str, tes
                 write_sigupd(params.temp_reg, test_data)
                 if not skip_check
                 else f"{INDENT}# offset too small, skipping self-check",
-                f"{INDENT}# Check destination register",
-                write_sigupd(params.rd, test_data),
+                # c.j hardwires rd to x0, so its link check would sign a constant 0
+                *(
+                    [f"{INDENT}# Check destination register", write_sigupd(params.rd, test_data)]
+                    if params.rd != 0
+                    else []
+                ),
                 "",
             ]
         )

--- a/generators/testgen/src/testgen/coverpoints/special/cp_offset.py
+++ b/generators/testgen/src/testgen/coverpoints/special/cp_offset.py
@@ -75,10 +75,17 @@ def make_offset(instr_name: str, instr_type: str, coverpoint: str, test_data: Te
                 f"addi x{params.temp_reg}, x{params.temp_reg}, -2 # jump not taken, decrement check value",
                 "3:  # done with sequence",
                 write_sigupd(params.temp_reg, test_data),
-                f"{INDENT}# check return address from {instr_name}",
-                f"auipc x{params.temp_reg}, 0 # get current PC",
-                f"sub x{params.rd}, x{params.rd}, x{params.temp_reg} # subtract PC to make position-independent",
-                write_sigupd(params.rd, test_data),
+                # c.jr has no link register, so its return address check would sign a constant 0
+                *(
+                    [
+                        f"{INDENT}# check return address from {instr_name}",
+                        f"auipc x{params.temp_reg}, 0 # get current PC",
+                        f"sub x{params.rd}, x{params.rd}, x{params.temp_reg} # subtract PC to make position-independent",
+                        write_sigupd(params.rd, test_data),
+                    ]
+                    if params.rd != 0
+                    else []
+                ),
             ]
         )
     elif instr_type in ["CJ", "CJAL"]:
@@ -175,10 +182,17 @@ def make_offset_lsbs(instr_name: str, instr_type: str, test_data: TestData) -> l
                     f"addi x{params.temp_reg}, x{params.temp_reg}, 2 # should execute; branch taken",
                     f"{INDENT}# check jump taken",
                     write_sigupd(params.temp_reg, test_data),
-                    f"{INDENT}# check return address from {instr_name}",
-                    f"auipc x{params.temp_reg}, 0 # get current PC",
-                    f"sub x{params.rd}, x{params.rd}, x{params.temp_reg} # subtract PC to make position-independent",
-                    write_sigupd(params.rd, test_data),
+                    # c.jr has no link register, so its return address check would sign a constant 0
+                    *(
+                        [
+                            f"{INDENT}# check return address from {instr_name}",
+                            f"auipc x{params.temp_reg}, 0 # get current PC",
+                            f"sub x{params.rd}, x{params.rd}, x{params.temp_reg} # subtract PC to make position-independent",
+                            write_sigupd(params.rd, test_data),
+                        ]
+                        if params.rd != 0
+                        else []
+                    ),
                 ]
             )
             return_testcase_registers(test_data, params)

--- a/tests/rv32e/Zca/Zca-c.j-00.S
+++ b/tests/rv32e/Zca/Zca-c.j-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 51
+#define SIGUPD_COUNT 30
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -59,9 +59,6 @@ Zca_c_j_cg_cp_imm_edges_c_jal_b_1:
 cp_imm_edges_c_jal_fwd_b_2:
   # Check jump taken/not-taken
   # offset too small, skipping self-check
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_1, Zca_c_j_cg_cp_imm_edges_c_jal_b_1_str)
 
 # cp_imm_edges_c_jal: forward jump by 4
   c.li x14, 1 # success code
@@ -74,9 +71,6 @@ cp_imm_edges_c_jal_fwd_b_4:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_2, Zca_c_j_cg_cp_imm_edges_c_jal_b_2_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_2, Zca_c_j_cg_cp_imm_edges_c_jal_b_2_str)
 
 # cp_imm_edges_c_jal: forward jump by 8
   c.li x14, 1 # success code
@@ -89,9 +83,6 @@ cp_imm_edges_c_jal_fwd_b_8:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_3, Zca_c_j_cg_cp_imm_edges_c_jal_b_3_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_3, Zca_c_j_cg_cp_imm_edges_c_jal_b_3_str)
 
 # cp_imm_edges_c_jal: forward jump by 16
   c.li x14, 1 # success code
@@ -104,9 +95,6 @@ cp_imm_edges_c_jal_fwd_b_16:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_4, Zca_c_j_cg_cp_imm_edges_c_jal_b_4_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_4, Zca_c_j_cg_cp_imm_edges_c_jal_b_4_str)
 
 # cp_imm_edges_c_jal: forward jump by 32
   c.li x14, 1 # success code
@@ -119,9 +107,6 @@ cp_imm_edges_c_jal_fwd_b_32:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_5, Zca_c_j_cg_cp_imm_edges_c_jal_b_5_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_5, Zca_c_j_cg_cp_imm_edges_c_jal_b_5_str)
 
 # cp_imm_edges_c_jal: forward jump by 64
   c.li x14, 1 # success code
@@ -134,9 +119,6 @@ cp_imm_edges_c_jal_fwd_b_64:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_6, Zca_c_j_cg_cp_imm_edges_c_jal_b_6_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_6, Zca_c_j_cg_cp_imm_edges_c_jal_b_6_str)
 
 # cp_imm_edges_c_jal: forward jump by 128
   c.li x14, 1 # success code
@@ -149,9 +131,6 @@ cp_imm_edges_c_jal_fwd_b_128:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_7, Zca_c_j_cg_cp_imm_edges_c_jal_b_7_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_7, Zca_c_j_cg_cp_imm_edges_c_jal_b_7_str)
 
 # cp_imm_edges_c_jal: forward jump by 256
   c.li x14, 1 # success code
@@ -164,9 +143,6 @@ cp_imm_edges_c_jal_fwd_b_256:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_8, Zca_c_j_cg_cp_imm_edges_c_jal_b_8_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_8, Zca_c_j_cg_cp_imm_edges_c_jal_b_8_str)
 
 # cp_imm_edges_c_jal: forward jump by 512
   c.li x14, 1 # success code
@@ -179,9 +155,6 @@ cp_imm_edges_c_jal_fwd_b_512:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_9, Zca_c_j_cg_cp_imm_edges_c_jal_b_9_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_9, Zca_c_j_cg_cp_imm_edges_c_jal_b_9_str)
 
 # cp_imm_edges_c_jal: forward jump by 1024
   c.li x14, 1 # success code
@@ -194,9 +167,6 @@ cp_imm_edges_c_jal_fwd_b_1024:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_10, Zca_c_j_cg_cp_imm_edges_c_jal_b_10_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_10, Zca_c_j_cg_cp_imm_edges_c_jal_b_10_str)
 
 # cp_imm_edges_c_jal: backward jump by 2
   # offset too small, skipping self-check
@@ -213,9 +183,6 @@ cp_imm_edges_c_jal_skip_b_m2:
 cp_imm_edges_c_jal_done_b_m2:
   # Check jump taken/not-taken
   # offset too small, skipping self-check
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m1, Zca_c_j_cg_cp_imm_edges_c_jal_b_m1_str)
 
 # cp_imm_edges_c_jal: backward jump by 4
   c.li x14, 1 # success code
@@ -233,9 +200,6 @@ cp_imm_edges_c_jal_done_b_m4:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m2, Zca_c_j_cg_cp_imm_edges_c_jal_b_m2_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m2, Zca_c_j_cg_cp_imm_edges_c_jal_b_m2_str)
 
 # cp_imm_edges_c_jal: backward jump by 8
   c.li x14, 1 # success code
@@ -253,9 +217,6 @@ cp_imm_edges_c_jal_done_b_m8:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m3, Zca_c_j_cg_cp_imm_edges_c_jal_b_m3_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m3, Zca_c_j_cg_cp_imm_edges_c_jal_b_m3_str)
 
 # cp_imm_edges_c_jal: backward jump by 16
   c.li x14, 1 # success code
@@ -273,9 +234,6 @@ cp_imm_edges_c_jal_done_b_m16:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m4, Zca_c_j_cg_cp_imm_edges_c_jal_b_m4_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m4, Zca_c_j_cg_cp_imm_edges_c_jal_b_m4_str)
 
 # cp_imm_edges_c_jal: backward jump by 32
   c.li x14, 1 # success code
@@ -293,9 +251,6 @@ cp_imm_edges_c_jal_done_b_m32:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m5, Zca_c_j_cg_cp_imm_edges_c_jal_b_m5_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m5, Zca_c_j_cg_cp_imm_edges_c_jal_b_m5_str)
 
 # cp_imm_edges_c_jal: backward jump by 64
   c.li x14, 1 # success code
@@ -313,9 +268,6 @@ cp_imm_edges_c_jal_done_b_m64:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m6, Zca_c_j_cg_cp_imm_edges_c_jal_b_m6_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m6, Zca_c_j_cg_cp_imm_edges_c_jal_b_m6_str)
 
 # cp_imm_edges_c_jal: backward jump by 128
   c.li x14, 1 # success code
@@ -333,9 +285,6 @@ cp_imm_edges_c_jal_done_b_m128:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m7, Zca_c_j_cg_cp_imm_edges_c_jal_b_m7_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m7, Zca_c_j_cg_cp_imm_edges_c_jal_b_m7_str)
 
 # cp_imm_edges_c_jal: backward jump by 256
   c.li x14, 1 # success code
@@ -353,9 +302,6 @@ cp_imm_edges_c_jal_done_b_m256:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m8, Zca_c_j_cg_cp_imm_edges_c_jal_b_m8_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m8, Zca_c_j_cg_cp_imm_edges_c_jal_b_m8_str)
 
 # cp_imm_edges_c_jal: backward jump by 512
   c.li x14, 1 # success code
@@ -373,9 +319,6 @@ cp_imm_edges_c_jal_done_b_m512:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m9, Zca_c_j_cg_cp_imm_edges_c_jal_b_m9_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m9, Zca_c_j_cg_cp_imm_edges_c_jal_b_m9_str)
 
 # cp_imm_edges_c_jal: backward jump by 1024
   c.li x14, 1 # success code
@@ -393,9 +336,6 @@ cp_imm_edges_c_jal_done_b_m1024:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m10, Zca_c_j_cg_cp_imm_edges_c_jal_b_m10_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m10, Zca_c_j_cg_cp_imm_edges_c_jal_b_m10_str)
 
 # cp_imm_edges_c_jal: backward jump by 2048
   c.li x14, 1 # success code
@@ -413,9 +353,6 @@ cp_imm_edges_c_jal_done_b_m2048:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m11, Zca_c_j_cg_cp_imm_edges_c_jal_b_m11_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m11, Zca_c_j_cg_cp_imm_edges_c_jal_b_m11_str)
 
 
 // Instantiate trap handlers and other epilog code, call RVMODEL_HALT at end of test

--- a/tests/rv32e/Zca/Zca-c.jr-00.S
+++ b/tests/rv32e/Zca/Zca-c.jr-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 35
+#define SIGUPD_COUNT 30
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -207,11 +207,6 @@ Zca_c_jr_cg_cp_offset_c_jr_neg:
 3:  # done with sequence
   # Check if x13 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x13, Zca_c_jr_cg_cp_offset_c_jr_neg, Zca_c_jr_cg_cp_offset_c_jr_neg_str)
-  # check return address from c.jr
-  auipc x13, 0 # get current PC
-  sub x0, x0, x13 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x3, x5, x4, x0, Zca_c_jr_cg_cp_offset_c_jr_neg, Zca_c_jr_cg_cp_offset_c_jr_neg_str)
 
 # Testcase cp_offset_lsbs (rs1 LSB=0)
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load jump check value: x10 = 0xa7507a62
@@ -226,11 +221,6 @@ jalrlsb_0:
   # check jump taken
   # Check if x10 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x10, Zca_c_jr_cg_cp_offset_lsbs_00, Zca_c_jr_cg_cp_offset_lsbs_00_str)
-  # check return address from c.jr
-  auipc x10, 0 # get current PC
-  sub x0, x0, x10 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x3, x5, x4, x0, Zca_c_jr_cg_cp_offset_lsbs_00, Zca_c_jr_cg_cp_offset_lsbs_00_str)
 
 # Testcase cp_offset_lsbs (rs1 LSB=1)
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load jump check value: x11 = 0x692974e2
@@ -245,11 +235,6 @@ jalrlsb_1:
   # check jump taken
   # Check if x11 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x11, Zca_c_jr_cg_cp_offset_lsbs_01, Zca_c_jr_cg_cp_offset_lsbs_01_str)
-  # check return address from c.jr
-  auipc x11, 0 # get current PC
-  sub x0, x0, x11 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x3, x5, x4, x0, Zca_c_jr_cg_cp_offset_lsbs_01, Zca_c_jr_cg_cp_offset_lsbs_01_str)
 
 # Testcase cp_offset_lsbs (rs1 LSB=2)
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load jump check value: x14 = 0x8060a6a8
@@ -264,11 +249,6 @@ jalrlsb_2: c.nop
   # check jump taken
   # Check if x14 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x14, Zca_c_jr_cg_cp_offset_lsbs_10, Zca_c_jr_cg_cp_offset_lsbs_10_str)
-  # check return address from c.jr
-  auipc x14, 0 # get current PC
-  sub x0, x0, x14 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x3, x5, x4, x0, Zca_c_jr_cg_cp_offset_lsbs_10, Zca_c_jr_cg_cp_offset_lsbs_10_str)
 
 # Testcase cp_offset_lsbs (rs1 LSB=3)
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load jump check value: x6 = 0x4aae5c89
@@ -283,11 +263,6 @@ jalrlsb_3: c.nop
   # check jump taken
   # Check if x6 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x6, Zca_c_jr_cg_cp_offset_lsbs_11, Zca_c_jr_cg_cp_offset_lsbs_11_str)
-  # check return address from c.jr
-  auipc x6, 0 # get current PC
-  sub x0, x0, x6 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x3, x5, x4, x0, Zca_c_jr_cg_cp_offset_lsbs_11, Zca_c_jr_cg_cp_offset_lsbs_11_str)
 
   mv x2, x3 # restore signature pointer to default register for teardown
 

--- a/tests/rv32i/Zca/Zca-c.j-00.S
+++ b/tests/rv32i/Zca/Zca-c.j-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 51
+#define SIGUPD_COUNT 30
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -59,9 +59,6 @@ Zca_c_j_cg_cp_imm_edges_c_jal_b_1:
 cp_imm_edges_c_jal_fwd_b_2:
   # Check jump taken/not-taken
   # offset too small, skipping self-check
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_1, Zca_c_j_cg_cp_imm_edges_c_jal_b_1_str)
 
 # cp_imm_edges_c_jal: forward jump by 4
   c.li x24, 1 # success code
@@ -74,9 +71,6 @@ cp_imm_edges_c_jal_fwd_b_4:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_2, Zca_c_j_cg_cp_imm_edges_c_jal_b_2_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_2, Zca_c_j_cg_cp_imm_edges_c_jal_b_2_str)
 
 # cp_imm_edges_c_jal: forward jump by 8
   c.li x24, 1 # success code
@@ -89,9 +83,6 @@ cp_imm_edges_c_jal_fwd_b_8:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_3, Zca_c_j_cg_cp_imm_edges_c_jal_b_3_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_3, Zca_c_j_cg_cp_imm_edges_c_jal_b_3_str)
 
 # cp_imm_edges_c_jal: forward jump by 16
   c.li x24, 1 # success code
@@ -104,9 +95,6 @@ cp_imm_edges_c_jal_fwd_b_16:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_4, Zca_c_j_cg_cp_imm_edges_c_jal_b_4_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_4, Zca_c_j_cg_cp_imm_edges_c_jal_b_4_str)
 
 # cp_imm_edges_c_jal: forward jump by 32
   c.li x24, 1 # success code
@@ -119,9 +107,6 @@ cp_imm_edges_c_jal_fwd_b_32:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_5, Zca_c_j_cg_cp_imm_edges_c_jal_b_5_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_5, Zca_c_j_cg_cp_imm_edges_c_jal_b_5_str)
 
 # cp_imm_edges_c_jal: forward jump by 64
   c.li x24, 1 # success code
@@ -134,9 +119,6 @@ cp_imm_edges_c_jal_fwd_b_64:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_6, Zca_c_j_cg_cp_imm_edges_c_jal_b_6_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_6, Zca_c_j_cg_cp_imm_edges_c_jal_b_6_str)
 
 # cp_imm_edges_c_jal: forward jump by 128
   c.li x24, 1 # success code
@@ -149,9 +131,6 @@ cp_imm_edges_c_jal_fwd_b_128:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_7, Zca_c_j_cg_cp_imm_edges_c_jal_b_7_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_7, Zca_c_j_cg_cp_imm_edges_c_jal_b_7_str)
 
 # cp_imm_edges_c_jal: forward jump by 256
   c.li x24, 1 # success code
@@ -164,9 +143,6 @@ cp_imm_edges_c_jal_fwd_b_256:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_8, Zca_c_j_cg_cp_imm_edges_c_jal_b_8_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_8, Zca_c_j_cg_cp_imm_edges_c_jal_b_8_str)
 
 # cp_imm_edges_c_jal: forward jump by 512
   c.li x24, 1 # success code
@@ -179,9 +155,6 @@ cp_imm_edges_c_jal_fwd_b_512:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_9, Zca_c_j_cg_cp_imm_edges_c_jal_b_9_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_9, Zca_c_j_cg_cp_imm_edges_c_jal_b_9_str)
 
 # cp_imm_edges_c_jal: forward jump by 1024
   c.li x24, 1 # success code
@@ -194,9 +167,6 @@ cp_imm_edges_c_jal_fwd_b_1024:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_10, Zca_c_j_cg_cp_imm_edges_c_jal_b_10_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_10, Zca_c_j_cg_cp_imm_edges_c_jal_b_10_str)
 
 # cp_imm_edges_c_jal: backward jump by 2
   # offset too small, skipping self-check
@@ -213,9 +183,6 @@ cp_imm_edges_c_jal_skip_b_m2:
 cp_imm_edges_c_jal_done_b_m2:
   # Check jump taken/not-taken
   # offset too small, skipping self-check
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m1, Zca_c_j_cg_cp_imm_edges_c_jal_b_m1_str)
 
 # cp_imm_edges_c_jal: backward jump by 4
   c.li x24, 1 # success code
@@ -233,9 +200,6 @@ cp_imm_edges_c_jal_done_b_m4:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m2, Zca_c_j_cg_cp_imm_edges_c_jal_b_m2_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m2, Zca_c_j_cg_cp_imm_edges_c_jal_b_m2_str)
 
 # cp_imm_edges_c_jal: backward jump by 8
   c.li x24, 1 # success code
@@ -253,9 +217,6 @@ cp_imm_edges_c_jal_done_b_m8:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m3, Zca_c_j_cg_cp_imm_edges_c_jal_b_m3_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m3, Zca_c_j_cg_cp_imm_edges_c_jal_b_m3_str)
 
 # cp_imm_edges_c_jal: backward jump by 16
   c.li x24, 1 # success code
@@ -273,9 +234,6 @@ cp_imm_edges_c_jal_done_b_m16:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m4, Zca_c_j_cg_cp_imm_edges_c_jal_b_m4_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m4, Zca_c_j_cg_cp_imm_edges_c_jal_b_m4_str)
 
 # cp_imm_edges_c_jal: backward jump by 32
   c.li x24, 1 # success code
@@ -293,9 +251,6 @@ cp_imm_edges_c_jal_done_b_m32:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m5, Zca_c_j_cg_cp_imm_edges_c_jal_b_m5_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m5, Zca_c_j_cg_cp_imm_edges_c_jal_b_m5_str)
 
 # cp_imm_edges_c_jal: backward jump by 64
   c.li x24, 1 # success code
@@ -313,9 +268,6 @@ cp_imm_edges_c_jal_done_b_m64:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m6, Zca_c_j_cg_cp_imm_edges_c_jal_b_m6_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m6, Zca_c_j_cg_cp_imm_edges_c_jal_b_m6_str)
 
 # cp_imm_edges_c_jal: backward jump by 128
   c.li x24, 1 # success code
@@ -333,9 +285,6 @@ cp_imm_edges_c_jal_done_b_m128:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m7, Zca_c_j_cg_cp_imm_edges_c_jal_b_m7_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m7, Zca_c_j_cg_cp_imm_edges_c_jal_b_m7_str)
 
 # cp_imm_edges_c_jal: backward jump by 256
   c.li x24, 1 # success code
@@ -353,9 +302,6 @@ cp_imm_edges_c_jal_done_b_m256:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m8, Zca_c_j_cg_cp_imm_edges_c_jal_b_m8_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m8, Zca_c_j_cg_cp_imm_edges_c_jal_b_m8_str)
 
 # cp_imm_edges_c_jal: backward jump by 512
   c.li x24, 1 # success code
@@ -373,9 +319,6 @@ cp_imm_edges_c_jal_done_b_m512:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m9, Zca_c_j_cg_cp_imm_edges_c_jal_b_m9_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m9, Zca_c_j_cg_cp_imm_edges_c_jal_b_m9_str)
 
 # cp_imm_edges_c_jal: backward jump by 1024
   c.li x24, 1 # success code
@@ -393,9 +336,6 @@ cp_imm_edges_c_jal_done_b_m1024:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m10, Zca_c_j_cg_cp_imm_edges_c_jal_b_m10_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m10, Zca_c_j_cg_cp_imm_edges_c_jal_b_m10_str)
 
 # cp_imm_edges_c_jal: backward jump by 2048
   c.li x24, 1 # success code
@@ -413,9 +353,6 @@ cp_imm_edges_c_jal_done_b_m2048:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m11, Zca_c_j_cg_cp_imm_edges_c_jal_b_m11_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m11, Zca_c_j_cg_cp_imm_edges_c_jal_b_m11_str)
 
 
 // Instantiate trap handlers and other epilog code, call RVMODEL_HALT at end of test

--- a/tests/rv32i/Zca/Zca-c.jr-00.S
+++ b/tests/rv32i/Zca/Zca-c.jr-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 51
+#define SIGUPD_COUNT 46
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -370,11 +370,6 @@ Zca_c_jr_cg_cp_offset_c_jr_neg:
 3:  # done with sequence
   # Check if x18 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x18, Zca_c_jr_cg_cp_offset_c_jr_neg, Zca_c_jr_cg_cp_offset_c_jr_neg_str)
-  # check return address from c.jr
-  auipc x18, 0 # get current PC
-  sub x0, x0, x18 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_jr_cg_cp_offset_c_jr_neg, Zca_c_jr_cg_cp_offset_c_jr_neg_str)
 
 # Testcase cp_offset_lsbs (rs1 LSB=0)
   RVTEST_TESTDATA_LOAD_INT(x6, x21) # load jump check value: x21 = 0xa7507a62
@@ -389,11 +384,6 @@ jalrlsb_0:
   # check jump taken
   # Check if x21 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x21, Zca_c_jr_cg_cp_offset_lsbs_00, Zca_c_jr_cg_cp_offset_lsbs_00_str)
-  # check return address from c.jr
-  auipc x21, 0 # get current PC
-  sub x0, x0, x21 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_jr_cg_cp_offset_lsbs_00, Zca_c_jr_cg_cp_offset_lsbs_00_str)
 
 # Testcase cp_offset_lsbs (rs1 LSB=1)
   RVTEST_TESTDATA_LOAD_INT(x6, x21) # load jump check value: x21 = 0x692974e2
@@ -408,11 +398,6 @@ jalrlsb_1:
   # check jump taken
   # Check if x21 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x21, Zca_c_jr_cg_cp_offset_lsbs_01, Zca_c_jr_cg_cp_offset_lsbs_01_str)
-  # check return address from c.jr
-  auipc x21, 0 # get current PC
-  sub x0, x0, x21 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_jr_cg_cp_offset_lsbs_01, Zca_c_jr_cg_cp_offset_lsbs_01_str)
 
 # Testcase cp_offset_lsbs (rs1 LSB=2)
   RVTEST_TESTDATA_LOAD_INT(x6, x1) # load jump check value: x1 = 0xbd58f414
@@ -427,11 +412,6 @@ jalrlsb_2: c.nop
   # check jump taken
   # Check if x1 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x1, Zca_c_jr_cg_cp_offset_lsbs_10, Zca_c_jr_cg_cp_offset_lsbs_10_str)
-  # check return address from c.jr
-  auipc x1, 0 # get current PC
-  sub x0, x0, x1 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_jr_cg_cp_offset_lsbs_10, Zca_c_jr_cg_cp_offset_lsbs_10_str)
 
 # Testcase cp_offset_lsbs (rs1 LSB=3)
   RVTEST_TESTDATA_LOAD_INT(x6, x22) # load jump check value: x22 = 0x49f9664e
@@ -446,11 +426,6 @@ jalrlsb_3: c.nop
   # check jump taken
   # Check if x22 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x22, Zca_c_jr_cg_cp_offset_lsbs_11, Zca_c_jr_cg_cp_offset_lsbs_11_str)
-  # check return address from c.jr
-  auipc x22, 0 # get current PC
-  sub x0, x0, x22 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_jr_cg_cp_offset_lsbs_11, Zca_c_jr_cg_cp_offset_lsbs_11_str)
 
 // Instantiate trap handlers and other epilog code, call RVMODEL_HALT at end of test
 RVTEST_CODE_END

--- a/tests/rv64e/Zca/Zca-c.j-00.S
+++ b/tests/rv64e/Zca/Zca-c.j-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 51
+#define SIGUPD_COUNT 30
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -59,9 +59,6 @@ Zca_c_j_cg_cp_imm_edges_c_jal_b_1:
 cp_imm_edges_c_jal_fwd_b_2:
   # Check jump taken/not-taken
   # offset too small, skipping self-check
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_1, Zca_c_j_cg_cp_imm_edges_c_jal_b_1_str)
 
 # cp_imm_edges_c_jal: forward jump by 4
   c.li x14, 1 # success code
@@ -74,9 +71,6 @@ cp_imm_edges_c_jal_fwd_b_4:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_2, Zca_c_j_cg_cp_imm_edges_c_jal_b_2_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_2, Zca_c_j_cg_cp_imm_edges_c_jal_b_2_str)
 
 # cp_imm_edges_c_jal: forward jump by 8
   c.li x14, 1 # success code
@@ -89,9 +83,6 @@ cp_imm_edges_c_jal_fwd_b_8:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_3, Zca_c_j_cg_cp_imm_edges_c_jal_b_3_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_3, Zca_c_j_cg_cp_imm_edges_c_jal_b_3_str)
 
 # cp_imm_edges_c_jal: forward jump by 16
   c.li x14, 1 # success code
@@ -104,9 +95,6 @@ cp_imm_edges_c_jal_fwd_b_16:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_4, Zca_c_j_cg_cp_imm_edges_c_jal_b_4_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_4, Zca_c_j_cg_cp_imm_edges_c_jal_b_4_str)
 
 # cp_imm_edges_c_jal: forward jump by 32
   c.li x14, 1 # success code
@@ -119,9 +107,6 @@ cp_imm_edges_c_jal_fwd_b_32:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_5, Zca_c_j_cg_cp_imm_edges_c_jal_b_5_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_5, Zca_c_j_cg_cp_imm_edges_c_jal_b_5_str)
 
 # cp_imm_edges_c_jal: forward jump by 64
   c.li x14, 1 # success code
@@ -134,9 +119,6 @@ cp_imm_edges_c_jal_fwd_b_64:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_6, Zca_c_j_cg_cp_imm_edges_c_jal_b_6_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_6, Zca_c_j_cg_cp_imm_edges_c_jal_b_6_str)
 
 # cp_imm_edges_c_jal: forward jump by 128
   c.li x14, 1 # success code
@@ -149,9 +131,6 @@ cp_imm_edges_c_jal_fwd_b_128:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_7, Zca_c_j_cg_cp_imm_edges_c_jal_b_7_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_7, Zca_c_j_cg_cp_imm_edges_c_jal_b_7_str)
 
 # cp_imm_edges_c_jal: forward jump by 256
   c.li x14, 1 # success code
@@ -164,9 +143,6 @@ cp_imm_edges_c_jal_fwd_b_256:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_8, Zca_c_j_cg_cp_imm_edges_c_jal_b_8_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_8, Zca_c_j_cg_cp_imm_edges_c_jal_b_8_str)
 
 # cp_imm_edges_c_jal: forward jump by 512
   c.li x14, 1 # success code
@@ -179,9 +155,6 @@ cp_imm_edges_c_jal_fwd_b_512:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_9, Zca_c_j_cg_cp_imm_edges_c_jal_b_9_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_9, Zca_c_j_cg_cp_imm_edges_c_jal_b_9_str)
 
 # cp_imm_edges_c_jal: forward jump by 1024
   c.li x14, 1 # success code
@@ -194,9 +167,6 @@ cp_imm_edges_c_jal_fwd_b_1024:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_10, Zca_c_j_cg_cp_imm_edges_c_jal_b_10_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_10, Zca_c_j_cg_cp_imm_edges_c_jal_b_10_str)
 
 # cp_imm_edges_c_jal: backward jump by 2
   # offset too small, skipping self-check
@@ -213,9 +183,6 @@ cp_imm_edges_c_jal_skip_b_m2:
 cp_imm_edges_c_jal_done_b_m2:
   # Check jump taken/not-taken
   # offset too small, skipping self-check
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m1, Zca_c_j_cg_cp_imm_edges_c_jal_b_m1_str)
 
 # cp_imm_edges_c_jal: backward jump by 4
   c.li x14, 1 # success code
@@ -233,9 +200,6 @@ cp_imm_edges_c_jal_done_b_m4:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m2, Zca_c_j_cg_cp_imm_edges_c_jal_b_m2_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m2, Zca_c_j_cg_cp_imm_edges_c_jal_b_m2_str)
 
 # cp_imm_edges_c_jal: backward jump by 8
   c.li x14, 1 # success code
@@ -253,9 +217,6 @@ cp_imm_edges_c_jal_done_b_m8:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m3, Zca_c_j_cg_cp_imm_edges_c_jal_b_m3_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m3, Zca_c_j_cg_cp_imm_edges_c_jal_b_m3_str)
 
 # cp_imm_edges_c_jal: backward jump by 16
   c.li x14, 1 # success code
@@ -273,9 +234,6 @@ cp_imm_edges_c_jal_done_b_m16:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m4, Zca_c_j_cg_cp_imm_edges_c_jal_b_m4_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m4, Zca_c_j_cg_cp_imm_edges_c_jal_b_m4_str)
 
 # cp_imm_edges_c_jal: backward jump by 32
   c.li x14, 1 # success code
@@ -293,9 +251,6 @@ cp_imm_edges_c_jal_done_b_m32:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m5, Zca_c_j_cg_cp_imm_edges_c_jal_b_m5_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m5, Zca_c_j_cg_cp_imm_edges_c_jal_b_m5_str)
 
 # cp_imm_edges_c_jal: backward jump by 64
   c.li x14, 1 # success code
@@ -313,9 +268,6 @@ cp_imm_edges_c_jal_done_b_m64:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m6, Zca_c_j_cg_cp_imm_edges_c_jal_b_m6_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m6, Zca_c_j_cg_cp_imm_edges_c_jal_b_m6_str)
 
 # cp_imm_edges_c_jal: backward jump by 128
   c.li x14, 1 # success code
@@ -333,9 +285,6 @@ cp_imm_edges_c_jal_done_b_m128:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m7, Zca_c_j_cg_cp_imm_edges_c_jal_b_m7_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m7, Zca_c_j_cg_cp_imm_edges_c_jal_b_m7_str)
 
 # cp_imm_edges_c_jal: backward jump by 256
   c.li x14, 1 # success code
@@ -353,9 +302,6 @@ cp_imm_edges_c_jal_done_b_m256:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m8, Zca_c_j_cg_cp_imm_edges_c_jal_b_m8_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m8, Zca_c_j_cg_cp_imm_edges_c_jal_b_m8_str)
 
 # cp_imm_edges_c_jal: backward jump by 512
   c.li x14, 1 # success code
@@ -373,9 +319,6 @@ cp_imm_edges_c_jal_done_b_m512:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m9, Zca_c_j_cg_cp_imm_edges_c_jal_b_m9_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m9, Zca_c_j_cg_cp_imm_edges_c_jal_b_m9_str)
 
 # cp_imm_edges_c_jal: backward jump by 1024
   c.li x14, 1 # success code
@@ -393,9 +336,6 @@ cp_imm_edges_c_jal_done_b_m1024:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m10, Zca_c_j_cg_cp_imm_edges_c_jal_b_m10_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m10, Zca_c_j_cg_cp_imm_edges_c_jal_b_m10_str)
 
 # cp_imm_edges_c_jal: backward jump by 2048
   c.li x14, 1 # success code
@@ -413,9 +353,6 @@ cp_imm_edges_c_jal_done_b_m2048:
   # Check jump taken/not-taken
   # Check if x14 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x14, Zca_c_j_cg_cp_imm_edges_c_jal_b_m11, Zca_c_j_cg_cp_imm_edges_c_jal_b_m11_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m11, Zca_c_j_cg_cp_imm_edges_c_jal_b_m11_str)
 
 
 // Instantiate trap handlers and other epilog code, call RVMODEL_HALT at end of test

--- a/tests/rv64e/Zca/Zca-c.jr-00.S
+++ b/tests/rv64e/Zca/Zca-c.jr-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 35
+#define SIGUPD_COUNT 30
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -207,11 +207,6 @@ Zca_c_jr_cg_cp_offset_c_jr_neg:
 3:  # done with sequence
   # Check if x12 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x12, Zca_c_jr_cg_cp_offset_c_jr_neg, Zca_c_jr_cg_cp_offset_c_jr_neg_str)
-  # check return address from c.jr
-  auipc x12, 0 # get current PC
-  sub x0, x0, x12 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x3, x5, x4, x0, Zca_c_jr_cg_cp_offset_c_jr_neg, Zca_c_jr_cg_cp_offset_c_jr_neg_str)
 
 # Testcase cp_offset_lsbs (rs1 LSB=0)
   RVTEST_TESTDATA_LOAD_INT(x2, x14) # load jump check value: x14 = 0x9d89414427507a62
@@ -226,11 +221,6 @@ jalrlsb_0:
   # check jump taken
   # Check if x14 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x14, Zca_c_jr_cg_cp_offset_lsbs_00, Zca_c_jr_cg_cp_offset_lsbs_00_str)
-  # check return address from c.jr
-  auipc x14, 0 # get current PC
-  sub x0, x0, x14 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x3, x5, x4, x0, Zca_c_jr_cg_cp_offset_lsbs_00, Zca_c_jr_cg_cp_offset_lsbs_00_str)
 
 # Testcase cp_offset_lsbs (rs1 LSB=1)
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load jump check value: x11 = 0x8060a6a8cb91ac47
@@ -245,11 +235,6 @@ jalrlsb_1:
   # check jump taken
   # Check if x11 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x11, Zca_c_jr_cg_cp_offset_lsbs_01, Zca_c_jr_cg_cp_offset_lsbs_01_str)
-  # check return address from c.jr
-  auipc x11, 0 # get current PC
-  sub x0, x0, x11 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x3, x5, x4, x0, Zca_c_jr_cg_cp_offset_lsbs_01, Zca_c_jr_cg_cp_offset_lsbs_01_str)
 
 # Testcase cp_offset_lsbs (rs1 LSB=2)
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load jump check value: x6 = 0x405e7d4609fccb23
@@ -264,11 +249,6 @@ jalrlsb_2: c.nop
   # check jump taken
   # Check if x6 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x6, Zca_c_jr_cg_cp_offset_lsbs_10, Zca_c_jr_cg_cp_offset_lsbs_10_str)
-  # check return address from c.jr
-  auipc x6, 0 # get current PC
-  sub x0, x0, x6 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x3, x5, x4, x0, Zca_c_jr_cg_cp_offset_lsbs_10, Zca_c_jr_cg_cp_offset_lsbs_10_str)
 
 # Testcase cp_offset_lsbs (rs1 LSB=3)
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load jump check value: x6 = 0x64c869b756407dd4
@@ -283,11 +263,6 @@ jalrlsb_3: c.nop
   # check jump taken
   # Check if x6 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x3, x5, x4, x6, Zca_c_jr_cg_cp_offset_lsbs_11, Zca_c_jr_cg_cp_offset_lsbs_11_str)
-  # check return address from c.jr
-  auipc x6, 0 # get current PC
-  sub x0, x0, x6 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x3, x5, x4, x0, Zca_c_jr_cg_cp_offset_lsbs_11, Zca_c_jr_cg_cp_offset_lsbs_11_str)
 
   mv x2, x3 # restore signature pointer to default register for teardown
 

--- a/tests/rv64i/Zca/Zca-c.j-00.S
+++ b/tests/rv64i/Zca/Zca-c.j-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 51
+#define SIGUPD_COUNT 30
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -59,9 +59,6 @@ Zca_c_j_cg_cp_imm_edges_c_jal_b_1:
 cp_imm_edges_c_jal_fwd_b_2:
   # Check jump taken/not-taken
   # offset too small, skipping self-check
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_1, Zca_c_j_cg_cp_imm_edges_c_jal_b_1_str)
 
 # cp_imm_edges_c_jal: forward jump by 4
   c.li x24, 1 # success code
@@ -74,9 +71,6 @@ cp_imm_edges_c_jal_fwd_b_4:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_2, Zca_c_j_cg_cp_imm_edges_c_jal_b_2_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_2, Zca_c_j_cg_cp_imm_edges_c_jal_b_2_str)
 
 # cp_imm_edges_c_jal: forward jump by 8
   c.li x24, 1 # success code
@@ -89,9 +83,6 @@ cp_imm_edges_c_jal_fwd_b_8:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_3, Zca_c_j_cg_cp_imm_edges_c_jal_b_3_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_3, Zca_c_j_cg_cp_imm_edges_c_jal_b_3_str)
 
 # cp_imm_edges_c_jal: forward jump by 16
   c.li x24, 1 # success code
@@ -104,9 +95,6 @@ cp_imm_edges_c_jal_fwd_b_16:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_4, Zca_c_j_cg_cp_imm_edges_c_jal_b_4_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_4, Zca_c_j_cg_cp_imm_edges_c_jal_b_4_str)
 
 # cp_imm_edges_c_jal: forward jump by 32
   c.li x24, 1 # success code
@@ -119,9 +107,6 @@ cp_imm_edges_c_jal_fwd_b_32:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_5, Zca_c_j_cg_cp_imm_edges_c_jal_b_5_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_5, Zca_c_j_cg_cp_imm_edges_c_jal_b_5_str)
 
 # cp_imm_edges_c_jal: forward jump by 64
   c.li x24, 1 # success code
@@ -134,9 +119,6 @@ cp_imm_edges_c_jal_fwd_b_64:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_6, Zca_c_j_cg_cp_imm_edges_c_jal_b_6_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_6, Zca_c_j_cg_cp_imm_edges_c_jal_b_6_str)
 
 # cp_imm_edges_c_jal: forward jump by 128
   c.li x24, 1 # success code
@@ -149,9 +131,6 @@ cp_imm_edges_c_jal_fwd_b_128:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_7, Zca_c_j_cg_cp_imm_edges_c_jal_b_7_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_7, Zca_c_j_cg_cp_imm_edges_c_jal_b_7_str)
 
 # cp_imm_edges_c_jal: forward jump by 256
   c.li x24, 1 # success code
@@ -164,9 +143,6 @@ cp_imm_edges_c_jal_fwd_b_256:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_8, Zca_c_j_cg_cp_imm_edges_c_jal_b_8_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_8, Zca_c_j_cg_cp_imm_edges_c_jal_b_8_str)
 
 # cp_imm_edges_c_jal: forward jump by 512
   c.li x24, 1 # success code
@@ -179,9 +155,6 @@ cp_imm_edges_c_jal_fwd_b_512:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_9, Zca_c_j_cg_cp_imm_edges_c_jal_b_9_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_9, Zca_c_j_cg_cp_imm_edges_c_jal_b_9_str)
 
 # cp_imm_edges_c_jal: forward jump by 1024
   c.li x24, 1 # success code
@@ -194,9 +167,6 @@ cp_imm_edges_c_jal_fwd_b_1024:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_10, Zca_c_j_cg_cp_imm_edges_c_jal_b_10_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_10, Zca_c_j_cg_cp_imm_edges_c_jal_b_10_str)
 
 # cp_imm_edges_c_jal: backward jump by 2
   # offset too small, skipping self-check
@@ -213,9 +183,6 @@ cp_imm_edges_c_jal_skip_b_m2:
 cp_imm_edges_c_jal_done_b_m2:
   # Check jump taken/not-taken
   # offset too small, skipping self-check
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m1, Zca_c_j_cg_cp_imm_edges_c_jal_b_m1_str)
 
 # cp_imm_edges_c_jal: backward jump by 4
   c.li x24, 1 # success code
@@ -233,9 +200,6 @@ cp_imm_edges_c_jal_done_b_m4:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m2, Zca_c_j_cg_cp_imm_edges_c_jal_b_m2_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m2, Zca_c_j_cg_cp_imm_edges_c_jal_b_m2_str)
 
 # cp_imm_edges_c_jal: backward jump by 8
   c.li x24, 1 # success code
@@ -253,9 +217,6 @@ cp_imm_edges_c_jal_done_b_m8:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m3, Zca_c_j_cg_cp_imm_edges_c_jal_b_m3_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m3, Zca_c_j_cg_cp_imm_edges_c_jal_b_m3_str)
 
 # cp_imm_edges_c_jal: backward jump by 16
   c.li x24, 1 # success code
@@ -273,9 +234,6 @@ cp_imm_edges_c_jal_done_b_m16:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m4, Zca_c_j_cg_cp_imm_edges_c_jal_b_m4_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m4, Zca_c_j_cg_cp_imm_edges_c_jal_b_m4_str)
 
 # cp_imm_edges_c_jal: backward jump by 32
   c.li x24, 1 # success code
@@ -293,9 +251,6 @@ cp_imm_edges_c_jal_done_b_m32:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m5, Zca_c_j_cg_cp_imm_edges_c_jal_b_m5_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m5, Zca_c_j_cg_cp_imm_edges_c_jal_b_m5_str)
 
 # cp_imm_edges_c_jal: backward jump by 64
   c.li x24, 1 # success code
@@ -313,9 +268,6 @@ cp_imm_edges_c_jal_done_b_m64:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m6, Zca_c_j_cg_cp_imm_edges_c_jal_b_m6_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m6, Zca_c_j_cg_cp_imm_edges_c_jal_b_m6_str)
 
 # cp_imm_edges_c_jal: backward jump by 128
   c.li x24, 1 # success code
@@ -333,9 +285,6 @@ cp_imm_edges_c_jal_done_b_m128:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m7, Zca_c_j_cg_cp_imm_edges_c_jal_b_m7_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m7, Zca_c_j_cg_cp_imm_edges_c_jal_b_m7_str)
 
 # cp_imm_edges_c_jal: backward jump by 256
   c.li x24, 1 # success code
@@ -353,9 +302,6 @@ cp_imm_edges_c_jal_done_b_m256:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m8, Zca_c_j_cg_cp_imm_edges_c_jal_b_m8_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m8, Zca_c_j_cg_cp_imm_edges_c_jal_b_m8_str)
 
 # cp_imm_edges_c_jal: backward jump by 512
   c.li x24, 1 # success code
@@ -373,9 +319,6 @@ cp_imm_edges_c_jal_done_b_m512:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m9, Zca_c_j_cg_cp_imm_edges_c_jal_b_m9_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m9, Zca_c_j_cg_cp_imm_edges_c_jal_b_m9_str)
 
 # cp_imm_edges_c_jal: backward jump by 1024
   c.li x24, 1 # success code
@@ -393,9 +336,6 @@ cp_imm_edges_c_jal_done_b_m1024:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m10, Zca_c_j_cg_cp_imm_edges_c_jal_b_m10_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m10, Zca_c_j_cg_cp_imm_edges_c_jal_b_m10_str)
 
 # cp_imm_edges_c_jal: backward jump by 2048
   c.li x24, 1 # success code
@@ -413,9 +353,6 @@ cp_imm_edges_c_jal_done_b_m2048:
   # Check jump taken/not-taken
   # Check if x24 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
   RVTEST_SIGUPD(x2, x5, x4, x24, Zca_c_j_cg_cp_imm_edges_c_jal_b_m11, Zca_c_j_cg_cp_imm_edges_c_jal_b_m11_str)
-  # Check destination register
-  # Check if x0 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x0, Zca_c_j_cg_cp_imm_edges_c_jal_b_m11, Zca_c_j_cg_cp_imm_edges_c_jal_b_m11_str)
 
 
 // Instantiate trap handlers and other epilog code, call RVMODEL_HALT at end of test

--- a/tests/rv64i/Zca/Zca-c.jr-00.S
+++ b/tests/rv64i/Zca/Zca-c.jr-00.S
@@ -16,7 +16,7 @@
 ##### END_TEST_CONFIG #####
 
 // Define the size of the signature region
-#define SIGUPD_COUNT 51
+#define SIGUPD_COUNT 46
 
 // Extra defines (if needed) to enable trap handlers, fpu, vector, etc.
 
@@ -369,11 +369,6 @@ Zca_c_jr_cg_cp_offset_c_jr_neg:
 3:  # done with sequence
   # Check if x19 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x3, x8, x7, x19, Zca_c_jr_cg_cp_offset_c_jr_neg, Zca_c_jr_cg_cp_offset_c_jr_neg_str)
-  # check return address from c.jr
-  auipc x19, 0 # get current PC
-  sub x0, x0, x19 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x3, x8, x7, x0, Zca_c_jr_cg_cp_offset_c_jr_neg, Zca_c_jr_cg_cp_offset_c_jr_neg_str)
 
 # Testcase cp_offset_lsbs (rs1 LSB=0)
   RVTEST_TESTDATA_LOAD_INT(x15, x16) # load jump check value: x16 = 0xefa1fc096208d81c
@@ -388,11 +383,6 @@ jalrlsb_0:
   # check jump taken
   # Check if x16 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x3, x8, x7, x16, Zca_c_jr_cg_cp_offset_lsbs_00, Zca_c_jr_cg_cp_offset_lsbs_00_str)
-  # check return address from c.jr
-  auipc x16, 0 # get current PC
-  sub x0, x0, x16 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x3, x8, x7, x0, Zca_c_jr_cg_cp_offset_lsbs_00, Zca_c_jr_cg_cp_offset_lsbs_00_str)
 
 # Testcase cp_offset_lsbs (rs1 LSB=1)
   RVTEST_TESTDATA_LOAD_INT(x15, x10) # load jump check value: x10 = 0x4b91ac4781582bc5
@@ -407,11 +397,6 @@ jalrlsb_1:
   # check jump taken
   # Check if x10 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x3, x8, x7, x10, Zca_c_jr_cg_cp_offset_lsbs_01, Zca_c_jr_cg_cp_offset_lsbs_01_str)
-  # check return address from c.jr
-  auipc x10, 0 # get current PC
-  sub x0, x0, x10 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x3, x8, x7, x0, Zca_c_jr_cg_cp_offset_lsbs_01, Zca_c_jr_cg_cp_offset_lsbs_01_str)
 
 # Testcase cp_offset_lsbs (rs1 LSB=2)
   RVTEST_TESTDATA_LOAD_INT(x15, x31) # load jump check value: x31 = 0x9459dec83d58f414
@@ -426,11 +411,6 @@ jalrlsb_2: c.nop
   # check jump taken
   # Check if x31 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x3, x8, x7, x31, Zca_c_jr_cg_cp_offset_lsbs_10, Zca_c_jr_cg_cp_offset_lsbs_10_str)
-  # check return address from c.jr
-  auipc x31, 0 # get current PC
-  sub x0, x0, x31 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x3, x8, x7, x0, Zca_c_jr_cg_cp_offset_lsbs_10, Zca_c_jr_cg_cp_offset_lsbs_10_str)
 
 # Testcase cp_offset_lsbs (rs1 LSB=3)
   RVTEST_TESTDATA_LOAD_INT(x15, x22) # load jump check value: x22 = 0x9165be0abddd2dd2
@@ -445,11 +425,6 @@ jalrlsb_3: c.nop
   # check jump taken
   # Check if x22 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
   RVTEST_SIGUPD(x3, x8, x7, x22, Zca_c_jr_cg_cp_offset_lsbs_11, Zca_c_jr_cg_cp_offset_lsbs_11_str)
-  # check return address from c.jr
-  auipc x22, 0 # get current PC
-  sub x0, x0, x22 # subtract PC to make position-independent
-  # Check if x0 contains the expected result. x3 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x3, x8, x7, x0, Zca_c_jr_cg_cp_offset_lsbs_11, Zca_c_jr_cg_cp_offset_lsbs_11_str)
 
   mv x2, x3 # restore signature pointer to default register for teardown
 


### PR DESCRIPTION
Issue #2147 item 8.

`cp_imm_edges_jal.py` correctly passes `rd=0` for `c.j` (it is `c.jal` with rd hard-wired to x0), but the destination-register check called `write_sigupd(params.rd, ...)` unconditionally, signing 21 constant-zero words per test file (10 forward alignment bins + 11 backward). `cp_offset.py` has the same pattern for `c.jr`, which sets `rd=0` deliberately because it has no link register: 5 more constant-zero words per file (1 in the main negative-offset sequence, 4 in `cp_offset_lsbs`).

**Fix:** guard both checks with `if params.rd != 0`. For `c.jr` the `auipc`/`sub` that compute the position-independent return address are guarded with the signature write, since they are dead without it.

**Confirmed not to fire on the link-register cases:** `c.jal` uses `rd=1` and `c.jalr` uses `rd=1` (both in `cp_offset` and in `cp_offset_lsbs`), so their checks are untouched — neither `Zca-c.jal-00.S` nor `Zca-c.jalr-00.S` changes. `jalr` (Type JR) also draws a random rd that could in principle be x0; it happens not to be in any generated file, so `I-jalr` and `E-jalr` are unchanged too.

**Measured:** 8 files change (c.j and c.jr for rv32i/rv32e/rv64i/rv64e). SIGUPD_COUNT: c.j 51 -> 30 (-21) on all four, c.jr 51 -> 46 on rv32i/rv64i and 35 -> 30 on rv32e/rv64e (-5). 104 constant-zero signature words removed in total; no `RVTEST_SIGUPD` with check register x0 remains in any of the 8 files.

**Consequence worth knowing:** the c.j forward-align-1 and backward-align-(-1) bins already skip their jump-taken self-check because the offset is too small to fit the inline check, so with this guard they emit no signature word at all and become trap-only. Nothing real is lost — their only current assertion is that x0 reads zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTjX9BBLNAQkWwTTq6vfxq
