### PR TITLE
Correct FP NaN-box and fflags cells in three testplans

### DIFF
--- a/coverpoints/norm/Zfhmin.yaml
+++ b/coverpoints/norm/Zfhmin.yaml
@@ -9,7 +9,7 @@ normative_rule_definitions:
     # never round
     coverpoint:
       [
-        "Zfhmin_fcvt_h_s_cg/{cp_fs1, cp_fd, cp_fs1_edges, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm, cp_NaNBox_S_H}",
+        "Zfhmin_fcvt_h_s_cg/{cp_fs1, cp_fd, cp_fs1_edges, cp_frm_2, cp_csr_fflags_voun, cp_csr_frm, cp_NaNBox_S_H}",
       ]
   - name: fcvt-s-h_op
     # FCVT.S.H or

--- a/coverpoints/unpriv/ZfaZfhD_coverage.svh
+++ b/coverpoints/unpriv/ZfaZfhD_coverage.svh
@@ -182,20 +182,20 @@ covergroup ZfaZfhD_fround_h_cg with function sample(ins_t ins);
         bins NaNBox = {48'hffffffffffff};
     }
 
-    cp_fs1_badNB_S_H : coverpoint unsigned'(ins.current.fs1_val[31:0])  iff (ins.trap == 0 )  {
-        // "FS1 Bad NaNBox edges (half NaNBoxed to 32 bits)";
-        bins pos0             = {32'h0000_0000};
-        bins neg0             = {32'hfffe_8000};
-        bins pos1             = {32'h7fff_3C00};
-        bins neg1             = {32'hbeef_BC00};
-        bins posminnorm       = {32'hfeff_0400};
-        bins negminnorm       = {32'h0fff_8400};
-        bins posmaxnorm       = {32'hefff_7BFF};
-        bins negmaxnorm       = {32'hc0de_FBFF};
-        bins posinfinity      = {32'h4f1a_7C00};
-        bins neginfinity      = {32'h0fff_FC00};
-        bins posQNaN          = {[32'hffef_7E00:32'hfeef_7FFF]};
-        bins posSNaN          = {[32'ha1b2_7C01:32'h4fd7_7DFF]};
+    cp_fs1_badNB_D_H : coverpoint unsigned'(ins.current.fs1_val[63:0])  iff (ins.trap == 0 )  {
+        //// "FS1 Bad NaNBox edges (half NaNBoxed to 64 bits)";
+        bins pos0             = {64'hffffffff0000_0000};
+        bins neg0             = {64'hfffffffffffe_8000};
+        bins pos1             = {64'h7fffffffffff_3C00};
+        bins neg1             = {64'hfeedbee5beef_BC00};
+        bins posminnorm       = {64'hffffffefffff_0400};
+        bins negminnorm       = {64'h00000000ffff_8400};
+        bins posmaxnorm       = {64'hefffffffffff_7BFF};
+        bins negmaxnorm       = {64'hc0dec0dec0de_FBFF};
+        bins posinfinity      = {64'ha83ef1cc4f1a_7C00};
+        bins neginfinity      = {64'hffffffff0fff_FC00};
+        bins posQNaN          = {[64'hfffeffffffff_7E00:64'hffffffefffff_7FFF]};
+        bins posSNaN          = {[64'ha1b2c3d4e5f6_7C01:64'hfffffffcffff_7DFF]};
     }
 
 endgroup

--- a/coverpoints/unpriv/Zfbfmin_coverage.svh
+++ b/coverpoints/unpriv/Zfbfmin_coverage.svh
@@ -32,10 +32,14 @@ covergroup Zfbfmin_fcvt_bf16_s_cg with function sample(ins_t ins);
         bins count[]  = {1};
     }
 
-    cp_csr_fflags_vn : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_AFTER, "fcsr", "fflags") iff (ins.trap == 0 )  {
+    cp_csr_fflags_voun : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_AFTER, "fcsr", "fflags") iff (ins.trap == 0 )  {
         // Value of FCSR.fflags
         wildcard bins NV   = (5'b0???? => 5'b1????);
         wildcard bins NV1  = (5'b1???? => 5'b1????);
+        wildcard bins OF   = (5'b??0?? => 5'b??1??);
+        wildcard bins OF1  = (5'b??1?? => 5'b??1??);
+        wildcard bins UF   = (5'b???0? => 5'b???1?);
+        wildcard bins UF1  = (5'b???1? => 5'b???1?);
         wildcard bins NX   = (5'b????0 => 5'b????1);
         wildcard bins NX1  = (5'b????1 => 5'b????1);
     }

--- a/coverpoints/unpriv/Zfhmin_coverage.svh
+++ b/coverpoints/unpriv/Zfhmin_coverage.svh
@@ -32,10 +32,14 @@ covergroup Zfhmin_fcvt_h_s_cg with function sample(ins_t ins);
         bins count[]  = {1};
     }
 
-    cp_csr_fflags_vn : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_AFTER, "fcsr", "fflags") iff (ins.trap == 0 )  {
+    cp_csr_fflags_voun : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_AFTER, "fcsr", "fflags") iff (ins.trap == 0 )  {
         // Value of FCSR.fflags
         wildcard bins NV   = (5'b0???? => 5'b1????);
         wildcard bins NV1  = (5'b1???? => 5'b1????);
+        wildcard bins OF   = (5'b??0?? => 5'b??1??);
+        wildcard bins OF1  = (5'b??1?? => 5'b??1??);
+        wildcard bins UF   = (5'b???0? => 5'b???1?);
+        wildcard bins UF1  = (5'b???1? => 5'b???1?);
         wildcard bins NX   = (5'b????0 => 5'b????1);
         wildcard bins NX1  = (5'b????1 => 5'b????1);
     }

--- a/testplans/ZfaZfhD.csv
+++ b/testplans/ZfaZfhD.csv
@@ -4,5 +4,5 @@ fli.h,FLI,x,x,D_H,,
 fltq.h,FC,x,x,,D_H,D_H
 fmaxm.h,FR,x,x,D_H,D_H,D_H
 fminm.h,FR,x,x,D_H,D_H,D_H
-fround.h,FI,x,x,D_H,S_H,
+fround.h,FI,x,x,D_H,D_H,
 froundnx.h,FI,x,x,D_H,D_H,

--- a/testplans/Zfbfmin.csv
+++ b/testplans/Zfbfmin.csv
@@ -1,5 +1,5 @@
 Instruction,Type,RV32,RV64,cp_asm_count,cp_rs1,cp_rd,cp_rs1_edges,cp_imm_edges,cp_fs1,cp_fs2,cp_fd,cp_fs1_edges,cp_fs2_edges,cmp_fd_fs1,cp_frm,cp_csr_fflags,cp_csr_frm,cp_NaNBox,cp_fs1_badNB,cp_fs2_badNB
-fcvt.bf16.s,FI,x,x,x,,,,,x,,x,x,,x,2,vn,x,S_H,,
+fcvt.bf16.s,FI,x,x,x,,,,,x,,x,x,,x,2,voun,x,S_H,,
 fcvt.s.bf16,FI,x,x,x,,,,,x,,x,BF16,,x,,v,,,S_H,
 flh,FL,x,x,x,nx0,,,x,,,x,,,,,,,S_H,,
 fmv.h.x,X2F,x,x,x,x,,x,,,,x,,,,,,,S_H,,

--- a/testplans/Zfhmin.csv
+++ b/testplans/Zfhmin.csv
@@ -1,5 +1,5 @@
 Instruction,Type,RV32,RV64,cp_asm_count,cp_rs1,cp_rd,cp_rs1_edges,cp_imm_edges,cp_fs1,cp_fs2,cp_fd,cp_fs1_edges,cp_fs2_edges,cmp_fd_fs1,cp_frm,cp_csr_fflags,cp_csr_frm,cp_NaNBox,cp_fs1_badNB,cp_fs2_badNB
-fcvt.h.s,FI,x,x,x,,,,,x,,x,x,,x,2,vn,x,S_H,,
+fcvt.h.s,FI,x,x,x,,,,,x,,x,x,,x,2,voun,x,S_H,,
 fcvt.s.h,FI,x,x,x,,,,,x,,x,H,,x,,v,,,S_H,
 flh,FL,x,x,x,nx0,,,x,,,x,,,,,,,S_H,,
 fmv.h.x,X2F,x,x,x,x,,x,,,,x,,,,,,,S_H,,

--- a/tests/rv32i/ZfaZfhD/ZfaZfhD-fround.h-00.S
+++ b/tests/rv32i/ZfaZfhD/ZfaZfhD-fround.h-00.S
@@ -42,120 +42,120 @@ ZfaZfhD_fround_h_cg_cp_NaNBox_D_H_NaNBox:
   RVTEST_SIGUPD_F(x2, x5, x4, f4, f15, ZfaZfhD_fround_h_cg_cp_NaNBox_D_H_NaNBox, ZfaZfhD_fround_h_cg_cp_NaNBox_D_H_NaNBox_str)
 
 /////////////////////////////////
-// cp_fs1_badNB_S_H
+// cp_fs1_badNB_D_H
 /////////////////////////////////
 
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x0000000000000000)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f29) # load fs1: f29 = 0x00000000
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xffffffff00000000)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f29) # load fs1: f29 = 0xffffffff00000000
   fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x0:
-  fround.h f12, f29 # perform operation
-  # Check if f12 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f12, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x0, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x0_str)
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffff00000000:
+  fround.h f26, f29 # perform operation
+  # Check if f26 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f26, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffff00000000, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffff00000000_str)
 
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x00000000fffe8000)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f11) # load fs1: f11 = 0xfffe8000
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xfffffffffffe8000)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f22) # load fs1: f22 = 0xfffffffffffe8000
   fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfffe8000:
-  fround.h f5, f11 # perform operation
-  # Check if f5 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f5, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfffe8000, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfffe8000_str)
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffffffffffe8000:
+  fround.h f28, f22 # perform operation
+  # Check if f28 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f28, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffffffffffe8000, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffffffffffe8000_str)
 
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x000000007fff3c00)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f6) # load fs1: f6 = 0x7fff3c00
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0x7fffffffffff3c00)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f20) # load fs1: f20 = 0x7fffffffffff3c00
   fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x7fff3c00:
-  fround.h f13, f6 # perform operation
-  # Check if f13 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f13, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x7fff3c00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x7fff3c00_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x00000000beefbc00)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f7) # load fs1: f7 = 0xbeefbc00
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xbeefbc00:
-  fround.h f21, f7 # perform operation
-  # Check if f21 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f21, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xbeefbc00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xbeefbc00_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x00000000feff0400)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f2) # load fs1: f2 = 0xfeff0400
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfeff0400:
-  fround.h f14, f2 # perform operation
-  # Check if f14 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f14, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfeff0400, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfeff0400_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x000000000fff8400)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f30) # load fs1: f30 = 0x0fff8400
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfff8400:
-  fround.h f10, f30 # perform operation
-  # Check if f10 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f10, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfff8400, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfff8400_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x00000000efff7bff)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f11) # load fs1: f11 = 0xefff7bff
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xefff7bff:
-  fround.h f31, f11 # perform operation
-  # Check if f31 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f31, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xefff7bff, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xefff7bff_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x00000000c0defbff)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f29) # load fs1: f29 = 0xc0defbff
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xc0defbff:
-  fround.h f10, f29 # perform operation
-  # Check if f10 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f10, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xc0defbff, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xc0defbff_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x000000004f1a7c00)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f22) # load fs1: f22 = 0x4f1a7c00
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x4f1a7c00:
-  fround.h f5, f22 # perform operation
-  # Check if f5 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f5, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x4f1a7c00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x4f1a7c00_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x000000000ffffc00)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f26) # load fs1: f26 = 0x0ffffc00
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xffffc00:
-  fround.h f7, f26 # perform operation
-  # Check if f7 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f7, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xffffc00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xffffc00_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x00000000ffef7e00)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f20) # load fs1: f20 = 0xffef7e00
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xffef7e00:
-  fround.h f29, f20 # perform operation
-  # Check if f29 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f29, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xffef7e00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xffef7e00_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x00000000feef7fff)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f21) # load fs1: f21 = 0xfeef7fff
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfeef7fff:
-  fround.h f9, f21 # perform operation
-  # Check if f9 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f9, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfeef7fff, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfeef7fff_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x00000000a1b27c01)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f21) # load fs1: f21 = 0xa1b27c01
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xa1b27c01:
-  fround.h f2, f21 # perform operation
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0x7fffffffffff3c00:
+  fround.h f2, f20 # perform operation
   # Check if f2 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f2, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xa1b27c01, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xa1b27c01_str)
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f2, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0x7fffffffffff3c00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0x7fffffffffff3c00_str)
 
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x000000004fd77dff)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f27) # load fs1: f27 = 0x4fd77dff
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xfeedbee5beefbc00)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f17) # load fs1: f17 = 0xfeedbee5beefbc00
   fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x4fd77dff:
-  fround.h f19, f27 # perform operation
-  # Check if f19 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f19, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x4fd77dff, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x4fd77dff_str)
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfeedbee5beefbc00:
+  fround.h f1, f17 # perform operation
+  # Check if f1 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f1, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfeedbee5beefbc00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfeedbee5beefbc00_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xffffffefffff0400)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f10) # load fs1: f10 = 0xffffffefffff0400
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffefffff0400:
+  fround.h f2, f10 # perform operation
+  # Check if f2 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f2, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffefffff0400, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffefffff0400_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0x00000000ffff8400)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f10) # load fs1: f10 = 0x00000000ffff8400
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffff8400:
+  fround.h f14, f10 # perform operation
+  # Check if f14 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f14, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffff8400, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffff8400_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xefffffffffff7bff)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f14) # load fs1: f14 = 0xefffffffffff7bff
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xefffffffffff7bff:
+  fround.h f29, f14 # perform operation
+  # Check if f29 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f29, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xefffffffffff7bff, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xefffffffffff7bff_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xc0dec0dec0defbff)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f22) # load fs1: f22 = 0xc0dec0dec0defbff
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xc0dec0dec0defbff:
+  fround.h f20, f22 # perform operation
+  # Check if f20 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f20, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xc0dec0dec0defbff, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xc0dec0dec0defbff_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xa83ef1cc4f1a7c00)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f16) # load fs1: f16 = 0xa83ef1cc4f1a7c00
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xa83ef1cc4f1a7c00:
+  fround.h f18, f16 # perform operation
+  # Check if f18 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f18, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xa83ef1cc4f1a7c00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xa83ef1cc4f1a7c00_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xffffffff0ffffc00)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f11) # load fs1: f11 = 0xffffffff0ffffc00
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffff0ffffc00:
+  fround.h f27, f11 # perform operation
+  # Check if f27 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f27, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffff0ffffc00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffff0ffffc00_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xfffeffffffff7e00)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f29) # load fs1: f29 = 0xfffeffffffff7e00
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffeffffffff7e00:
+  fround.h f30, f29 # perform operation
+  # Check if f30 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f30, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffeffffffff7e00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffeffffffff7e00_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xffffffefffff7fff)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f2) # load fs1: f2 = 0xffffffefffff7fff
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffefffff7fff:
+  fround.h f12, f2 # perform operation
+  # Check if f12 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f12, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffefffff7fff, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffefffff7fff_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xa1b2c3d4e5f67c01)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f6) # load fs1: f6 = 0xa1b2c3d4e5f67c01
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xa1b2c3d4e5f67c01:
+  fround.h f7, f6 # perform operation
+  # Check if f7 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f7, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xa1b2c3d4e5f67c01, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xa1b2c3d4e5f67c01_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xfffffffcffff7dff)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f31) # load fs1: f31 = 0xfffffffcffff7dff
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffffffcffff7dff:
+  fround.h f3, f31 # perform operation
+  # Check if f3 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f3, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffffffcffff7dff, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffffffcffff7dff_str)
 
 // Instantiate trap handlers and other epilog code, call RVMODEL_HALT at end of test
 RVTEST_CODE_END
@@ -165,37 +165,37 @@ RVTEST_DATA_BEGIN
 
 // Test data
 .dword 0xa4f052df1c5f2be6
-.dword 0x0000000000000000
-.dword 0x00000000fffe8000
-.dword 0x000000007fff3c00
-.dword 0x00000000beefbc00
-.dword 0x00000000feff0400
-.dword 0x000000000fff8400
-.dword 0x00000000efff7bff
-.dword 0x00000000c0defbff
-.dword 0x000000004f1a7c00
-.dword 0x000000000ffffc00
-.dword 0x00000000ffef7e00
-.dword 0x00000000feef7fff
-.dword 0x00000000a1b27c01
-.dword 0x000000004fd77dff
+.dword 0xffffffff00000000
+.dword 0xfffffffffffe8000
+.dword 0x7fffffffffff3c00
+.dword 0xfeedbee5beefbc00
+.dword 0xffffffefffff0400
+.dword 0x00000000ffff8400
+.dword 0xefffffffffff7bff
+.dword 0xc0dec0dec0defbff
+.dword 0xa83ef1cc4f1a7c00
+.dword 0xffffffff0ffffc00
+.dword 0xfffeffffffff7e00
+.dword 0xffffffefffff7fff
+.dword 0xa1b2c3d4e5f67c01
+.dword 0xfffffffcffff7dff
 
 // Testcase strings
 ZfaZfhD_fround_h_cg_cp_NaNBox_D_H_NaNBox_str: .string "\"test: 1; cg: ZfaZfhD_fround.h_cg; cp: cp_NaNBox_D_H; bin: NaNBox\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x0_str: .string "\"test: 2; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0x0\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfffe8000_str: .string "\"test: 3; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xfffe8000\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x7fff3c00_str: .string "\"test: 4; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0x7fff3c00\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xbeefbc00_str: .string "\"test: 5; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xbeefbc00\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfeff0400_str: .string "\"test: 6; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xfeff0400\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfff8400_str: .string "\"test: 7; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xfff8400\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xefff7bff_str: .string "\"test: 8; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xefff7bff\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xc0defbff_str: .string "\"test: 9; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xc0defbff\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x4f1a7c00_str: .string "\"test: 10; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0x4f1a7c00\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xffffc00_str: .string "\"test: 11; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xffffc00\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xffef7e00_str: .string "\"test: 12; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xffef7e00\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfeef7fff_str: .string "\"test: 13; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xfeef7fff\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xa1b27c01_str: .string "\"test: 14; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xa1b27c01\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x4fd77dff_str: .string "\"test: 15; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0x4fd77dff\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffff00000000_str: .string "\"test: 2; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xffffffff00000000\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffffffffffe8000_str: .string "\"test: 3; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xfffffffffffe8000\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0x7fffffffffff3c00_str: .string "\"test: 4; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0x7fffffffffff3c00\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfeedbee5beefbc00_str: .string "\"test: 5; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xfeedbee5beefbc00\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffefffff0400_str: .string "\"test: 6; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xffffffefffff0400\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffff8400_str: .string "\"test: 7; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xffff8400\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xefffffffffff7bff_str: .string "\"test: 8; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xefffffffffff7bff\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xc0dec0dec0defbff_str: .string "\"test: 9; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xc0dec0dec0defbff\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xa83ef1cc4f1a7c00_str: .string "\"test: 10; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xa83ef1cc4f1a7c00\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffff0ffffc00_str: .string "\"test: 11; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xffffffff0ffffc00\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffeffffffff7e00_str: .string "\"test: 12; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xfffeffffffff7e00\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffefffff7fff_str: .string "\"test: 13; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xffffffefffff7fff\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xa1b2c3d4e5f67c01_str: .string "\"test: 14; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xa1b2c3d4e5f67c01\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffffffcffff7dff_str: .string "\"test: 15; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xfffffffcffff7dff\""
 
 // End of test data section and model specific data
 RVTEST_DATA_END

--- a/tests/rv64i/ZfaZfhD/ZfaZfhD-fround.h-00.S
+++ b/tests/rv64i/ZfaZfhD/ZfaZfhD-fround.h-00.S
@@ -42,120 +42,120 @@ ZfaZfhD_fround_h_cg_cp_NaNBox_D_H_NaNBox:
   RVTEST_SIGUPD_F(x2, x5, x4, f4, f15, ZfaZfhD_fround_h_cg_cp_NaNBox_D_H_NaNBox, ZfaZfhD_fround_h_cg_cp_NaNBox_D_H_NaNBox_str)
 
 /////////////////////////////////
-// cp_fs1_badNB_S_H
+// cp_fs1_badNB_D_H
 /////////////////////////////////
 
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x0000000000000000)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f29) # load fs1: f29 = 0x00000000
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xffffffff00000000)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f29) # load fs1: f29 = 0xffffffff00000000
   fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x0:
-  fround.h f12, f29 # perform operation
-  # Check if f12 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f12, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x0, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x0_str)
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffff00000000:
+  fround.h f26, f29 # perform operation
+  # Check if f26 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f26, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffff00000000, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffff00000000_str)
 
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x00000000fffe8000)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f11) # load fs1: f11 = 0xfffe8000
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xfffffffffffe8000)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f22) # load fs1: f22 = 0xfffffffffffe8000
   fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfffe8000:
-  fround.h f5, f11 # perform operation
-  # Check if f5 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f5, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfffe8000, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfffe8000_str)
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffffffffffe8000:
+  fround.h f28, f22 # perform operation
+  # Check if f28 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f28, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffffffffffe8000, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffffffffffe8000_str)
 
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x000000007fff3c00)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f6) # load fs1: f6 = 0x7fff3c00
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0x7fffffffffff3c00)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f20) # load fs1: f20 = 0x7fffffffffff3c00
   fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x7fff3c00:
-  fround.h f13, f6 # perform operation
-  # Check if f13 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f13, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x7fff3c00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x7fff3c00_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x00000000beefbc00)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f7) # load fs1: f7 = 0xbeefbc00
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xbeefbc00:
-  fround.h f21, f7 # perform operation
-  # Check if f21 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f21, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xbeefbc00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xbeefbc00_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x00000000feff0400)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f2) # load fs1: f2 = 0xfeff0400
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfeff0400:
-  fround.h f14, f2 # perform operation
-  # Check if f14 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f14, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfeff0400, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfeff0400_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x000000000fff8400)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f30) # load fs1: f30 = 0x0fff8400
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfff8400:
-  fround.h f10, f30 # perform operation
-  # Check if f10 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f10, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfff8400, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfff8400_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x00000000efff7bff)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f11) # load fs1: f11 = 0xefff7bff
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xefff7bff:
-  fround.h f31, f11 # perform operation
-  # Check if f31 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f31, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xefff7bff, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xefff7bff_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x00000000c0defbff)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f29) # load fs1: f29 = 0xc0defbff
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xc0defbff:
-  fround.h f10, f29 # perform operation
-  # Check if f10 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f10, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xc0defbff, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xc0defbff_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x000000004f1a7c00)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f22) # load fs1: f22 = 0x4f1a7c00
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x4f1a7c00:
-  fround.h f5, f22 # perform operation
-  # Check if f5 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f5, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x4f1a7c00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x4f1a7c00_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x000000000ffffc00)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f26) # load fs1: f26 = 0x0ffffc00
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xffffc00:
-  fround.h f7, f26 # perform operation
-  # Check if f7 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f7, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xffffc00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xffffc00_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x00000000ffef7e00)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f20) # load fs1: f20 = 0xffef7e00
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xffef7e00:
-  fround.h f29, f20 # perform operation
-  # Check if f29 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f29, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xffef7e00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xffef7e00_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x00000000feef7fff)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f21) # load fs1: f21 = 0xfeef7fff
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfeef7fff:
-  fround.h f9, f21 # perform operation
-  # Check if f9 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f9, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfeef7fff, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfeef7fff_str)
-
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x00000000a1b27c01)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f21) # load fs1: f21 = 0xa1b27c01
-  fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xa1b27c01:
-  fround.h f2, f21 # perform operation
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0x7fffffffffff3c00:
+  fround.h f2, f20 # perform operation
   # Check if f2 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f2, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xa1b27c01, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xa1b27c01_str)
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f2, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0x7fffffffffff3c00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0x7fffffffffff3c00_str)
 
-# Testcase cp_fs1_badNB_S_H (Test source fs1 value = 0x000000004fd77dff)
-  RVTEST_TESTDATA_LOAD_FLOAT_SINGLE(x3, f27) # load fs1: f27 = 0x4fd77dff
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xfeedbee5beefbc00)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f17) # load fs1: f17 = 0xfeedbee5beefbc00
   fsflagsi 0b00000 # clear all fflags
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x4fd77dff:
-  fround.h f19, f27 # perform operation
-  # Check if f19 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
-  RVTEST_SIGUPD_F(x2, x5, x4, f4, f19, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x4fd77dff, ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x4fd77dff_str)
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfeedbee5beefbc00:
+  fround.h f1, f17 # perform operation
+  # Check if f1 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f1, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfeedbee5beefbc00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfeedbee5beefbc00_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xffffffefffff0400)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f10) # load fs1: f10 = 0xffffffefffff0400
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffefffff0400:
+  fround.h f2, f10 # perform operation
+  # Check if f2 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f2, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffefffff0400, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffefffff0400_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0x00000000ffff8400)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f10) # load fs1: f10 = 0x00000000ffff8400
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffff8400:
+  fround.h f14, f10 # perform operation
+  # Check if f14 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f14, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffff8400, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffff8400_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xefffffffffff7bff)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f14) # load fs1: f14 = 0xefffffffffff7bff
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xefffffffffff7bff:
+  fround.h f29, f14 # perform operation
+  # Check if f29 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f29, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xefffffffffff7bff, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xefffffffffff7bff_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xc0dec0dec0defbff)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f22) # load fs1: f22 = 0xc0dec0dec0defbff
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xc0dec0dec0defbff:
+  fround.h f20, f22 # perform operation
+  # Check if f20 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f20, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xc0dec0dec0defbff, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xc0dec0dec0defbff_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xa83ef1cc4f1a7c00)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f16) # load fs1: f16 = 0xa83ef1cc4f1a7c00
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xa83ef1cc4f1a7c00:
+  fround.h f18, f16 # perform operation
+  # Check if f18 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f18, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xa83ef1cc4f1a7c00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xa83ef1cc4f1a7c00_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xffffffff0ffffc00)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f11) # load fs1: f11 = 0xffffffff0ffffc00
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffff0ffffc00:
+  fround.h f27, f11 # perform operation
+  # Check if f27 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f27, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffff0ffffc00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffff0ffffc00_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xfffeffffffff7e00)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f29) # load fs1: f29 = 0xfffeffffffff7e00
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffeffffffff7e00:
+  fround.h f30, f29 # perform operation
+  # Check if f30 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f30, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffeffffffff7e00, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffeffffffff7e00_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xffffffefffff7fff)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f2) # load fs1: f2 = 0xffffffefffff7fff
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffefffff7fff:
+  fround.h f12, f2 # perform operation
+  # Check if f12 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f12, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffefffff7fff, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffefffff7fff_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xa1b2c3d4e5f67c01)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f6) # load fs1: f6 = 0xa1b2c3d4e5f67c01
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xa1b2c3d4e5f67c01:
+  fround.h f7, f6 # perform operation
+  # Check if f7 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f7, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xa1b2c3d4e5f67c01, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xa1b2c3d4e5f67c01_str)
+
+# Testcase cp_fs1_badNB_D_H (Test source fs1 value = 0xfffffffcffff7dff)
+  RVTEST_TESTDATA_LOAD_FLOAT_DOUBLE(x3, f31) # load fs1: f31 = 0xfffffffcffff7dff
+  fsflagsi 0b00000 # clear all fflags
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffffffcffff7dff:
+  fround.h f3, f31 # perform operation
+  # Check if f3 contains the expected result. Also checks fflags. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg, f4 is a floating point temp reg.
+  RVTEST_SIGUPD_F(x2, x5, x4, f4, f3, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffffffcffff7dff, ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffffffcffff7dff_str)
 
 // Instantiate trap handlers and other epilog code, call RVMODEL_HALT at end of test
 RVTEST_CODE_END
@@ -165,37 +165,37 @@ RVTEST_DATA_BEGIN
 
 // Test data
 .dword 0xa4f052df1c5f2be6
-.dword 0x0000000000000000
-.dword 0x00000000fffe8000
-.dword 0x000000007fff3c00
-.dword 0x00000000beefbc00
-.dword 0x00000000feff0400
-.dword 0x000000000fff8400
-.dword 0x00000000efff7bff
-.dword 0x00000000c0defbff
-.dword 0x000000004f1a7c00
-.dword 0x000000000ffffc00
-.dword 0x00000000ffef7e00
-.dword 0x00000000feef7fff
-.dword 0x00000000a1b27c01
-.dword 0x000000004fd77dff
+.dword 0xffffffff00000000
+.dword 0xfffffffffffe8000
+.dword 0x7fffffffffff3c00
+.dword 0xfeedbee5beefbc00
+.dword 0xffffffefffff0400
+.dword 0x00000000ffff8400
+.dword 0xefffffffffff7bff
+.dword 0xc0dec0dec0defbff
+.dword 0xa83ef1cc4f1a7c00
+.dword 0xffffffff0ffffc00
+.dword 0xfffeffffffff7e00
+.dword 0xffffffefffff7fff
+.dword 0xa1b2c3d4e5f67c01
+.dword 0xfffffffcffff7dff
 
 // Testcase strings
 ZfaZfhD_fround_h_cg_cp_NaNBox_D_H_NaNBox_str: .string "\"test: 1; cg: ZfaZfhD_fround.h_cg; cp: cp_NaNBox_D_H; bin: NaNBox\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x0_str: .string "\"test: 2; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0x0\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfffe8000_str: .string "\"test: 3; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xfffe8000\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x7fff3c00_str: .string "\"test: 4; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0x7fff3c00\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xbeefbc00_str: .string "\"test: 5; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xbeefbc00\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfeff0400_str: .string "\"test: 6; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xfeff0400\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfff8400_str: .string "\"test: 7; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xfff8400\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xefff7bff_str: .string "\"test: 8; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xefff7bff\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xc0defbff_str: .string "\"test: 9; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xc0defbff\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x4f1a7c00_str: .string "\"test: 10; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0x4f1a7c00\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xffffc00_str: .string "\"test: 11; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xffffc00\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xffef7e00_str: .string "\"test: 12; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xffef7e00\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xfeef7fff_str: .string "\"test: 13; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xfeef7fff\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0xa1b27c01_str: .string "\"test: 14; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0xa1b27c01\""
-ZfaZfhD_fround_h_cg_cp_fs1_badNB_S_H_b0x4fd77dff_str: .string "\"test: 15; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_S_H; bin: b0x4fd77dff\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffff00000000_str: .string "\"test: 2; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xffffffff00000000\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffffffffffe8000_str: .string "\"test: 3; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xfffffffffffe8000\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0x7fffffffffff3c00_str: .string "\"test: 4; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0x7fffffffffff3c00\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfeedbee5beefbc00_str: .string "\"test: 5; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xfeedbee5beefbc00\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffefffff0400_str: .string "\"test: 6; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xffffffefffff0400\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffff8400_str: .string "\"test: 7; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xffff8400\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xefffffffffff7bff_str: .string "\"test: 8; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xefffffffffff7bff\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xc0dec0dec0defbff_str: .string "\"test: 9; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xc0dec0dec0defbff\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xa83ef1cc4f1a7c00_str: .string "\"test: 10; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xa83ef1cc4f1a7c00\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffff0ffffc00_str: .string "\"test: 11; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xffffffff0ffffc00\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffeffffffff7e00_str: .string "\"test: 12; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xfffeffffffff7e00\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xffffffefffff7fff_str: .string "\"test: 13; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xffffffefffff7fff\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xa1b2c3d4e5f67c01_str: .string "\"test: 14; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xa1b2c3d4e5f67c01\""
+ZfaZfhD_fround_h_cg_cp_fs1_badNB_D_H_b0xfffffffcffff7dff_str: .string "\"test: 15; cg: ZfaZfhD_fround.h_cg; cp: cp_fs1_badNB_D_H; bin: b0xfffffffcffff7dff\""
 
 // End of test data section and model specific data
 RVTEST_DATA_END


### PR DESCRIPTION
Issue #2147 item 47. Two unrelated cell corrections in the FP testplans.

`ZfaZfhD.csv` fround.h used `S_H` bad-NaN-box stimulus instead of `D_H`.

`Zfhmin.csv` fcvt.h.s and `Zfbfmin.csv` fcvt.bf16.s set `cp_csr_fflags` to `vn` instead of `voun`.
FP32->FP16 clearly reaches OF and UF. FP32->BF16 does too:
BF16 shares FP32's exponent width but has 7 mantissa bits, so max FP32 rounds
up past max BF16 to infinity (OF), and FP32's smallest subnormal 2^-149 is far
below BF16's smallest subnormal 2^-133 and flushes to zero inexactly (UF).