### PR TITLE
Align covergroup coverpoint names with testgen coverpoint names

### DIFF
--- a/coverpoints/norm/Zca.yaml
+++ b/coverpoints/norm/Zca.yaml
@@ -82,7 +82,7 @@ normative_rule_definitions:
   - name: c-sw_op
     coverpoint: ["Zca_c_sw_cg/{cp_rs1_p, cp_rs2_p, cp_rs2_edges, cp_imm_mul}"]
   - name: c-swsp_op
-    coverpoint: ["Zca_c_swsp_cg/{cp_rs2, cp_rs2_edges, cp_imm_mul}"]
+    coverpoint: ["Zca_c_swsp_cg/{cp_rs2, cp_rs2_edges, cp_imm_mul_4sp}"]
   - name: c-xor_op
     coverpoint: ["Zca_c_xor_cg/{cp_rs1_p, cp_rs2_p, cr_rs1_rs2_edges}"]
 

--- a/coverpoints/norm/Zca.yaml
+++ b/coverpoints/norm/Zca.yaml
@@ -18,7 +18,7 @@ normative_rule_definitions:
   - name: c-addi4spn_op
     coverpoint: ["Zca_c_addi4spn_cg/{cp_imm_mul_addi4spn}"]
   - name: c-addi_nop
-    coverpoint: ["Zca_c_nop_cg/{cp_asm_count}"]
+    coverpoint: ["Zca_c_nop_cg/{cp_asm_count_nop}"]
   - name: c-addi_op
     coverpoint: ["Zca_c_addi_cg/{cp_rs1_nx0, cr_rs1_imm_edges_6bit_n0}"]
   - name: c-addiw_op
@@ -58,7 +58,7 @@ normative_rule_definitions:
   - name: c-mv_op
     coverpoint: ["Zca_c_mv_cg/{cp_rd_nx0, cp_rs2_nx0}"]
   - name: c-nop_op
-    coverpoint: ["Zca_c_nop_cg/{cp_asm_count}"]
+    coverpoint: ["Zca_c_nop_cg/{cp_asm_count_nop}"]
   - name: c-or_op
     coverpoint: ["Zca_c_or_cg/{cp_rs1_p, cp_rs2_p, cr_rs1_rs2_edges}"]
   - name: c-sd_op
@@ -68,13 +68,13 @@ normative_rule_definitions:
   - name: c-slli_op
     coverpoint: ["Zca_c_slli_cg/{cp_rs1_nx0, cr_rs1_imm_edges_c}"]
   - name: c-slli_shamt5
-    coverpoint: ["Zca_c_slli_cg/{cp_slli_uimm_n0}"]
+    coverpoint: ["Zca_c_slli_cg/{cp_uimm_n0}"]
   - name: c-srai_op
     coverpoint: ["Zca_c_srai_cg/{cp_rs1_p, cr_rs1_imm_edges_c}"]
   - name: c-srli_op
     coverpoint: ["Zca_c_srli_cg/{cp_rs1_p, cr_rs1_imm_edges_c}"]
   - name: c-srli_shamt5
-    coverpoint: ["Zca_c_srli_cg/{cp_slli_uimm_n0}"]
+    coverpoint: ["Zca_c_srli_cg/{cp_uimm_n0}"]
   - name: c-sub_op
     coverpoint: ["Zca_c_sub_cg/{cp_rs1_p, cp_rs2_p, cr_rs1_rs2_edges}"]
   - name: c-subw_op

--- a/coverpoints/norm/Zca.yaml
+++ b/coverpoints/norm/Zca.yaml
@@ -8,7 +8,7 @@ normative_rule_definitions:
       ]
   - name: Zca_regs8
     # Use a representative coverpoint; applies to others too
-    coverpoint: ["Zca_c_and_cg/{cp_rs1p, cp_rs2p}"]
+    coverpoint: ["Zca_c_and_cg/{cp_rs1_p, cp_rs2_p}"]
   - name: c-add_op
     coverpoint: ["Zca_c_add_cg/{cp_rs1_nx0, cp_rs2_nx0, cr_rs1_rs2_edges}"]
   - name: c-add_val
@@ -24,15 +24,15 @@ normative_rule_definitions:
   - name: c-addiw_op
     coverpoint: ["Zca_c_addiw_cg/{cp_rs1_nx0, cr_rs1_imm_edges_6bit}"]
   - name: c-addw_op
-    coverpoint: ["Zca_c_addw_cg/{cp_rs1p, cp_rs2p, cr_rs1_rs2_edges}"]
+    coverpoint: ["Zca_c_addw_cg/{cp_rs1_p, cp_rs2_p, cr_rs1_rs2_edges}"]
   - name: c-and_op
-    coverpoint: ["Zca_c_and_cg/{cp_rs1p, cp_rs2p, cr_rs1_rs2_edges}"]
+    coverpoint: ["Zca_c_and_cg/{cp_rs1_p, cp_rs2_p, cr_rs1_rs2_edges}"]
   - name: c-andi_op
-    coverpoint: ["Zca_c_andi_cg/{cp_rs1p, cr_rs1_imm_edges_6bit}"]
+    coverpoint: ["Zca_c_andi_cg/{cp_rs1_p, cr_rs1_imm_edges_6bit}"]
   - name: c-beqz_op
-    coverpoint: ["Zca_c_beqz_cg/{cp_rs1p, cp_rs1_edges, cp_offset}"]
+    coverpoint: ["Zca_c_beqz_cg/{cp_rs1_p, cp_rs1_edges, cp_offset}"]
   - name: c-bnez_op
-    coverpoint: ["Zca_c_bnez_cg/{cp_rs1p, cp_rs1_edges, cp_offset}"]
+    coverpoint: ["Zca_c_bnez_cg/{cp_rs1_p, cp_rs1_edges, cp_offset}"]
   - name: c-j_op
     coverpoint: ["Zca_c_j_cg/{cp_imm_edges_c_jal}"]
   - name: c-jal_op
@@ -42,7 +42,7 @@ normative_rule_definitions:
   - name: c-jr_op
     coverpoint: ["Zca_c_jr_cg/{cp_rs1_nx0, cp_offset_c_jr}"]
   - name: c-ld_op
-    coverpoint: ["Zca_c_ld_cg/{cp_rs1p, cp_rdp, cp_imm_mul_8}"]
+    coverpoint: ["Zca_c_ld_cg/{cp_rs1_p, cp_rd_p, cp_imm_mul_8}"]
   - name: c-ldsp_op
     coverpoint: ["Zca_c_ldsp_cg/{cp_rd_nx0, cp_imm_mul_8sp}"]
   - name: c-li_op
@@ -50,7 +50,7 @@ normative_rule_definitions:
   - name: c-lui_op
     coverpoint: ["Zca_c_lui_cg/{cp_rs1_nx2, cr_rs1_imm_edges_6bit_n0}"]
   - name: c-lw_op
-    coverpoint: ["Zca_c_lw_cg/{cp_rs1p, cp_rdp, cp_imm_mul}"]
+    coverpoint: ["Zca_c_lw_cg/{cp_rs1_p, cp_rd_p, cp_imm_mul}"]
   - name: c-lwsp_op
     coverpoint: ["Zca_c_lwsp_cg/{cp_rd_nx0, cp_imm_mul_4sp}"]
   - name: c-mv_jr
@@ -60,9 +60,9 @@ normative_rule_definitions:
   - name: c-nop_op
     coverpoint: ["Zca_c_nop_cg/{cp_asm_count}"]
   - name: c-or_op
-    coverpoint: ["Zca_c_or_cg/{cp_rs1p, cp_rs2p, cr_rs1_rs2_edges}"]
+    coverpoint: ["Zca_c_or_cg/{cp_rs1_p, cp_rs2_p, cr_rs1_rs2_edges}"]
   - name: c-sd_op
-    coverpoint: ["Zca_c_sd_cg/{cp_rs1p, cp_rs2p, cp_rs2_edges, cp_imm_mul_8}"]
+    coverpoint: ["Zca_c_sd_cg/{cp_rs1_p, cp_rs2_p, cp_rs2_edges, cp_imm_mul_8}"]
   - name: c-sdsp_op
     coverpoint: ["Zca_c_sdsp_cg/{cp_rs2, cp_rs2_edges, cp_imm_mul_8sp}"]
   - name: c-slli_op
@@ -76,15 +76,15 @@ normative_rule_definitions:
   - name: c-srli_shamt5
     coverpoint: ["Zca_c_srli_cg/{cp_slli_uimm_n0}"]
   - name: c-sub_op
-    coverpoint: ["Zca_c_sub_cg/{cp_rs1p, cp_rs2p, cr_rs1_rs2_edges}"]
+    coverpoint: ["Zca_c_sub_cg/{cp_rs1_p, cp_rs2_p, cr_rs1_rs2_edges}"]
   - name: c-subw_op
-    coverpoint: ["Zca_c_subw_cg/{cp_rs1p, cp_rs2p, cr_rs1_rs2_edges}"]
+    coverpoint: ["Zca_c_subw_cg/{cp_rs1_p, cp_rs2_p, cr_rs1_rs2_edges}"]
   - name: c-sw_op
-    coverpoint: ["Zca_c_sw_cg/{cp_rs1p, cp_rs2p, cp_rs2_edges, cp_imm_mul}"]
+    coverpoint: ["Zca_c_sw_cg/{cp_rs1_p, cp_rs2_p, cp_rs2_edges, cp_imm_mul}"]
   - name: c-swsp_op
     coverpoint: ["Zca_c_swsp_cg/{cp_rs2, cp_rs2_edges, cp_imm_mul}"]
   - name: c-xor_op
-    coverpoint: ["Zca_c_xor_cg/{cp_rs1p, cp_rs2p, cr_rs1_rs2_edges}"]
+    coverpoint: ["Zca_c_xor_cg/{cp_rs1_p, cp_rs2_p, cr_rs1_rs2_edges}"]
 
   # compressed Zca_hints
   - name: Zca_hints

--- a/coverpoints/norm/Zca.yaml
+++ b/coverpoints/norm/Zca.yaml
@@ -38,23 +38,23 @@ normative_rule_definitions:
   - name: c-jal_op
     coverpoint: ["Zca_c_jal_cg/{cp_imm_edges_c_jal}"]
   - name: c-jalr_op
-    coverpoint: ["Zca_c_jalr_cg/{cp_rs1_nx0, cp_offset_c_jr}"]
+    coverpoint: ["Zca_c_jalr_cg/{cp_rs1_nx0, cp_offset_lsbs}"]
   - name: c-jr_op
-    coverpoint: ["Zca_c_jr_cg/{cp_rs1_nx0, cp_offset_c_jr}"]
+    coverpoint: ["Zca_c_jr_cg/{cp_rs1_nx0, cp_offset_lsbs}"]
   - name: c-ld_op
     coverpoint: ["Zca_c_ld_cg/{cp_rs1_p, cp_rd_p, cp_imm_mul_8}"]
   - name: c-ldsp_op
     coverpoint: ["Zca_c_ldsp_cg/{cp_rd_nx0, cp_imm_mul_8sp}"]
   - name: c-li_op
-    coverpoint: ["Zca_c_li_cg/{cp_rs1_nx0, cr_rs1_imm_edges_6bit}"]
+    coverpoint: ["Zca_c_li_cg/{cp_rs1_nx0, cp_imm_edges_6bit}"]
   - name: c-lui_op
-    coverpoint: ["Zca_c_lui_cg/{cp_rs1_nx2, cr_rs1_imm_edges_6bit_n0}"]
+    coverpoint: ["Zca_c_lui_cg/{cp_rs1_nx2, cp_imm_edges_6bit_n0}"]
   - name: c-lw_op
     coverpoint: ["Zca_c_lw_cg/{cp_rs1_p, cp_rd_p, cp_imm_mul}"]
   - name: c-lwsp_op
     coverpoint: ["Zca_c_lwsp_cg/{cp_rd_nx0, cp_imm_mul_4sp}"]
   - name: c-mv_jr
-    coverpoint: ["Zca_c_jr_cg/{cp_rs1_nx0, cp_offset_c_jr}"]
+    coverpoint: ["Zca_c_jr_cg/{cp_rs1_nx0, cp_offset_lsbs}"]
   - name: c-mv_op
     coverpoint: ["Zca_c_mv_cg/{cp_rd_nx0, cp_rs2_nx0}"]
   - name: c-nop_op

--- a/coverpoints/norm/Zcb.yaml
+++ b/coverpoints/norm/Zcb.yaml
@@ -3,29 +3,29 @@
 normative_rule_definitions:
   - name: c-lbu_op
     coverpoint:
-      ["Zcb_c_lbu_cg/{cp_rs1p, cp_rdp}"]
+      ["Zcb_c_lbu_cg/{cp_rs1_p, cp_rd_p}"]
       # loads a byte from the memory address formed by adding rs1' to the zero extended immediate uimm. The resulting byte is zero extended to XLEN bits and is written to rd'.
   - name: c-lh_op
     coverpoint:
-      ["Zcb_c_lh_cg/{cp_rs1p, cp_rdp}"]
+      ["Zcb_c_lh_cg/{cp_rs1_p, cp_rd_p}"]
       # loads a halfword from the memory address formed by adding rs1' to the zero extended immediate uimm. The resulting halfword is sign extended to XLEN bits and is written to rd'.
   - name: c-lhu_op
     coverpoint:
-      ["Zcb_c_lhu_cg/{cp_rs1p, cp_rdp}"]
+      ["Zcb_c_lhu_cg/{cp_rs1_p, cp_rd_p}"]
       # loads a halfword from the memory address formed by adding rs1' to the zero extended immediate uimm. The resulting halfword is zero extended to XLEN bits and is written to rd'.
   - name: c-not_op
     coverpoint:
-      ["Zcb_c_not_cg/{cp_rs1p, cp_rs1_edges}"]
+      ["Zcb_c_not_cg/{cp_rs1_p, cp_rs1_edges}"]
       # takes the one's complement of rd'/rs1' and writes the result to the same register.
   - name: c-sb_op
     coverpoint:
-      ["Zcb_c_sb_cg/{cp_rs1p, cp_rs2p}"]
+      ["Zcb_c_sb_cg/{cp_rs1_p, cp_rs2_p}"]
       # stores the least significant byte of rs2' to the memory address formed by adding rs1' to the zero extended immediate uimm.
   - name: c-sh_op
     coverpoint:
-      ["Zcb_c_sh_cg/{cp_rs1p, cp_rs2p}"]
+      ["Zcb_c_sh_cg/{cp_rs1_p, cp_rs2_p}"]
       # stores the least significant halfword of rs2' to the memory address formed by adding rs1' to the zero extended immediate uimm.
   - name: c-zext-b_op
     coverpoint:
-      ["Zcb_c_zext_b_cg/{cp_rs1p, cp_rs1_edges}"]
+      ["Zcb_c_zext_b_cg/{cp_rs1_p, cp_rs1_edges}"]
       # zero-extends the least-significant byte of the operand to XLEN bits by inserting zeros into all of the bits more significant than 7.

--- a/coverpoints/norm/ZcbM.yaml
+++ b/coverpoints/norm/ZcbM.yaml
@@ -3,5 +3,5 @@
 normative_rule_definitions:
   - name: c-mul_op
     coverpoint:
-      ["Zcb_c_mul_cg/{cp_rs1_p, cp_rs2_p, cr_rs1_rs2_edges}"]
+      ["ZcbM_c_mul_cg/{cp_rs1_p, cp_rs2_p, cr_rs1_rs2_edges}"]
       # multiplies XLEN bits of the source operands from rsd' and rs2' and writes the lowest XLEN bits of the result to rsd'.

--- a/coverpoints/norm/ZcbM.yaml
+++ b/coverpoints/norm/ZcbM.yaml
@@ -3,5 +3,5 @@
 normative_rule_definitions:
   - name: c-mul_op
     coverpoint:
-      ["Zcb_c_mul_cg/{cp_rs1p, cp_rs2p, cr_rs1_rs2_edges}"]
+      ["Zcb_c_mul_cg/{cp_rs1_p, cp_rs2_p, cr_rs1_rs2_edges}"]
       # multiplies XLEN bits of the source operands from rsd' and rs2' and writes the lowest XLEN bits of the result to rsd'.

--- a/coverpoints/norm/ZcbZba.yaml
+++ b/coverpoints/norm/ZcbZba.yaml
@@ -3,5 +3,5 @@
 normative_rule_definitions:
   - name: c-zext-w_op
     coverpoint:
-      ["Zcb_c_zext_w_cg/{cp_rs1p, cp_rs1_edges}"]
+      ["Zcb_c_zext_w_cg/{cp_rs1_p, cp_rs1_edges}"]
       # zero-extends the least-significant word of the operand to XLEN bits by inserting zeros into all of the bits more significant than 31.

--- a/coverpoints/norm/ZcbZba.yaml
+++ b/coverpoints/norm/ZcbZba.yaml
@@ -3,5 +3,5 @@
 normative_rule_definitions:
   - name: c-zext-w_op
     coverpoint:
-      ["Zcb_c_zext_w_cg/{cp_rs1_p, cp_rs1_edges}"]
+      ["ZcbZba_c_zext_w_cg/{cp_rs1_p, cp_rs1_edges}"]
       # zero-extends the least-significant word of the operand to XLEN bits by inserting zeros into all of the bits more significant than 31.

--- a/coverpoints/norm/ZcbZbb.yaml
+++ b/coverpoints/norm/ZcbZbb.yaml
@@ -3,13 +3,13 @@
 normative_rule_definitions:
   - name: c-sext-b_op
     coverpoint:
-      ["Zcb_c_sext_b_cg/{cp_rs1_p, cp_rs1_edges}"]
+      ["ZcbZbb_c_sext_b_cg/{cp_rs1_p, cp_rs1_edges}"]
       # sign-extends the least-significant byte in the operand to XLEN bits by copying the most-significant bit in the byte (i.e., bit 7) to all of the more-significant bits.
   - name: c-sext-h_op
     coverpoint:
-      ["Zcb_c_sext_h_cg/{cp_rs1_p, cp_rs1_edges}"]
+      ["ZcbZbb_c_sext_h_cg/{cp_rs1_p, cp_rs1_edges}"]
       # sign-extends the least-significant halfword in the operand to XLEN bits by copying the most-significant bit in the halfword (i.e., bit 15) to all of the more-significant bits.
   - name: c-zext-h_op
     coverpoint:
-      ["Zcb_c_zext_h_cg/{cp_rs1_p, cp_rs1_edges}"]
+      ["ZcbZbb_c_zext_h_cg/{cp_rs1_p, cp_rs1_edges}"]
       # zero-extends the least-significant halfword of the operand to XLEN bits by inserting zeros into all of the bits more significant than 15.

--- a/coverpoints/norm/ZcbZbb.yaml
+++ b/coverpoints/norm/ZcbZbb.yaml
@@ -3,13 +3,13 @@
 normative_rule_definitions:
   - name: c-sext-b_op
     coverpoint:
-      ["Zcb_c_sext_b_cg/{cp_rs1p, cp_rs1_edges}"]
+      ["Zcb_c_sext_b_cg/{cp_rs1_p, cp_rs1_edges}"]
       # sign-extends the least-significant byte in the operand to XLEN bits by copying the most-significant bit in the byte (i.e., bit 7) to all of the more-significant bits.
   - name: c-sext-h_op
     coverpoint:
-      ["Zcb_c_sext_h_cg/{cp_rs1p, cp_rs1_edges}"]
+      ["Zcb_c_sext_h_cg/{cp_rs1_p, cp_rs1_edges}"]
       # sign-extends the least-significant halfword in the operand to XLEN bits by copying the most-significant bit in the halfword (i.e., bit 15) to all of the more-significant bits.
   - name: c-zext-h_op
     coverpoint:
-      ["Zcb_c_zext_h_cg/{cp_rs1p, cp_rs1_edges}"]
+      ["Zcb_c_zext_h_cg/{cp_rs1_p, cp_rs1_edges}"]
       # zero-extends the least-significant halfword of the operand to XLEN bits by inserting zeros into all of the bits more significant than 15.

--- a/coverpoints/norm/Zcd.yaml
+++ b/coverpoints/norm/Zcd.yaml
@@ -3,12 +3,12 @@
 normative_rule_definitions:
   - name: Zc_fp_regs
     # Use a representative coverpoint; applies to others too
-    coverpoint: ["Zcd_c_fld_cg/{cp_fdp}"]
+    coverpoint: ["Zcd_c_fld_cg/{cp_fd_p}"]
   - name: c-fldsp_op
-    coverpoint: ["Zcf_c_fldsp_cg/{cp_rs1p, cp_fdp, cp_imm_mul8sp}"]
+    coverpoint: ["Zcf_c_fldsp_cg/{cp_rs1_p, cp_fd_p, cp_imm_mul8sp}"]
   - name: c-fld_op
-    coverpoint: ["Zcf_c_fld_cg/{cp_rs1p, cp_fdp, cp_imm_mul8}"]
+    coverpoint: ["Zcf_c_fld_cg/{cp_rs1_p, cp_fd_p, cp_imm_mul8}"]
   - name: c-fsd_op
-    coverpoint: ["Zcf_c_fsd_cg/{cp_rs1p, cp_fs2p, cp_imm_mul8}"]
+    coverpoint: ["Zcf_c_fsd_cg/{cp_rs1_p, cp_fs2_p, cp_imm_mul8}"]
   - name: c-fsdwsp_op
-    coverpoint: ["Zcf_c_fsdwsp_cg/{cp_rs1p, cp_fs2p, cp_imm_mul8sp}"]
+    coverpoint: ["Zcf_c_fsdwsp_cg/{cp_rs1_p, cp_fs2_p, cp_imm_mul8sp}"]

--- a/coverpoints/norm/Zcd.yaml
+++ b/coverpoints/norm/Zcd.yaml
@@ -5,10 +5,10 @@ normative_rule_definitions:
     # Use a representative coverpoint; applies to others too
     coverpoint: ["Zcd_c_fld_cg/{cp_fd_p}"]
   - name: c-fldsp_op
-    coverpoint: ["Zcf_c_fldsp_cg/{cp_rs1_p, cp_fd_p, cp_imm_mul8sp}"]
+    coverpoint: ["Zcd_c_fldsp_cg/{cp_fd, cp_imm_mul_8sp}"]
   - name: c-fld_op
-    coverpoint: ["Zcf_c_fld_cg/{cp_rs1_p, cp_fd_p, cp_imm_mul8}"]
+    coverpoint: ["Zcd_c_fld_cg/{cp_rs1_p, cp_fd_p, cp_imm_mul_8}"]
   - name: c-fsd_op
-    coverpoint: ["Zcf_c_fsd_cg/{cp_rs1_p, cp_fs2_p, cp_imm_mul8}"]
+    coverpoint: ["Zcd_c_fsd_cg/{cp_rs1_p, cp_fs2_p, cp_imm_mul_8}"]
   - name: c-fsdwsp_op
-    coverpoint: ["Zcf_c_fsdwsp_cg/{cp_rs1_p, cp_fs2_p, cp_imm_mul8sp}"]
+    coverpoint: ["Zcd_c_fsdsp_cg/{cp_fs2, cp_imm_mul_8sp}"]

--- a/coverpoints/norm/Zcf.yaml
+++ b/coverpoints/norm/Zcf.yaml
@@ -5,10 +5,10 @@ normative_rule_definitions:
     # Use a representative coverpoint; applies to others too
     coverpoint: ["Zcf_c_flw_cg/{cp_fd_p}"]
   - name: c-flw_op
-    coverpoint: ["Zcf_c_flw_cg/{cp_rs1_p, cp_fd_p, cp_imm_mul4}"]
+    coverpoint: ["Zcf_c_flw_cg/{cp_rs1_p, cp_fd_p, cp_imm_mul}"]
   - name: c-flwsp_op
-    coverpoint: ["Zcf_c_flwsp_cg/{cp_rs1_p, cp_fd_p, cp_imm_mul4sp}"]
+    coverpoint: ["Zcf_c_flwsp_cg/{cp_fd, cp_imm_mul_4sp}"]
   - name: c-fsw_op
-    coverpoint: ["Zcf_c_fsw_cg/{cp_rs1_p, cp_fs2_p, cp_imm_mul4}"]
+    coverpoint: ["Zcf_c_fsw_cg/{cp_rs1_p, cp_fs2_p, cp_imm_mul}"]
   - name: c-fswsp_op
-    coverpoint: ["Zcf_c_fswsp_cg/{cp_rs1_p, cp_fs2_p, cp_imm_mul4sp}"]
+    coverpoint: ["Zcf_c_fswsp_cg/{cp_fs2, cp_imm_mul_4sp}"]

--- a/coverpoints/norm/Zcf.yaml
+++ b/coverpoints/norm/Zcf.yaml
@@ -3,12 +3,12 @@
 normative_rule_definitions:
   - name: Zc_fp_regs
     # Use a representative coverpoint; applies to others too
-    coverpoint: ["Zcf_c_flw_cg/{cp_fdp}"]
+    coverpoint: ["Zcf_c_flw_cg/{cp_fd_p}"]
   - name: c-flw_op
-    coverpoint: ["Zcf_c_flw_cg/{cp_rs1p, cp_fdp, cp_imm_mul4}"]
+    coverpoint: ["Zcf_c_flw_cg/{cp_rs1_p, cp_fd_p, cp_imm_mul4}"]
   - name: c-flwsp_op
-    coverpoint: ["Zcf_c_flwsp_cg/{cp_rs1p, cp_fdp, cp_imm_mul4sp}"]
+    coverpoint: ["Zcf_c_flwsp_cg/{cp_rs1_p, cp_fd_p, cp_imm_mul4sp}"]
   - name: c-fsw_op
-    coverpoint: ["Zcf_c_fsw_cg/{cp_rs1p, cp_fs2p, cp_imm_mul4}"]
+    coverpoint: ["Zcf_c_fsw_cg/{cp_rs1_p, cp_fs2_p, cp_imm_mul4}"]
   - name: c-fswsp_op
-    coverpoint: ["Zcf_c_fswsp_cg/{cp_rs1p, cp_fs2p, cp_imm_mul4sp}"]
+    coverpoint: ["Zcf_c_fswsp_cg/{cp_rs1_p, cp_fs2_p, cp_imm_mul4sp}"]

--- a/coverpoints/unpriv/Zca_coverage.svh
+++ b/coverpoints/unpriv/Zca_coverage.svh
@@ -211,7 +211,7 @@ covergroup Zca_c_addi4spn_cg with function sample(ins_t ins);
         bins offset[] = {[4:1020]} with (item % 4 == 0);
     }
 
-    cp_rdp : coverpoint ins.get_gpr_c_reg(ins.current.rd)  iff (ins.trap == 0 )  {
+    cp_rd_p : coverpoint ins.get_gpr_c_reg(ins.current.rd)  iff (ins.trap == 0 )  {
         // RD register assignment
     }
 
@@ -262,7 +262,7 @@ covergroup Zca_c_and_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -300,7 +300,7 @@ covergroup Zca_c_and_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs2p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
+    cp_rs2_p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
         // RS2 register assignment
     }
 
@@ -351,7 +351,7 @@ covergroup Zca_c_andi_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -423,7 +423,7 @@ covergroup Zca_c_beqz_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -476,7 +476,7 @@ covergroup Zca_c_bnez_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -656,11 +656,11 @@ covergroup Zca_c_lw_cg with function sample(ins_t ins);
         bins offset[] = {[0:124]} with (item % 4 == 0);
     }
 
-    cp_rdp : coverpoint ins.get_gpr_c_reg(ins.current.rd)  iff (ins.trap == 0 )  {
+    cp_rd_p : coverpoint ins.get_gpr_c_reg(ins.current.rd)  iff (ins.trap == 0 )  {
         // RD register assignment
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -750,7 +750,7 @@ endgroup
 // ---------------------
 covergroup Zca_c_nop_cg with function sample(ins_t ins);
     option.per_instance = 0;
-    cp_asm_count : coverpoint ins.ins_str == "c.nop" iff (ins.trap == 0 && ins.current.imm == 0) {
+    cp_asm_count_nop : coverpoint ins.ins_str == "c.nop" iff (ins.trap == 0 && ins.current.imm == 0) {
         // Number of times the canonical c.nop (imm == 0) is executed
         bins count[] = {1};
     }
@@ -808,7 +808,7 @@ covergroup Zca_c_or_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -846,7 +846,7 @@ covergroup Zca_c_or_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs2p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
+    cp_rs2_p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
         // RS2 register assignment
     }
 
@@ -902,7 +902,7 @@ covergroup Zca_c_slli_cg with function sample(ins_t ins);
         ignore_bins x0 = {x0};
     }
 
-    cp_uimm : coverpoint unsigned'(ins.current.imm)  iff (ins.trap == 0 )  {
+    cp_uimm_n0 : coverpoint unsigned'(ins.current.imm)  iff (ins.trap == 0 )  {
         bins uimm[] = {[1:`UDB_MXLEN - 1]}; // 5/6 bit immediates, skip 0
     }
 
@@ -973,11 +973,11 @@ covergroup Zca_c_srai_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
-    cp_uimm : coverpoint unsigned'(ins.current.imm)  iff (ins.trap == 0 )  {
+    cp_uimm_n0 : coverpoint unsigned'(ins.current.imm)  iff (ins.trap == 0 )  {
         bins uimm[] = {[1:`UDB_MXLEN - 1]}; // 5/6 bit immediates, skip 0
     }
 
@@ -1048,11 +1048,11 @@ covergroup Zca_c_srli_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
-    cp_uimm : coverpoint unsigned'(ins.current.imm)  iff (ins.trap == 0 )  {
+    cp_uimm_n0 : coverpoint unsigned'(ins.current.imm)  iff (ins.trap == 0 )  {
         bins uimm[] = {[1:`UDB_MXLEN - 1]}; // 5/6 bit immediates, skip 0
     }
 
@@ -1127,7 +1127,7 @@ covergroup Zca_c_sub_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -1165,7 +1165,7 @@ covergroup Zca_c_sub_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs2p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
+    cp_rs2_p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
         // RS2 register assignment
     }
 
@@ -1187,7 +1187,7 @@ covergroup Zca_c_sw_cg with function sample(ins_t ins);
         bins offset[] = {[0:124]} with (item % 4 == 0);
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -1225,7 +1225,7 @@ covergroup Zca_c_sw_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs2p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
+    cp_rs2_p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
         // RS2 register assignment
     }
 
@@ -1328,7 +1328,7 @@ covergroup Zca_c_xor_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -1366,7 +1366,7 @@ covergroup Zca_c_xor_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs2p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
+    cp_rs2_p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
         // RS2 register assignment
     }
 
@@ -1532,7 +1532,7 @@ covergroup Zca_c_addw_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -1570,7 +1570,7 @@ covergroup Zca_c_addw_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs2p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
+    cp_rs2_p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
         // RS2 register assignment
     }
 
@@ -1596,11 +1596,11 @@ covergroup Zca_c_ld_cg with function sample(ins_t ins);
         bins offset[] = {[0:248]} with (item % 8 == 0);
     }
 
-    cp_rdp : coverpoint ins.get_gpr_c_reg(ins.current.rd)  iff (ins.trap == 0 )  {
+    cp_rd_p : coverpoint ins.get_gpr_c_reg(ins.current.rd)  iff (ins.trap == 0 )  {
         // RD register assignment
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -1637,7 +1637,7 @@ covergroup Zca_c_sd_cg with function sample(ins_t ins);
         bins offset[] = {[0:248]} with (item % 8 == 0);
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -1675,7 +1675,7 @@ covergroup Zca_c_sd_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs2p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
+    cp_rs2_p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
         // RS2 register assignment
     }
 
@@ -1778,7 +1778,7 @@ covergroup Zca_c_subw_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -1816,7 +1816,7 @@ covergroup Zca_c_subw_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs2p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
+    cp_rs2_p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
         // RS2 register assignment
     }
 

--- a/coverpoints/unpriv/ZcbM_coverage.svh
+++ b/coverpoints/unpriv/ZcbM_coverage.svh
@@ -57,7 +57,7 @@ covergroup ZcbM_c_mul_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -95,7 +95,7 @@ covergroup ZcbM_c_mul_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs2p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
+    cp_rs2_p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
         // RS2 register assignment
     }
 

--- a/coverpoints/unpriv/ZcbZba_coverage.svh
+++ b/coverpoints/unpriv/ZcbZba_coverage.svh
@@ -54,7 +54,7 @@ covergroup ZcbZba_c_zext_w_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 

--- a/coverpoints/unpriv/ZcbZbb_coverage.svh
+++ b/coverpoints/unpriv/ZcbZbb_coverage.svh
@@ -53,7 +53,7 @@ covergroup ZcbZbb_c_sext_b_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -100,7 +100,7 @@ covergroup ZcbZbb_c_sext_h_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -147,7 +147,7 @@ covergroup ZcbZbb_c_zext_h_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 

--- a/coverpoints/unpriv/Zcb_coverage.svh
+++ b/coverpoints/unpriv/Zcb_coverage.svh
@@ -23,11 +23,11 @@ covergroup Zcb_c_lbu_cg with function sample(ins_t ins);
         bins count[]  = {1};
     }
 
-    cp_rdp : coverpoint ins.get_gpr_c_reg(ins.current.rd)  iff (ins.trap == 0 )  {
+    cp_rd_p : coverpoint ins.get_gpr_c_reg(ins.current.rd)  iff (ins.trap == 0 )  {
         // RD register assignment
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -44,11 +44,11 @@ covergroup Zcb_c_lh_cg with function sample(ins_t ins);
         bins count[]  = {1};
     }
 
-    cp_rdp : coverpoint ins.get_gpr_c_reg(ins.current.rd)  iff (ins.trap == 0 )  {
+    cp_rd_p : coverpoint ins.get_gpr_c_reg(ins.current.rd)  iff (ins.trap == 0 )  {
         // RD register assignment
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -65,11 +65,11 @@ covergroup Zcb_c_lhu_cg with function sample(ins_t ins);
         bins count[]  = {1};
     }
 
-    cp_rdp : coverpoint ins.get_gpr_c_reg(ins.current.rd)  iff (ins.trap == 0 )  {
+    cp_rd_p : coverpoint ins.get_gpr_c_reg(ins.current.rd)  iff (ins.trap == 0 )  {
         // RD register assignment
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -116,7 +116,7 @@ covergroup Zcb_c_not_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -129,7 +129,7 @@ covergroup Zcb_c_sb_cg with function sample(ins_t ins);
         bins count[]  = {1};
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -167,7 +167,7 @@ covergroup Zcb_c_sb_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs2p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
+    cp_rs2_p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
         // RS2 register assignment
     }
 
@@ -180,7 +180,7 @@ covergroup Zcb_c_sh_cg with function sample(ins_t ins);
         bins count[]  = {1};
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -218,7 +218,7 @@ covergroup Zcb_c_sh_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs2p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
+    cp_rs2_p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
         // RS2 register assignment
     }
 
@@ -265,7 +265,7 @@ covergroup Zcb_c_zext_b_cg with function sample(ins_t ins);
         `endif
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 

--- a/coverpoints/unpriv/Zcd_coverage.svh
+++ b/coverpoints/unpriv/Zcd_coverage.svh
@@ -19,7 +19,7 @@ covergroup Zcd_c_fld_cg with function sample(ins_t ins);
         bins count[]  = {1};
     }
 
-    cp_fdp : coverpoint ins.get_fpr_c_reg(ins.current.fd)  iff (ins.trap == 0 )  {
+    cp_fd_p : coverpoint ins.get_fpr_c_reg(ins.current.fd)  iff (ins.trap == 0 )  {
         // FD register assignment
     }
 
@@ -28,7 +28,7 @@ covergroup Zcd_c_fld_cg with function sample(ins_t ins);
         bins offset[] = {[0:248]} with (item % 8 == 0);
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -59,7 +59,7 @@ covergroup Zcd_c_fsd_cg with function sample(ins_t ins);
         bins count[]  = {1};
     }
 
-    cp_fs2p : coverpoint ins.get_fpr_c_reg(ins.current.fs2)  iff (ins.trap == 0 )  {
+    cp_fs2_p : coverpoint ins.get_fpr_c_reg(ins.current.fs2)  iff (ins.trap == 0 )  {
         // FS2 register assignment
     }
 
@@ -68,7 +68,7 @@ covergroup Zcd_c_fsd_cg with function sample(ins_t ins);
         bins offset[] = {[0:248]} with (item % 8 == 0);
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 

--- a/coverpoints/unpriv/Zcf_coverage.svh
+++ b/coverpoints/unpriv/Zcf_coverage.svh
@@ -20,7 +20,7 @@ covergroup Zcf_c_flw_cg with function sample(ins_t ins);
         bins count[]  = {1};
     }
 
-    cp_fdp : coverpoint ins.get_fpr_c_reg(ins.current.fd)  iff (ins.trap == 0 )  {
+    cp_fd_p : coverpoint ins.get_fpr_c_reg(ins.current.fd)  iff (ins.trap == 0 )  {
         // FD register assignment
     }
 
@@ -29,7 +29,7 @@ covergroup Zcf_c_flw_cg with function sample(ins_t ins);
         bins offset[] = {[0:124]} with (item % 4 == 0);
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 
@@ -60,7 +60,7 @@ covergroup Zcf_c_fsw_cg with function sample(ins_t ins);
         bins count[]  = {1};
     }
 
-    cp_fs2p : coverpoint ins.get_fpr_c_reg(ins.current.fs2)  iff (ins.trap == 0 )  {
+    cp_fs2_p : coverpoint ins.get_fpr_c_reg(ins.current.fs2)  iff (ins.trap == 0 )  {
         // FS2 register assignment
     }
 
@@ -69,7 +69,7 @@ covergroup Zcf_c_fsw_cg with function sample(ins_t ins);
         bins offset[] = {[0:124]} with (item % 4 == 0);
     }
 
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }
 

--- a/generators/coverage/src/covergroupgen/templates/cp_asm_count_nop.sv
+++ b/generators/coverage/src/covergroupgen/templates/cp_asm_count_nop.sv
@@ -1,4 +1,4 @@
-    cp_asm_count : coverpoint ins.ins_str == "INSTR" iff (ins.trap == 0 && ins.current.imm == 0) {
+    cp_asm_count_nop : coverpoint ins.ins_str == "INSTR" iff (ins.trap == 0 && ins.current.imm == 0) {
         // Number of times the canonical INSTR (imm == 0) is executed
         bins count[] = {1};
     }

--- a/generators/coverage/src/covergroupgen/templates/cp_fd_p.sv
+++ b/generators/coverage/src/covergroupgen/templates/cp_fd_p.sv
@@ -1,3 +1,3 @@
-    cp_fdp : coverpoint ins.get_fpr_c_reg(ins.current.fd)  iff (ins.trap == 0 )  {
+    cp_fd_p : coverpoint ins.get_fpr_c_reg(ins.current.fd)  iff (ins.trap == 0 )  {
         // FD register assignment
     }

--- a/generators/coverage/src/covergroupgen/templates/cp_fs2_p.sv
+++ b/generators/coverage/src/covergroupgen/templates/cp_fs2_p.sv
@@ -1,3 +1,3 @@
-    cp_fs2p : coverpoint ins.get_fpr_c_reg(ins.current.fs2)  iff (ins.trap == 0 )  {
+    cp_fs2_p : coverpoint ins.get_fpr_c_reg(ins.current.fs2)  iff (ins.trap == 0 )  {
         // FS2 register assignment
     }

--- a/generators/coverage/src/covergroupgen/templates/cp_rd_p.sv
+++ b/generators/coverage/src/covergroupgen/templates/cp_rd_p.sv
@@ -1,3 +1,3 @@
-    cp_rdp : coverpoint ins.get_gpr_c_reg(ins.current.rd)  iff (ins.trap == 0 )  {
+    cp_rd_p : coverpoint ins.get_gpr_c_reg(ins.current.rd)  iff (ins.trap == 0 )  {
         // RD register assignment
     }

--- a/generators/coverage/src/covergroupgen/templates/cp_rs1_p.sv
+++ b/generators/coverage/src/covergroupgen/templates/cp_rs1_p.sv
@@ -1,3 +1,3 @@
-    cp_rs1p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
+    cp_rs1_p : coverpoint ins.get_gpr_c_reg(ins.current.rs1)  iff (ins.trap == 0 )  {
         // RS1 register assignment
     }

--- a/generators/coverage/src/covergroupgen/templates/cp_rs2_p.sv
+++ b/generators/coverage/src/covergroupgen/templates/cp_rs2_p.sv
@@ -1,3 +1,3 @@
-    cp_rs2p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
+    cp_rs2_p : coverpoint ins.get_gpr_c_reg(ins.current.rs2)  iff (ins.trap == 0 )  {
         // RS2 register assignment
     }

--- a/generators/coverage/src/covergroupgen/templates/cp_uimm_n0.sv
+++ b/generators/coverage/src/covergroupgen/templates/cp_uimm_n0.sv
@@ -1,3 +1,3 @@
-    cp_uimm : coverpoint unsigned'(ins.current.imm)  iff (ins.trap == 0 )  {
+    cp_uimm_n0 : coverpoint unsigned'(ins.current.imm)  iff (ins.trap == 0 )  {
         bins uimm[] = {[1:`UDB_MXLEN - 1]}; // 5/6 bit immediates, skip 0
     }


### PR DESCRIPTION
Issue #2147 item 37.

testgen names a coverpoint by joining the testplan CSV column with the cell
value (`cp_rs1` + `p` -> `cp_rs1_p`), but seven covergroup templates declared a
SystemVerilog identifier with the separator dropped (`cp_rs1p`, `cp_uimm`,
`cp_asm_count`). Testcase labels in `tests/` therefore never matched the bin
names in the covergroups for the compressed suites.

Fixed in covergroupgen rather than testgen: 7 template lines instead of
thousands of generated testcase labels, and it makes
`generators/ctp/norm_yaml_gen.py` (which already builds names the testgen way)
correct by construction.

No `cross` anywhere references the old identifiers, and no covergroup declares
both `cp_uimm` and `cp_uimm_n0` (or the `cp_asm_count` pair), so nothing else
had to change. Regenerating touches only the 7 compressed-suite covergroups
(56 lines) and leaves `tests/` untouched.

The 7 matching `coverpoints/norm/*.yaml` cited the old spelling in 63 places and are renamed in the
same commit — leaving them would have added 96 findings to `tools/check_testplans.py`. They are not
`make tests` outputs (`norm_yaml_gen.py` has no Makefile target), so they are edited directly.
`check_testplans.py` totals 1039 findings before and after, and `norm-svh` 109 before and after, so
this is checker-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTjX9BBLNAQkWwTTq6vfxq
