### PR TITLE
Reject operands a formatter does not declare, and honour rdval and rd

### DIFF
--- a/generators/testgen/src/testgen/coverpoints/special/cmp_values.py
+++ b/generators/testgen/src/testgen/coverpoints/special/cmp_values.py
@@ -7,7 +7,6 @@
 
 """Compare register values coverpoint generators (cmp_rd_rs1_val_eq, cmp_rd_rs1_val_lsb, cmp_rd_rs1_val_hw, cmp_rd_rs1_val_w, cmp_rd_rs1_pair_partial_val, cmp_rd_sign_ext)."""
 
-from testgen.asm.helpers import load_int_reg
 from testgen.coverpoints.registry import add_coverpoint_generator
 from testgen.data.random import random_range
 from testgen.data.state import TestData, return_testcase_registers
@@ -54,18 +53,13 @@ def generate_cmp_testcase(
     if params.rd is None or params.rs1 is None or params.rs2 is None:
         raise ValueError("Could not allocate registers for CAS instruction")
 
-    rd = params.rd
-
-    params.rdval = rd_val
+    params.rdval = rd_val if load_rd else None
     params.rs1val = rs1_val
 
     # Begin testcase
     tc = test_data.begin_test_chunk()
     tc.code.append(f"# Testcase {desc}")
     label_line = test_data.add_testcase(bin_name, coverpoint)
-
-    if load_rd and not is_pair:
-        tc.code.append(load_int_reg("rd compare value", rd, rd_val, test_data))
 
     # Generate instruction, setup, test, and check tc.code
     setup, test, check = format_instruction(instr_name, instr_type, test_data, params)

--- a/generators/testgen/src/testgen/formatters/registry.py
+++ b/generators/testgen/src/testgen/formatters/registry.py
@@ -71,6 +71,7 @@ class InstructionTypeConfig:
 
     Attributes:
         required_params: Set of parameters required for this instruction type (rs1, rdval, immval, etc.).
+        optional_params: Parameters a coverpoint may set that this type uses but never fills in randomly.
         reg_range: Iterable of valid register numbers for this instruction type.
         imm_bits: Number of bits for immediates. Can also be "xlen", "xlen_log2", "flen", or "flen_log2".
         imm_range: Explicit (min, max) range for immediate values. Mutually exclusive with imm_bits.
@@ -83,6 +84,7 @@ class InstructionTypeConfig:
     """
 
     required_params: set[str] | None = None
+    optional_params: set[str] | None = None
     reg_range: Iterable[int] | None = None
     imm_bits: int | Literal["xlen", "xlen_log2", "flen", "flen_log2"] | None = None
     imm_range: tuple[int, int] | None = None  # Explicit (min, max) range

--- a/generators/testgen/src/testgen/formatters/types/a_type.py
+++ b/generators/testgen/src/testgen/formatters/types/a_type.py
@@ -10,7 +10,10 @@ from testgen.data.params import InstructionParams
 from testgen.data.state import TestData
 from testgen.formatters.registry import InstructionTypeConfig, add_instruction_formatter
 
-a_config = InstructionTypeConfig(required_params={"rd", "rs1", "rs1val", "rs2", "rs2val", "temp_reg"})
+a_config = InstructionTypeConfig(
+    required_params={"rd", "rs1", "rs1val", "rs2", "rs2val", "temp_reg"},
+    optional_params={"rdval"},
+)
 
 
 @add_instruction_formatter("A", a_config)
@@ -30,6 +33,11 @@ def format_a_type(
     setup = [
         load_int_reg("value in memory", params.temp_reg, params.rs1val, test_data),
         load_int_reg("rs2", params.rs2, params.rs2val, test_data),
+    ]
+    if params.rdval is not None:
+        # amocas compares rd against memory, so rd has to hold the comparand
+        setup.append(load_int_reg("rd compare value", params.rd, params.rdval, test_data))
+    setup += [
         f"LA(x{params.rs1}, scratch) # load base address into rs1",
         f"SREG x{params.temp_reg}, 0(x{params.rs1}) # store value into memory at address in rs1",
     ]

--- a/generators/testgen/src/testgen/formatters/types/cj_type.py
+++ b/generators/testgen/src/testgen/formatters/types/cj_type.py
@@ -9,7 +9,11 @@ from testgen.data.params import InstructionParams
 from testgen.data.state import TestData
 from testgen.formatters.registry import InstructionTypeConfig, add_instruction_formatter
 
-cj_config = InstructionTypeConfig(required_params={"temp_reg", "temp_val", "immval"}, imm_bits=11)
+cj_config = InstructionTypeConfig(
+    required_params={"temp_reg", "temp_val", "immval"},
+    optional_params={"rd"},  # the link register is fixed by the encoding, not drawn
+    imm_bits=11,
+)
 
 
 @add_instruction_formatter("CJ", cj_config)

--- a/generators/testgen/src/testgen/formatters/types/cjal_type.py
+++ b/generators/testgen/src/testgen/formatters/types/cjal_type.py
@@ -9,7 +9,11 @@ from testgen.data.params import InstructionParams
 from testgen.data.state import TestData
 from testgen.formatters.registry import InstructionTypeConfig, add_instruction_formatter
 
-cjal_config = InstructionTypeConfig(required_params={"temp_reg", "temp_val", "immval"}, imm_bits=11)
+cjal_config = InstructionTypeConfig(
+    required_params={"temp_reg", "temp_val", "immval"},
+    optional_params={"rd"},  # the link register is fixed by the encoding, not drawn
+    imm_bits=11,
+)
 
 
 @add_instruction_formatter("CJAL", cjal_config)

--- a/generators/testgen/src/testgen/formatters/types/cjalr_type.py
+++ b/generators/testgen/src/testgen/formatters/types/cjalr_type.py
@@ -9,7 +9,11 @@ from testgen.data.params import InstructionParams
 from testgen.data.state import TestData
 from testgen.formatters.registry import InstructionTypeConfig, add_instruction_formatter
 
-cjalr_config = InstructionTypeConfig(required_params={"rs1", "temp_reg", "temp_val"}, reg_range=range(1, 32))
+cjalr_config = InstructionTypeConfig(
+    required_params={"rs1", "temp_reg", "temp_val"},
+    optional_params={"rd"},  # the link register is fixed by the encoding, not drawn
+    reg_range=range(1, 32),
+)
 
 
 @add_instruction_formatter("CJALR", cjalr_config)

--- a/generators/testgen/src/testgen/formatters/types/cjr_type.py
+++ b/generators/testgen/src/testgen/formatters/types/cjr_type.py
@@ -9,7 +9,11 @@ from testgen.data.params import InstructionParams
 from testgen.data.state import TestData
 from testgen.formatters.registry import InstructionTypeConfig, add_instruction_formatter
 
-cjr_config = InstructionTypeConfig(required_params={"rs1", "temp_reg", "temp_val"}, reg_range=range(1, 32))
+cjr_config = InstructionTypeConfig(
+    required_params={"rs1", "temp_reg", "temp_val"},
+    optional_params={"rd"},  # the link register is fixed by the encoding, not drawn
+    reg_range=range(1, 32),
+)
 
 
 @add_instruction_formatter("CJR", cjr_config)

--- a/generators/testgen/src/testgen/formatters/types/cn_type.py
+++ b/generators/testgen/src/testgen/formatters/types/cn_type.py
@@ -11,7 +11,7 @@ from testgen.data.params import InstructionParams
 from testgen.data.state import TestData
 from testgen.formatters.registry import InstructionTypeConfig, add_instruction_formatter
 
-cn_config = InstructionTypeConfig(required_params=set(), imm_bits=6, imm_signed=True)
+cn_config = InstructionTypeConfig(required_params=set(), optional_params={"immval"}, imm_bits=6, imm_signed=True)
 
 
 @add_instruction_formatter("CN", cn_config)

--- a/generators/testgen/src/testgen/formatters/types/cr_type.py
+++ b/generators/testgen/src/testgen/formatters/types/cr_type.py
@@ -9,7 +9,7 @@ from testgen.data.params import InstructionParams
 from testgen.data.state import TestData
 from testgen.formatters.registry import InstructionTypeConfig, add_instruction_formatter
 
-cr_config = InstructionTypeConfig(required_params={"rs1", "rs1val", "rs2", "rs2val"})
+cr_config = InstructionTypeConfig(required_params={"rs1", "rs1val", "rs2", "rs2val"}, optional_params={"rd"})
 
 
 @add_instruction_formatter("CR", cr_config)
@@ -19,6 +19,10 @@ def format_cr_type(
     """Format CR-type instruction."""
     assert params.rs1 is not None and params.rs1val is not None
     assert params.rs2 is not None and params.rs2val is not None
+    # CR encodes the destination in the rs1 field, so a requested rd lands there
+    if params.rd is not None and params.rd != params.rs1:
+        test_data.int_regs.return_register(params.rs1)
+        params.rs1 = params.rd
     # x0 is not allowed as rs2 for c.add and c.mv
     if instr_name in ["c.add", "c.mv"] and params.rs2 == 0:
         test_data.int_regs.return_register(params.rs2)

--- a/generators/testgen/src/testgen/instructions/params.py
+++ b/generators/testgen/src/testgen/instructions/params.py
@@ -40,6 +40,32 @@ from testgen.data.random import random_int, random_range
 from testgen.data.state import TestData
 from testgen.formatters import get_instruction_type_config
 
+OPERAND_PARAMS = frozenset(
+    {
+        "rd",
+        "rdval",
+        "rs1",
+        "rs1val",
+        "rs2",
+        "rs2val",
+        "rs3",
+        "rs3val",
+        "fd",
+        "fdval",
+        "fs1",
+        "fs1val",
+        "fs2",
+        "fs2val",
+        "fs3",
+        "fs3val",
+        "temp_reg",
+        "temp_val",
+        "temp_freg",
+        "temp_fval",
+        "immval",
+    }
+)
+
 
 def generate_random_params(
     test_data: TestData,
@@ -80,6 +106,14 @@ def generate_random_params(
             f"Unknown params for instruction type '{instr_type}'. Please add it to the instruction formatter decorator."
         )
     pair_regs = instr_type_config.pair_regs or set()  # Registers that need pairs
+    # A coverpoint that sets an operand the formatter never declared is silently ignored, so reject it.
+    declared = required_params | (instr_type_config.optional_params or set())
+    undeclared = sorted((set(fixed_params) & OPERAND_PARAMS) - declared)
+    if undeclared:
+        raise ValueError(
+            f"Instruction type '{instr_type}' was given {undeclared}, which it does not declare in "
+            f"required_params or optional_params, so the formatter would ignore them."
+        )
 
     # Determine the register range to use (extracted from formatters)
     reg_range_raw = instr_type_config.reg_range if instr_type_config.reg_range is not None else range(32)

--- a/tests/rv32e/Zca/Zca-c.mv-00.S
+++ b/tests/rv32e/Zca/Zca-c.mv-00.S
@@ -167,133 +167,133 @@ Zca_c_mv_cg_cp_rs2_nx0_b15:
 
   mv x12, x1 # switch data pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x1)
-  RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rd/rs1: x7 = 0xdebef189
+  RVTEST_TESTDATA_LOAD_INT(x12, x1) # load rd/rs1: x1 = 0xdebef189
   RVTEST_TESTDATA_LOAD_INT(x12, x11) # load rs2: x11 = 0x1976270f
 Zca_c_mv_cg_cp_rd_nx0_b1:
-  c.mv x7, x11 # perform operation
-  # Check if x7 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x3, x5, x4, x7, Zca_c_mv_cg_cp_rd_nx0_b1, Zca_c_mv_cg_cp_rd_nx0_b1_str)
+  c.mv x1, x11 # perform operation
+  # Check if x1 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x3, x5, x4, x1, Zca_c_mv_cg_cp_rd_nx0_b1, Zca_c_mv_cg_cp_rd_nx0_b1_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x2)
-  RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rd/rs1: x10 = 0xa43be7ee
+  RVTEST_TESTDATA_LOAD_INT(x12, x2) # load rd/rs1: x2 = 0xa43be7ee
   RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rs2: x7 = 0x1ae58866
 Zca_c_mv_cg_cp_rd_nx0_b2:
-  c.mv x10, x7 # perform operation
-  # Check if x10 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x3, x5, x4, x10, Zca_c_mv_cg_cp_rd_nx0_b2, Zca_c_mv_cg_cp_rd_nx0_b2_str)
+  c.mv x2, x7 # perform operation
+  # Check if x2 contains the expected result. x3 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x3, x5, x4, x2, Zca_c_mv_cg_cp_rd_nx0_b2, Zca_c_mv_cg_cp_rd_nx0_b2_str)
 
   mv x15, x3 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x3)
-  RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rd/rs1: x10 = 0xc3b256f0
+  RVTEST_TESTDATA_LOAD_INT(x12, x3) # load rd/rs1: x3 = 0xc3b256f0
   RVTEST_TESTDATA_LOAD_INT(x12, x13) # load rs2: x13 = 0xccabf957
 Zca_c_mv_cg_cp_rd_nx0_b3:
-  c.mv x10, x13 # perform operation
-  # Check if x10 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x15, x5, x4, x10, Zca_c_mv_cg_cp_rd_nx0_b3, Zca_c_mv_cg_cp_rd_nx0_b3_str)
+  c.mv x3, x13 # perform operation
+  # Check if x3 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x15, x5, x4, x3, Zca_c_mv_cg_cp_rd_nx0_b3, Zca_c_mv_cg_cp_rd_nx0_b3_str)
 
   mv x7, x4 # switch temp register to avoid conflict with test
   mv x8, x5 # switch link pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x4)
-  RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rd/rs1: x9 = 0x6de4a799
+  RVTEST_TESTDATA_LOAD_INT(x12, x4) # load rd/rs1: x4 = 0x6de4a799
   RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rs2: x10 = 0x5c11e270
 Zca_c_mv_cg_cp_rd_nx0_b4:
-  c.mv x9, x10 # perform operation
-  # Check if x9 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x15, x8, x7, x9, Zca_c_mv_cg_cp_rd_nx0_b4, Zca_c_mv_cg_cp_rd_nx0_b4_str)
+  c.mv x4, x10 # perform operation
+  # Check if x4 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x15, x8, x7, x4, Zca_c_mv_cg_cp_rd_nx0_b4, Zca_c_mv_cg_cp_rd_nx0_b4_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x5)
-  RVTEST_TESTDATA_LOAD_INT(x12, x0) # load rd/rs1: x0 = 0xc04501f9
+  RVTEST_TESTDATA_LOAD_INT(x12, x5) # load rd/rs1: x5 = 0xc04501f9
   RVTEST_TESTDATA_LOAD_INT(x12, x13) # load rs2: x13 = 0xce8d6c12
 Zca_c_mv_cg_cp_rd_nx0_b5:
-  c.mv x0, x13 # perform operation
-  # Check if x0 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x15, x8, x7, x0, Zca_c_mv_cg_cp_rd_nx0_b5, Zca_c_mv_cg_cp_rd_nx0_b5_str)
+  c.mv x5, x13 # perform operation
+  # Check if x5 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x15, x8, x7, x5, Zca_c_mv_cg_cp_rd_nx0_b5, Zca_c_mv_cg_cp_rd_nx0_b5_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x6)
-  RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rd/rs1: x10 = 0x78cd8eba
+  RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rd/rs1: x6 = 0x78cd8eba
   RVTEST_TESTDATA_LOAD_INT(x12, x14) # load rs2: x14 = 0xaa571e2a
 Zca_c_mv_cg_cp_rd_nx0_b6:
-  c.mv x10, x14 # perform operation
-  # Check if x10 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x15, x8, x7, x10, Zca_c_mv_cg_cp_rd_nx0_b6, Zca_c_mv_cg_cp_rd_nx0_b6_str)
+  c.mv x6, x14 # perform operation
+  # Check if x6 contains the expected result. x15 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x15, x8, x7, x6, Zca_c_mv_cg_cp_rd_nx0_b6, Zca_c_mv_cg_cp_rd_nx0_b6_str)
 
   mv x13, x7 # switch temp register to avoid conflict with test
   mv x14, x8 # switch link pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x7)
-  RVTEST_TESTDATA_LOAD_INT(x12, x4) # load rd/rs1: x4 = 0xbba5aa6c
+  RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rd/rs1: x7 = 0xbba5aa6c
   RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rs2: x10 = 0xba2c9c19
 Zca_c_mv_cg_cp_rd_nx0_b7:
-  c.mv x4, x10 # perform operation
-  # Check if x4 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x15, x14, x13, x4, Zca_c_mv_cg_cp_rd_nx0_b7, Zca_c_mv_cg_cp_rd_nx0_b7_str)
+  c.mv x7, x10 # perform operation
+  # Check if x7 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x15, x14, x13, x7, Zca_c_mv_cg_cp_rd_nx0_b7, Zca_c_mv_cg_cp_rd_nx0_b7_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x8)
-  RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rd/rs1: x9 = 0xd9934e6e
+  RVTEST_TESTDATA_LOAD_INT(x12, x8) # load rd/rs1: x8 = 0xd9934e6e
   RVTEST_TESTDATA_LOAD_INT(x12, x11) # load rs2: x11 = 0x093e8f51
 Zca_c_mv_cg_cp_rd_nx0_b8:
-  c.mv x9, x11 # perform operation
-  # Check if x9 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x15, x14, x13, x9, Zca_c_mv_cg_cp_rd_nx0_b8, Zca_c_mv_cg_cp_rd_nx0_b8_str)
+  c.mv x8, x11 # perform operation
+  # Check if x8 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x15, x14, x13, x8, Zca_c_mv_cg_cp_rd_nx0_b8, Zca_c_mv_cg_cp_rd_nx0_b8_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x9)
-  RVTEST_TESTDATA_LOAD_INT(x12, x11) # load rd/rs1: x11 = 0x4260f149
+  RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rd/rs1: x9 = 0x4260f149
   RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rs2: x10 = 0x68812222
 Zca_c_mv_cg_cp_rd_nx0_b9:
-  c.mv x11, x10 # perform operation
-  # Check if x11 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x15, x14, x13, x11, Zca_c_mv_cg_cp_rd_nx0_b9, Zca_c_mv_cg_cp_rd_nx0_b9_str)
+  c.mv x9, x10 # perform operation
+  # Check if x9 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x15, x14, x13, x9, Zca_c_mv_cg_cp_rd_nx0_b9, Zca_c_mv_cg_cp_rd_nx0_b9_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x10)
-  RVTEST_TESTDATA_LOAD_INT(x12, x4) # load rd/rs1: x4 = 0x14d8af6f
+  RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rd/rs1: x10 = 0x14d8af6f
   RVTEST_TESTDATA_LOAD_INT(x12, x5) # load rs2: x5 = 0xcf215490
 Zca_c_mv_cg_cp_rd_nx0_b10:
-  c.mv x4, x5 # perform operation
-  # Check if x4 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x15, x14, x13, x4, Zca_c_mv_cg_cp_rd_nx0_b10, Zca_c_mv_cg_cp_rd_nx0_b10_str)
+  c.mv x10, x5 # perform operation
+  # Check if x10 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x15, x14, x13, x10, Zca_c_mv_cg_cp_rd_nx0_b10, Zca_c_mv_cg_cp_rd_nx0_b10_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x11)
-  RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rd/rs1: x9 = 0x87a7d08d
+  RVTEST_TESTDATA_LOAD_INT(x12, x11) # load rd/rs1: x11 = 0x87a7d08d
   RVTEST_TESTDATA_LOAD_INT(x12, x8) # load rs2: x8 = 0x56d1ee33
 Zca_c_mv_cg_cp_rd_nx0_b11:
-  c.mv x9, x8 # perform operation
-  # Check if x9 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x15, x14, x13, x9, Zca_c_mv_cg_cp_rd_nx0_b11, Zca_c_mv_cg_cp_rd_nx0_b11_str)
+  c.mv x11, x8 # perform operation
+  # Check if x11 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x15, x14, x13, x11, Zca_c_mv_cg_cp_rd_nx0_b11, Zca_c_mv_cg_cp_rd_nx0_b11_str)
 
   mv x3, x12 # switch data pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x12)
-  RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rd/rs1: x10 = 0xab916e86
+  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rd/rs1: x12 = 0xab916e86
   RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0xfb1d6790
 Zca_c_mv_cg_cp_rd_nx0_b12:
-  c.mv x10, x6 # perform operation
-  # Check if x10 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x15, x14, x13, x10, Zca_c_mv_cg_cp_rd_nx0_b12, Zca_c_mv_cg_cp_rd_nx0_b12_str)
+  c.mv x12, x6 # perform operation
+  # Check if x12 contains the expected result. x15 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x15, x14, x13, x12, Zca_c_mv_cg_cp_rd_nx0_b12, Zca_c_mv_cg_cp_rd_nx0_b12_str)
 
   mv x4, x13 # switch temp register to avoid conflict with test
   mv x5, x14 # switch link pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x13)
-  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rd/rs1: x12 = 0x0bf66be4
+  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rd/rs1: x13 = 0x0bf66be4
   RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0x1e593a9c
 Zca_c_mv_cg_cp_rd_nx0_b13:
-  c.mv x12, x6 # perform operation
-  # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x15, x5, x4, x12, Zca_c_mv_cg_cp_rd_nx0_b13, Zca_c_mv_cg_cp_rd_nx0_b13_str)
+  c.mv x13, x6 # perform operation
+  # Check if x13 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x15, x5, x4, x13, Zca_c_mv_cg_cp_rd_nx0_b13, Zca_c_mv_cg_cp_rd_nx0_b13_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x14)
-  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rd/rs1: x12 = 0x45cff92c
+  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rd/rs1: x14 = 0x45cff92c
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0xd6267b29
 Zca_c_mv_cg_cp_rd_nx0_b14:
-  c.mv x12, x1 # perform operation
-  # Check if x12 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x15, x5, x4, x12, Zca_c_mv_cg_cp_rd_nx0_b14, Zca_c_mv_cg_cp_rd_nx0_b14_str)
+  c.mv x14, x1 # perform operation
+  # Check if x14 contains the expected result. x15 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x15, x5, x4, x14, Zca_c_mv_cg_cp_rd_nx0_b14, Zca_c_mv_cg_cp_rd_nx0_b14_str)
 
   mv x11, x15 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x15)
-  RVTEST_TESTDATA_LOAD_INT(x3, x7) # load rd/rs1: x7 = 0x2de0282a
+  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rd/rs1: x15 = 0x2de0282a
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0x734133ad
 Zca_c_mv_cg_cp_rd_nx0_b15:
-  c.mv x7, x1 # perform operation
-  # Check if x7 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x11, x5, x4, x7, Zca_c_mv_cg_cp_rd_nx0_b15, Zca_c_mv_cg_cp_rd_nx0_b15_str)
+  c.mv x15, x1 # perform operation
+  # Check if x15 contains the expected result. x11 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x11, x5, x4, x15, Zca_c_mv_cg_cp_rd_nx0_b15, Zca_c_mv_cg_cp_rd_nx0_b15_str)
 
 /////////////////////////////////
 // cp_rs2_edges

--- a/tests/rv32i/Zacas/Zacas-amocas.w-00.S
+++ b/tests/rv32i/Zacas/Zacas-amocas.w-00.S
@@ -36,6 +36,7 @@ RVTEST_BEGIN
 # Testcase cp_rs1_nx0 (Test source rs1 = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load value in memory: x11 = 0x4ffc9eb6
   RVTEST_TESTDATA_LOAD_INT(x3, x7) # load rs2: x7 = 0xa05a7a33
+  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rd compare value: x12 = 0x4ffc9eb6
   LA(x1, scratch) # load base address into rs1
   SREG x11, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b1_equal:
@@ -49,6 +50,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b1_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x26) # load value in memory: x26 = 0xff00fd95
   RVTEST_TESTDATA_LOAD_INT(x3, x7) # load rs2: x7 = 0x5f58e971
+  RVTEST_TESTDATA_LOAD_INT(x3, x29) # load rd compare value: x29 = 0x8a1d8aed
   LA(x1, scratch) # load base address into rs1
   SREG x26, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b1_not_equal:
@@ -63,6 +65,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b1_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x29) # load value in memory: x29 = 0xa73918b7
   RVTEST_TESTDATA_LOAD_INT(x3, x18) # load rs2: x18 = 0x4cdcba92
+  RVTEST_TESTDATA_LOAD_INT(x3, x23) # load rd compare value: x23 = 0xa73918b7
   LA(x2, scratch) # load base address into rs1
   SREG x29, 0(x2) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b2_equal:
@@ -76,6 +79,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b2_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x16) # load value in memory: x16 = 0x6c982925
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x7bc624fd
+  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rd compare value: x6 = 0x7f4abe45
   LA(x2, scratch) # load base address into rs1
   SREG x16, 0(x2) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b2_not_equal:
@@ -90,6 +94,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b2_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x11) # load value in memory: x11 = 0xf6ad3329
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load rs2: x6 = 0x06ff2c16
+  RVTEST_TESTDATA_LOAD_INT(x17, x23) # load rd compare value: x23 = 0xf6ad3329
   LA(x3, scratch) # load base address into rs1
   SREG x11, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b3_equal:
@@ -103,6 +108,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b3_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load value in memory: x13 = 0xc6a0f366
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load rs2: x15 = 0xe26424c3
+  RVTEST_TESTDATA_LOAD_INT(x17, x20) # load rd compare value: x20 = 0x4bd34dad
   LA(x3, scratch) # load base address into rs1
   SREG x13, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b3_not_equal:
@@ -118,6 +124,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b3_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x11) # load value in memory: x11 = 0x5de6dea0
   RVTEST_TESTDATA_LOAD_INT(x17, x20) # load rs2: x20 = 0x1711f4d2
+  RVTEST_TESTDATA_LOAD_INT(x17, x18) # load rd compare value: x18 = 0x5de6dea0
   LA(x4, scratch) # load base address into rs1
   SREG x11, 0(x4) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b4_equal:
@@ -131,6 +138,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b4_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load value in memory: x1 = 0x726baf91
   RVTEST_TESTDATA_LOAD_INT(x17, x16) # load rs2: x16 = 0xa42e7e46
+  RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rd compare value: x14 = 0x181a77a4
   LA(x4, scratch) # load base address into rs1
   SREG x1, 0(x4) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b4_not_equal:
@@ -144,6 +152,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b4_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x18) # load value in memory: x18 = 0x3543d5ff
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rs2: x9 = 0x852cf4b5
+  RVTEST_TESTDATA_LOAD_INT(x17, x31) # load rd compare value: x31 = 0x3543d5ff
   LA(x5, scratch) # load base address into rs1
   SREG x18, 0(x5) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b5_equal:
@@ -157,6 +166,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b5_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load value in memory: x15 = 0x3bca9813
   RVTEST_TESTDATA_LOAD_INT(x17, x4) # load rs2: x4 = 0x04bef3f4
+  RVTEST_TESTDATA_LOAD_INT(x17, x20) # load rd compare value: x20 = 0x78c1ff64
   LA(x5, scratch) # load base address into rs1
   SREG x15, 0(x5) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b5_not_equal:
@@ -170,6 +180,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b5_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load value in memory: x14 = 0x87d0bb55
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load rs2: x15 = 0x6fbe5b74
+  RVTEST_TESTDATA_LOAD_INT(x17, x3) # load rd compare value: x3 = 0x87d0bb55
   LA(x6, scratch) # load base address into rs1
   SREG x14, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b6_equal:
@@ -183,6 +194,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b6_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x5) # load value in memory: x5 = 0x2906c7e7
   RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rs2: x0 = 0x6bd6ab30
+  RVTEST_TESTDATA_LOAD_INT(x17, x24) # load rd compare value: x24 = 0x0f938295
   LA(x6, scratch) # load base address into rs1
   SREG x5, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b6_not_equal:
@@ -198,6 +210,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b6_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load value in memory: x13 = 0x45c86b14
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load rs2: x1 = 0xb997c936
+  RVTEST_TESTDATA_LOAD_INT(x17, x29) # load rd compare value: x29 = 0x45c86b14
   LA(x7, scratch) # load base address into rs1
   SREG x13, 0(x7) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b7_equal:
@@ -211,6 +224,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b7_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x19) # load value in memory: x19 = 0x0d14fab2
   RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rs2: x0 = 0x76ad8f69
+  RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rd compare value: x2 = 0x14d3e5ff
   LA(x7, scratch) # load base address into rs1
   SREG x19, 0(x7) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b7_not_equal:
@@ -224,6 +238,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b7_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load value in memory: x14 = 0xaeb1b3a2
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rs2: x9 = 0x5b52bd50
+  RVTEST_TESTDATA_LOAD_INT(x17, x18) # load rd compare value: x18 = 0xaeb1b3a2
   LA(x8, scratch) # load base address into rs1
   SREG x14, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b8_equal:
@@ -237,6 +252,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b8_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x30) # load value in memory: x30 = 0x587ac726
   RVTEST_TESTDATA_LOAD_INT(x17, x23) # load rs2: x23 = 0xd47b5863
+  RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rd compare value: x14 = 0x22dbffff
   LA(x8, scratch) # load base address into rs1
   SREG x30, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b8_not_equal:
@@ -250,6 +266,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b8_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x31) # load value in memory: x31 = 0xdf3be6ab
   RVTEST_TESTDATA_LOAD_INT(x17, x27) # load rs2: x27 = 0xf8237ec0
+  RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rd compare value: x2 = 0xdf3be6ab
   LA(x9, scratch) # load base address into rs1
   SREG x31, 0(x9) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b9_equal:
@@ -263,6 +280,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b9_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load value in memory: x6 = 0x58a3c29b
   RVTEST_TESTDATA_LOAD_INT(x17, x22) # load rs2: x22 = 0x0ad3d73b
+  RVTEST_TESTDATA_LOAD_INT(x17, x21) # load rd compare value: x21 = 0x7dfc586b
   LA(x9, scratch) # load base address into rs1
   SREG x6, 0(x9) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b9_not_equal:
@@ -276,6 +294,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b9_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x26) # load value in memory: x26 = 0x56ee66fa
   RVTEST_TESTDATA_LOAD_INT(x17, x28) # load rs2: x28 = 0xf073f8a2
+  RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rd compare value: x2 = 0x56ee66fa
   LA(x10, scratch) # load base address into rs1
   SREG x26, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b10_equal:
@@ -289,6 +308,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b10_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x19) # load value in memory: x19 = 0x32322776
   RVTEST_TESTDATA_LOAD_INT(x17, x7) # load rs2: x7 = 0x53faa5d0
+  RVTEST_TESTDATA_LOAD_INT(x17, x24) # load rd compare value: x24 = 0x83414d7c
   LA(x10, scratch) # load base address into rs1
   SREG x19, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b10_not_equal:
@@ -302,6 +322,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b10_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load value in memory: x6 = 0x84b72a64
   RVTEST_TESTDATA_LOAD_INT(x17, x10) # load rs2: x10 = 0xa0f054c1
+  RVTEST_TESTDATA_LOAD_INT(x17, x8) # load rd compare value: x8 = 0x84b72a64
   LA(x11, scratch) # load base address into rs1
   SREG x6, 0(x11) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b11_equal:
@@ -315,6 +336,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b11_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load value in memory: x1 = 0x937c76d9
   RVTEST_TESTDATA_LOAD_INT(x17, x10) # load rs2: x10 = 0x7b56846a
+  RVTEST_TESTDATA_LOAD_INT(x17, x8) # load rd compare value: x8 = 0x72eab756
   LA(x11, scratch) # load base address into rs1
   SREG x1, 0(x11) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b11_not_equal:
@@ -329,6 +351,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b11_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x3) # load value in memory: x3 = 0x354cb6ae
   RVTEST_TESTDATA_LOAD_INT(x17, x23) # load rs2: x23 = 0x346f685b
+  RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rd compare value: x0 = 0x354cb6ae
   LA(x12, scratch) # load base address into rs1
   SREG x3, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b12_equal:
@@ -342,6 +365,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b12_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load value in memory: x13 = 0x018899a6
   RVTEST_TESTDATA_LOAD_INT(x17, x24) # load rs2: x24 = 0xa5ef20cc
+  RVTEST_TESTDATA_LOAD_INT(x17, x15) # load rd compare value: x15 = 0x257768fe
   LA(x12, scratch) # load base address into rs1
   SREG x13, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b12_not_equal:
@@ -355,6 +379,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b12_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load value in memory: x6 = 0xbffeda35
   RVTEST_TESTDATA_LOAD_INT(x17, x28) # load rs2: x28 = 0x0cbd8f1e
+  RVTEST_TESTDATA_LOAD_INT(x17, x11) # load rd compare value: x11 = 0xbffeda35
   LA(x13, scratch) # load base address into rs1
   SREG x6, 0(x13) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b13_equal:
@@ -368,6 +393,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b13_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x7) # load value in memory: x7 = 0xdac793c6
   RVTEST_TESTDATA_LOAD_INT(x17, x30) # load rs2: x30 = 0xcb05efea
+  RVTEST_TESTDATA_LOAD_INT(x17, x10) # load rd compare value: x10 = 0xc6a59de9
   LA(x13, scratch) # load base address into rs1
   SREG x7, 0(x13) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b13_not_equal:
@@ -381,6 +407,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b13_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x12) # load value in memory: x12 = 0x627e075a
   RVTEST_TESTDATA_LOAD_INT(x17, x16) # load rs2: x16 = 0x917e1f3a
+  RVTEST_TESTDATA_LOAD_INT(x17, x3) # load rd compare value: x3 = 0x627e075a
   LA(x14, scratch) # load base address into rs1
   SREG x12, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b14_equal:
@@ -394,6 +421,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b14_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x18) # load value in memory: x18 = 0xf6e56fbe
   RVTEST_TESTDATA_LOAD_INT(x17, x22) # load rs2: x22 = 0x5435bce2
+  RVTEST_TESTDATA_LOAD_INT(x17, x8) # load rd compare value: x8 = 0x84b2620d
   LA(x14, scratch) # load base address into rs1
   SREG x18, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b14_not_equal:
@@ -407,6 +435,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b14_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x27) # load value in memory: x27 = 0x866c2c45
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rs2: x9 = 0xadb5330b
+  RVTEST_TESTDATA_LOAD_INT(x17, x22) # load rd compare value: x22 = 0x866c2c45
   LA(x15, scratch) # load base address into rs1
   SREG x27, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b15_equal:
@@ -420,6 +449,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b15_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x29) # load value in memory: x29 = 0xabae2a0d
   RVTEST_TESTDATA_LOAD_INT(x17, x24) # load rs2: x24 = 0x399061be
+  RVTEST_TESTDATA_LOAD_INT(x17, x13) # load rd compare value: x13 = 0xa9f01df4
   LA(x15, scratch) # load base address into rs1
   SREG x29, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b15_not_equal:
@@ -433,6 +463,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b15_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x10) # load value in memory: x10 = 0x582c96c1
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rs2: x9 = 0xe8524c8c
+  RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rd compare value: x14 = 0x582c96c1
   LA(x16, scratch) # load base address into rs1
   SREG x10, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b16_equal:
@@ -446,6 +477,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b16_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x19) # load value in memory: x19 = 0xd0d0ce74
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load rs2: x13 = 0x14f28ef4
+  RVTEST_TESTDATA_LOAD_INT(x17, x3) # load rd compare value: x3 = 0xe23703ef
   LA(x16, scratch) # load base address into rs1
   SREG x19, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b16_not_equal:
@@ -460,6 +492,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b16_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load value in memory: x6 = 0xd465601f
   RVTEST_TESTDATA_LOAD_INT(x2, x31) # load rs2: x31 = 0x0f66fd14
+  RVTEST_TESTDATA_LOAD_INT(x2, x0) # load rd compare value: x0 = 0xd465601f
   LA(x17, scratch) # load base address into rs1
   SREG x6, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b17_equal:
@@ -473,6 +506,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b17_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x21) # load value in memory: x21 = 0xf035054e
   RVTEST_TESTDATA_LOAD_INT(x2, x9) # load rs2: x9 = 0x2bd8acb1
+  RVTEST_TESTDATA_LOAD_INT(x2, x8) # load rd compare value: x8 = 0x785e2550
   LA(x17, scratch) # load base address into rs1
   SREG x21, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b17_not_equal:
@@ -486,6 +520,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b17_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x25) # load value in memory: x25 = 0x7e090d3d
   RVTEST_TESTDATA_LOAD_INT(x2, x31) # load rs2: x31 = 0xe44d6bb5
+  RVTEST_TESTDATA_LOAD_INT(x2, x21) # load rd compare value: x21 = 0x7e090d3d
   LA(x18, scratch) # load base address into rs1
   SREG x25, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b18_equal:
@@ -499,6 +534,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b18_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x19) # load value in memory: x19 = 0x2fa54925
   RVTEST_TESTDATA_LOAD_INT(x2, x14) # load rs2: x14 = 0xb8875162
+  RVTEST_TESTDATA_LOAD_INT(x2, x15) # load rd compare value: x15 = 0xdaaf0c88
   LA(x18, scratch) # load base address into rs1
   SREG x19, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b18_not_equal:
@@ -512,6 +548,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b18_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x18) # load value in memory: x18 = 0x1be89d3e
   RVTEST_TESTDATA_LOAD_INT(x2, x9) # load rs2: x9 = 0x01f6b985
+  RVTEST_TESTDATA_LOAD_INT(x2, x12) # load rd compare value: x12 = 0x1be89d3e
   LA(x19, scratch) # load base address into rs1
   SREG x18, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b19_equal:
@@ -525,6 +562,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b19_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x31) # load value in memory: x31 = 0xc9912fe7
   RVTEST_TESTDATA_LOAD_INT(x2, x15) # load rs2: x15 = 0xa4d5116c
+  RVTEST_TESTDATA_LOAD_INT(x2, x8) # load rd compare value: x8 = 0x2823dfef
   LA(x19, scratch) # load base address into rs1
   SREG x31, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b19_not_equal:
@@ -538,6 +576,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b19_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x27) # load value in memory: x27 = 0x4755077d
   RVTEST_TESTDATA_LOAD_INT(x2, x25) # load rs2: x25 = 0x4f4c2a47
+  RVTEST_TESTDATA_LOAD_INT(x2, x29) # load rd compare value: x29 = 0x4755077d
   LA(x20, scratch) # load base address into rs1
   SREG x27, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b20_equal:
@@ -551,6 +590,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b20_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x9) # load value in memory: x9 = 0xdcef1a91
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load rs2: x6 = 0x0be4be86
+  RVTEST_TESTDATA_LOAD_INT(x2, x3) # load rd compare value: x3 = 0x2eca0de0
   LA(x20, scratch) # load base address into rs1
   SREG x9, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b20_not_equal:
@@ -564,6 +604,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b20_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x17) # load value in memory: x17 = 0xaf6b6460
   RVTEST_TESTDATA_LOAD_INT(x2, x22) # load rs2: x22 = 0x2de4f9fa
+  RVTEST_TESTDATA_LOAD_INT(x2, x14) # load rd compare value: x14 = 0xaf6b6460
   LA(x21, scratch) # load base address into rs1
   SREG x17, 0(x21) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b21_equal:
@@ -577,6 +618,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b21_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load value in memory: x6 = 0x262263c8
   RVTEST_TESTDATA_LOAD_INT(x2, x3) # load rs2: x3 = 0x2c0ca0c9
+  RVTEST_TESTDATA_LOAD_INT(x2, x31) # load rd compare value: x31 = 0xd6455b4a
   LA(x21, scratch) # load base address into rs1
   SREG x6, 0(x21) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b21_not_equal:
@@ -590,6 +632,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b21_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x21) # load value in memory: x21 = 0xcb9d4eb2
   RVTEST_TESTDATA_LOAD_INT(x2, x0) # load rs2: x0 = 0x1ceda7e0
+  RVTEST_TESTDATA_LOAD_INT(x2, x6) # load rd compare value: x6 = 0xcb9d4eb2
   LA(x22, scratch) # load base address into rs1
   SREG x21, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b22_equal:
@@ -603,6 +646,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b22_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x18) # load value in memory: x18 = 0xf9da4cae
   RVTEST_TESTDATA_LOAD_INT(x2, x30) # load rs2: x30 = 0xc20d2cfd
+  RVTEST_TESTDATA_LOAD_INT(x2, x17) # load rd compare value: x17 = 0x7d3dbd0c
   LA(x22, scratch) # load base address into rs1
   SREG x18, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b22_not_equal:
@@ -616,6 +660,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b22_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load value in memory: x11 = 0xdc7ec8d5
   RVTEST_TESTDATA_LOAD_INT(x2, x20) # load rs2: x20 = 0xf15f5225
+  RVTEST_TESTDATA_LOAD_INT(x2, x22) # load rd compare value: x22 = 0xdc7ec8d5
   LA(x23, scratch) # load base address into rs1
   SREG x11, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b23_equal:
@@ -629,6 +674,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b23_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x9) # load value in memory: x9 = 0x8dc361fd
   RVTEST_TESTDATA_LOAD_INT(x2, x19) # load rs2: x19 = 0xcb6dadf5
+  RVTEST_TESTDATA_LOAD_INT(x2, x0) # load rd compare value: x0 = 0x283b582e
   LA(x23, scratch) # load base address into rs1
   SREG x9, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b23_not_equal:
@@ -642,6 +688,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b23_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x9) # load value in memory: x9 = 0x71d35cfc
   RVTEST_TESTDATA_LOAD_INT(x2, x27) # load rs2: x27 = 0xb9b36cd4
+  RVTEST_TESTDATA_LOAD_INT(x2, x16) # load rd compare value: x16 = 0x71d35cfc
   LA(x24, scratch) # load base address into rs1
   SREG x9, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b24_equal:
@@ -655,6 +702,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b24_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x20) # load value in memory: x20 = 0x5cbc5931
   RVTEST_TESTDATA_LOAD_INT(x2, x22) # load rs2: x22 = 0x01c8efef
+  RVTEST_TESTDATA_LOAD_INT(x2, x19) # load rd compare value: x19 = 0x71e929eb
   LA(x24, scratch) # load base address into rs1
   SREG x20, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b24_not_equal:
@@ -668,6 +716,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b24_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x8) # load value in memory: x8 = 0xe01a8476
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load rs2: x6 = 0x05035c34
+  RVTEST_TESTDATA_LOAD_INT(x2, x7) # load rd compare value: x7 = 0xe01a8476
   LA(x25, scratch) # load base address into rs1
   SREG x8, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b25_equal:
@@ -681,6 +730,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b25_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load value in memory: x6 = 0x75276317
   RVTEST_TESTDATA_LOAD_INT(x2, x19) # load rs2: x19 = 0x92865dec
+  RVTEST_TESTDATA_LOAD_INT(x2, x17) # load rd compare value: x17 = 0x3db7c437
   LA(x25, scratch) # load base address into rs1
   SREG x6, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b25_not_equal:
@@ -694,6 +744,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b25_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x8) # load value in memory: x8 = 0xa769f328
   RVTEST_TESTDATA_LOAD_INT(x2, x10) # load rs2: x10 = 0xfd07adce
+  RVTEST_TESTDATA_LOAD_INT(x2, x15) # load rd compare value: x15 = 0xa769f328
   LA(x26, scratch) # load base address into rs1
   SREG x8, 0(x26) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b26_equal:
@@ -707,6 +758,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b26_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x8) # load value in memory: x8 = 0xdfa9c4d7
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load rs2: x6 = 0xaa1a05af
+  RVTEST_TESTDATA_LOAD_INT(x2, x10) # load rd compare value: x10 = 0x0c4dd600
   LA(x26, scratch) # load base address into rs1
   SREG x8, 0(x26) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b26_not_equal:
@@ -720,6 +772,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b26_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x28) # load value in memory: x28 = 0x7c33a440
   RVTEST_TESTDATA_LOAD_INT(x2, x7) # load rs2: x7 = 0x85782b0a
+  RVTEST_TESTDATA_LOAD_INT(x2, x21) # load rd compare value: x21 = 0x7c33a440
   LA(x27, scratch) # load base address into rs1
   SREG x28, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b27_equal:
@@ -733,6 +786,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b27_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x7) # load value in memory: x7 = 0x9075d8c6
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load rs2: x11 = 0x581df4d2
+  RVTEST_TESTDATA_LOAD_INT(x2, x24) # load rd compare value: x24 = 0xaac1ba47
   LA(x27, scratch) # load base address into rs1
   SREG x7, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b27_not_equal:
@@ -746,6 +800,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b27_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x20) # load value in memory: x20 = 0xa77d5fe8
   RVTEST_TESTDATA_LOAD_INT(x2, x23) # load rs2: x23 = 0x23b1ed93
+  RVTEST_TESTDATA_LOAD_INT(x2, x27) # load rd compare value: x27 = 0xa77d5fe8
   LA(x28, scratch) # load base address into rs1
   SREG x20, 0(x28) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b28_equal:
@@ -759,6 +814,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b28_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load value in memory: x11 = 0x7fe74641
   RVTEST_TESTDATA_LOAD_INT(x2, x15) # load rs2: x15 = 0xfb58b964
+  RVTEST_TESTDATA_LOAD_INT(x2, x21) # load rd compare value: x21 = 0xf6350794
   LA(x28, scratch) # load base address into rs1
   SREG x11, 0(x28) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b28_not_equal:
@@ -772,6 +828,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b28_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x17) # load value in memory: x17 = 0xe749a1ce
   RVTEST_TESTDATA_LOAD_INT(x2, x24) # load rs2: x24 = 0xa972ef64
+  RVTEST_TESTDATA_LOAD_INT(x2, x18) # load rd compare value: x18 = 0xe749a1ce
   LA(x29, scratch) # load base address into rs1
   SREG x17, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b29_equal:
@@ -785,6 +842,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b29_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x14) # load value in memory: x14 = 0xd0055a9e
   RVTEST_TESTDATA_LOAD_INT(x2, x22) # load rs2: x22 = 0x0f3c0a10
+  RVTEST_TESTDATA_LOAD_INT(x2, x0) # load rd compare value: x0 = 0x3ad18ecb
   LA(x29, scratch) # load base address into rs1
   SREG x14, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b29_not_equal:
@@ -798,6 +856,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b29_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x25) # load value in memory: x25 = 0xb185629f
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load rs2: x11 = 0x6d1aa8e3
+  RVTEST_TESTDATA_LOAD_INT(x2, x3) # load rd compare value: x3 = 0xb185629f
   LA(x30, scratch) # load base address into rs1
   SREG x25, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b30_equal:
@@ -811,6 +870,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b30_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x19) # load value in memory: x19 = 0xd17f48d2
   RVTEST_TESTDATA_LOAD_INT(x2, x28) # load rs2: x28 = 0x0981e070
+  RVTEST_TESTDATA_LOAD_INT(x2, x17) # load rd compare value: x17 = 0x4273dd23
   LA(x30, scratch) # load base address into rs1
   SREG x19, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b30_not_equal:
@@ -824,6 +884,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b30_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x24) # load value in memory: x24 = 0xd83b9bfb
   RVTEST_TESTDATA_LOAD_INT(x2, x29) # load rs2: x29 = 0x126eab4c
+  RVTEST_TESTDATA_LOAD_INT(x2, x14) # load rd compare value: x14 = 0xd83b9bfb
   LA(x31, scratch) # load base address into rs1
   SREG x24, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b31_equal:
@@ -837,6 +898,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b31_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x13) # load value in memory: x13 = 0x7a1cf6b7
   RVTEST_TESTDATA_LOAD_INT(x2, x28) # load rs2: x28 = 0x5b9bed96
+  RVTEST_TESTDATA_LOAD_INT(x2, x8) # load rd compare value: x8 = 0xd465db21
   LA(x31, scratch) # load base address into rs1
   SREG x13, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b31_not_equal:
@@ -854,6 +916,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b31_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x0, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x17) # load value in memory: x17 = 0xbd34b68d
   RVTEST_TESTDATA_LOAD_INT(x2, x0) # load rs2: x0 = 0x444cc2d2
+  RVTEST_TESTDATA_LOAD_INT(x2, x15) # load rd compare value: x15 = 0xbd34b68d
   LA(x13, scratch) # load base address into rs1
   SREG x17, 0(x13) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b0_equal:
@@ -867,6 +930,7 @@ Zacas_amocas_w_cg_cp_rs2_b0_equal:
 # Testcase cp_rs2 (Test source rs2 = x0, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x7) # load value in memory: x7 = 0xdbeade6c
   RVTEST_TESTDATA_LOAD_INT(x2, x0) # load rs2: x0 = 0x61f08ccb
+  RVTEST_TESTDATA_LOAD_INT(x2, x14) # load rd compare value: x14 = 0x70d95352
   LA(x11, scratch) # load base address into rs1
   SREG x7, 0(x11) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b0_not_equal:
@@ -881,6 +945,7 @@ Zacas_amocas_w_cg_cp_rs2_b0_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x15) # load value in memory: x15 = 0x505de7cb
   RVTEST_TESTDATA_LOAD_INT(x2, x1) # load rs2: x1 = 0x7c8436ec
+  RVTEST_TESTDATA_LOAD_INT(x2, x30) # load rd compare value: x30 = 0x505de7cb
   LA(x31, scratch) # load base address into rs1
   SREG x15, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b1_equal:
@@ -894,6 +959,7 @@ Zacas_amocas_w_cg_cp_rs2_b1_equal:
 # Testcase cp_rs2 (Test source rs2 = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load value in memory: x6 = 0xd29ff27b
   RVTEST_TESTDATA_LOAD_INT(x2, x1) # load rs2: x1 = 0x2da4e199
+  RVTEST_TESTDATA_LOAD_INT(x2, x22) # load rd compare value: x22 = 0x5b4887b6
   LA(x10, scratch) # load base address into rs1
   SREG x6, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b1_not_equal:
@@ -908,6 +974,7 @@ Zacas_amocas_w_cg_cp_rs2_b1_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x9) # load value in memory: x9 = 0xe10fa38f
   RVTEST_TESTDATA_LOAD_INT(x28, x2) # load rs2: x2 = 0xa66f401b
+  RVTEST_TESTDATA_LOAD_INT(x28, x24) # load rd compare value: x24 = 0xe10fa38f
   LA(x3, scratch) # load base address into rs1
   SREG x9, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b2_equal:
@@ -921,6 +988,7 @@ Zacas_amocas_w_cg_cp_rs2_b2_equal:
 # Testcase cp_rs2 (Test source rs2 = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x27) # load value in memory: x27 = 0x0e65c3ed
   RVTEST_TESTDATA_LOAD_INT(x28, x2) # load rs2: x2 = 0xbae87016
+  RVTEST_TESTDATA_LOAD_INT(x28, x23) # load rd compare value: x23 = 0x09b372c8
   LA(x16, scratch) # load base address into rs1
   SREG x27, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b2_not_equal:
@@ -934,6 +1002,7 @@ Zacas_amocas_w_cg_cp_rs2_b2_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x16) # load value in memory: x16 = 0xf49beb03
   RVTEST_TESTDATA_LOAD_INT(x28, x3) # load rs2: x3 = 0x96eaf810
+  RVTEST_TESTDATA_LOAD_INT(x28, x10) # load rd compare value: x10 = 0xf49beb03
   LA(x23, scratch) # load base address into rs1
   SREG x16, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b3_equal:
@@ -947,6 +1016,7 @@ Zacas_amocas_w_cg_cp_rs2_b3_equal:
 # Testcase cp_rs2 (Test source rs2 = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load value in memory: x24 = 0x745d5331
   RVTEST_TESTDATA_LOAD_INT(x28, x3) # load rs2: x3 = 0x52db7da1
+  RVTEST_TESTDATA_LOAD_INT(x28, x12) # load rd compare value: x12 = 0x4dee1585
   LA(x15, scratch) # load base address into rs1
   SREG x24, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b3_not_equal:
@@ -962,6 +1032,7 @@ Zacas_amocas_w_cg_cp_rs2_b3_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x9) # load value in memory: x9 = 0xc4352d96
   RVTEST_TESTDATA_LOAD_INT(x28, x4) # load rs2: x4 = 0x850fb30e
+  RVTEST_TESTDATA_LOAD_INT(x28, x26) # load rd compare value: x26 = 0xc4352d96
   LA(x8, scratch) # load base address into rs1
   SREG x9, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b4_equal:
@@ -975,6 +1046,7 @@ Zacas_amocas_w_cg_cp_rs2_b4_equal:
 # Testcase cp_rs2 (Test source rs2 = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x17) # load value in memory: x17 = 0x792b14bd
   RVTEST_TESTDATA_LOAD_INT(x28, x4) # load rs2: x4 = 0xeccbc3d3
+  RVTEST_TESTDATA_LOAD_INT(x28, x15) # load rd compare value: x15 = 0xd093c73a
   LA(x24, scratch) # load base address into rs1
   SREG x17, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b4_not_equal:
@@ -988,6 +1060,7 @@ Zacas_amocas_w_cg_cp_rs2_b4_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x4) # load value in memory: x4 = 0x306f039b
   RVTEST_TESTDATA_LOAD_INT(x28, x5) # load rs2: x5 = 0x541bb67e
+  RVTEST_TESTDATA_LOAD_INT(x28, x17) # load rd compare value: x17 = 0x306f039b
   LA(x16, scratch) # load base address into rs1
   SREG x4, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b5_equal:
@@ -1001,6 +1074,7 @@ Zacas_amocas_w_cg_cp_rs2_b5_equal:
 # Testcase cp_rs2 (Test source rs2 = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x11) # load value in memory: x11 = 0xfdf11d25
   RVTEST_TESTDATA_LOAD_INT(x28, x5) # load rs2: x5 = 0x3c5ade38
+  RVTEST_TESTDATA_LOAD_INT(x28, x17) # load rd compare value: x17 = 0x2e070f88
   LA(x25, scratch) # load base address into rs1
   SREG x11, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b5_not_equal:
@@ -1014,6 +1088,7 @@ Zacas_amocas_w_cg_cp_rs2_b5_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x27) # load value in memory: x27 = 0xb40e737a
   RVTEST_TESTDATA_LOAD_INT(x28, x6) # load rs2: x6 = 0xf3adc13b
+  RVTEST_TESTDATA_LOAD_INT(x28, x31) # load rd compare value: x31 = 0xb40e737a
   LA(x20, scratch) # load base address into rs1
   SREG x27, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b6_equal:
@@ -1027,6 +1102,7 @@ Zacas_amocas_w_cg_cp_rs2_b6_equal:
 # Testcase cp_rs2 (Test source rs2 = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x8) # load value in memory: x8 = 0xaa613e5d
   RVTEST_TESTDATA_LOAD_INT(x28, x6) # load rs2: x6 = 0xaa4380fe
+  RVTEST_TESTDATA_LOAD_INT(x28, x16) # load rd compare value: x16 = 0xbf0ce552
   LA(x15, scratch) # load base address into rs1
   SREG x8, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b6_not_equal:
@@ -1040,6 +1116,7 @@ Zacas_amocas_w_cg_cp_rs2_b6_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x22) # load value in memory: x22 = 0x61f2dbba
   RVTEST_TESTDATA_LOAD_INT(x28, x7) # load rs2: x7 = 0x723883c1
+  RVTEST_TESTDATA_LOAD_INT(x28, x3) # load rd compare value: x3 = 0x61f2dbba
   LA(x9, scratch) # load base address into rs1
   SREG x22, 0(x9) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b7_equal:
@@ -1053,6 +1130,7 @@ Zacas_amocas_w_cg_cp_rs2_b7_equal:
 # Testcase cp_rs2 (Test source rs2 = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x27) # load value in memory: x27 = 0x141b1f57
   RVTEST_TESTDATA_LOAD_INT(x28, x7) # load rs2: x7 = 0x6a7df2b0
+  RVTEST_TESTDATA_LOAD_INT(x28, x1) # load rd compare value: x1 = 0x981e18e4
   LA(x8, scratch) # load base address into rs1
   SREG x27, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b7_not_equal:
@@ -1066,6 +1144,7 @@ Zacas_amocas_w_cg_cp_rs2_b7_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x12) # load value in memory: x12 = 0x12c40312
   RVTEST_TESTDATA_LOAD_INT(x28, x8) # load rs2: x8 = 0xdbce53a8
+  RVTEST_TESTDATA_LOAD_INT(x28, x2) # load rd compare value: x2 = 0x12c40312
   LA(x24, scratch) # load base address into rs1
   SREG x12, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b8_equal:
@@ -1079,6 +1158,7 @@ Zacas_amocas_w_cg_cp_rs2_b8_equal:
 # Testcase cp_rs2 (Test source rs2 = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x7) # load value in memory: x7 = 0xe3ce7c1e
   RVTEST_TESTDATA_LOAD_INT(x28, x8) # load rs2: x8 = 0x850e3b56
+  RVTEST_TESTDATA_LOAD_INT(x28, x25) # load rd compare value: x25 = 0xe326bc08
   LA(x20, scratch) # load base address into rs1
   SREG x7, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b8_not_equal:
@@ -1092,6 +1172,7 @@ Zacas_amocas_w_cg_cp_rs2_b8_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x4) # load value in memory: x4 = 0xd015530f
   RVTEST_TESTDATA_LOAD_INT(x28, x9) # load rs2: x9 = 0x269bb8f8
+  RVTEST_TESTDATA_LOAD_INT(x28, x22) # load rd compare value: x22 = 0xd015530f
   LA(x25, scratch) # load base address into rs1
   SREG x4, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b9_equal:
@@ -1105,6 +1186,7 @@ Zacas_amocas_w_cg_cp_rs2_b9_equal:
 # Testcase cp_rs2 (Test source rs2 = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x16) # load value in memory: x16 = 0xaacfecec
   RVTEST_TESTDATA_LOAD_INT(x28, x9) # load rs2: x9 = 0x01a2d481
+  RVTEST_TESTDATA_LOAD_INT(x28, x30) # load rd compare value: x30 = 0x2a0366e5
   LA(x1, scratch) # load base address into rs1
   SREG x16, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b9_not_equal:
@@ -1118,6 +1200,7 @@ Zacas_amocas_w_cg_cp_rs2_b9_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x26) # load value in memory: x26 = 0x1a1e07ef
   RVTEST_TESTDATA_LOAD_INT(x28, x10) # load rs2: x10 = 0xc6c46f8b
+  RVTEST_TESTDATA_LOAD_INT(x28, x4) # load rd compare value: x4 = 0x1a1e07ef
   LA(x27, scratch) # load base address into rs1
   SREG x26, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b10_equal:
@@ -1131,6 +1214,7 @@ Zacas_amocas_w_cg_cp_rs2_b10_equal:
 # Testcase cp_rs2 (Test source rs2 = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x3) # load value in memory: x3 = 0x57a49263
   RVTEST_TESTDATA_LOAD_INT(x28, x10) # load rs2: x10 = 0x678dc17e
+  RVTEST_TESTDATA_LOAD_INT(x28, x11) # load rd compare value: x11 = 0x367b6462
   LA(x23, scratch) # load base address into rs1
   SREG x3, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b10_not_equal:
@@ -1144,6 +1228,7 @@ Zacas_amocas_w_cg_cp_rs2_b10_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x7) # load value in memory: x7 = 0x1cff4035
   RVTEST_TESTDATA_LOAD_INT(x28, x11) # load rs2: x11 = 0xa4f42b7f
+  RVTEST_TESTDATA_LOAD_INT(x28, x1) # load rd compare value: x1 = 0x1cff4035
   LA(x26, scratch) # load base address into rs1
   SREG x7, 0(x26) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b11_equal:
@@ -1157,6 +1242,7 @@ Zacas_amocas_w_cg_cp_rs2_b11_equal:
 # Testcase cp_rs2 (Test source rs2 = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x18) # load value in memory: x18 = 0xa31275aa
   RVTEST_TESTDATA_LOAD_INT(x28, x11) # load rs2: x11 = 0x299e4754
+  RVTEST_TESTDATA_LOAD_INT(x28, x10) # load rd compare value: x10 = 0x2ab0d0d3
   LA(x21, scratch) # load base address into rs1
   SREG x18, 0(x21) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b11_not_equal:
@@ -1170,6 +1256,7 @@ Zacas_amocas_w_cg_cp_rs2_b11_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x6) # load value in memory: x6 = 0x78ac69eb
   RVTEST_TESTDATA_LOAD_INT(x28, x12) # load rs2: x12 = 0xefdd2ca2
+  RVTEST_TESTDATA_LOAD_INT(x28, x16) # load rd compare value: x16 = 0x78ac69eb
   LA(x5, scratch) # load base address into rs1
   SREG x6, 0(x5) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b12_equal:
@@ -1183,6 +1270,7 @@ Zacas_amocas_w_cg_cp_rs2_b12_equal:
 # Testcase cp_rs2 (Test source rs2 = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x27) # load value in memory: x27 = 0x074461fa
   RVTEST_TESTDATA_LOAD_INT(x28, x12) # load rs2: x12 = 0xcc2863a6
+  RVTEST_TESTDATA_LOAD_INT(x28, x26) # load rd compare value: x26 = 0x03839b36
   LA(x3, scratch) # load base address into rs1
   SREG x27, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b12_not_equal:
@@ -1198,6 +1286,7 @@ Zacas_amocas_w_cg_cp_rs2_b12_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x1) # load value in memory: x1 = 0xfb57c386
   RVTEST_TESTDATA_LOAD_INT(x28, x13) # load rs2: x13 = 0x40fd72a9
+  RVTEST_TESTDATA_LOAD_INT(x28, x29) # load rd compare value: x29 = 0xfb57c386
   LA(x2, scratch) # load base address into rs1
   SREG x1, 0(x2) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b13_equal:
@@ -1211,6 +1300,7 @@ Zacas_amocas_w_cg_cp_rs2_b13_equal:
 # Testcase cp_rs2 (Test source rs2 = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x12) # load value in memory: x12 = 0x0a18316c
   RVTEST_TESTDATA_LOAD_INT(x28, x13) # load rs2: x13 = 0x9da6aa75
+  RVTEST_TESTDATA_LOAD_INT(x28, x2) # load rd compare value: x2 = 0x7e4cf42a
   LA(x6, scratch) # load base address into rs1
   SREG x12, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b13_not_equal:
@@ -1224,6 +1314,7 @@ Zacas_amocas_w_cg_cp_rs2_b13_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x15) # load value in memory: x15 = 0x76de738b
   RVTEST_TESTDATA_LOAD_INT(x28, x14) # load rs2: x14 = 0x551274a3
+  RVTEST_TESTDATA_LOAD_INT(x28, x21) # load rd compare value: x21 = 0x76de738b
   LA(x1, scratch) # load base address into rs1
   SREG x15, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b14_equal:
@@ -1237,6 +1328,7 @@ Zacas_amocas_w_cg_cp_rs2_b14_equal:
 # Testcase cp_rs2 (Test source rs2 = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x9) # load value in memory: x9 = 0xec8ce1a3
   RVTEST_TESTDATA_LOAD_INT(x28, x14) # load rs2: x14 = 0xec8dbfef
+  RVTEST_TESTDATA_LOAD_INT(x28, x30) # load rd compare value: x30 = 0x770d352c
   LA(x31, scratch) # load base address into rs1
   SREG x9, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b14_not_equal:
@@ -1250,6 +1342,7 @@ Zacas_amocas_w_cg_cp_rs2_b14_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x1) # load value in memory: x1 = 0x62067f08
   RVTEST_TESTDATA_LOAD_INT(x28, x15) # load rs2: x15 = 0x6a97c92a
+  RVTEST_TESTDATA_LOAD_INT(x28, x6) # load rd compare value: x6 = 0x62067f08
   LA(x12, scratch) # load base address into rs1
   SREG x1, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b15_equal:
@@ -1263,6 +1356,7 @@ Zacas_amocas_w_cg_cp_rs2_b15_equal:
 # Testcase cp_rs2 (Test source rs2 = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x30) # load value in memory: x30 = 0x40403d9f
   RVTEST_TESTDATA_LOAD_INT(x28, x15) # load rs2: x15 = 0x99955ff9
+  RVTEST_TESTDATA_LOAD_INT(x28, x9) # load rd compare value: x9 = 0x49ef8140
   LA(x31, scratch) # load base address into rs1
   SREG x30, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b15_not_equal:
@@ -1276,6 +1370,7 @@ Zacas_amocas_w_cg_cp_rs2_b15_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x21) # load value in memory: x21 = 0xca961d07
   RVTEST_TESTDATA_LOAD_INT(x28, x16) # load rs2: x16 = 0x5bc0bdc6
+  RVTEST_TESTDATA_LOAD_INT(x28, x10) # load rd compare value: x10 = 0xca961d07
   LA(x25, scratch) # load base address into rs1
   SREG x21, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b16_equal:
@@ -1289,6 +1384,7 @@ Zacas_amocas_w_cg_cp_rs2_b16_equal:
 # Testcase cp_rs2 (Test source rs2 = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x26) # load value in memory: x26 = 0x678c1f61
   RVTEST_TESTDATA_LOAD_INT(x28, x16) # load rs2: x16 = 0x3cbe5fa4
+  RVTEST_TESTDATA_LOAD_INT(x28, x24) # load rd compare value: x24 = 0x19c52536
   LA(x4, scratch) # load base address into rs1
   SREG x26, 0(x4) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b16_not_equal:
@@ -1302,6 +1398,7 @@ Zacas_amocas_w_cg_cp_rs2_b16_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x29) # load value in memory: x29 = 0x408878d0
   RVTEST_TESTDATA_LOAD_INT(x28, x17) # load rs2: x17 = 0x2ef3c18c
+  RVTEST_TESTDATA_LOAD_INT(x28, x6) # load rd compare value: x6 = 0x408878d0
   LA(x30, scratch) # load base address into rs1
   SREG x29, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b17_equal:
@@ -1315,6 +1412,7 @@ Zacas_amocas_w_cg_cp_rs2_b17_equal:
 # Testcase cp_rs2 (Test source rs2 = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x4) # load value in memory: x4 = 0xad51b420
   RVTEST_TESTDATA_LOAD_INT(x28, x17) # load rs2: x17 = 0xdae4152a
+  RVTEST_TESTDATA_LOAD_INT(x28, x16) # load rd compare value: x16 = 0xee69d061
   LA(x23, scratch) # load base address into rs1
   SREG x4, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b17_not_equal:
@@ -1328,6 +1426,7 @@ Zacas_amocas_w_cg_cp_rs2_b17_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x21) # load value in memory: x21 = 0xf48ece8a
   RVTEST_TESTDATA_LOAD_INT(x28, x18) # load rs2: x18 = 0x609d9cfa
+  RVTEST_TESTDATA_LOAD_INT(x28, x25) # load rd compare value: x25 = 0xf48ece8a
   LA(x14, scratch) # load base address into rs1
   SREG x21, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b18_equal:
@@ -1341,6 +1440,7 @@ Zacas_amocas_w_cg_cp_rs2_b18_equal:
 # Testcase cp_rs2 (Test source rs2 = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x13) # load value in memory: x13 = 0xef794004
   RVTEST_TESTDATA_LOAD_INT(x28, x18) # load rs2: x18 = 0x270d88f1
+  RVTEST_TESTDATA_LOAD_INT(x28, x27) # load rd compare value: x27 = 0xcebb1f8d
   LA(x30, scratch) # load base address into rs1
   SREG x13, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b18_not_equal:
@@ -1355,6 +1455,7 @@ Zacas_amocas_w_cg_cp_rs2_b18_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x20) # load value in memory: x20 = 0x1cbeadfc
   RVTEST_TESTDATA_LOAD_INT(x28, x19) # load rs2: x19 = 0x6401d72b
+  RVTEST_TESTDATA_LOAD_INT(x28, x26) # load rd compare value: x26 = 0x1cbeadfc
   LA(x23, scratch) # load base address into rs1
   SREG x20, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b19_equal:
@@ -1368,6 +1469,7 @@ Zacas_amocas_w_cg_cp_rs2_b19_equal:
 # Testcase cp_rs2 (Test source rs2 = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x29) # load value in memory: x29 = 0xcb96557a
   RVTEST_TESTDATA_LOAD_INT(x28, x19) # load rs2: x19 = 0x9705d985
+  RVTEST_TESTDATA_LOAD_INT(x28, x18) # load rd compare value: x18 = 0xc38bc6cc
   LA(x24, scratch) # load base address into rs1
   SREG x29, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b19_not_equal:
@@ -1381,6 +1483,7 @@ Zacas_amocas_w_cg_cp_rs2_b19_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x29) # load value in memory: x29 = 0x0b751a67
   RVTEST_TESTDATA_LOAD_INT(x28, x20) # load rs2: x20 = 0x69b3b0a1
+  RVTEST_TESTDATA_LOAD_INT(x28, x19) # load rd compare value: x19 = 0x0b751a67
   LA(x17, scratch) # load base address into rs1
   SREG x29, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b20_equal:
@@ -1394,6 +1497,7 @@ Zacas_amocas_w_cg_cp_rs2_b20_equal:
 # Testcase cp_rs2 (Test source rs2 = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x14) # load value in memory: x14 = 0xd3a3770c
   RVTEST_TESTDATA_LOAD_INT(x28, x20) # load rs2: x20 = 0xfeb7b05a
+  RVTEST_TESTDATA_LOAD_INT(x28, x15) # load rd compare value: x15 = 0x8457f556
   LA(x27, scratch) # load base address into rs1
   SREG x14, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b20_not_equal:
@@ -1407,6 +1511,7 @@ Zacas_amocas_w_cg_cp_rs2_b20_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load value in memory: x24 = 0x7d3c8a1d
   RVTEST_TESTDATA_LOAD_INT(x28, x21) # load rs2: x21 = 0xa427dbe3
+  RVTEST_TESTDATA_LOAD_INT(x28, x15) # load rd compare value: x15 = 0x7d3c8a1d
   LA(x23, scratch) # load base address into rs1
   SREG x24, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b21_equal:
@@ -1420,6 +1525,7 @@ Zacas_amocas_w_cg_cp_rs2_b21_equal:
 # Testcase cp_rs2 (Test source rs2 = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x17) # load value in memory: x17 = 0xa9f502e9
   RVTEST_TESTDATA_LOAD_INT(x28, x21) # load rs2: x21 = 0x743e7a5e
+  RVTEST_TESTDATA_LOAD_INT(x28, x4) # load rd compare value: x4 = 0x479803e3
   LA(x25, scratch) # load base address into rs1
   SREG x17, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b21_not_equal:
@@ -1433,6 +1539,7 @@ Zacas_amocas_w_cg_cp_rs2_b21_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x25) # load value in memory: x25 = 0x0e3ed6e1
   RVTEST_TESTDATA_LOAD_INT(x28, x22) # load rs2: x22 = 0x41a98612
+  RVTEST_TESTDATA_LOAD_INT(x28, x14) # load rd compare value: x14 = 0x0e3ed6e1
   LA(x15, scratch) # load base address into rs1
   SREG x25, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b22_equal:
@@ -1446,6 +1553,7 @@ Zacas_amocas_w_cg_cp_rs2_b22_equal:
 # Testcase cp_rs2 (Test source rs2 = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x12) # load value in memory: x12 = 0x350609d8
   RVTEST_TESTDATA_LOAD_INT(x28, x22) # load rs2: x22 = 0xaf9361de
+  RVTEST_TESTDATA_LOAD_INT(x28, x3) # load rd compare value: x3 = 0x47b76478
   LA(x17, scratch) # load base address into rs1
   SREG x12, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b22_not_equal:
@@ -1459,6 +1567,7 @@ Zacas_amocas_w_cg_cp_rs2_b22_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x4) # load value in memory: x4 = 0x312fd0ee
   RVTEST_TESTDATA_LOAD_INT(x28, x23) # load rs2: x23 = 0xbdfb0b4c
+  RVTEST_TESTDATA_LOAD_INT(x28, x2) # load rd compare value: x2 = 0x312fd0ee
   LA(x15, scratch) # load base address into rs1
   SREG x4, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b23_equal:
@@ -1472,6 +1581,7 @@ Zacas_amocas_w_cg_cp_rs2_b23_equal:
 # Testcase cp_rs2 (Test source rs2 = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x17) # load value in memory: x17 = 0x6b3cdcbf
   RVTEST_TESTDATA_LOAD_INT(x28, x23) # load rs2: x23 = 0xcb60db2c
+  RVTEST_TESTDATA_LOAD_INT(x28, x9) # load rd compare value: x9 = 0x2a40bd55
   LA(x30, scratch) # load base address into rs1
   SREG x17, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b23_not_equal:
@@ -1485,6 +1595,7 @@ Zacas_amocas_w_cg_cp_rs2_b23_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x17) # load value in memory: x17 = 0xbe4de47e
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load rs2: x24 = 0x21c70762
+  RVTEST_TESTDATA_LOAD_INT(x28, x2) # load rd compare value: x2 = 0xbe4de47e
   LA(x15, scratch) # load base address into rs1
   SREG x17, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b24_equal:
@@ -1498,6 +1609,7 @@ Zacas_amocas_w_cg_cp_rs2_b24_equal:
 # Testcase cp_rs2 (Test source rs2 = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x1) # load value in memory: x1 = 0xb96d7e32
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load rs2: x24 = 0x1debc09f
+  RVTEST_TESTDATA_LOAD_INT(x28, x12) # load rd compare value: x12 = 0xa4cefebc
   LA(x16, scratch) # load base address into rs1
   SREG x1, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b24_not_equal:
@@ -1511,6 +1623,7 @@ Zacas_amocas_w_cg_cp_rs2_b24_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load value in memory: x24 = 0xa1a5f156
   RVTEST_TESTDATA_LOAD_INT(x28, x25) # load rs2: x25 = 0x1508bb45
+  RVTEST_TESTDATA_LOAD_INT(x28, x9) # load rd compare value: x9 = 0xa1a5f156
   LA(x13, scratch) # load base address into rs1
   SREG x24, 0(x13) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b25_equal:
@@ -1524,6 +1637,7 @@ Zacas_amocas_w_cg_cp_rs2_b25_equal:
 # Testcase cp_rs2 (Test source rs2 = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load value in memory: x24 = 0xb6cffdc6
   RVTEST_TESTDATA_LOAD_INT(x28, x25) # load rs2: x25 = 0x919bd39a
+  RVTEST_TESTDATA_LOAD_INT(x28, x22) # load rd compare value: x22 = 0x5cdf0412
   LA(x5, scratch) # load base address into rs1
   SREG x24, 0(x5) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b25_not_equal:
@@ -1537,6 +1651,7 @@ Zacas_amocas_w_cg_cp_rs2_b25_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x5) # load value in memory: x5 = 0xeffd3c3d
   RVTEST_TESTDATA_LOAD_INT(x28, x26) # load rs2: x26 = 0x75c393fb
+  RVTEST_TESTDATA_LOAD_INT(x28, x2) # load rd compare value: x2 = 0xeffd3c3d
   LA(x10, scratch) # load base address into rs1
   SREG x5, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b26_equal:
@@ -1550,6 +1665,7 @@ Zacas_amocas_w_cg_cp_rs2_b26_equal:
 # Testcase cp_rs2 (Test source rs2 = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x15) # load value in memory: x15 = 0x1c2e183e
   RVTEST_TESTDATA_LOAD_INT(x28, x26) # load rs2: x26 = 0xc80066c2
+  RVTEST_TESTDATA_LOAD_INT(x28, x21) # load rd compare value: x21 = 0xd2c4cd8c
   LA(x30, scratch) # load base address into rs1
   SREG x15, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b26_not_equal:
@@ -1563,6 +1679,7 @@ Zacas_amocas_w_cg_cp_rs2_b26_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x16) # load value in memory: x16 = 0xb102eaf1
   RVTEST_TESTDATA_LOAD_INT(x28, x27) # load rs2: x27 = 0xbc0e5884
+  RVTEST_TESTDATA_LOAD_INT(x28, x24) # load rd compare value: x24 = 0xb102eaf1
   LA(x4, scratch) # load base address into rs1
   SREG x16, 0(x4) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b27_equal:
@@ -1576,6 +1693,7 @@ Zacas_amocas_w_cg_cp_rs2_b27_equal:
 # Testcase cp_rs2 (Test source rs2 = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x4) # load value in memory: x4 = 0xd050b55b
   RVTEST_TESTDATA_LOAD_INT(x28, x27) # load rs2: x27 = 0x8c64f1aa
+  RVTEST_TESTDATA_LOAD_INT(x28, x20) # load rd compare value: x20 = 0x6fb1956b
   LA(x13, scratch) # load base address into rs1
   SREG x4, 0(x13) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b27_not_equal:
@@ -1590,6 +1708,7 @@ Zacas_amocas_w_cg_cp_rs2_b27_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x29, x19) # load value in memory: x19 = 0xe8894296
   RVTEST_TESTDATA_LOAD_INT(x29, x28) # load rs2: x28 = 0x042f1cf8
+  RVTEST_TESTDATA_LOAD_INT(x29, x13) # load rd compare value: x13 = 0xe8894296
   LA(x18, scratch) # load base address into rs1
   SREG x19, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b28_equal:
@@ -1603,6 +1722,7 @@ Zacas_amocas_w_cg_cp_rs2_b28_equal:
 # Testcase cp_rs2 (Test source rs2 = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x29, x18) # load value in memory: x18 = 0xf259fe2b
   RVTEST_TESTDATA_LOAD_INT(x29, x28) # load rs2: x28 = 0x5be58383
+  RVTEST_TESTDATA_LOAD_INT(x29, x26) # load rd compare value: x26 = 0x1bfcd829
   LA(x15, scratch) # load base address into rs1
   SREG x18, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b28_not_equal:
@@ -1617,6 +1737,7 @@ Zacas_amocas_w_cg_cp_rs2_b28_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x27) # load value in memory: x27 = 0x9ad5244a
   RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rs2: x29 = 0x60ea4a62
+  RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rd compare value: x12 = 0x9ad5244a
   LA(x9, scratch) # load base address into rs1
   SREG x27, 0(x9) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b29_equal:
@@ -1630,6 +1751,7 @@ Zacas_amocas_w_cg_cp_rs2_b29_equal:
 # Testcase cp_rs2 (Test source rs2 = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x19) # load value in memory: x19 = 0xcfac4d7a
   RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rs2: x29 = 0x420ed58e
+  RVTEST_TESTDATA_LOAD_INT(x15, x31) # load rd compare value: x31 = 0x5097d0e2
   LA(x14, scratch) # load base address into rs1
   SREG x19, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b29_not_equal:
@@ -1643,6 +1765,7 @@ Zacas_amocas_w_cg_cp_rs2_b29_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x1) # load value in memory: x1 = 0x6fe6aa73
   RVTEST_TESTDATA_LOAD_INT(x15, x30) # load rs2: x30 = 0xb171535b
+  RVTEST_TESTDATA_LOAD_INT(x15, x4) # load rd compare value: x4 = 0x6fe6aa73
   LA(x3, scratch) # load base address into rs1
   SREG x1, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b30_equal:
@@ -1656,6 +1779,7 @@ Zacas_amocas_w_cg_cp_rs2_b30_equal:
 # Testcase cp_rs2 (Test source rs2 = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x18) # load value in memory: x18 = 0x9052838b
   RVTEST_TESTDATA_LOAD_INT(x15, x30) # load rs2: x30 = 0x920ef9f4
+  RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rd compare value: x9 = 0xb6b83c74
   LA(x14, scratch) # load base address into rs1
   SREG x18, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b30_not_equal:
@@ -1669,6 +1793,7 @@ Zacas_amocas_w_cg_cp_rs2_b30_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x14) # load value in memory: x14 = 0x94a8e5ef
   RVTEST_TESTDATA_LOAD_INT(x15, x31) # load rs2: x31 = 0x1705fb6a
+  RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rd compare value: x29 = 0x94a8e5ef
   LA(x25, scratch) # load base address into rs1
   SREG x14, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b31_equal:
@@ -1682,6 +1807,7 @@ Zacas_amocas_w_cg_cp_rs2_b31_equal:
 # Testcase cp_rs2 (Test source rs2 = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x21) # load value in memory: x21 = 0x6dcc574f
   RVTEST_TESTDATA_LOAD_INT(x15, x31) # load rs2: x31 = 0x8631068a
+  RVTEST_TESTDATA_LOAD_INT(x15, x2) # load rd compare value: x2 = 0xaa951675
   LA(x28, scratch) # load base address into rs1
   SREG x21, 0(x28) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b31_not_equal:
@@ -1699,6 +1825,7 @@ Zacas_amocas_w_cg_cp_rs2_b31_not_equal:
 # Testcase cp_rd (Test destination rd = x0, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x25) # load value in memory: x25 = 0xd6331454
   RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rs2: x9 = 0xc28961f3
+  RVTEST_TESTDATA_LOAD_INT(x15, x0) # load rd compare value: x0 = 0xd6331454
   LA(x27, scratch) # load base address into rs1
   SREG x25, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b0_equal:
@@ -1712,6 +1839,7 @@ Zacas_amocas_w_cg_cp_rd_b0_equal:
 # Testcase cp_rd (Test destination rd = x0, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x30) # load value in memory: x30 = 0x0ff5b6d6
   RVTEST_TESTDATA_LOAD_INT(x15, x17) # load rs2: x17 = 0x853515e3
+  RVTEST_TESTDATA_LOAD_INT(x15, x0) # load rd compare value: x0 = 0xd8674601
   LA(x23, scratch) # load base address into rs1
   SREG x30, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b0_not_equal:
@@ -1725,6 +1853,7 @@ Zacas_amocas_w_cg_cp_rd_b0_not_equal:
 # Testcase cp_rd (Test destination rd = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x18) # load value in memory: x18 = 0xd6e34586
   RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rs2: x12 = 0x8d5e2e05
+  RVTEST_TESTDATA_LOAD_INT(x15, x1) # load rd compare value: x1 = 0xd6e34586
   LA(x2, scratch) # load base address into rs1
   SREG x18, 0(x2) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b1_equal:
@@ -1738,6 +1867,7 @@ Zacas_amocas_w_cg_cp_rd_b1_equal:
 # Testcase cp_rd (Test destination rd = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x13) # load value in memory: x13 = 0xca79b6e8
   RVTEST_TESTDATA_LOAD_INT(x15, x25) # load rs2: x25 = 0x49fdb31d
+  RVTEST_TESTDATA_LOAD_INT(x15, x1) # load rd compare value: x1 = 0x6c2950fe
   LA(x10, scratch) # load base address into rs1
   SREG x13, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b1_not_equal:
@@ -1751,6 +1881,7 @@ Zacas_amocas_w_cg_cp_rd_b1_not_equal:
 # Testcase cp_rd (Test destination rd = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x22) # load value in memory: x22 = 0xc3ff0de0
   RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rs2: x29 = 0x522001a7
+  RVTEST_TESTDATA_LOAD_INT(x15, x2) # load rd compare value: x2 = 0xc3ff0de0
   LA(x30, scratch) # load base address into rs1
   SREG x22, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b2_equal:
@@ -1764,6 +1895,7 @@ Zacas_amocas_w_cg_cp_rd_b2_equal:
 # Testcase cp_rd (Test destination rd = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x1) # load value in memory: x1 = 0xa40024e5
   RVTEST_TESTDATA_LOAD_INT(x15, x20) # load rs2: x20 = 0x87b5c092
+  RVTEST_TESTDATA_LOAD_INT(x15, x2) # load rd compare value: x2 = 0xe9dae6a3
   LA(x9, scratch) # load base address into rs1
   SREG x1, 0(x9) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b2_not_equal:
@@ -1777,6 +1909,7 @@ Zacas_amocas_w_cg_cp_rd_b2_not_equal:
 # Testcase cp_rd (Test destination rd = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x13) # load value in memory: x13 = 0xc7f326ef
   RVTEST_TESTDATA_LOAD_INT(x15, x19) # load rs2: x19 = 0xab24373f
+  RVTEST_TESTDATA_LOAD_INT(x15, x3) # load rd compare value: x3 = 0xc7f326ef
   LA(x22, scratch) # load base address into rs1
   SREG x13, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b3_equal:
@@ -1790,6 +1923,7 @@ Zacas_amocas_w_cg_cp_rd_b3_equal:
 # Testcase cp_rd (Test destination rd = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x13) # load value in memory: x13 = 0xb5cc81b1
   RVTEST_TESTDATA_LOAD_INT(x15, x28) # load rs2: x28 = 0x25b3c30e
+  RVTEST_TESTDATA_LOAD_INT(x15, x3) # load rd compare value: x3 = 0x6accb197
   LA(x16, scratch) # load base address into rs1
   SREG x13, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b3_not_equal:
@@ -1803,6 +1937,7 @@ Zacas_amocas_w_cg_cp_rd_b3_not_equal:
 # Testcase cp_rd (Test destination rd = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x10) # load value in memory: x10 = 0x8f17f15c
   RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rs2: x9 = 0x848170bb
+  RVTEST_TESTDATA_LOAD_INT(x15, x4) # load rd compare value: x4 = 0x8f17f15c
   LA(x25, scratch) # load base address into rs1
   SREG x10, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b4_equal:
@@ -1816,6 +1951,7 @@ Zacas_amocas_w_cg_cp_rd_b4_equal:
 # Testcase cp_rd (Test destination rd = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x25) # load value in memory: x25 = 0xff5e8bb0
   RVTEST_TESTDATA_LOAD_INT(x15, x11) # load rs2: x11 = 0x53c3f6bc
+  RVTEST_TESTDATA_LOAD_INT(x15, x4) # load rd compare value: x4 = 0xc004d0f3
   LA(x19, scratch) # load base address into rs1
   SREG x25, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b4_not_equal:
@@ -1829,6 +1965,7 @@ Zacas_amocas_w_cg_cp_rd_b4_not_equal:
 # Testcase cp_rd (Test destination rd = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x22) # load value in memory: x22 = 0xdacbee00
   RVTEST_TESTDATA_LOAD_INT(x15, x3) # load rs2: x3 = 0x19830e86
+  RVTEST_TESTDATA_LOAD_INT(x15, x5) # load rd compare value: x5 = 0xdacbee00
   LA(x30, scratch) # load base address into rs1
   SREG x22, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b5_equal:
@@ -1842,6 +1979,7 @@ Zacas_amocas_w_cg_cp_rd_b5_equal:
 # Testcase cp_rd (Test destination rd = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x29) # load value in memory: x29 = 0xb06f9892
   RVTEST_TESTDATA_LOAD_INT(x15, x4) # load rs2: x4 = 0x522d21ae
+  RVTEST_TESTDATA_LOAD_INT(x15, x5) # load rd compare value: x5 = 0x8042963b
   LA(x21, scratch) # load base address into rs1
   SREG x29, 0(x21) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b5_not_equal:
@@ -1856,6 +1994,7 @@ Zacas_amocas_w_cg_cp_rd_b5_not_equal:
 # Testcase cp_rd (Test destination rd = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x5) # load value in memory: x5 = 0xcfd6e8b2
   RVTEST_TESTDATA_LOAD_INT(x15, x20) # load rs2: x20 = 0x1b98c6b9
+  RVTEST_TESTDATA_LOAD_INT(x15, x6) # load rd compare value: x6 = 0xcfd6e8b2
   LA(x21, scratch) # load base address into rs1
   SREG x5, 0(x21) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b6_equal:
@@ -1869,6 +2008,7 @@ Zacas_amocas_w_cg_cp_rd_b6_equal:
 # Testcase cp_rd (Test destination rd = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x3) # load value in memory: x3 = 0x7f288fc3
   RVTEST_TESTDATA_LOAD_INT(x15, x16) # load rs2: x16 = 0x728f3d74
+  RVTEST_TESTDATA_LOAD_INT(x15, x6) # load rd compare value: x6 = 0xafb07251
   LA(x18, scratch) # load base address into rs1
   SREG x3, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b6_not_equal:
@@ -1884,6 +2024,7 @@ Zacas_amocas_w_cg_cp_rd_b6_not_equal:
 # Testcase cp_rd (Test destination rd = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x3) # load value in memory: x3 = 0xb3849b55
   RVTEST_TESTDATA_LOAD_INT(x15, x31) # load rs2: x31 = 0xd4842674
+  RVTEST_TESTDATA_LOAD_INT(x15, x7) # load rd compare value: x7 = 0xb3849b55
   LA(x29, scratch) # load base address into rs1
   SREG x3, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b7_equal:
@@ -1897,6 +2038,7 @@ Zacas_amocas_w_cg_cp_rd_b7_equal:
 # Testcase cp_rd (Test destination rd = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x31) # load value in memory: x31 = 0x5a38ca6c
   RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rs2: x9 = 0xcb42e73e
+  RVTEST_TESTDATA_LOAD_INT(x15, x7) # load rd compare value: x7 = 0xa2e175be
   LA(x25, scratch) # load base address into rs1
   SREG x31, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b7_not_equal:
@@ -1910,6 +2052,7 @@ Zacas_amocas_w_cg_cp_rd_b7_not_equal:
 # Testcase cp_rd (Test destination rd = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x1) # load value in memory: x1 = 0x9301493e
   RVTEST_TESTDATA_LOAD_INT(x15, x20) # load rs2: x20 = 0xed8d7433
+  RVTEST_TESTDATA_LOAD_INT(x15, x8) # load rd compare value: x8 = 0x9301493e
   LA(x23, scratch) # load base address into rs1
   SREG x1, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b8_equal:
@@ -1923,6 +2066,7 @@ Zacas_amocas_w_cg_cp_rd_b8_equal:
 # Testcase cp_rd (Test destination rd = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x11) # load value in memory: x11 = 0x8efa1d8f
   RVTEST_TESTDATA_LOAD_INT(x15, x18) # load rs2: x18 = 0x55ea3982
+  RVTEST_TESTDATA_LOAD_INT(x15, x8) # load rd compare value: x8 = 0x625098bd
   LA(x25, scratch) # load base address into rs1
   SREG x11, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b8_not_equal:
@@ -1936,6 +2080,7 @@ Zacas_amocas_w_cg_cp_rd_b8_not_equal:
 # Testcase cp_rd (Test destination rd = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x10) # load value in memory: x10 = 0x3b50cc74
   RVTEST_TESTDATA_LOAD_INT(x15, x20) # load rs2: x20 = 0xdf49096b
+  RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rd compare value: x9 = 0x3b50cc74
   LA(x30, scratch) # load base address into rs1
   SREG x10, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b9_equal:
@@ -1949,6 +2094,7 @@ Zacas_amocas_w_cg_cp_rd_b9_equal:
 # Testcase cp_rd (Test destination rd = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x10) # load value in memory: x10 = 0x53999bd6
   RVTEST_TESTDATA_LOAD_INT(x15, x4) # load rs2: x4 = 0x11c2ccdb
+  RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rd compare value: x9 = 0x8a74865c
   LA(x8, scratch) # load base address into rs1
   SREG x10, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b9_not_equal:
@@ -1962,6 +2108,7 @@ Zacas_amocas_w_cg_cp_rd_b9_not_equal:
 # Testcase cp_rd (Test destination rd = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x27) # load value in memory: x27 = 0x15680d94
   RVTEST_TESTDATA_LOAD_INT(x15, x30) # load rs2: x30 = 0x7dd4aebe
+  RVTEST_TESTDATA_LOAD_INT(x15, x10) # load rd compare value: x10 = 0x15680d94
   LA(x6, scratch) # load base address into rs1
   SREG x27, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b10_equal:
@@ -1975,6 +2122,7 @@ Zacas_amocas_w_cg_cp_rd_b10_equal:
 # Testcase cp_rd (Test destination rd = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x4) # load value in memory: x4 = 0xaa6f1d34
   RVTEST_TESTDATA_LOAD_INT(x15, x19) # load rs2: x19 = 0x50285057
+  RVTEST_TESTDATA_LOAD_INT(x15, x10) # load rd compare value: x10 = 0xf0ad8501
   LA(x29, scratch) # load base address into rs1
   SREG x4, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b10_not_equal:
@@ -1988,6 +2136,7 @@ Zacas_amocas_w_cg_cp_rd_b10_not_equal:
 # Testcase cp_rd (Test destination rd = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x7) # load value in memory: x7 = 0x238016f7
   RVTEST_TESTDATA_LOAD_INT(x15, x8) # load rs2: x8 = 0x583c8fac
+  RVTEST_TESTDATA_LOAD_INT(x15, x11) # load rd compare value: x11 = 0x238016f7
   LA(x4, scratch) # load base address into rs1
   SREG x7, 0(x4) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b11_equal:
@@ -2001,6 +2150,7 @@ Zacas_amocas_w_cg_cp_rd_b11_equal:
 # Testcase cp_rd (Test destination rd = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x29) # load value in memory: x29 = 0xcbe48d8d
   RVTEST_TESTDATA_LOAD_INT(x15, x1) # load rs2: x1 = 0x7a073099
+  RVTEST_TESTDATA_LOAD_INT(x15, x11) # load rd compare value: x11 = 0x5300b1b2
   LA(x6, scratch) # load base address into rs1
   SREG x29, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b11_not_equal:
@@ -2014,6 +2164,7 @@ Zacas_amocas_w_cg_cp_rd_b11_not_equal:
 # Testcase cp_rd (Test destination rd = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x22) # load value in memory: x22 = 0x0e10721a
   RVTEST_TESTDATA_LOAD_INT(x15, x1) # load rs2: x1 = 0x594d3170
+  RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rd compare value: x12 = 0x0e10721a
   LA(x27, scratch) # load base address into rs1
   SREG x22, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b12_equal:
@@ -2027,6 +2178,7 @@ Zacas_amocas_w_cg_cp_rd_b12_equal:
 # Testcase cp_rd (Test destination rd = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x3) # load value in memory: x3 = 0xc658b92f
   RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rs2: x29 = 0xf18c8384
+  RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rd compare value: x12 = 0x1c196d2b
   LA(x27, scratch) # load base address into rs1
   SREG x3, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b12_not_equal:
@@ -2042,6 +2194,7 @@ Zacas_amocas_w_cg_cp_rd_b12_not_equal:
 # Testcase cp_rd (Test destination rd = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x21) # load value in memory: x21 = 0xd8acd1a6
   RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rs2: x12 = 0xc4594ae3
+  RVTEST_TESTDATA_LOAD_INT(x15, x13) # load rd compare value: x13 = 0xd8acd1a6
   LA(x1, scratch) # load base address into rs1
   SREG x21, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b13_equal:
@@ -2055,6 +2208,7 @@ Zacas_amocas_w_cg_cp_rd_b13_equal:
 # Testcase cp_rd (Test destination rd = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x7) # load value in memory: x7 = 0x58dfa105
   RVTEST_TESTDATA_LOAD_INT(x15, x19) # load rs2: x19 = 0x2de2ff7f
+  RVTEST_TESTDATA_LOAD_INT(x15, x13) # load rd compare value: x13 = 0xa8e327c0
   LA(x20, scratch) # load base address into rs1
   SREG x7, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b13_not_equal:
@@ -2068,6 +2222,7 @@ Zacas_amocas_w_cg_cp_rd_b13_not_equal:
 # Testcase cp_rd (Test destination rd = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x19) # load value in memory: x19 = 0x860357f5
   RVTEST_TESTDATA_LOAD_INT(x15, x30) # load rs2: x30 = 0xd9b03afe
+  RVTEST_TESTDATA_LOAD_INT(x15, x14) # load rd compare value: x14 = 0x860357f5
   LA(x10, scratch) # load base address into rs1
   SREG x19, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b14_equal:
@@ -2081,6 +2236,7 @@ Zacas_amocas_w_cg_cp_rd_b14_equal:
 # Testcase cp_rd (Test destination rd = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x28) # load value in memory: x28 = 0x485ee413
   RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rs2: x12 = 0xf5cb62d5
+  RVTEST_TESTDATA_LOAD_INT(x15, x14) # load rd compare value: x14 = 0xe1afbf7a
   LA(x6, scratch) # load base address into rs1
   SREG x28, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b14_not_equal:
@@ -2095,6 +2251,7 @@ Zacas_amocas_w_cg_cp_rd_b14_not_equal:
 # Testcase cp_rd (Test destination rd = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load value in memory: x19 = 0x4cf0591d
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x7f28e4d6
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rd compare value: x15 = 0x4cf0591d
   LA(x27, scratch) # load base address into rs1
   SREG x19, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b15_equal:
@@ -2108,6 +2265,7 @@ Zacas_amocas_w_cg_cp_rd_b15_equal:
 # Testcase cp_rd (Test destination rd = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load value in memory: x25 = 0x6862e75b
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xeae88d41
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rd compare value: x15 = 0x7ef4ffd8
   LA(x22, scratch) # load base address into rs1
   SREG x25, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b15_not_equal:
@@ -2121,6 +2279,7 @@ Zacas_amocas_w_cg_cp_rd_b15_not_equal:
 # Testcase cp_rd (Test destination rd = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load value in memory: x21 = 0x790957c6
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0x72159ef6
+  RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rd compare value: x16 = 0x790957c6
   LA(x30, scratch) # load base address into rs1
   SREG x21, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b16_equal:
@@ -2134,6 +2293,7 @@ Zacas_amocas_w_cg_cp_rd_b16_equal:
 # Testcase cp_rd (Test destination rd = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load value in memory: x25 = 0xf9cd5e5f
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x1ad8bf39
+  RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rd compare value: x16 = 0x1c249807
   LA(x3, scratch) # load base address into rs1
   SREG x25, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b16_not_equal:
@@ -2147,6 +2307,7 @@ Zacas_amocas_w_cg_cp_rd_b16_not_equal:
 # Testcase cp_rd (Test destination rd = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load value in memory: x11 = 0xc47f5a46
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x4879e492
+  RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rd compare value: x17 = 0xc47f5a46
   LA(x25, scratch) # load base address into rs1
   SREG x11, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b17_equal:
@@ -2160,6 +2321,7 @@ Zacas_amocas_w_cg_cp_rd_b17_equal:
 # Testcase cp_rd (Test destination rd = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load value in memory: x13 = 0xd6928f8e
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0xf227e004
+  RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rd compare value: x17 = 0xec2f58f2
   LA(x11, scratch) # load base address into rs1
   SREG x13, 0(x11) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b17_not_equal:
@@ -2173,6 +2335,7 @@ Zacas_amocas_w_cg_cp_rd_b17_not_equal:
 # Testcase cp_rd (Test destination rd = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load value in memory: x10 = 0x4a39ca34
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x63233351
+  RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rd compare value: x18 = 0x4a39ca34
   LA(x2, scratch) # load base address into rs1
   SREG x10, 0(x2) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b18_equal:
@@ -2186,6 +2349,7 @@ Zacas_amocas_w_cg_cp_rd_b18_equal:
 # Testcase cp_rd (Test destination rd = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load value in memory: x6 = 0xf5277d88
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x8be65d23
+  RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rd compare value: x18 = 0x8c92e5a3
   LA(x22, scratch) # load base address into rs1
   SREG x6, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b18_not_equal:
@@ -2199,6 +2363,7 @@ Zacas_amocas_w_cg_cp_rd_b18_not_equal:
 # Testcase cp_rd (Test destination rd = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load value in memory: x31 = 0x90022404
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0xd2f3ffd4
+  RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rd compare value: x19 = 0x90022404
   LA(x11, scratch) # load base address into rs1
   SREG x31, 0(x11) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b19_equal:
@@ -2212,6 +2377,7 @@ Zacas_amocas_w_cg_cp_rd_b19_equal:
 # Testcase cp_rd (Test destination rd = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load value in memory: x6 = 0xbabe58f1
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x217b4c5d
+  RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rd compare value: x19 = 0x6af19230
   LA(x16, scratch) # load base address into rs1
   SREG x6, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b19_not_equal:
@@ -2225,6 +2391,7 @@ Zacas_amocas_w_cg_cp_rd_b19_not_equal:
 # Testcase cp_rd (Test destination rd = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load value in memory: x13 = 0x9d015e6a
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x7aff4913
+  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rd compare value: x20 = 0x9d015e6a
   LA(x16, scratch) # load base address into rs1
   SREG x13, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b20_equal:
@@ -2238,6 +2405,7 @@ Zacas_amocas_w_cg_cp_rd_b20_equal:
 # Testcase cp_rd (Test destination rd = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load value in memory: x28 = 0x27f7132e
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x102bc516
+  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rd compare value: x20 = 0x19b4169f
   LA(x19, scratch) # load base address into rs1
   SREG x28, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b20_not_equal:
@@ -2251,6 +2419,7 @@ Zacas_amocas_w_cg_cp_rd_b20_not_equal:
 # Testcase cp_rd (Test destination rd = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load value in memory: x27 = 0x5f930393
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0xfda2afe6
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rd compare value: x21 = 0x5f930393
   LA(x14, scratch) # load base address into rs1
   SREG x27, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b21_equal:
@@ -2264,6 +2433,7 @@ Zacas_amocas_w_cg_cp_rd_b21_equal:
 # Testcase cp_rd (Test destination rd = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load value in memory: x7 = 0x50d9f349
   RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x34477649
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rd compare value: x21 = 0x79b6ce9b
   LA(x31, scratch) # load base address into rs1
   SREG x7, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b21_not_equal:
@@ -2277,6 +2447,7 @@ Zacas_amocas_w_cg_cp_rd_b21_not_equal:
 # Testcase cp_rd (Test destination rd = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load value in memory: x14 = 0xb9590ae0
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0xe5bf0236
+  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rd compare value: x22 = 0xb9590ae0
   LA(x16, scratch) # load base address into rs1
   SREG x14, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b22_equal:
@@ -2290,6 +2461,7 @@ Zacas_amocas_w_cg_cp_rd_b22_equal:
 # Testcase cp_rd (Test destination rd = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load value in memory: x6 = 0xb6fcc608
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x6003de25
+  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rd compare value: x22 = 0x0560abb4
   LA(x17, scratch) # load base address into rs1
   SREG x6, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b22_not_equal:
@@ -2303,6 +2475,7 @@ Zacas_amocas_w_cg_cp_rd_b22_not_equal:
 # Testcase cp_rd (Test destination rd = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load value in memory: x9 = 0xdb383518
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0xc0c49817
+  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rd compare value: x23 = 0xdb383518
   LA(x3, scratch) # load base address into rs1
   SREG x9, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b23_equal:
@@ -2316,6 +2489,7 @@ Zacas_amocas_w_cg_cp_rd_b23_equal:
 # Testcase cp_rd (Test destination rd = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load value in memory: x3 = 0x7c319a2b
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x17799c6d
+  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rd compare value: x23 = 0x5899e179
   LA(x31, scratch) # load base address into rs1
   SREG x3, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b23_not_equal:
@@ -2329,6 +2503,7 @@ Zacas_amocas_w_cg_cp_rd_b23_not_equal:
 # Testcase cp_rd (Test destination rd = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load value in memory: x31 = 0xcfce1aa3
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x8afc45b9
+  RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rd compare value: x24 = 0xcfce1aa3
   LA(x6, scratch) # load base address into rs1
   SREG x31, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b24_equal:
@@ -2342,6 +2517,7 @@ Zacas_amocas_w_cg_cp_rd_b24_equal:
 # Testcase cp_rd (Test destination rd = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load value in memory: x7 = 0x18bf5e52
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x99288ffa
+  RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rd compare value: x24 = 0x214ca299
   LA(x27, scratch) # load base address into rs1
   SREG x7, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b24_not_equal:
@@ -2355,6 +2531,7 @@ Zacas_amocas_w_cg_cp_rd_b24_not_equal:
 # Testcase cp_rd (Test destination rd = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load value in memory: x13 = 0x225e1cd2
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0xaba66973
+  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rd compare value: x25 = 0x225e1cd2
   LA(x30, scratch) # load base address into rs1
   SREG x13, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b25_equal:
@@ -2368,6 +2545,7 @@ Zacas_amocas_w_cg_cp_rd_b25_equal:
 # Testcase cp_rd (Test destination rd = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load value in memory: x23 = 0xe4efb0bf
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x702d4a82
+  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rd compare value: x25 = 0xf2615aa3
   LA(x16, scratch) # load base address into rs1
   SREG x23, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b25_not_equal:
@@ -2382,6 +2560,7 @@ Zacas_amocas_w_cg_cp_rd_b25_not_equal:
 # Testcase cp_rd (Test destination rd = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load value in memory: x8 = 0x69266b77
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x2e1d99eb
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rd compare value: x26 = 0x69266b77
   LA(x22, scratch) # load base address into rs1
   SREG x8, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b26_equal:
@@ -2395,6 +2574,7 @@ Zacas_amocas_w_cg_cp_rd_b26_equal:
 # Testcase cp_rd (Test destination rd = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load value in memory: x15 = 0x384b7875
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x75eac200
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rd compare value: x26 = 0x7e8b786f
   LA(x22, scratch) # load base address into rs1
   SREG x15, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b26_not_equal:
@@ -2408,6 +2588,7 @@ Zacas_amocas_w_cg_cp_rd_b26_not_equal:
 # Testcase cp_rd (Test destination rd = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load value in memory: x6 = 0xe1365c2a
   RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x138feef2
+  RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rd compare value: x27 = 0xe1365c2a
   LA(x8, scratch) # load base address into rs1
   SREG x6, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b27_equal:
@@ -2421,6 +2602,7 @@ Zacas_amocas_w_cg_cp_rd_b27_equal:
 # Testcase cp_rd (Test destination rd = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load value in memory: x22 = 0xa17a6a46
   RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0xad131e05
+  RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rd compare value: x27 = 0xe27b88aa
   LA(x19, scratch) # load base address into rs1
   SREG x22, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b27_not_equal:
@@ -2434,6 +2616,7 @@ Zacas_amocas_w_cg_cp_rd_b27_not_equal:
 # Testcase cp_rd (Test destination rd = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load value in memory: x6 = 0xadeb9c47
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x192cf1ba
+  RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rd compare value: x28 = 0xadeb9c47
   LA(x20, scratch) # load base address into rs1
   SREG x6, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b28_equal:
@@ -2447,6 +2630,7 @@ Zacas_amocas_w_cg_cp_rd_b28_equal:
 # Testcase cp_rd (Test destination rd = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x18) # load value in memory: x18 = 0x1b588ff7
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0xbb7cbe78
+  RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rd compare value: x28 = 0xd2da4750
   LA(x25, scratch) # load base address into rs1
   SREG x18, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b28_not_equal:
@@ -2460,6 +2644,7 @@ Zacas_amocas_w_cg_cp_rd_b28_not_equal:
 # Testcase cp_rd (Test destination rd = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load value in memory: x12 = 0x2a40cb61
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x0fc5cd1e
+  RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rd compare value: x29 = 0x2a40cb61
   LA(x20, scratch) # load base address into rs1
   SREG x12, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b29_equal:
@@ -2473,6 +2658,7 @@ Zacas_amocas_w_cg_cp_rd_b29_equal:
 # Testcase cp_rd (Test destination rd = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load value in memory: x31 = 0x0e49dc88
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x59d39b01
+  RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rd compare value: x29 = 0x6f0b7de9
   LA(x18, scratch) # load base address into rs1
   SREG x31, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b29_not_equal:
@@ -2486,6 +2672,7 @@ Zacas_amocas_w_cg_cp_rd_b29_not_equal:
 # Testcase cp_rd (Test destination rd = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load value in memory: x10 = 0x9c994a82
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0xbe78931b
+  RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rd compare value: x30 = 0x9c994a82
   LA(x21, scratch) # load base address into rs1
   SREG x10, 0(x21) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b30_equal:
@@ -2499,6 +2686,7 @@ Zacas_amocas_w_cg_cp_rd_b30_equal:
 # Testcase cp_rd (Test destination rd = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load value in memory: x22 = 0x7a96ef97
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x722ee0b2
+  RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rd compare value: x30 = 0x5b72cc26
   LA(x15, scratch) # load base address into rs1
   SREG x22, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b30_not_equal:
@@ -2512,6 +2700,7 @@ Zacas_amocas_w_cg_cp_rd_b30_not_equal:
 # Testcase cp_rd (Test destination rd = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x17) # load value in memory: x17 = 0x346e7364
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0xd701d09d
+  RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rd compare value: x31 = 0x346e7364
   LA(x30, scratch) # load base address into rs1
   SREG x17, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b31_equal:
@@ -2525,6 +2714,7 @@ Zacas_amocas_w_cg_cp_rd_b31_equal:
 # Testcase cp_rd (Test destination rd = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x18) # load value in memory: x18 = 0x7d1246cd
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0xdadfa95e
+  RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rd compare value: x31 = 0xf102be78
   LA(x28, scratch) # load base address into rs1
   SREG x18, 0(x28) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b31_not_equal:
@@ -4469,9 +4659,9 @@ Zacas_amocas_w_cg_cp_align_word_b4:
 /////////////////////////////////
 
 # Testcase cmp_rd_rs1_val_eq (rd_val == mem_val)
-  RVTEST_TESTDATA_LOAD_INT(x15, x18) # load rd compare value: x18 = 0x8bb185da
   RVTEST_TESTDATA_LOAD_INT(x15, x3) # load value in memory: x3 = 0x8bb185da
   RVTEST_TESTDATA_LOAD_INT(x15, x11) # load rs2: x11 = 0x8646c310
+  RVTEST_TESTDATA_LOAD_INT(x15, x18) # load rd compare value: x18 = 0x8bb185da
   LA(x17, scratch) # load base address into rs1
   SREG x3, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cmp_rd_rs1_val_eq_equal:
@@ -4483,9 +4673,9 @@ Zacas_amocas_w_cg_cmp_rd_rs1_val_eq_equal:
   RVTEST_SIGUPD(x20, x8, x7, x17, Zacas_amocas_w_cg_cmp_rd_rs1_val_eq_equal, Zacas_amocas_w_cg_cmp_rd_rs1_val_eq_equal_str)
 
 # Testcase cmp_rd_rs1_val_eq (rd_val != mem_val)
-  RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rd compare value: x29 = 0xac2b2906
   RVTEST_TESTDATA_LOAD_INT(x15, x4) # load value in memory: x4 = 0x8bed4131
   RVTEST_TESTDATA_LOAD_INT(x15, x14) # load rs2: x14 = 0x4d6acdbd
+  RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rd compare value: x29 = 0xac2b2906
   LA(x9, scratch) # load base address into rs1
   SREG x4, 0(x9) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cmp_rd_rs1_val_eq_not_equal:
@@ -4501,9 +4691,9 @@ Zacas_amocas_w_cg_cmp_rd_rs1_val_eq_not_equal:
 /////////////////////////////////
 
 # Testcase cmp_rd_rs1_val_lsb (rd_val[7:0] == mem_val[7:0])
-  RVTEST_TESTDATA_LOAD_INT(x15, x22) # load rd compare value: x22 = 0xb632a2d2
   RVTEST_TESTDATA_LOAD_INT(x15, x12) # load value in memory: x12 = 0xd57ab8d2
   RVTEST_TESTDATA_LOAD_INT(x15, x19) # load rs2: x19 = 0x49f2b0fc
+  RVTEST_TESTDATA_LOAD_INT(x15, x22) # load rd compare value: x22 = 0xb632a2d2
   LA(x31, scratch) # load base address into rs1
   SREG x12, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cmp_rd_rs1_val_lsb_equal:
@@ -4515,9 +4705,9 @@ Zacas_amocas_w_cg_cmp_rd_rs1_val_lsb_equal:
   RVTEST_SIGUPD(x20, x8, x7, x31, Zacas_amocas_w_cg_cmp_rd_rs1_val_lsb_equal, Zacas_amocas_w_cg_cmp_rd_rs1_val_lsb_equal_str)
 
 # Testcase cmp_rd_rs1_val_lsb (rd_val[7:0] != mem_val[7:0])
-  RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rd compare value: x12 = 0xf09eb0c1
   RVTEST_TESTDATA_LOAD_INT(x15, x28) # load value in memory: x28 = 0xf09eb033
   RVTEST_TESTDATA_LOAD_INT(x15, x3) # load rs2: x3 = 0x8150a784
+  RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rd compare value: x12 = 0xf09eb0c1
   LA(x26, scratch) # load base address into rs1
   SREG x28, 0(x26) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cmp_rd_rs1_val_lsb_not_equal:
@@ -4533,9 +4723,9 @@ Zacas_amocas_w_cg_cmp_rd_rs1_val_lsb_not_equal:
 /////////////////////////////////
 
 # Testcase cmp_rd_rs1_val_hw (rd_val[15:0] == mem_val[15:0])
-  RVTEST_TESTDATA_LOAD_INT(x15, x25) # load rd compare value: x25 = 0x6f603142
   RVTEST_TESTDATA_LOAD_INT(x15, x30) # load value in memory: x30 = 0x54823142
   RVTEST_TESTDATA_LOAD_INT(x15, x5) # load rs2: x5 = 0x4a6c5a16
+  RVTEST_TESTDATA_LOAD_INT(x15, x25) # load rd compare value: x25 = 0x6f603142
   LA(x12, scratch) # load base address into rs1
   SREG x30, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cmp_rd_rs1_val_hw_equal:
@@ -4547,9 +4737,9 @@ Zacas_amocas_w_cg_cmp_rd_rs1_val_hw_equal:
   RVTEST_SIGUPD(x20, x8, x7, x12, Zacas_amocas_w_cg_cmp_rd_rs1_val_hw_equal, Zacas_amocas_w_cg_cmp_rd_rs1_val_hw_equal_str)
 
 # Testcase cmp_rd_rs1_val_hw (rd_val[15:0] != mem_val[15:0])
-  RVTEST_TESTDATA_LOAD_INT(x15, x4) # load rd compare value: x4 = 0x9b0db31f
   RVTEST_TESTDATA_LOAD_INT(x15, x6) # load value in memory: x6 = 0x9b0d22f1
   RVTEST_TESTDATA_LOAD_INT(x15, x1) # load rs2: x1 = 0x8d95f270
+  RVTEST_TESTDATA_LOAD_INT(x15, x4) # load rd compare value: x4 = 0x9b0db31f
   LA(x13, scratch) # load base address into rs1
   SREG x6, 0(x13) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cmp_rd_rs1_val_hw_not_equal:
@@ -4571,384 +4761,574 @@ RVTEST_DATA_BEGIN
 // Test data
 .word 0x4ffc9eb6
 .word 0xa05a7a33
+.word 0x4ffc9eb6
 .word 0xff00fd95
 .word 0x5f58e971
+.word 0x8a1d8aed
 .word 0xa73918b7
 .word 0x4cdcba92
+.word 0xa73918b7
 .word 0x6c982925
 .word 0x7bc624fd
+.word 0x7f4abe45
 .word 0xf6ad3329
 .word 0x06ff2c16
+.word 0xf6ad3329
 .word 0xc6a0f366
 .word 0xe26424c3
+.word 0x4bd34dad
 .word 0x5de6dea0
 .word 0x1711f4d2
+.word 0x5de6dea0
 .word 0x726baf91
 .word 0xa42e7e46
+.word 0x181a77a4
 .word 0x3543d5ff
 .word 0x852cf4b5
+.word 0x3543d5ff
 .word 0x3bca9813
 .word 0x04bef3f4
+.word 0x78c1ff64
 .word 0x87d0bb55
 .word 0x6fbe5b74
+.word 0x87d0bb55
 .word 0x2906c7e7
 .word 0x6bd6ab30
+.word 0x0f938295
 .word 0x45c86b14
 .word 0xb997c936
+.word 0x45c86b14
 .word 0x0d14fab2
 .word 0x76ad8f69
+.word 0x14d3e5ff
 .word 0xaeb1b3a2
 .word 0x5b52bd50
+.word 0xaeb1b3a2
 .word 0x587ac726
 .word 0xd47b5863
+.word 0x22dbffff
 .word 0xdf3be6ab
 .word 0xf8237ec0
+.word 0xdf3be6ab
 .word 0x58a3c29b
 .word 0x0ad3d73b
+.word 0x7dfc586b
 .word 0x56ee66fa
 .word 0xf073f8a2
+.word 0x56ee66fa
 .word 0x32322776
 .word 0x53faa5d0
+.word 0x83414d7c
 .word 0x84b72a64
 .word 0xa0f054c1
+.word 0x84b72a64
 .word 0x937c76d9
 .word 0x7b56846a
+.word 0x72eab756
 .word 0x354cb6ae
 .word 0x346f685b
+.word 0x354cb6ae
 .word 0x018899a6
 .word 0xa5ef20cc
+.word 0x257768fe
 .word 0xbffeda35
 .word 0x0cbd8f1e
+.word 0xbffeda35
 .word 0xdac793c6
 .word 0xcb05efea
+.word 0xc6a59de9
 .word 0x627e075a
 .word 0x917e1f3a
+.word 0x627e075a
 .word 0xf6e56fbe
 .word 0x5435bce2
+.word 0x84b2620d
 .word 0x866c2c45
 .word 0xadb5330b
+.word 0x866c2c45
 .word 0xabae2a0d
 .word 0x399061be
+.word 0xa9f01df4
 .word 0x582c96c1
 .word 0xe8524c8c
+.word 0x582c96c1
 .word 0xd0d0ce74
 .word 0x14f28ef4
+.word 0xe23703ef
 .word 0xd465601f
 .word 0x0f66fd14
+.word 0xd465601f
 .word 0xf035054e
 .word 0x2bd8acb1
+.word 0x785e2550
 .word 0x7e090d3d
 .word 0xe44d6bb5
+.word 0x7e090d3d
 .word 0x2fa54925
 .word 0xb8875162
+.word 0xdaaf0c88
 .word 0x1be89d3e
 .word 0x01f6b985
+.word 0x1be89d3e
 .word 0xc9912fe7
 .word 0xa4d5116c
+.word 0x2823dfef
 .word 0x4755077d
 .word 0x4f4c2a47
+.word 0x4755077d
 .word 0xdcef1a91
 .word 0x0be4be86
+.word 0x2eca0de0
 .word 0xaf6b6460
 .word 0x2de4f9fa
+.word 0xaf6b6460
 .word 0x262263c8
 .word 0x2c0ca0c9
+.word 0xd6455b4a
 .word 0xcb9d4eb2
 .word 0x1ceda7e0
+.word 0xcb9d4eb2
 .word 0xf9da4cae
 .word 0xc20d2cfd
+.word 0x7d3dbd0c
 .word 0xdc7ec8d5
 .word 0xf15f5225
+.word 0xdc7ec8d5
 .word 0x8dc361fd
 .word 0xcb6dadf5
+.word 0x283b582e
 .word 0x71d35cfc
 .word 0xb9b36cd4
+.word 0x71d35cfc
 .word 0x5cbc5931
 .word 0x01c8efef
+.word 0x71e929eb
 .word 0xe01a8476
 .word 0x05035c34
+.word 0xe01a8476
 .word 0x75276317
 .word 0x92865dec
+.word 0x3db7c437
 .word 0xa769f328
 .word 0xfd07adce
+.word 0xa769f328
 .word 0xdfa9c4d7
 .word 0xaa1a05af
+.word 0x0c4dd600
 .word 0x7c33a440
 .word 0x85782b0a
+.word 0x7c33a440
 .word 0x9075d8c6
 .word 0x581df4d2
+.word 0xaac1ba47
 .word 0xa77d5fe8
 .word 0x23b1ed93
+.word 0xa77d5fe8
 .word 0x7fe74641
 .word 0xfb58b964
+.word 0xf6350794
 .word 0xe749a1ce
 .word 0xa972ef64
+.word 0xe749a1ce
 .word 0xd0055a9e
 .word 0x0f3c0a10
+.word 0x3ad18ecb
 .word 0xb185629f
 .word 0x6d1aa8e3
+.word 0xb185629f
 .word 0xd17f48d2
 .word 0x0981e070
+.word 0x4273dd23
 .word 0xd83b9bfb
 .word 0x126eab4c
+.word 0xd83b9bfb
 .word 0x7a1cf6b7
 .word 0x5b9bed96
+.word 0xd465db21
 .word 0xbd34b68d
 .word 0x444cc2d2
+.word 0xbd34b68d
 .word 0xdbeade6c
 .word 0x61f08ccb
+.word 0x70d95352
 .word 0x505de7cb
 .word 0x7c8436ec
+.word 0x505de7cb
 .word 0xd29ff27b
 .word 0x2da4e199
+.word 0x5b4887b6
 .word 0xe10fa38f
 .word 0xa66f401b
+.word 0xe10fa38f
 .word 0x0e65c3ed
 .word 0xbae87016
+.word 0x09b372c8
 .word 0xf49beb03
 .word 0x96eaf810
+.word 0xf49beb03
 .word 0x745d5331
 .word 0x52db7da1
+.word 0x4dee1585
 .word 0xc4352d96
 .word 0x850fb30e
+.word 0xc4352d96
 .word 0x792b14bd
 .word 0xeccbc3d3
+.word 0xd093c73a
 .word 0x306f039b
 .word 0x541bb67e
+.word 0x306f039b
 .word 0xfdf11d25
 .word 0x3c5ade38
+.word 0x2e070f88
 .word 0xb40e737a
 .word 0xf3adc13b
+.word 0xb40e737a
 .word 0xaa613e5d
 .word 0xaa4380fe
+.word 0xbf0ce552
 .word 0x61f2dbba
 .word 0x723883c1
+.word 0x61f2dbba
 .word 0x141b1f57
 .word 0x6a7df2b0
+.word 0x981e18e4
 .word 0x12c40312
 .word 0xdbce53a8
+.word 0x12c40312
 .word 0xe3ce7c1e
 .word 0x850e3b56
+.word 0xe326bc08
 .word 0xd015530f
 .word 0x269bb8f8
+.word 0xd015530f
 .word 0xaacfecec
 .word 0x01a2d481
+.word 0x2a0366e5
 .word 0x1a1e07ef
 .word 0xc6c46f8b
+.word 0x1a1e07ef
 .word 0x57a49263
 .word 0x678dc17e
+.word 0x367b6462
 .word 0x1cff4035
 .word 0xa4f42b7f
+.word 0x1cff4035
 .word 0xa31275aa
 .word 0x299e4754
+.word 0x2ab0d0d3
 .word 0x78ac69eb
 .word 0xefdd2ca2
+.word 0x78ac69eb
 .word 0x074461fa
 .word 0xcc2863a6
+.word 0x03839b36
 .word 0xfb57c386
 .word 0x40fd72a9
+.word 0xfb57c386
 .word 0x0a18316c
 .word 0x9da6aa75
+.word 0x7e4cf42a
 .word 0x76de738b
 .word 0x551274a3
+.word 0x76de738b
 .word 0xec8ce1a3
 .word 0xec8dbfef
+.word 0x770d352c
 .word 0x62067f08
 .word 0x6a97c92a
+.word 0x62067f08
 .word 0x40403d9f
 .word 0x99955ff9
+.word 0x49ef8140
 .word 0xca961d07
 .word 0x5bc0bdc6
+.word 0xca961d07
 .word 0x678c1f61
 .word 0x3cbe5fa4
+.word 0x19c52536
 .word 0x408878d0
 .word 0x2ef3c18c
+.word 0x408878d0
 .word 0xad51b420
 .word 0xdae4152a
+.word 0xee69d061
 .word 0xf48ece8a
 .word 0x609d9cfa
+.word 0xf48ece8a
 .word 0xef794004
 .word 0x270d88f1
+.word 0xcebb1f8d
 .word 0x1cbeadfc
 .word 0x6401d72b
+.word 0x1cbeadfc
 .word 0xcb96557a
 .word 0x9705d985
+.word 0xc38bc6cc
 .word 0x0b751a67
 .word 0x69b3b0a1
+.word 0x0b751a67
 .word 0xd3a3770c
 .word 0xfeb7b05a
+.word 0x8457f556
 .word 0x7d3c8a1d
 .word 0xa427dbe3
+.word 0x7d3c8a1d
 .word 0xa9f502e9
 .word 0x743e7a5e
+.word 0x479803e3
 .word 0x0e3ed6e1
 .word 0x41a98612
+.word 0x0e3ed6e1
 .word 0x350609d8
 .word 0xaf9361de
+.word 0x47b76478
 .word 0x312fd0ee
 .word 0xbdfb0b4c
+.word 0x312fd0ee
 .word 0x6b3cdcbf
 .word 0xcb60db2c
+.word 0x2a40bd55
 .word 0xbe4de47e
 .word 0x21c70762
+.word 0xbe4de47e
 .word 0xb96d7e32
 .word 0x1debc09f
+.word 0xa4cefebc
 .word 0xa1a5f156
 .word 0x1508bb45
+.word 0xa1a5f156
 .word 0xb6cffdc6
 .word 0x919bd39a
+.word 0x5cdf0412
 .word 0xeffd3c3d
 .word 0x75c393fb
+.word 0xeffd3c3d
 .word 0x1c2e183e
 .word 0xc80066c2
+.word 0xd2c4cd8c
 .word 0xb102eaf1
 .word 0xbc0e5884
+.word 0xb102eaf1
 .word 0xd050b55b
 .word 0x8c64f1aa
+.word 0x6fb1956b
 .word 0xe8894296
 .word 0x042f1cf8
+.word 0xe8894296
 .word 0xf259fe2b
 .word 0x5be58383
+.word 0x1bfcd829
 .word 0x9ad5244a
 .word 0x60ea4a62
+.word 0x9ad5244a
 .word 0xcfac4d7a
 .word 0x420ed58e
+.word 0x5097d0e2
 .word 0x6fe6aa73
 .word 0xb171535b
+.word 0x6fe6aa73
 .word 0x9052838b
 .word 0x920ef9f4
+.word 0xb6b83c74
 .word 0x94a8e5ef
 .word 0x1705fb6a
+.word 0x94a8e5ef
 .word 0x6dcc574f
 .word 0x8631068a
+.word 0xaa951675
 .word 0xd6331454
 .word 0xc28961f3
+.word 0xd6331454
 .word 0x0ff5b6d6
 .word 0x853515e3
+.word 0xd8674601
 .word 0xd6e34586
 .word 0x8d5e2e05
+.word 0xd6e34586
 .word 0xca79b6e8
 .word 0x49fdb31d
+.word 0x6c2950fe
 .word 0xc3ff0de0
 .word 0x522001a7
+.word 0xc3ff0de0
 .word 0xa40024e5
 .word 0x87b5c092
+.word 0xe9dae6a3
 .word 0xc7f326ef
 .word 0xab24373f
+.word 0xc7f326ef
 .word 0xb5cc81b1
 .word 0x25b3c30e
+.word 0x6accb197
 .word 0x8f17f15c
 .word 0x848170bb
+.word 0x8f17f15c
 .word 0xff5e8bb0
 .word 0x53c3f6bc
+.word 0xc004d0f3
 .word 0xdacbee00
 .word 0x19830e86
+.word 0xdacbee00
 .word 0xb06f9892
 .word 0x522d21ae
+.word 0x8042963b
 .word 0xcfd6e8b2
 .word 0x1b98c6b9
+.word 0xcfd6e8b2
 .word 0x7f288fc3
 .word 0x728f3d74
+.word 0xafb07251
 .word 0xb3849b55
 .word 0xd4842674
+.word 0xb3849b55
 .word 0x5a38ca6c
 .word 0xcb42e73e
+.word 0xa2e175be
 .word 0x9301493e
 .word 0xed8d7433
+.word 0x9301493e
 .word 0x8efa1d8f
 .word 0x55ea3982
+.word 0x625098bd
 .word 0x3b50cc74
 .word 0xdf49096b
+.word 0x3b50cc74
 .word 0x53999bd6
 .word 0x11c2ccdb
+.word 0x8a74865c
 .word 0x15680d94
 .word 0x7dd4aebe
+.word 0x15680d94
 .word 0xaa6f1d34
 .word 0x50285057
+.word 0xf0ad8501
 .word 0x238016f7
 .word 0x583c8fac
+.word 0x238016f7
 .word 0xcbe48d8d
 .word 0x7a073099
+.word 0x5300b1b2
 .word 0x0e10721a
 .word 0x594d3170
+.word 0x0e10721a
 .word 0xc658b92f
 .word 0xf18c8384
+.word 0x1c196d2b
 .word 0xd8acd1a6
 .word 0xc4594ae3
+.word 0xd8acd1a6
 .word 0x58dfa105
 .word 0x2de2ff7f
+.word 0xa8e327c0
 .word 0x860357f5
 .word 0xd9b03afe
+.word 0x860357f5
 .word 0x485ee413
 .word 0xf5cb62d5
+.word 0xe1afbf7a
 .word 0x4cf0591d
 .word 0x7f28e4d6
+.word 0x4cf0591d
 .word 0x6862e75b
 .word 0xeae88d41
+.word 0x7ef4ffd8
 .word 0x790957c6
 .word 0x72159ef6
+.word 0x790957c6
 .word 0xf9cd5e5f
 .word 0x1ad8bf39
+.word 0x1c249807
 .word 0xc47f5a46
 .word 0x4879e492
+.word 0xc47f5a46
 .word 0xd6928f8e
 .word 0xf227e004
+.word 0xec2f58f2
 .word 0x4a39ca34
 .word 0x63233351
+.word 0x4a39ca34
 .word 0xf5277d88
 .word 0x8be65d23
+.word 0x8c92e5a3
 .word 0x90022404
 .word 0xd2f3ffd4
+.word 0x90022404
 .word 0xbabe58f1
 .word 0x217b4c5d
+.word 0x6af19230
 .word 0x9d015e6a
 .word 0x7aff4913
+.word 0x9d015e6a
 .word 0x27f7132e
 .word 0x102bc516
+.word 0x19b4169f
 .word 0x5f930393
 .word 0xfda2afe6
+.word 0x5f930393
 .word 0x50d9f349
 .word 0x34477649
+.word 0x79b6ce9b
 .word 0xb9590ae0
 .word 0xe5bf0236
+.word 0xb9590ae0
 .word 0xb6fcc608
 .word 0x6003de25
+.word 0x0560abb4
 .word 0xdb383518
 .word 0xc0c49817
+.word 0xdb383518
 .word 0x7c319a2b
 .word 0x17799c6d
+.word 0x5899e179
 .word 0xcfce1aa3
 .word 0x8afc45b9
+.word 0xcfce1aa3
 .word 0x18bf5e52
 .word 0x99288ffa
+.word 0x214ca299
 .word 0x225e1cd2
 .word 0xaba66973
+.word 0x225e1cd2
 .word 0xe4efb0bf
 .word 0x702d4a82
+.word 0xf2615aa3
 .word 0x69266b77
 .word 0x2e1d99eb
+.word 0x69266b77
 .word 0x384b7875
 .word 0x75eac200
+.word 0x7e8b786f
 .word 0xe1365c2a
 .word 0x138feef2
+.word 0xe1365c2a
 .word 0xa17a6a46
 .word 0xad131e05
+.word 0xe27b88aa
 .word 0xadeb9c47
 .word 0x192cf1ba
+.word 0xadeb9c47
 .word 0x1b588ff7
 .word 0xbb7cbe78
+.word 0xd2da4750
 .word 0x2a40cb61
 .word 0x0fc5cd1e
+.word 0x2a40cb61
 .word 0x0e49dc88
 .word 0x59d39b01
+.word 0x6f0b7de9
 .word 0x9c994a82
 .word 0xbe78931b
+.word 0x9c994a82
 .word 0x7a96ef97
 .word 0x722ee0b2
+.word 0x5b72cc26
 .word 0x346e7364
 .word 0xd701d09d
+.word 0x346e7364
 .word 0x7d1246cd
 .word 0xdadfa95e
+.word 0xf102be78
 .word 0x81a93e73
 .word 0x00000000
 .word 0xc6b777c6
@@ -5228,23 +5608,23 @@ RVTEST_DATA_BEGIN
 .word 0x611de7a6
 .word 0x53e41115
 .word 0x8bb185da
-.word 0x8bb185da
 .word 0x8646c310
-.word 0xac2b2906
+.word 0x8bb185da
 .word 0x8bed4131
 .word 0x4d6acdbd
-.word 0xb632a2d2
+.word 0xac2b2906
 .word 0xd57ab8d2
 .word 0x49f2b0fc
-.word 0xf09eb0c1
+.word 0xb632a2d2
 .word 0xf09eb033
 .word 0x8150a784
-.word 0x6f603142
+.word 0xf09eb0c1
 .word 0x54823142
 .word 0x4a6c5a16
-.word 0x9b0db31f
+.word 0x6f603142
 .word 0x9b0d22f1
 .word 0x8d95f270
+.word 0x9b0db31f
 
 // Testcase strings
 Zacas_amocas_w_cg_cp_rs1_nx0_b1_equal_str: .string "\"test: 1; cg: Zacas_amocas.w_cg; cp: cp_rs1_nx0; bin: b1_equal\""

--- a/tests/rv32i/ZacasZabha/ZacasZabha-amocas.b-00.S
+++ b/tests/rv32i/ZacasZabha/ZacasZabha-amocas.b-00.S
@@ -36,6 +36,7 @@ RVTEST_BEGIN
 # Testcase cp_rs1_nx0 (Test source rs1 = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x20) # load value in memory: x20 = 0x000000cd
   RVTEST_TESTDATA_LOAD_INT(x3, x21) # load rs2: x21 = 0x00000098
+  RVTEST_TESTDATA_LOAD_INT(x3, x29) # load rd compare value: x29 = 0x000000cd
   LA(x1, scratch) # load base address into rs1
   SREG x20, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b1_equal:
@@ -49,6 +50,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b1_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x21) # load value in memory: x21 = 0x0000002d
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x000000dd
+  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rd compare value: x6 = 0x0000009c
   LA(x1, scratch) # load base address into rs1
   SREG x21, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b1_not_equal:
@@ -63,6 +65,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b1_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x28) # load value in memory: x28 = 0x00000002
   RVTEST_TESTDATA_LOAD_INT(x3, x21) # load rs2: x21 = 0x00000061
+  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rd compare value: x11 = 0x00000002
   LA(x2, scratch) # load base address into rs1
   SREG x28, 0(x2) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b2_equal:
@@ -76,6 +79,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b2_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x19) # load value in memory: x19 = 0x0000009b
   RVTEST_TESTDATA_LOAD_INT(x3, x29) # load rs2: x29 = 0x000000c9
+  RVTEST_TESTDATA_LOAD_INT(x3, x21) # load rd compare value: x21 = 0x00000016
   LA(x2, scratch) # load base address into rs1
   SREG x19, 0(x2) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b2_not_equal:
@@ -90,6 +94,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b2_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x14) # load value in memory: x14 = 0x00000043
   RVTEST_TESTDATA_LOAD_INT(x15, x25) # load rs2: x25 = 0x00000078
+  RVTEST_TESTDATA_LOAD_INT(x15, x26) # load rd compare value: x26 = 0x00000043
   LA(x3, scratch) # load base address into rs1
   SREG x14, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b3_equal:
@@ -103,6 +108,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b3_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x23) # load value in memory: x23 = 0x00000093
   RVTEST_TESTDATA_LOAD_INT(x15, x22) # load rs2: x22 = 0x0000008c
+  RVTEST_TESTDATA_LOAD_INT(x15, x18) # load rd compare value: x18 = 0x000000fe
   LA(x3, scratch) # load base address into rs1
   SREG x23, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b3_not_equal:
@@ -118,6 +124,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b3_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x21) # load value in memory: x21 = 0x000000f7
   RVTEST_TESTDATA_LOAD_INT(x15, x10) # load rs2: x10 = 0x000000d3
+  RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rd compare value: x29 = 0x000000f7
   LA(x4, scratch) # load base address into rs1
   SREG x21, 0(x4) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b4_equal:
@@ -131,6 +138,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b4_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x11) # load value in memory: x11 = 0x000000c3
   RVTEST_TESTDATA_LOAD_INT(x15, x10) # load rs2: x10 = 0x000000c3
+  RVTEST_TESTDATA_LOAD_INT(x15, x30) # load rd compare value: x30 = 0x000000dc
   LA(x4, scratch) # load base address into rs1
   SREG x11, 0(x4) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b4_not_equal:
@@ -144,6 +152,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b4_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x6) # load value in memory: x6 = 0x00000047
   RVTEST_TESTDATA_LOAD_INT(x15, x22) # load rs2: x22 = 0x00000069
+  RVTEST_TESTDATA_LOAD_INT(x15, x1) # load rd compare value: x1 = 0x00000047
   LA(x5, scratch) # load base address into rs1
   SREG x6, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b5_equal:
@@ -157,6 +166,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b5_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x30) # load value in memory: x30 = 0x000000df
   RVTEST_TESTDATA_LOAD_INT(x15, x27) # load rs2: x27 = 0x0000008e
+  RVTEST_TESTDATA_LOAD_INT(x15, x19) # load rd compare value: x19 = 0x00000070
   LA(x5, scratch) # load base address into rs1
   SREG x30, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b5_not_equal:
@@ -170,6 +180,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b5_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x11) # load value in memory: x11 = 0x00000027
   RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rs2: x29 = 0x000000a0
+  RVTEST_TESTDATA_LOAD_INT(x15, x0) # load rd compare value: x0 = 0x00000027
   LA(x6, scratch) # load base address into rs1
   SREG x11, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b6_equal:
@@ -183,6 +194,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b6_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x24) # load value in memory: x24 = 0x000000bc
   RVTEST_TESTDATA_LOAD_INT(x15, x8) # load rs2: x8 = 0x000000f8
+  RVTEST_TESTDATA_LOAD_INT(x15, x2) # load rd compare value: x2 = 0x00000065
   LA(x6, scratch) # load base address into rs1
   SREG x24, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b6_not_equal:
@@ -196,6 +208,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b6_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x31) # load value in memory: x31 = 0x000000bc
   RVTEST_TESTDATA_LOAD_INT(x15, x3) # load rs2: x3 = 0x00000052
+  RVTEST_TESTDATA_LOAD_INT(x15, x5) # load rd compare value: x5 = 0x000000bc
   LA(x7, scratch) # load base address into rs1
   SREG x31, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b7_equal:
@@ -209,6 +222,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b7_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x16) # load value in memory: x16 = 0x000000f0
   RVTEST_TESTDATA_LOAD_INT(x15, x11) # load rs2: x11 = 0x00000054
+  RVTEST_TESTDATA_LOAD_INT(x15, x2) # load rd compare value: x2 = 0x00000003
   LA(x7, scratch) # load base address into rs1
   SREG x16, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b7_not_equal:
@@ -222,6 +236,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b7_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x25) # load value in memory: x25 = 0x000000c5
   RVTEST_TESTDATA_LOAD_INT(x15, x23) # load rs2: x23 = 0x00000097
+  RVTEST_TESTDATA_LOAD_INT(x15, x30) # load rd compare value: x30 = 0x000000c5
   LA(x8, scratch) # load base address into rs1
   SREG x25, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b8_equal:
@@ -235,6 +250,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b8_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x16) # load value in memory: x16 = 0x0000007c
   RVTEST_TESTDATA_LOAD_INT(x15, x4) # load rs2: x4 = 0x000000c4
+  RVTEST_TESTDATA_LOAD_INT(x15, x30) # load rd compare value: x30 = 0x00000037
   LA(x8, scratch) # load base address into rs1
   SREG x16, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b8_not_equal:
@@ -248,6 +264,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b8_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x25) # load value in memory: x25 = 0x0000000a
   RVTEST_TESTDATA_LOAD_INT(x15, x24) # load rs2: x24 = 0x000000d2
+  RVTEST_TESTDATA_LOAD_INT(x15, x7) # load rd compare value: x7 = 0x0000000a
   LA(x9, scratch) # load base address into rs1
   SREG x25, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b9_equal:
@@ -261,6 +278,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b9_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x8) # load value in memory: x8 = 0x000000e7
   RVTEST_TESTDATA_LOAD_INT(x15, x28) # load rs2: x28 = 0x00000059
+  RVTEST_TESTDATA_LOAD_INT(x15, x6) # load rd compare value: x6 = 0x000000a5
   LA(x9, scratch) # load base address into rs1
   SREG x8, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b9_not_equal:
@@ -274,6 +292,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b9_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x27) # load value in memory: x27 = 0x000000c4
   RVTEST_TESTDATA_LOAD_INT(x15, x31) # load rs2: x31 = 0x000000eb
+  RVTEST_TESTDATA_LOAD_INT(x15, x16) # load rd compare value: x16 = 0x000000c4
   LA(x10, scratch) # load base address into rs1
   SREG x27, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b10_equal:
@@ -287,6 +306,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b10_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x16) # load value in memory: x16 = 0x00000064
   RVTEST_TESTDATA_LOAD_INT(x15, x22) # load rs2: x22 = 0x0000007e
+  RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rd compare value: x29 = 0x00000045
   LA(x10, scratch) # load base address into rs1
   SREG x16, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b10_not_equal:
@@ -300,6 +320,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b10_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x19) # load value in memory: x19 = 0x0000005f
   RVTEST_TESTDATA_LOAD_INT(x15, x1) # load rs2: x1 = 0x0000007b
+  RVTEST_TESTDATA_LOAD_INT(x15, x8) # load rd compare value: x8 = 0x0000005f
   LA(x11, scratch) # load base address into rs1
   SREG x19, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b11_equal:
@@ -313,6 +334,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b11_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x19) # load value in memory: x19 = 0x00000089
   RVTEST_TESTDATA_LOAD_INT(x15, x2) # load rs2: x2 = 0x0000008d
+  RVTEST_TESTDATA_LOAD_INT(x15, x27) # load rd compare value: x27 = 0x000000b6
   LA(x11, scratch) # load base address into rs1
   SREG x19, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b11_not_equal:
@@ -326,6 +348,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b11_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x17) # load value in memory: x17 = 0x00000051
   RVTEST_TESTDATA_LOAD_INT(x15, x10) # load rs2: x10 = 0x0000004d
+  RVTEST_TESTDATA_LOAD_INT(x15, x0) # load rd compare value: x0 = 0x00000051
   LA(x12, scratch) # load base address into rs1
   SREG x17, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b12_equal:
@@ -339,6 +362,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b12_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x21) # load value in memory: x21 = 0x000000b7
   RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rs2: x9 = 0x000000a6
+  RVTEST_TESTDATA_LOAD_INT(x15, x3) # load rd compare value: x3 = 0x0000009e
   LA(x12, scratch) # load base address into rs1
   SREG x21, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b12_not_equal:
@@ -354,6 +378,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b12_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x18) # load value in memory: x18 = 0x000000ae
   RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rs2: x9 = 0x000000e7
+  RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rd compare value: x29 = 0x000000ae
   LA(x13, scratch) # load base address into rs1
   SREG x18, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b13_equal:
@@ -367,6 +392,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b13_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x23) # load value in memory: x23 = 0x0000004a
   RVTEST_TESTDATA_LOAD_INT(x15, x24) # load rs2: x24 = 0x0000004e
+  RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rd compare value: x29 = 0x000000b8
   LA(x13, scratch) # load base address into rs1
   SREG x23, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b13_not_equal:
@@ -380,6 +406,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b13_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x18) # load value in memory: x18 = 0x00000070
   RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rs2: x12 = 0x000000f2
+  RVTEST_TESTDATA_LOAD_INT(x15, x3) # load rd compare value: x3 = 0x00000070
   LA(x14, scratch) # load base address into rs1
   SREG x18, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b14_equal:
@@ -393,6 +420,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b14_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x5) # load value in memory: x5 = 0x000000dd
   RVTEST_TESTDATA_LOAD_INT(x15, x1) # load rs2: x1 = 0x000000e7
+  RVTEST_TESTDATA_LOAD_INT(x15, x25) # load rd compare value: x25 = 0x000000c9
   LA(x14, scratch) # load base address into rs1
   SREG x5, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b14_not_equal:
@@ -407,6 +435,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b14_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x21) # load value in memory: x21 = 0x00000095
   RVTEST_TESTDATA_LOAD_INT(x23, x25) # load rs2: x25 = 0x0000009b
+  RVTEST_TESTDATA_LOAD_INT(x23, x22) # load rd compare value: x22 = 0x00000095
   LA(x15, scratch) # load base address into rs1
   SREG x21, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b15_equal:
@@ -420,6 +449,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b15_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x11) # load value in memory: x11 = 0x00000064
   RVTEST_TESTDATA_LOAD_INT(x23, x10) # load rs2: x10 = 0x000000da
+  RVTEST_TESTDATA_LOAD_INT(x23, x25) # load rd compare value: x25 = 0x00000086
   LA(x15, scratch) # load base address into rs1
   SREG x11, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b15_not_equal:
@@ -433,6 +463,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b15_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x18) # load value in memory: x18 = 0x0000007d
   RVTEST_TESTDATA_LOAD_INT(x23, x12) # load rs2: x12 = 0x00000056
+  RVTEST_TESTDATA_LOAD_INT(x23, x30) # load rd compare value: x30 = 0x0000007d
   LA(x16, scratch) # load base address into rs1
   SREG x18, 0(x16) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b16_equal:
@@ -446,6 +477,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b16_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x18) # load value in memory: x18 = 0x000000ab
   RVTEST_TESTDATA_LOAD_INT(x23, x4) # load rs2: x4 = 0x000000dc
+  RVTEST_TESTDATA_LOAD_INT(x23, x3) # load rd compare value: x3 = 0x00000056
   LA(x16, scratch) # load base address into rs1
   SREG x18, 0(x16) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b16_not_equal:
@@ -459,6 +491,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b16_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x30) # load value in memory: x30 = 0x0000005f
   RVTEST_TESTDATA_LOAD_INT(x23, x28) # load rs2: x28 = 0x0000009d
+  RVTEST_TESTDATA_LOAD_INT(x23, x1) # load rd compare value: x1 = 0x0000005f
   LA(x17, scratch) # load base address into rs1
   SREG x30, 0(x17) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b17_equal:
@@ -472,6 +505,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b17_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x15) # load value in memory: x15 = 0x00000074
   RVTEST_TESTDATA_LOAD_INT(x23, x27) # load rs2: x27 = 0x00000000
+  RVTEST_TESTDATA_LOAD_INT(x23, x5) # load rd compare value: x5 = 0x00000041
   LA(x17, scratch) # load base address into rs1
   SREG x15, 0(x17) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b17_not_equal:
@@ -485,6 +519,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b17_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x13) # load value in memory: x13 = 0x00000031
   RVTEST_TESTDATA_LOAD_INT(x23, x21) # load rs2: x21 = 0x00000065
+  RVTEST_TESTDATA_LOAD_INT(x23, x10) # load rd compare value: x10 = 0x00000031
   LA(x18, scratch) # load base address into rs1
   SREG x13, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b18_equal:
@@ -498,6 +533,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b18_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x12) # load value in memory: x12 = 0x0000005f
   RVTEST_TESTDATA_LOAD_INT(x23, x13) # load rs2: x13 = 0x00000037
+  RVTEST_TESTDATA_LOAD_INT(x23, x21) # load rd compare value: x21 = 0x00000079
   LA(x18, scratch) # load base address into rs1
   SREG x12, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b18_not_equal:
@@ -511,6 +547,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b18_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x27) # load value in memory: x27 = 0x0000007a
   RVTEST_TESTDATA_LOAD_INT(x23, x14) # load rs2: x14 = 0x00000003
+  RVTEST_TESTDATA_LOAD_INT(x23, x13) # load rd compare value: x13 = 0x0000007a
   LA(x19, scratch) # load base address into rs1
   SREG x27, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b19_equal:
@@ -524,6 +561,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b19_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x29) # load value in memory: x29 = 0x0000002c
   RVTEST_TESTDATA_LOAD_INT(x23, x1) # load rs2: x1 = 0x000000bf
+  RVTEST_TESTDATA_LOAD_INT(x23, x26) # load rd compare value: x26 = 0x000000e5
   LA(x19, scratch) # load base address into rs1
   SREG x29, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b19_not_equal:
@@ -538,6 +576,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b19_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x4) # load value in memory: x4 = 0x0000005b
   RVTEST_TESTDATA_LOAD_INT(x23, x15) # load rs2: x15 = 0x000000ec
+  RVTEST_TESTDATA_LOAD_INT(x23, x13) # load rd compare value: x13 = 0x0000005b
   LA(x20, scratch) # load base address into rs1
   SREG x4, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b20_equal:
@@ -551,6 +590,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b20_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x26) # load value in memory: x26 = 0x000000eb
   RVTEST_TESTDATA_LOAD_INT(x23, x14) # load rs2: x14 = 0x000000c2
+  RVTEST_TESTDATA_LOAD_INT(x23, x24) # load rd compare value: x24 = 0x00000038
   LA(x20, scratch) # load base address into rs1
   SREG x26, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b20_not_equal:
@@ -564,6 +604,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b20_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x27) # load value in memory: x27 = 0x0000001e
   RVTEST_TESTDATA_LOAD_INT(x23, x1) # load rs2: x1 = 0x0000006a
+  RVTEST_TESTDATA_LOAD_INT(x23, x24) # load rd compare value: x24 = 0x0000001e
   LA(x21, scratch) # load base address into rs1
   SREG x27, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b21_equal:
@@ -577,6 +618,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b21_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x16) # load value in memory: x16 = 0x0000007d
   RVTEST_TESTDATA_LOAD_INT(x23, x9) # load rs2: x9 = 0x0000004d
+  RVTEST_TESTDATA_LOAD_INT(x23, x1) # load rd compare value: x1 = 0x00000034
   LA(x21, scratch) # load base address into rs1
   SREG x16, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b21_not_equal:
@@ -591,6 +633,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b21_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x31) # load value in memory: x31 = 0x00000052
   RVTEST_TESTDATA_LOAD_INT(x23, x5) # load rs2: x5 = 0x00000058
+  RVTEST_TESTDATA_LOAD_INT(x23, x4) # load rd compare value: x4 = 0x00000052
   LA(x22, scratch) # load base address into rs1
   SREG x31, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b22_equal:
@@ -604,6 +647,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b22_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x21) # load value in memory: x21 = 0x00000061
   RVTEST_TESTDATA_LOAD_INT(x23, x11) # load rs2: x11 = 0x000000a4
+  RVTEST_TESTDATA_LOAD_INT(x23, x31) # load rd compare value: x31 = 0x000000c8
   LA(x22, scratch) # load base address into rs1
   SREG x21, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b22_not_equal:
@@ -618,6 +662,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b22_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x20) # load value in memory: x20 = 0x0000000b
   RVTEST_TESTDATA_LOAD_INT(x17, x3) # load rs2: x3 = 0x0000007e
+  RVTEST_TESTDATA_LOAD_INT(x17, x11) # load rd compare value: x11 = 0x0000000b
   LA(x23, scratch) # load base address into rs1
   SREG x20, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b23_equal:
@@ -631,6 +676,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b23_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load value in memory: x13 = 0x00000077
   RVTEST_TESTDATA_LOAD_INT(x17, x19) # load rs2: x19 = 0x000000be
+  RVTEST_TESTDATA_LOAD_INT(x17, x6) # load rd compare value: x6 = 0x0000008f
   LA(x23, scratch) # load base address into rs1
   SREG x13, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b23_not_equal:
@@ -644,6 +690,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b23_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load value in memory: x13 = 0x00000032
   RVTEST_TESTDATA_LOAD_INT(x17, x26) # load rs2: x26 = 0x0000008d
+  RVTEST_TESTDATA_LOAD_INT(x17, x29) # load rd compare value: x29 = 0x00000032
   LA(x24, scratch) # load base address into rs1
   SREG x13, 0(x24) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b24_equal:
@@ -657,6 +704,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b24_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x29) # load value in memory: x29 = 0x0000008e
   RVTEST_TESTDATA_LOAD_INT(x17, x4) # load rs2: x4 = 0x0000006a
+  RVTEST_TESTDATA_LOAD_INT(x17, x25) # load rd compare value: x25 = 0x000000c3
   LA(x24, scratch) # load base address into rs1
   SREG x29, 0(x24) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b24_not_equal:
@@ -670,6 +718,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b24_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load value in memory: x13 = 0x00000073
   RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rs2: x2 = 0x000000c3
+  RVTEST_TESTDATA_LOAD_INT(x17, x18) # load rd compare value: x18 = 0x00000073
   LA(x25, scratch) # load base address into rs1
   SREG x13, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b25_equal:
@@ -683,6 +732,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b25_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load value in memory: x9 = 0x000000fc
   RVTEST_TESTDATA_LOAD_INT(x17, x23) # load rs2: x23 = 0x00000093
+  RVTEST_TESTDATA_LOAD_INT(x17, x5) # load rd compare value: x5 = 0x00000008
   LA(x25, scratch) # load base address into rs1
   SREG x9, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b25_not_equal:
@@ -696,6 +746,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b25_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x21) # load value in memory: x21 = 0x00000064
   RVTEST_TESTDATA_LOAD_INT(x17, x29) # load rs2: x29 = 0x000000d6
+  RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rd compare value: x14 = 0x00000064
   LA(x26, scratch) # load base address into rs1
   SREG x21, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b26_equal:
@@ -709,6 +760,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b26_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x28) # load value in memory: x28 = 0x0000002d
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rs2: x14 = 0x000000ee
+  RVTEST_TESTDATA_LOAD_INT(x17, x24) # load rd compare value: x24 = 0x000000ac
   LA(x26, scratch) # load base address into rs1
   SREG x28, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b26_not_equal:
@@ -723,6 +775,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b26_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x25) # load value in memory: x25 = 0x0000003b
   RVTEST_TESTDATA_LOAD_INT(x17, x18) # load rs2: x18 = 0x000000d4
+  RVTEST_TESTDATA_LOAD_INT(x17, x16) # load rd compare value: x16 = 0x0000003b
   LA(x27, scratch) # load base address into rs1
   SREG x25, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b27_equal:
@@ -736,6 +789,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b27_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x22) # load value in memory: x22 = 0x000000fb
   RVTEST_TESTDATA_LOAD_INT(x17, x30) # load rs2: x30 = 0x0000003e
+  RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rd compare value: x2 = 0x0000006e
   LA(x27, scratch) # load base address into rs1
   SREG x22, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b27_not_equal:
@@ -749,6 +803,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b27_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load value in memory: x14 = 0x00000032
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load rs2: x15 = 0x000000c0
+  RVTEST_TESTDATA_LOAD_INT(x17, x10) # load rd compare value: x10 = 0x00000032
   LA(x28, scratch) # load base address into rs1
   SREG x14, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b28_equal:
@@ -762,6 +817,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b28_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x12) # load value in memory: x12 = 0x0000006c
   RVTEST_TESTDATA_LOAD_INT(x17, x20) # load rs2: x20 = 0x00000053
+  RVTEST_TESTDATA_LOAD_INT(x17, x18) # load rd compare value: x18 = 0x00000081
   LA(x28, scratch) # load base address into rs1
   SREG x12, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b28_not_equal:
@@ -775,6 +831,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b28_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x27) # load value in memory: x27 = 0x0000008b
   RVTEST_TESTDATA_LOAD_INT(x17, x28) # load rs2: x28 = 0x00000080
+  RVTEST_TESTDATA_LOAD_INT(x17, x10) # load rd compare value: x10 = 0x0000008b
   LA(x29, scratch) # load base address into rs1
   SREG x27, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b29_equal:
@@ -788,6 +845,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b29_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x3) # load value in memory: x3 = 0x000000ec
   RVTEST_TESTDATA_LOAD_INT(x17, x11) # load rs2: x11 = 0x00000047
+  RVTEST_TESTDATA_LOAD_INT(x17, x23) # load rd compare value: x23 = 0x00000031
   LA(x29, scratch) # load base address into rs1
   SREG x3, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b29_not_equal:
@@ -801,6 +859,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b29_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x31) # load value in memory: x31 = 0x00000078
   RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rs2: x0 = 0x000000e3
+  RVTEST_TESTDATA_LOAD_INT(x17, x18) # load rd compare value: x18 = 0x00000078
   LA(x30, scratch) # load base address into rs1
   SREG x31, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b30_equal:
@@ -814,6 +873,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b30_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x19) # load value in memory: x19 = 0x0000005c
   RVTEST_TESTDATA_LOAD_INT(x17, x29) # load rs2: x29 = 0x00000090
+  RVTEST_TESTDATA_LOAD_INT(x17, x4) # load rd compare value: x4 = 0x000000a5
   LA(x30, scratch) # load base address into rs1
   SREG x19, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b30_not_equal:
@@ -827,6 +887,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b30_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x4) # load value in memory: x4 = 0x000000df
   RVTEST_TESTDATA_LOAD_INT(x17, x5) # load rs2: x5 = 0x00000039
+  RVTEST_TESTDATA_LOAD_INT(x17, x22) # load rd compare value: x22 = 0x000000df
   LA(x31, scratch) # load base address into rs1
   SREG x4, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b31_equal:
@@ -840,6 +901,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b31_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load value in memory: x1 = 0x00000089
   RVTEST_TESTDATA_LOAD_INT(x17, x26) # load rs2: x26 = 0x000000d0
+  RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rd compare value: x0 = 0x0000009f
   LA(x31, scratch) # load base address into rs1
   SREG x1, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b31_not_equal:
@@ -857,6 +919,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b31_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x0, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x16) # load value in memory: x16 = 0x000000b3
   RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rs2: x0 = 0x000000a4
+  RVTEST_TESTDATA_LOAD_INT(x17, x15) # load rd compare value: x15 = 0x000000b3
   LA(x13, scratch) # load base address into rs1
   SREG x16, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b0_equal:
@@ -870,6 +933,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b0_equal:
 # Testcase cp_rs2 (Test source rs2 = x0, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x12) # load value in memory: x12 = 0x00000005
   RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rs2: x0 = 0x000000f6
+  RVTEST_TESTDATA_LOAD_INT(x17, x13) # load rd compare value: x13 = 0x000000c5
   LA(x1, scratch) # load base address into rs1
   SREG x12, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b0_not_equal:
@@ -883,6 +947,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b0_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load value in memory: x15 = 0x00000015
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load rs2: x1 = 0x00000033
+  RVTEST_TESTDATA_LOAD_INT(x17, x4) # load rd compare value: x4 = 0x00000015
   LA(x25, scratch) # load base address into rs1
   SREG x15, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b1_equal:
@@ -896,6 +961,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b1_equal:
 # Testcase cp_rs2 (Test source rs2 = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x10) # load value in memory: x10 = 0x00000023
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load rs2: x1 = 0x0000002f
+  RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rd compare value: x0 = 0x0000003a
   LA(x26, scratch) # load base address into rs1
   SREG x10, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b1_not_equal:
@@ -909,6 +975,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b1_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x30) # load value in memory: x30 = 0x00000030
   RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rs2: x2 = 0x0000009d
+  RVTEST_TESTDATA_LOAD_INT(x17, x28) # load rd compare value: x28 = 0x00000030
   LA(x11, scratch) # load base address into rs1
   SREG x30, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b2_equal:
@@ -922,6 +989,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b2_equal:
 # Testcase cp_rs2 (Test source rs2 = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x10) # load value in memory: x10 = 0x00000097
   RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rs2: x2 = 0x00000072
+  RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rd compare value: x0 = 0x0000002c
   LA(x31, scratch) # load base address into rs1
   SREG x10, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b2_not_equal:
@@ -935,6 +1003,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b2_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x22) # load value in memory: x22 = 0x00000052
   RVTEST_TESTDATA_LOAD_INT(x17, x3) # load rs2: x3 = 0x00000060
+  RVTEST_TESTDATA_LOAD_INT(x17, x21) # load rd compare value: x21 = 0x00000052
   LA(x11, scratch) # load base address into rs1
   SREG x22, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b3_equal:
@@ -948,6 +1017,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b3_equal:
 # Testcase cp_rs2 (Test source rs2 = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x5) # load value in memory: x5 = 0x00000067
   RVTEST_TESTDATA_LOAD_INT(x17, x3) # load rs2: x3 = 0x00000077
+  RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rd compare value: x9 = 0x00000089
   LA(x1, scratch) # load base address into rs1
   SREG x5, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b3_not_equal:
@@ -961,6 +1031,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b3_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load value in memory: x9 = 0x000000cf
   RVTEST_TESTDATA_LOAD_INT(x17, x4) # load rs2: x4 = 0x00000003
+  RVTEST_TESTDATA_LOAD_INT(x17, x19) # load rd compare value: x19 = 0x000000cf
   LA(x15, scratch) # load base address into rs1
   SREG x9, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b4_equal:
@@ -974,6 +1045,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b4_equal:
 # Testcase cp_rs2 (Test source rs2 = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x26) # load value in memory: x26 = 0x00000031
   RVTEST_TESTDATA_LOAD_INT(x17, x4) # load rs2: x4 = 0x00000065
+  RVTEST_TESTDATA_LOAD_INT(x17, x30) # load rd compare value: x30 = 0x000000f9
   LA(x20, scratch) # load base address into rs1
   SREG x26, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b4_not_equal:
@@ -987,6 +1059,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b4_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x21) # load value in memory: x21 = 0x000000c8
   RVTEST_TESTDATA_LOAD_INT(x17, x5) # load rs2: x5 = 0x00000098
+  RVTEST_TESTDATA_LOAD_INT(x17, x29) # load rd compare value: x29 = 0x000000c8
   LA(x20, scratch) # load base address into rs1
   SREG x21, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b5_equal:
@@ -1000,6 +1073,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b5_equal:
 # Testcase cp_rs2 (Test source rs2 = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x18) # load value in memory: x18 = 0x000000fc
   RVTEST_TESTDATA_LOAD_INT(x17, x5) # load rs2: x5 = 0x00000075
+  RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rd compare value: x9 = 0x00000027
   LA(x11, scratch) # load base address into rs1
   SREG x18, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b5_not_equal:
@@ -1014,6 +1088,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b5_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x19) # load value in memory: x19 = 0x00000040
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load rs2: x6 = 0x00000089
+  RVTEST_TESTDATA_LOAD_INT(x17, x3) # load rd compare value: x3 = 0x00000040
   LA(x11, scratch) # load base address into rs1
   SREG x19, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b6_equal:
@@ -1027,6 +1102,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b6_equal:
 # Testcase cp_rs2 (Test source rs2 = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x31) # load value in memory: x31 = 0x00000090
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load rs2: x6 = 0x000000ea
+  RVTEST_TESTDATA_LOAD_INT(x17, x22) # load rd compare value: x22 = 0x0000002f
   LA(x13, scratch) # load base address into rs1
   SREG x31, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b6_not_equal:
@@ -1042,6 +1118,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b6_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x31) # load value in memory: x31 = 0x000000f8
   RVTEST_TESTDATA_LOAD_INT(x17, x7) # load rs2: x7 = 0x000000fe
+  RVTEST_TESTDATA_LOAD_INT(x17, x29) # load rd compare value: x29 = 0x000000f8
   LA(x14, scratch) # load base address into rs1
   SREG x31, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b7_equal:
@@ -1055,6 +1132,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b7_equal:
 # Testcase cp_rs2 (Test source rs2 = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x22) # load value in memory: x22 = 0x00000009
   RVTEST_TESTDATA_LOAD_INT(x17, x7) # load rs2: x7 = 0x000000ec
+  RVTEST_TESTDATA_LOAD_INT(x17, x1) # load rd compare value: x1 = 0x00000075
   LA(x30, scratch) # load base address into rs1
   SREG x22, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b7_not_equal:
@@ -1068,6 +1146,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b7_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load value in memory: x1 = 0x000000dd
   RVTEST_TESTDATA_LOAD_INT(x17, x8) # load rs2: x8 = 0x0000003e
+  RVTEST_TESTDATA_LOAD_INT(x17, x29) # load rd compare value: x29 = 0x000000dd
   LA(x28, scratch) # load base address into rs1
   SREG x1, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b8_equal:
@@ -1081,6 +1160,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b8_equal:
 # Testcase cp_rs2 (Test source rs2 = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load value in memory: x14 = 0x00000039
   RVTEST_TESTDATA_LOAD_INT(x17, x8) # load rs2: x8 = 0x00000073
+  RVTEST_TESTDATA_LOAD_INT(x17, x7) # load rd compare value: x7 = 0x000000f0
   LA(x22, scratch) # load base address into rs1
   SREG x14, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b8_not_equal:
@@ -1094,6 +1174,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b8_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x3) # load value in memory: x3 = 0x000000e5
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rs2: x9 = 0x00000054
+  RVTEST_TESTDATA_LOAD_INT(x17, x1) # load rd compare value: x1 = 0x000000e5
   LA(x18, scratch) # load base address into rs1
   SREG x3, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b9_equal:
@@ -1107,6 +1188,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b9_equal:
 # Testcase cp_rs2 (Test source rs2 = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x28) # load value in memory: x28 = 0x00000070
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rs2: x9 = 0x0000003d
+  RVTEST_TESTDATA_LOAD_INT(x17, x20) # load rd compare value: x20 = 0x000000d4
   LA(x29, scratch) # load base address into rs1
   SREG x28, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b9_not_equal:
@@ -1120,6 +1202,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b9_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x29) # load value in memory: x29 = 0x00000052
   RVTEST_TESTDATA_LOAD_INT(x17, x10) # load rs2: x10 = 0x00000035
+  RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rd compare value: x2 = 0x00000052
   LA(x14, scratch) # load base address into rs1
   SREG x29, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b10_equal:
@@ -1133,6 +1216,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b10_equal:
 # Testcase cp_rs2 (Test source rs2 = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load value in memory: x15 = 0x000000fb
   RVTEST_TESTDATA_LOAD_INT(x17, x10) # load rs2: x10 = 0x000000fc
+  RVTEST_TESTDATA_LOAD_INT(x17, x6) # load rd compare value: x6 = 0x0000006b
   LA(x21, scratch) # load base address into rs1
   SREG x15, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b10_not_equal:
@@ -1146,6 +1230,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b10_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load value in memory: x14 = 0x000000d9
   RVTEST_TESTDATA_LOAD_INT(x17, x11) # load rs2: x11 = 0x000000eb
+  RVTEST_TESTDATA_LOAD_INT(x17, x7) # load rd compare value: x7 = 0x000000d9
   LA(x29, scratch) # load base address into rs1
   SREG x14, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b11_equal:
@@ -1159,6 +1244,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b11_equal:
 # Testcase cp_rs2 (Test source rs2 = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load value in memory: x6 = 0x000000b3
   RVTEST_TESTDATA_LOAD_INT(x17, x11) # load rs2: x11 = 0x000000e5
+  RVTEST_TESTDATA_LOAD_INT(x17, x20) # load rd compare value: x20 = 0x000000fd
   LA(x30, scratch) # load base address into rs1
   SREG x6, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b11_not_equal:
@@ -1172,6 +1258,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b11_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x16) # load value in memory: x16 = 0x00000068
   RVTEST_TESTDATA_LOAD_INT(x17, x12) # load rs2: x12 = 0x000000c6
+  RVTEST_TESTDATA_LOAD_INT(x17, x21) # load rd compare value: x21 = 0x00000068
   LA(x30, scratch) # load base address into rs1
   SREG x16, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b12_equal:
@@ -1185,6 +1272,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b12_equal:
 # Testcase cp_rs2 (Test source rs2 = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x22) # load value in memory: x22 = 0x0000004f
   RVTEST_TESTDATA_LOAD_INT(x17, x12) # load rs2: x12 = 0x00000065
+  RVTEST_TESTDATA_LOAD_INT(x17, x27) # load rd compare value: x27 = 0x00000023
   LA(x14, scratch) # load base address into rs1
   SREG x22, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b12_not_equal:
@@ -1198,6 +1286,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b12_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load value in memory: x14 = 0x000000b2
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load rs2: x13 = 0x000000f8
+  RVTEST_TESTDATA_LOAD_INT(x17, x18) # load rd compare value: x18 = 0x000000b2
   LA(x7, scratch) # load base address into rs1
   SREG x14, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b13_equal:
@@ -1211,6 +1300,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b13_equal:
 # Testcase cp_rs2 (Test source rs2 = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x18) # load value in memory: x18 = 0x00000003
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load rs2: x13 = 0x000000f4
+  RVTEST_TESTDATA_LOAD_INT(x17, x24) # load rd compare value: x24 = 0x000000b7
   LA(x2, scratch) # load base address into rs1
   SREG x18, 0(x2) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b13_not_equal:
@@ -1224,6 +1314,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b13_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x12) # load value in memory: x12 = 0x00000040
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rs2: x14 = 0x00000052
+  RVTEST_TESTDATA_LOAD_INT(x17, x22) # load rd compare value: x22 = 0x00000040
   LA(x7, scratch) # load base address into rs1
   SREG x12, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b14_equal:
@@ -1237,6 +1328,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b14_equal:
 # Testcase cp_rs2 (Test source rs2 = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x16) # load value in memory: x16 = 0x000000b9
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rs2: x14 = 0x00000074
+  RVTEST_TESTDATA_LOAD_INT(x17, x11) # load rd compare value: x11 = 0x00000035
   LA(x3, scratch) # load base address into rs1
   SREG x16, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b14_not_equal:
@@ -1250,6 +1342,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b14_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x8) # load value in memory: x8 = 0x00000067
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load rs2: x15 = 0x000000bd
+  RVTEST_TESTDATA_LOAD_INT(x17, x24) # load rd compare value: x24 = 0x00000067
   LA(x13, scratch) # load base address into rs1
   SREG x8, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b15_equal:
@@ -1263,6 +1356,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b15_equal:
 # Testcase cp_rs2 (Test source rs2 = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load value in memory: x6 = 0x0000009c
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load rs2: x15 = 0x000000b4
+  RVTEST_TESTDATA_LOAD_INT(x17, x12) # load rd compare value: x12 = 0x00000058
   LA(x18, scratch) # load base address into rs1
   SREG x6, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b15_not_equal:
@@ -1276,6 +1370,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b15_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load value in memory: x15 = 0x00000049
   RVTEST_TESTDATA_LOAD_INT(x17, x16) # load rs2: x16 = 0x00000050
+  RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rd compare value: x14 = 0x00000049
   LA(x25, scratch) # load base address into rs1
   SREG x15, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b16_equal:
@@ -1289,6 +1384,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b16_equal:
 # Testcase cp_rs2 (Test source rs2 = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x21) # load value in memory: x21 = 0x0000009a
   RVTEST_TESTDATA_LOAD_INT(x17, x16) # load rs2: x16 = 0x00000025
+  RVTEST_TESTDATA_LOAD_INT(x17, x24) # load rd compare value: x24 = 0x0000005a
   LA(x30, scratch) # load base address into rs1
   SREG x21, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b16_not_equal:
@@ -1303,6 +1399,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b16_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x12) # load value in memory: x12 = 0x000000a2
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load rs2: x17 = 0x000000c3
+  RVTEST_TESTDATA_LOAD_INT(x24, x6) # load rd compare value: x6 = 0x000000a2
   LA(x7, scratch) # load base address into rs1
   SREG x12, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b17_equal:
@@ -1316,6 +1413,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b17_equal:
 # Testcase cp_rs2 (Test source rs2 = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x16) # load value in memory: x16 = 0x000000d1
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load rs2: x17 = 0x0000004c
+  RVTEST_TESTDATA_LOAD_INT(x24, x26) # load rd compare value: x26 = 0x000000af
   LA(x6, scratch) # load base address into rs1
   SREG x16, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b17_not_equal:
@@ -1329,6 +1427,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b17_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x8) # load value in memory: x8 = 0x0000003d
   RVTEST_TESTDATA_LOAD_INT(x24, x18) # load rs2: x18 = 0x00000063
+  RVTEST_TESTDATA_LOAD_INT(x24, x31) # load rd compare value: x31 = 0x0000003d
   LA(x6, scratch) # load base address into rs1
   SREG x8, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b18_equal:
@@ -1342,6 +1441,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b18_equal:
 # Testcase cp_rs2 (Test source rs2 = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x8) # load value in memory: x8 = 0x0000009c
   RVTEST_TESTDATA_LOAD_INT(x24, x18) # load rs2: x18 = 0x00000090
+  RVTEST_TESTDATA_LOAD_INT(x24, x25) # load rd compare value: x25 = 0x0000002b
   LA(x12, scratch) # load base address into rs1
   SREG x8, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b18_not_equal:
@@ -1355,6 +1455,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b18_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x11) # load value in memory: x11 = 0x00000002
   RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rs2: x19 = 0x000000c3
+  RVTEST_TESTDATA_LOAD_INT(x24, x13) # load rd compare value: x13 = 0x00000002
   LA(x25, scratch) # load base address into rs1
   SREG x11, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b19_equal:
@@ -1368,6 +1469,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b19_equal:
 # Testcase cp_rs2 (Test source rs2 = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load value in memory: x20 = 0x000000ee
   RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rs2: x19 = 0x000000f6
+  RVTEST_TESTDATA_LOAD_INT(x24, x25) # load rd compare value: x25 = 0x000000fb
   LA(x31, scratch) # load base address into rs1
   SREG x20, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b19_not_equal:
@@ -1381,6 +1483,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b19_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load value in memory: x3 = 0x00000083
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load rs2: x20 = 0x00000065
+  RVTEST_TESTDATA_LOAD_INT(x24, x30) # load rd compare value: x30 = 0x00000083
   LA(x15, scratch) # load base address into rs1
   SREG x3, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b20_equal:
@@ -1394,6 +1497,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b20_equal:
 # Testcase cp_rs2 (Test source rs2 = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load value in memory: x21 = 0x00000093
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load rs2: x20 = 0x000000c7
+  RVTEST_TESTDATA_LOAD_INT(x24, x16) # load rd compare value: x16 = 0x0000001c
   LA(x3, scratch) # load base address into rs1
   SREG x21, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b20_not_equal:
@@ -1407,6 +1511,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b20_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load value in memory: x1 = 0x00000075
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rs2: x21 = 0x0000001c
+  RVTEST_TESTDATA_LOAD_INT(x24, x7) # load rd compare value: x7 = 0x00000075
   LA(x25, scratch) # load base address into rs1
   SREG x1, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b21_equal:
@@ -1420,6 +1525,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b21_equal:
 # Testcase cp_rs2 (Test source rs2 = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x8) # load value in memory: x8 = 0x00000013
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rs2: x21 = 0x000000e5
+  RVTEST_TESTDATA_LOAD_INT(x24, x13) # load rd compare value: x13 = 0x00000027
   LA(x25, scratch) # load base address into rs1
   SREG x8, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b21_not_equal:
@@ -1433,6 +1539,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b21_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x15) # load value in memory: x15 = 0x0000002f
   RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rs2: x22 = 0x00000059
+  RVTEST_TESTDATA_LOAD_INT(x24, x7) # load rd compare value: x7 = 0x0000002f
   LA(x10, scratch) # load base address into rs1
   SREG x15, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b22_equal:
@@ -1446,6 +1553,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b22_equal:
 # Testcase cp_rs2 (Test source rs2 = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x14) # load value in memory: x14 = 0x0000004b
   RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rs2: x22 = 0x0000003a
+  RVTEST_TESTDATA_LOAD_INT(x24, x11) # load rd compare value: x11 = 0x0000006f
   LA(x21, scratch) # load base address into rs1
   SREG x14, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b22_not_equal:
@@ -1460,6 +1568,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b22_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x6) # load value in memory: x6 = 0x000000f8
   RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rs2: x23 = 0x00000061
+  RVTEST_TESTDATA_LOAD_INT(x24, x2) # load rd compare value: x2 = 0x000000f8
   LA(x12, scratch) # load base address into rs1
   SREG x6, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b23_equal:
@@ -1473,6 +1582,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b23_equal:
 # Testcase cp_rs2 (Test source rs2 = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x8) # load value in memory: x8 = 0x000000d9
   RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rs2: x23 = 0x0000004a
+  RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rd compare value: x21 = 0x0000000e
   LA(x22, scratch) # load base address into rs1
   SREG x8, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b23_not_equal:
@@ -1487,6 +1597,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b23_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x10) # load value in memory: x10 = 0x000000b9
   RVTEST_TESTDATA_LOAD_INT(x12, x24) # load rs2: x24 = 0x00000085
+  RVTEST_TESTDATA_LOAD_INT(x12, x18) # load rd compare value: x18 = 0x000000b9
   LA(x6, scratch) # load base address into rs1
   SREG x10, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b24_equal:
@@ -1500,6 +1611,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b24_equal:
 # Testcase cp_rs2 (Test source rs2 = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x17) # load value in memory: x17 = 0x000000c5
   RVTEST_TESTDATA_LOAD_INT(x12, x24) # load rs2: x24 = 0x00000011
+  RVTEST_TESTDATA_LOAD_INT(x12, x16) # load rd compare value: x16 = 0x00000029
   LA(x27, scratch) # load base address into rs1
   SREG x17, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b24_not_equal:
@@ -1513,6 +1625,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b24_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x31) # load value in memory: x31 = 0x00000086
   RVTEST_TESTDATA_LOAD_INT(x12, x25) # load rs2: x25 = 0x0000006e
+  RVTEST_TESTDATA_LOAD_INT(x12, x21) # load rd compare value: x21 = 0x00000086
   LA(x29, scratch) # load base address into rs1
   SREG x31, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b25_equal:
@@ -1526,6 +1639,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b25_equal:
 # Testcase cp_rs2 (Test source rs2 = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load value in memory: x1 = 0x000000ce
   RVTEST_TESTDATA_LOAD_INT(x12, x25) # load rs2: x25 = 0x00000005
+  RVTEST_TESTDATA_LOAD_INT(x12, x13) # load rd compare value: x13 = 0x00000041
   LA(x18, scratch) # load base address into rs1
   SREG x1, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b25_not_equal:
@@ -1540,6 +1654,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b25_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x24) # load value in memory: x24 = 0x000000bd
   RVTEST_TESTDATA_LOAD_INT(x12, x26) # load rs2: x26 = 0x0000000a
+  RVTEST_TESTDATA_LOAD_INT(x12, x31) # load rd compare value: x31 = 0x000000bd
   LA(x29, scratch) # load base address into rs1
   SREG x24, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b26_equal:
@@ -1553,6 +1668,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b26_equal:
 # Testcase cp_rs2 (Test source rs2 = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load value in memory: x1 = 0x00000049
   RVTEST_TESTDATA_LOAD_INT(x12, x26) # load rs2: x26 = 0x000000be
+  RVTEST_TESTDATA_LOAD_INT(x12, x15) # load rd compare value: x15 = 0x00000067
   LA(x25, scratch) # load base address into rs1
   SREG x1, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b26_not_equal:
@@ -1566,6 +1682,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b26_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x17) # load value in memory: x17 = 0x0000009b
   RVTEST_TESTDATA_LOAD_INT(x12, x27) # load rs2: x27 = 0x0000009e
+  RVTEST_TESTDATA_LOAD_INT(x12, x22) # load rd compare value: x22 = 0x0000009b
   LA(x13, scratch) # load base address into rs1
   SREG x17, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b27_equal:
@@ -1579,6 +1696,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b27_equal:
 # Testcase cp_rs2 (Test source rs2 = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x3) # load value in memory: x3 = 0x00000044
   RVTEST_TESTDATA_LOAD_INT(x12, x27) # load rs2: x27 = 0x000000e3
+  RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rd compare value: x7 = 0x00000018
   LA(x21, scratch) # load base address into rs1
   SREG x3, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b27_not_equal:
@@ -1592,6 +1710,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b27_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x13) # load value in memory: x13 = 0x00000061
   RVTEST_TESTDATA_LOAD_INT(x12, x28) # load rs2: x28 = 0x000000af
+  RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rd compare value: x6 = 0x00000061
   LA(x8, scratch) # load base address into rs1
   SREG x13, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b28_equal:
@@ -1605,6 +1724,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b28_equal:
 # Testcase cp_rs2 (Test source rs2 = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x18) # load value in memory: x18 = 0x00000092
   RVTEST_TESTDATA_LOAD_INT(x12, x28) # load rs2: x28 = 0x000000ae
+  RVTEST_TESTDATA_LOAD_INT(x12, x27) # load rd compare value: x27 = 0x000000b7
   LA(x6, scratch) # load base address into rs1
   SREG x18, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b28_not_equal:
@@ -1618,6 +1738,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b28_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x24) # load value in memory: x24 = 0x000000f1
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rs2: x29 = 0x000000d0
+  RVTEST_TESTDATA_LOAD_INT(x12, x15) # load rd compare value: x15 = 0x000000f1
   LA(x31, scratch) # load base address into rs1
   SREG x24, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b29_equal:
@@ -1631,6 +1752,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b29_equal:
 # Testcase cp_rs2 (Test source rs2 = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x23) # load value in memory: x23 = 0x000000a5
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rs2: x29 = 0x00000021
+  RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rd compare value: x9 = 0x00000087
   LA(x8, scratch) # load base address into rs1
   SREG x23, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b29_not_equal:
@@ -1645,6 +1767,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b29_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x13) # load value in memory: x13 = 0x00000018
   RVTEST_TESTDATA_LOAD_INT(x12, x30) # load rs2: x30 = 0x000000e1
+  RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rd compare value: x9 = 0x00000018
   LA(x27, scratch) # load base address into rs1
   SREG x13, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b30_equal:
@@ -1658,6 +1781,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b30_equal:
 # Testcase cp_rs2 (Test source rs2 = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x21) # load value in memory: x21 = 0x000000a8
   RVTEST_TESTDATA_LOAD_INT(x12, x30) # load rs2: x30 = 0x00000023
+  RVTEST_TESTDATA_LOAD_INT(x12, x15) # load rd compare value: x15 = 0x000000d4
   LA(x11, scratch) # load base address into rs1
   SREG x21, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b30_not_equal:
@@ -1671,6 +1795,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b30_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x3) # load value in memory: x3 = 0x000000b9
   RVTEST_TESTDATA_LOAD_INT(x12, x31) # load rs2: x31 = 0x000000fa
+  RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rd compare value: x10 = 0x000000b9
   LA(x27, scratch) # load base address into rs1
   SREG x3, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b31_equal:
@@ -1684,6 +1809,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b31_equal:
 # Testcase cp_rs2 (Test source rs2 = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x15) # load value in memory: x15 = 0x00000020
   RVTEST_TESTDATA_LOAD_INT(x12, x31) # load rs2: x31 = 0x000000a5
+  RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rd compare value: x7 = 0x000000b2
   LA(x26, scratch) # load base address into rs1
   SREG x15, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b31_not_equal:
@@ -1701,6 +1827,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b31_not_equal:
 # Testcase cp_rd (Test destination rd = x0, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x10) # load value in memory: x10 = 0x00000001
   RVTEST_TESTDATA_LOAD_INT(x12, x27) # load rs2: x27 = 0x000000a3
+  RVTEST_TESTDATA_LOAD_INT(x12, x0) # load rd compare value: x0 = 0x00000001
   LA(x28, scratch) # load base address into rs1
   SREG x10, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b0_equal:
@@ -1714,6 +1841,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b0_equal:
 # Testcase cp_rd (Test destination rd = x0, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x31) # load value in memory: x31 = 0x0000005c
   RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rs2: x9 = 0x000000cb
+  RVTEST_TESTDATA_LOAD_INT(x12, x0) # load rd compare value: x0 = 0x00000044
   LA(x19, scratch) # load base address into rs1
   SREG x31, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b0_not_equal:
@@ -1727,6 +1855,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b0_not_equal:
 # Testcase cp_rd (Test destination rd = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x19) # load value in memory: x19 = 0x00000021
   RVTEST_TESTDATA_LOAD_INT(x12, x17) # load rs2: x17 = 0x000000c5
+  RVTEST_TESTDATA_LOAD_INT(x12, x1) # load rd compare value: x1 = 0x00000021
   LA(x8, scratch) # load base address into rs1
   SREG x19, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b1_equal:
@@ -1740,6 +1869,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b1_equal:
 # Testcase cp_rd (Test destination rd = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x3) # load value in memory: x3 = 0x0000004a
   RVTEST_TESTDATA_LOAD_INT(x12, x28) # load rs2: x28 = 0x00000013
+  RVTEST_TESTDATA_LOAD_INT(x12, x1) # load rd compare value: x1 = 0x0000007f
   LA(x29, scratch) # load base address into rs1
   SREG x3, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b1_not_equal:
@@ -1753,6 +1883,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b1_not_equal:
 # Testcase cp_rd (Test destination rd = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x3) # load value in memory: x3 = 0x00000065
   RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rs2: x7 = 0x000000ee
+  RVTEST_TESTDATA_LOAD_INT(x12, x2) # load rd compare value: x2 = 0x00000065
   LA(x15, scratch) # load base address into rs1
   SREG x3, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b2_equal:
@@ -1766,6 +1897,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b2_equal:
 # Testcase cp_rd (Test destination rd = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load value in memory: x1 = 0x000000e8
   RVTEST_TESTDATA_LOAD_INT(x12, x16) # load rs2: x16 = 0x00000095
+  RVTEST_TESTDATA_LOAD_INT(x12, x2) # load rd compare value: x2 = 0x00000058
   LA(x31, scratch) # load base address into rs1
   SREG x1, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b2_not_equal:
@@ -1779,6 +1911,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b2_not_equal:
 # Testcase cp_rd (Test destination rd = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x21) # load value in memory: x21 = 0x000000b1
   RVTEST_TESTDATA_LOAD_INT(x12, x31) # load rs2: x31 = 0x000000ee
+  RVTEST_TESTDATA_LOAD_INT(x12, x3) # load rd compare value: x3 = 0x000000b1
   LA(x30, scratch) # load base address into rs1
   SREG x21, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b3_equal:
@@ -1792,6 +1925,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b3_equal:
 # Testcase cp_rd (Test destination rd = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x18) # load value in memory: x18 = 0x000000e0
   RVTEST_TESTDATA_LOAD_INT(x12, x8) # load rs2: x8 = 0x00000053
+  RVTEST_TESTDATA_LOAD_INT(x12, x3) # load rd compare value: x3 = 0x00000080
   LA(x9, scratch) # load base address into rs1
   SREG x18, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b3_not_equal:
@@ -1807,6 +1941,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b3_not_equal:
 # Testcase cp_rd (Test destination rd = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load value in memory: x1 = 0x0000000b
   RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rs2: x10 = 0x00000089
+  RVTEST_TESTDATA_LOAD_INT(x12, x4) # load rd compare value: x4 = 0x0000000b
   LA(x3, scratch) # load base address into rs1
   SREG x1, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b4_equal:
@@ -1820,6 +1955,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b4_equal:
 # Testcase cp_rd (Test destination rd = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x19) # load value in memory: x19 = 0x000000d0
   RVTEST_TESTDATA_LOAD_INT(x12, x13) # load rs2: x13 = 0x00000056
+  RVTEST_TESTDATA_LOAD_INT(x12, x4) # load rd compare value: x4 = 0x000000ae
   LA(x24, scratch) # load base address into rs1
   SREG x19, 0(x24) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b4_not_equal:
@@ -1833,6 +1969,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b4_not_equal:
 # Testcase cp_rd (Test destination rd = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x4) # load value in memory: x4 = 0x00000030
   RVTEST_TESTDATA_LOAD_INT(x12, x0) # load rs2: x0 = 0x000000d8
+  RVTEST_TESTDATA_LOAD_INT(x12, x5) # load rd compare value: x5 = 0x00000030
   LA(x31, scratch) # load base address into rs1
   SREG x4, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b5_equal:
@@ -1846,6 +1983,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b5_equal:
 # Testcase cp_rd (Test destination rd = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x21) # load value in memory: x21 = 0x0000004b
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rs2: x29 = 0x00000035
+  RVTEST_TESTDATA_LOAD_INT(x12, x5) # load rd compare value: x5 = 0x00000015
   LA(x13, scratch) # load base address into rs1
   SREG x21, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b5_not_equal:
@@ -1860,6 +1998,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b5_not_equal:
 # Testcase cp_rd (Test destination rd = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x22) # load value in memory: x22 = 0x0000005f
   RVTEST_TESTDATA_LOAD_INT(x12, x21) # load rs2: x21 = 0x0000006e
+  RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rd compare value: x6 = 0x0000005f
   LA(x27, scratch) # load base address into rs1
   SREG x22, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b6_equal:
@@ -1873,6 +2012,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b6_equal:
 # Testcase cp_rd (Test destination rd = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x28) # load value in memory: x28 = 0x00000056
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rs2: x29 = 0x00000050
+  RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rd compare value: x6 = 0x000000ab
   LA(x19, scratch) # load base address into rs1
   SREG x28, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b6_not_equal:
@@ -1888,6 +2028,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b6_not_equal:
 # Testcase cp_rd (Test destination rd = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load value in memory: x29 = 0x000000cf
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load rs2: x1 = 0x0000006a
+  RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rd compare value: x7 = 0x000000cf
   LA(x4, scratch) # load base address into rs1
   SREG x29, 0(x4) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b7_equal:
@@ -1901,6 +2042,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b7_equal:
 # Testcase cp_rd (Test destination rd = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x24) # load value in memory: x24 = 0x0000006f
   RVTEST_TESTDATA_LOAD_INT(x12, x19) # load rs2: x19 = 0x0000004a
+  RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rd compare value: x7 = 0x0000006c
   LA(x15, scratch) # load base address into rs1
   SREG x24, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b7_not_equal:
@@ -1914,6 +2056,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b7_not_equal:
 # Testcase cp_rd (Test destination rd = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x30) # load value in memory: x30 = 0x000000bc
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rs2: x29 = 0x00000008
+  RVTEST_TESTDATA_LOAD_INT(x12, x8) # load rd compare value: x8 = 0x000000bc
   LA(x2, scratch) # load base address into rs1
   SREG x30, 0(x2) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b8_equal:
@@ -1927,6 +2070,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b8_equal:
 # Testcase cp_rd (Test destination rd = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x31) # load value in memory: x31 = 0x000000b7
   RVTEST_TESTDATA_LOAD_INT(x12, x15) # load rs2: x15 = 0x00000078
+  RVTEST_TESTDATA_LOAD_INT(x12, x8) # load rd compare value: x8 = 0x00000058
   LA(x7, scratch) # load base address into rs1
   SREG x31, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b8_not_equal:
@@ -1940,6 +2084,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b8_not_equal:
 # Testcase cp_rd (Test destination rd = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x7) # load value in memory: x7 = 0x00000031
   RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rs2: x6 = 0x00000055
+  RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rd compare value: x9 = 0x00000031
   LA(x1, scratch) # load base address into rs1
   SREG x7, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b9_equal:
@@ -1953,6 +2098,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b9_equal:
 # Testcase cp_rd (Test destination rd = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load value in memory: x29 = 0x00000035
   RVTEST_TESTDATA_LOAD_INT(x12, x15) # load rs2: x15 = 0x00000012
+  RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rd compare value: x9 = 0x000000a7
   LA(x5, scratch) # load base address into rs1
   SREG x29, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b9_not_equal:
@@ -1966,6 +2112,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b9_not_equal:
 # Testcase cp_rd (Test destination rd = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x20) # load value in memory: x20 = 0x00000048
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load rs2: x1 = 0x000000ce
+  RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rd compare value: x10 = 0x00000048
   LA(x21, scratch) # load base address into rs1
   SREG x20, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b10_equal:
@@ -1979,6 +2126,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b10_equal:
 # Testcase cp_rd (Test destination rd = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x20) # load value in memory: x20 = 0x000000c2
   RVTEST_TESTDATA_LOAD_INT(x12, x18) # load rs2: x18 = 0x000000a4
+  RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rd compare value: x10 = 0x000000c4
   LA(x25, scratch) # load base address into rs1
   SREG x20, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b10_not_equal:
@@ -1992,6 +2140,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b10_not_equal:
 # Testcase cp_rd (Test destination rd = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x10) # load value in memory: x10 = 0x00000062
   RVTEST_TESTDATA_LOAD_INT(x12, x27) # load rs2: x27 = 0x0000000e
+  RVTEST_TESTDATA_LOAD_INT(x12, x11) # load rd compare value: x11 = 0x00000062
   LA(x30, scratch) # load base address into rs1
   SREG x10, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b11_equal:
@@ -2005,6 +2154,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b11_equal:
 # Testcase cp_rd (Test destination rd = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x17) # load value in memory: x17 = 0x00000020
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rs2: x29 = 0x0000009f
+  RVTEST_TESTDATA_LOAD_INT(x12, x11) # load rd compare value: x11 = 0x000000f4
   LA(x1, scratch) # load base address into rs1
   SREG x17, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b11_not_equal:
@@ -2019,6 +2169,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b11_not_equal:
 # Testcase cp_rd (Test destination rd = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x29) # load value in memory: x29 = 0x00000008
   RVTEST_TESTDATA_LOAD_INT(x27, x3) # load rs2: x3 = 0x00000021
+  RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rd compare value: x12 = 0x00000008
   LA(x22, scratch) # load base address into rs1
   SREG x29, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b12_equal:
@@ -2032,6 +2183,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b12_equal:
 # Testcase cp_rd (Test destination rd = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load value in memory: x1 = 0x00000020
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rs2: x10 = 0x00000000
+  RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rd compare value: x12 = 0x000000e4
   LA(x28, scratch) # load base address into rs1
   SREG x1, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b12_not_equal:
@@ -2047,6 +2199,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b12_not_equal:
 # Testcase cp_rd (Test destination rd = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x18) # load value in memory: x18 = 0x0000009d
   RVTEST_TESTDATA_LOAD_INT(x27, x2) # load rs2: x2 = 0x00000046
+  RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rd compare value: x13 = 0x0000009d
   LA(x29, scratch) # load base address into rs1
   SREG x18, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b13_equal:
@@ -2060,6 +2213,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b13_equal:
 # Testcase cp_rd (Test destination rd = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x6) # load value in memory: x6 = 0x00000097
   RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rs2: x21 = 0x000000f0
+  RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rd compare value: x13 = 0x000000ad
   LA(x3, scratch) # load base address into rs1
   SREG x6, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b13_not_equal:
@@ -2073,6 +2227,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b13_not_equal:
 # Testcase cp_rd (Test destination rd = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x15) # load value in memory: x15 = 0x00000041
   RVTEST_TESTDATA_LOAD_INT(x27, x23) # load rs2: x23 = 0x00000010
+  RVTEST_TESTDATA_LOAD_INT(x27, x14) # load rd compare value: x14 = 0x00000041
   LA(x29, scratch) # load base address into rs1
   SREG x15, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b14_equal:
@@ -2086,6 +2241,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b14_equal:
 # Testcase cp_rd (Test destination rd = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x11) # load value in memory: x11 = 0x000000ce
   RVTEST_TESTDATA_LOAD_INT(x27, x5) # load rs2: x5 = 0x0000002f
+  RVTEST_TESTDATA_LOAD_INT(x27, x14) # load rd compare value: x14 = 0x00000012
   LA(x15, scratch) # load base address into rs1
   SREG x11, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b14_not_equal:
@@ -2099,6 +2255,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b14_not_equal:
 # Testcase cp_rd (Test destination rd = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load value in memory: x10 = 0x00000099
   RVTEST_TESTDATA_LOAD_INT(x27, x5) # load rs2: x5 = 0x00000018
+  RVTEST_TESTDATA_LOAD_INT(x27, x15) # load rd compare value: x15 = 0x00000099
   LA(x14, scratch) # load base address into rs1
   SREG x10, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b15_equal:
@@ -2112,6 +2269,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b15_equal:
 # Testcase cp_rd (Test destination rd = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x23) # load value in memory: x23 = 0x000000b3
   RVTEST_TESTDATA_LOAD_INT(x27, x22) # load rs2: x22 = 0x00000013
+  RVTEST_TESTDATA_LOAD_INT(x27, x15) # load rd compare value: x15 = 0x00000043
   LA(x30, scratch) # load base address into rs1
   SREG x23, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b15_not_equal:
@@ -2125,6 +2283,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b15_not_equal:
 # Testcase cp_rd (Test destination rd = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x24) # load value in memory: x24 = 0x0000001b
   RVTEST_TESTDATA_LOAD_INT(x27, x11) # load rs2: x11 = 0x000000a5
+  RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rd compare value: x16 = 0x0000001b
   LA(x5, scratch) # load base address into rs1
   SREG x24, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b16_equal:
@@ -2138,6 +2297,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b16_equal:
 # Testcase cp_rd (Test destination rd = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x15) # load value in memory: x15 = 0x00000035
   RVTEST_TESTDATA_LOAD_INT(x27, x4) # load rs2: x4 = 0x00000067
+  RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rd compare value: x16 = 0x00000023
   LA(x23, scratch) # load base address into rs1
   SREG x15, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b16_not_equal:
@@ -2151,6 +2311,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b16_not_equal:
 # Testcase cp_rd (Test destination rd = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load value in memory: x1 = 0x000000fa
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rs2: x16 = 0x000000d5
+  RVTEST_TESTDATA_LOAD_INT(x27, x17) # load rd compare value: x17 = 0x000000fa
   LA(x6, scratch) # load base address into rs1
   SREG x1, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b17_equal:
@@ -2164,6 +2325,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b17_equal:
 # Testcase cp_rd (Test destination rd = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load value in memory: x13 = 0x000000a8
   RVTEST_TESTDATA_LOAD_INT(x27, x5) # load rs2: x5 = 0x000000ad
+  RVTEST_TESTDATA_LOAD_INT(x27, x17) # load rd compare value: x17 = 0x00000068
   LA(x21, scratch) # load base address into rs1
   SREG x13, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b17_not_equal:
@@ -2177,6 +2339,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b17_not_equal:
 # Testcase cp_rd (Test destination rd = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x14) # load value in memory: x14 = 0x000000d5
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rs2: x16 = 0x00000051
+  RVTEST_TESTDATA_LOAD_INT(x27, x18) # load rd compare value: x18 = 0x000000d5
   LA(x13, scratch) # load base address into rs1
   SREG x14, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b18_equal:
@@ -2190,6 +2353,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b18_equal:
 # Testcase cp_rd (Test destination rd = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x5) # load value in memory: x5 = 0x000000b5
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rs2: x16 = 0x000000fe
+  RVTEST_TESTDATA_LOAD_INT(x27, x18) # load rd compare value: x18 = 0x000000bd
   LA(x3, scratch) # load base address into rs1
   SREG x5, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b18_not_equal:
@@ -2203,6 +2367,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b18_not_equal:
 # Testcase cp_rd (Test destination rd = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x14) # load value in memory: x14 = 0x00000000
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rs2: x1 = 0x0000002a
+  RVTEST_TESTDATA_LOAD_INT(x27, x19) # load rd compare value: x19 = 0x00000000
   LA(x12, scratch) # load base address into rs1
   SREG x14, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b19_equal:
@@ -2216,6 +2381,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b19_equal:
 # Testcase cp_rd (Test destination rd = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x4) # load value in memory: x4 = 0x00000000
   RVTEST_TESTDATA_LOAD_INT(x27, x2) # load rs2: x2 = 0x000000ca
+  RVTEST_TESTDATA_LOAD_INT(x27, x19) # load rd compare value: x19 = 0x00000048
   LA(x13, scratch) # load base address into rs1
   SREG x4, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b19_not_equal:
@@ -2229,6 +2395,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b19_not_equal:
 # Testcase cp_rd (Test destination rd = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x28) # load value in memory: x28 = 0x00000000
   RVTEST_TESTDATA_LOAD_INT(x27, x11) # load rs2: x11 = 0x0000005f
+  RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rd compare value: x20 = 0x00000000
   LA(x30, scratch) # load base address into rs1
   SREG x28, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b20_equal:
@@ -2242,6 +2409,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b20_equal:
 # Testcase cp_rd (Test destination rd = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x23) # load value in memory: x23 = 0x0000009f
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rs2: x10 = 0x00000041
+  RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rd compare value: x20 = 0x000000f2
   LA(x9, scratch) # load base address into rs1
   SREG x23, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b20_not_equal:
@@ -2255,6 +2423,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b20_not_equal:
 # Testcase cp_rd (Test destination rd = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x23) # load value in memory: x23 = 0x00000099
   RVTEST_TESTDATA_LOAD_INT(x27, x9) # load rs2: x9 = 0x0000003f
+  RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rd compare value: x21 = 0x00000099
   LA(x13, scratch) # load base address into rs1
   SREG x23, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b21_equal:
@@ -2268,6 +2437,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b21_equal:
 # Testcase cp_rd (Test destination rd = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x20) # load value in memory: x20 = 0x000000f5
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rs2: x13 = 0x00000047
+  RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rd compare value: x21 = 0x00000063
   LA(x11, scratch) # load base address into rs1
   SREG x20, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b21_not_equal:
@@ -2281,6 +2451,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b21_not_equal:
 # Testcase cp_rd (Test destination rd = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x6) # load value in memory: x6 = 0x0000005c
   RVTEST_TESTDATA_LOAD_INT(x27, x15) # load rs2: x15 = 0x00000056
+  RVTEST_TESTDATA_LOAD_INT(x27, x22) # load rd compare value: x22 = 0x0000005c
   LA(x10, scratch) # load base address into rs1
   SREG x6, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b22_equal:
@@ -2294,6 +2465,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b22_equal:
 # Testcase cp_rd (Test destination rd = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x5) # load value in memory: x5 = 0x00000037
   RVTEST_TESTDATA_LOAD_INT(x27, x17) # load rs2: x17 = 0x000000a0
+  RVTEST_TESTDATA_LOAD_INT(x27, x22) # load rd compare value: x22 = 0x0000003e
   LA(x29, scratch) # load base address into rs1
   SREG x5, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b22_not_equal:
@@ -2307,6 +2479,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b22_not_equal:
 # Testcase cp_rd (Test destination rd = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load value in memory: x16 = 0x000000f8
   RVTEST_TESTDATA_LOAD_INT(x27, x25) # load rs2: x25 = 0x00000070
+  RVTEST_TESTDATA_LOAD_INT(x27, x23) # load rd compare value: x23 = 0x000000f8
   LA(x4, scratch) # load base address into rs1
   SREG x16, 0(x4) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b23_equal:
@@ -2320,6 +2493,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b23_equal:
 # Testcase cp_rd (Test destination rd = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load value in memory: x12 = 0x00000004
   RVTEST_TESTDATA_LOAD_INT(x27, x2) # load rs2: x2 = 0x00000059
+  RVTEST_TESTDATA_LOAD_INT(x27, x23) # load rd compare value: x23 = 0x00000083
   LA(x31, scratch) # load base address into rs1
   SREG x12, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b23_not_equal:
@@ -2333,6 +2507,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b23_not_equal:
 # Testcase cp_rd (Test destination rd = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x11) # load value in memory: x11 = 0x000000a6
   RVTEST_TESTDATA_LOAD_INT(x27, x4) # load rs2: x4 = 0x000000dc
+  RVTEST_TESTDATA_LOAD_INT(x27, x24) # load rd compare value: x24 = 0x000000a6
   LA(x6, scratch) # load base address into rs1
   SREG x11, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b24_equal:
@@ -2346,6 +2521,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b24_equal:
 # Testcase cp_rd (Test destination rd = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x30) # load value in memory: x30 = 0x000000b5
   RVTEST_TESTDATA_LOAD_INT(x27, x3) # load rs2: x3 = 0x00000069
+  RVTEST_TESTDATA_LOAD_INT(x27, x24) # load rd compare value: x24 = 0x000000d7
   LA(x14, scratch) # load base address into rs1
   SREG x30, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b24_not_equal:
@@ -2359,6 +2535,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b24_not_equal:
 # Testcase cp_rd (Test destination rd = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load value in memory: x1 = 0x00000059
   RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rs2: x21 = 0x000000d9
+  RVTEST_TESTDATA_LOAD_INT(x27, x25) # load rd compare value: x25 = 0x00000059
   LA(x5, scratch) # load base address into rs1
   SREG x1, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b25_equal:
@@ -2372,6 +2549,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b25_equal:
 # Testcase cp_rd (Test destination rd = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load value in memory: x10 = 0x0000007e
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rs2: x12 = 0x000000f9
+  RVTEST_TESTDATA_LOAD_INT(x27, x25) # load rd compare value: x25 = 0x000000b4
   LA(x9, scratch) # load base address into rs1
   SREG x10, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b25_not_equal:
@@ -2386,6 +2564,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b25_not_equal:
 # Testcase cp_rd (Test destination rd = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load value in memory: x1 = 0x00000001
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rs2: x12 = 0x000000d0
+  RVTEST_TESTDATA_LOAD_INT(x27, x26) # load rd compare value: x26 = 0x00000001
   LA(x19, scratch) # load base address into rs1
   SREG x1, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b26_equal:
@@ -2399,6 +2578,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b26_equal:
 # Testcase cp_rd (Test destination rd = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x14) # load value in memory: x14 = 0x00000027
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rs2: x16 = 0x000000ad
+  RVTEST_TESTDATA_LOAD_INT(x27, x26) # load rd compare value: x26 = 0x00000016
   LA(x25, scratch) # load base address into rs1
   SREG x14, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b26_not_equal:
@@ -2413,6 +2593,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b26_not_equal:
 # Testcase cp_rd (Test destination rd = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x10) # load value in memory: x10 = 0x000000f9
   RVTEST_TESTDATA_LOAD_INT(x26, x9) # load rs2: x9 = 0x0000005c
+  RVTEST_TESTDATA_LOAD_INT(x26, x27) # load rd compare value: x27 = 0x000000f9
   LA(x17, scratch) # load base address into rs1
   SREG x10, 0(x17) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b27_equal:
@@ -2426,6 +2607,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b27_equal:
 # Testcase cp_rd (Test destination rd = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x23) # load value in memory: x23 = 0x00000055
   RVTEST_TESTDATA_LOAD_INT(x26, x14) # load rs2: x14 = 0x000000eb
+  RVTEST_TESTDATA_LOAD_INT(x26, x27) # load rd compare value: x27 = 0x00000092
   LA(x3, scratch) # load base address into rs1
   SREG x23, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b27_not_equal:
@@ -2439,6 +2621,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b27_not_equal:
 # Testcase cp_rd (Test destination rd = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x11) # load value in memory: x11 = 0x000000a9
   RVTEST_TESTDATA_LOAD_INT(x26, x23) # load rs2: x23 = 0x000000ae
+  RVTEST_TESTDATA_LOAD_INT(x26, x28) # load rd compare value: x28 = 0x000000a9
   LA(x5, scratch) # load base address into rs1
   SREG x11, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b28_equal:
@@ -2452,6 +2635,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b28_equal:
 # Testcase cp_rd (Test destination rd = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x21) # load value in memory: x21 = 0x0000007e
   RVTEST_TESTDATA_LOAD_INT(x26, x19) # load rs2: x19 = 0x00000091
+  RVTEST_TESTDATA_LOAD_INT(x26, x28) # load rd compare value: x28 = 0x00000097
   LA(x4, scratch) # load base address into rs1
   SREG x21, 0(x4) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b28_not_equal:
@@ -2465,6 +2649,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b28_not_equal:
 # Testcase cp_rd (Test destination rd = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x5) # load value in memory: x5 = 0x00000024
   RVTEST_TESTDATA_LOAD_INT(x26, x21) # load rs2: x21 = 0x000000cb
+  RVTEST_TESTDATA_LOAD_INT(x26, x29) # load rd compare value: x29 = 0x00000024
   LA(x31, scratch) # load base address into rs1
   SREG x5, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b29_equal:
@@ -2478,6 +2663,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b29_equal:
 # Testcase cp_rd (Test destination rd = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x15) # load value in memory: x15 = 0x00000057
   RVTEST_TESTDATA_LOAD_INT(x26, x27) # load rs2: x27 = 0x000000d7
+  RVTEST_TESTDATA_LOAD_INT(x26, x29) # load rd compare value: x29 = 0x00000021
   LA(x17, scratch) # load base address into rs1
   SREG x15, 0(x17) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b29_not_equal:
@@ -2491,6 +2677,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b29_not_equal:
 # Testcase cp_rd (Test destination rd = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x3) # load value in memory: x3 = 0x000000ee
   RVTEST_TESTDATA_LOAD_INT(x26, x21) # load rs2: x21 = 0x000000b6
+  RVTEST_TESTDATA_LOAD_INT(x26, x30) # load rd compare value: x30 = 0x000000ee
   LA(x12, scratch) # load base address into rs1
   SREG x3, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b30_equal:
@@ -2504,6 +2691,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b30_equal:
 # Testcase cp_rd (Test destination rd = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x14) # load value in memory: x14 = 0x00000065
   RVTEST_TESTDATA_LOAD_INT(x26, x13) # load rs2: x13 = 0x000000b6
+  RVTEST_TESTDATA_LOAD_INT(x26, x30) # load rd compare value: x30 = 0x000000ab
   LA(x5, scratch) # load base address into rs1
   SREG x14, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b30_not_equal:
@@ -2517,6 +2705,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b30_not_equal:
 # Testcase cp_rd (Test destination rd = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x27) # load value in memory: x27 = 0x000000ca
   RVTEST_TESTDATA_LOAD_INT(x26, x28) # load rs2: x28 = 0x00000047
+  RVTEST_TESTDATA_LOAD_INT(x26, x31) # load rd compare value: x31 = 0x000000ca
   LA(x21, scratch) # load base address into rs1
   SREG x27, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b31_equal:
@@ -2530,6 +2719,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b31_equal:
 # Testcase cp_rd (Test destination rd = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x15) # load value in memory: x15 = 0x0000001e
   RVTEST_TESTDATA_LOAD_INT(x26, x30) # load rs2: x30 = 0x000000c9
+  RVTEST_TESTDATA_LOAD_INT(x26, x31) # load rd compare value: x31 = 0x000000d2
   LA(x6, scratch) # load base address into rs1
   SREG x15, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b31_not_equal:
@@ -4561,384 +4751,574 @@ RVTEST_DATA_BEGIN
 // Test data
 .word 0x000000cd
 .word 0x00000098
+.word 0x000000cd
 .word 0x0000002d
 .word 0x000000dd
+.word 0x0000009c
 .word 0x00000002
 .word 0x00000061
+.word 0x00000002
 .word 0x0000009b
 .word 0x000000c9
+.word 0x00000016
 .word 0x00000043
 .word 0x00000078
+.word 0x00000043
 .word 0x00000093
 .word 0x0000008c
+.word 0x000000fe
 .word 0x000000f7
 .word 0x000000d3
+.word 0x000000f7
 .word 0x000000c3
 .word 0x000000c3
+.word 0x000000dc
 .word 0x00000047
 .word 0x00000069
+.word 0x00000047
 .word 0x000000df
 .word 0x0000008e
+.word 0x00000070
 .word 0x00000027
 .word 0x000000a0
+.word 0x00000027
 .word 0x000000bc
 .word 0x000000f8
+.word 0x00000065
 .word 0x000000bc
 .word 0x00000052
+.word 0x000000bc
 .word 0x000000f0
 .word 0x00000054
+.word 0x00000003
 .word 0x000000c5
 .word 0x00000097
+.word 0x000000c5
 .word 0x0000007c
 .word 0x000000c4
+.word 0x00000037
 .word 0x0000000a
 .word 0x000000d2
+.word 0x0000000a
 .word 0x000000e7
 .word 0x00000059
+.word 0x000000a5
 .word 0x000000c4
 .word 0x000000eb
+.word 0x000000c4
 .word 0x00000064
 .word 0x0000007e
+.word 0x00000045
 .word 0x0000005f
 .word 0x0000007b
+.word 0x0000005f
 .word 0x00000089
 .word 0x0000008d
+.word 0x000000b6
 .word 0x00000051
 .word 0x0000004d
+.word 0x00000051
 .word 0x000000b7
 .word 0x000000a6
+.word 0x0000009e
 .word 0x000000ae
 .word 0x000000e7
+.word 0x000000ae
 .word 0x0000004a
 .word 0x0000004e
+.word 0x000000b8
 .word 0x00000070
 .word 0x000000f2
+.word 0x00000070
 .word 0x000000dd
 .word 0x000000e7
+.word 0x000000c9
 .word 0x00000095
 .word 0x0000009b
+.word 0x00000095
 .word 0x00000064
 .word 0x000000da
+.word 0x00000086
 .word 0x0000007d
 .word 0x00000056
+.word 0x0000007d
 .word 0x000000ab
 .word 0x000000dc
+.word 0x00000056
 .word 0x0000005f
 .word 0x0000009d
+.word 0x0000005f
 .word 0x00000074
 .word 0x00000000
+.word 0x00000041
 .word 0x00000031
 .word 0x00000065
+.word 0x00000031
 .word 0x0000005f
 .word 0x00000037
+.word 0x00000079
 .word 0x0000007a
 .word 0x00000003
+.word 0x0000007a
 .word 0x0000002c
 .word 0x000000bf
+.word 0x000000e5
 .word 0x0000005b
 .word 0x000000ec
+.word 0x0000005b
 .word 0x000000eb
 .word 0x000000c2
+.word 0x00000038
 .word 0x0000001e
 .word 0x0000006a
+.word 0x0000001e
 .word 0x0000007d
 .word 0x0000004d
+.word 0x00000034
 .word 0x00000052
 .word 0x00000058
+.word 0x00000052
 .word 0x00000061
 .word 0x000000a4
+.word 0x000000c8
 .word 0x0000000b
 .word 0x0000007e
+.word 0x0000000b
 .word 0x00000077
 .word 0x000000be
+.word 0x0000008f
 .word 0x00000032
 .word 0x0000008d
+.word 0x00000032
 .word 0x0000008e
 .word 0x0000006a
+.word 0x000000c3
 .word 0x00000073
 .word 0x000000c3
+.word 0x00000073
 .word 0x000000fc
 .word 0x00000093
+.word 0x00000008
 .word 0x00000064
 .word 0x000000d6
+.word 0x00000064
 .word 0x0000002d
 .word 0x000000ee
+.word 0x000000ac
 .word 0x0000003b
 .word 0x000000d4
+.word 0x0000003b
 .word 0x000000fb
 .word 0x0000003e
+.word 0x0000006e
 .word 0x00000032
 .word 0x000000c0
+.word 0x00000032
 .word 0x0000006c
 .word 0x00000053
+.word 0x00000081
 .word 0x0000008b
 .word 0x00000080
+.word 0x0000008b
 .word 0x000000ec
 .word 0x00000047
+.word 0x00000031
 .word 0x00000078
 .word 0x000000e3
+.word 0x00000078
 .word 0x0000005c
 .word 0x00000090
+.word 0x000000a5
 .word 0x000000df
 .word 0x00000039
+.word 0x000000df
 .word 0x00000089
 .word 0x000000d0
+.word 0x0000009f
 .word 0x000000b3
 .word 0x000000a4
+.word 0x000000b3
 .word 0x00000005
 .word 0x000000f6
+.word 0x000000c5
 .word 0x00000015
 .word 0x00000033
+.word 0x00000015
 .word 0x00000023
 .word 0x0000002f
+.word 0x0000003a
 .word 0x00000030
 .word 0x0000009d
+.word 0x00000030
 .word 0x00000097
 .word 0x00000072
+.word 0x0000002c
 .word 0x00000052
 .word 0x00000060
+.word 0x00000052
 .word 0x00000067
 .word 0x00000077
+.word 0x00000089
 .word 0x000000cf
 .word 0x00000003
+.word 0x000000cf
 .word 0x00000031
 .word 0x00000065
+.word 0x000000f9
 .word 0x000000c8
 .word 0x00000098
+.word 0x000000c8
 .word 0x000000fc
 .word 0x00000075
+.word 0x00000027
 .word 0x00000040
 .word 0x00000089
+.word 0x00000040
 .word 0x00000090
 .word 0x000000ea
+.word 0x0000002f
 .word 0x000000f8
 .word 0x000000fe
+.word 0x000000f8
 .word 0x00000009
 .word 0x000000ec
+.word 0x00000075
 .word 0x000000dd
 .word 0x0000003e
+.word 0x000000dd
 .word 0x00000039
 .word 0x00000073
+.word 0x000000f0
 .word 0x000000e5
 .word 0x00000054
+.word 0x000000e5
 .word 0x00000070
 .word 0x0000003d
+.word 0x000000d4
 .word 0x00000052
 .word 0x00000035
+.word 0x00000052
 .word 0x000000fb
 .word 0x000000fc
+.word 0x0000006b
 .word 0x000000d9
 .word 0x000000eb
+.word 0x000000d9
 .word 0x000000b3
 .word 0x000000e5
+.word 0x000000fd
 .word 0x00000068
 .word 0x000000c6
+.word 0x00000068
 .word 0x0000004f
 .word 0x00000065
+.word 0x00000023
 .word 0x000000b2
 .word 0x000000f8
+.word 0x000000b2
 .word 0x00000003
 .word 0x000000f4
+.word 0x000000b7
 .word 0x00000040
 .word 0x00000052
+.word 0x00000040
 .word 0x000000b9
 .word 0x00000074
+.word 0x00000035
 .word 0x00000067
 .word 0x000000bd
+.word 0x00000067
 .word 0x0000009c
 .word 0x000000b4
+.word 0x00000058
 .word 0x00000049
 .word 0x00000050
+.word 0x00000049
 .word 0x0000009a
 .word 0x00000025
+.word 0x0000005a
 .word 0x000000a2
 .word 0x000000c3
+.word 0x000000a2
 .word 0x000000d1
 .word 0x0000004c
+.word 0x000000af
 .word 0x0000003d
 .word 0x00000063
+.word 0x0000003d
 .word 0x0000009c
 .word 0x00000090
+.word 0x0000002b
 .word 0x00000002
 .word 0x000000c3
+.word 0x00000002
 .word 0x000000ee
 .word 0x000000f6
+.word 0x000000fb
 .word 0x00000083
 .word 0x00000065
+.word 0x00000083
 .word 0x00000093
 .word 0x000000c7
+.word 0x0000001c
 .word 0x00000075
 .word 0x0000001c
+.word 0x00000075
 .word 0x00000013
 .word 0x000000e5
+.word 0x00000027
 .word 0x0000002f
 .word 0x00000059
+.word 0x0000002f
 .word 0x0000004b
 .word 0x0000003a
+.word 0x0000006f
 .word 0x000000f8
 .word 0x00000061
+.word 0x000000f8
 .word 0x000000d9
 .word 0x0000004a
+.word 0x0000000e
 .word 0x000000b9
 .word 0x00000085
+.word 0x000000b9
 .word 0x000000c5
 .word 0x00000011
+.word 0x00000029
 .word 0x00000086
 .word 0x0000006e
+.word 0x00000086
 .word 0x000000ce
 .word 0x00000005
+.word 0x00000041
 .word 0x000000bd
 .word 0x0000000a
+.word 0x000000bd
 .word 0x00000049
 .word 0x000000be
+.word 0x00000067
 .word 0x0000009b
 .word 0x0000009e
+.word 0x0000009b
 .word 0x00000044
 .word 0x000000e3
+.word 0x00000018
 .word 0x00000061
 .word 0x000000af
+.word 0x00000061
 .word 0x00000092
 .word 0x000000ae
+.word 0x000000b7
 .word 0x000000f1
 .word 0x000000d0
+.word 0x000000f1
 .word 0x000000a5
 .word 0x00000021
+.word 0x00000087
 .word 0x00000018
 .word 0x000000e1
+.word 0x00000018
 .word 0x000000a8
 .word 0x00000023
+.word 0x000000d4
 .word 0x000000b9
 .word 0x000000fa
+.word 0x000000b9
 .word 0x00000020
 .word 0x000000a5
+.word 0x000000b2
 .word 0x00000001
 .word 0x000000a3
+.word 0x00000001
 .word 0x0000005c
 .word 0x000000cb
+.word 0x00000044
 .word 0x00000021
 .word 0x000000c5
+.word 0x00000021
 .word 0x0000004a
 .word 0x00000013
+.word 0x0000007f
 .word 0x00000065
 .word 0x000000ee
+.word 0x00000065
 .word 0x000000e8
 .word 0x00000095
+.word 0x00000058
 .word 0x000000b1
 .word 0x000000ee
+.word 0x000000b1
 .word 0x000000e0
 .word 0x00000053
+.word 0x00000080
 .word 0x0000000b
 .word 0x00000089
+.word 0x0000000b
 .word 0x000000d0
 .word 0x00000056
+.word 0x000000ae
 .word 0x00000030
 .word 0x000000d8
+.word 0x00000030
 .word 0x0000004b
 .word 0x00000035
+.word 0x00000015
 .word 0x0000005f
 .word 0x0000006e
+.word 0x0000005f
 .word 0x00000056
 .word 0x00000050
+.word 0x000000ab
 .word 0x000000cf
 .word 0x0000006a
+.word 0x000000cf
 .word 0x0000006f
 .word 0x0000004a
+.word 0x0000006c
 .word 0x000000bc
 .word 0x00000008
+.word 0x000000bc
 .word 0x000000b7
 .word 0x00000078
+.word 0x00000058
 .word 0x00000031
 .word 0x00000055
+.word 0x00000031
 .word 0x00000035
 .word 0x00000012
+.word 0x000000a7
 .word 0x00000048
 .word 0x000000ce
+.word 0x00000048
 .word 0x000000c2
 .word 0x000000a4
+.word 0x000000c4
 .word 0x00000062
 .word 0x0000000e
+.word 0x00000062
 .word 0x00000020
 .word 0x0000009f
+.word 0x000000f4
 .word 0x00000008
 .word 0x00000021
+.word 0x00000008
 .word 0x00000020
 .word 0x00000000
+.word 0x000000e4
 .word 0x0000009d
 .word 0x00000046
+.word 0x0000009d
 .word 0x00000097
 .word 0x000000f0
+.word 0x000000ad
 .word 0x00000041
 .word 0x00000010
+.word 0x00000041
 .word 0x000000ce
 .word 0x0000002f
+.word 0x00000012
 .word 0x00000099
 .word 0x00000018
+.word 0x00000099
 .word 0x000000b3
 .word 0x00000013
+.word 0x00000043
 .word 0x0000001b
 .word 0x000000a5
+.word 0x0000001b
 .word 0x00000035
 .word 0x00000067
+.word 0x00000023
 .word 0x000000fa
 .word 0x000000d5
+.word 0x000000fa
 .word 0x000000a8
 .word 0x000000ad
+.word 0x00000068
 .word 0x000000d5
 .word 0x00000051
+.word 0x000000d5
 .word 0x000000b5
 .word 0x000000fe
+.word 0x000000bd
 .word 0x00000000
 .word 0x0000002a
 .word 0x00000000
+.word 0x00000000
 .word 0x000000ca
+.word 0x00000048
 .word 0x00000000
 .word 0x0000005f
+.word 0x00000000
 .word 0x0000009f
 .word 0x00000041
+.word 0x000000f2
 .word 0x00000099
 .word 0x0000003f
+.word 0x00000099
 .word 0x000000f5
 .word 0x00000047
+.word 0x00000063
 .word 0x0000005c
 .word 0x00000056
+.word 0x0000005c
 .word 0x00000037
 .word 0x000000a0
+.word 0x0000003e
 .word 0x000000f8
 .word 0x00000070
+.word 0x000000f8
 .word 0x00000004
 .word 0x00000059
+.word 0x00000083
 .word 0x000000a6
 .word 0x000000dc
+.word 0x000000a6
 .word 0x000000b5
 .word 0x00000069
+.word 0x000000d7
 .word 0x00000059
 .word 0x000000d9
+.word 0x00000059
 .word 0x0000007e
 .word 0x000000f9
+.word 0x000000b4
 .word 0x00000001
 .word 0x000000d0
+.word 0x00000001
 .word 0x00000027
 .word 0x000000ad
+.word 0x00000016
 .word 0x000000f9
 .word 0x0000005c
+.word 0x000000f9
 .word 0x00000055
 .word 0x000000eb
+.word 0x00000092
 .word 0x000000a9
 .word 0x000000ae
+.word 0x000000a9
 .word 0x0000007e
 .word 0x00000091
+.word 0x00000097
 .word 0x00000024
 .word 0x000000cb
+.word 0x00000024
 .word 0x00000057
 .word 0x000000d7
+.word 0x00000021
 .word 0x000000ee
 .word 0x000000b6
+.word 0x000000ee
 .word 0x00000065
 .word 0x000000b6
+.word 0x000000ab
 .word 0x000000ca
 .word 0x00000047
+.word 0x000000ca
 .word 0x0000001e
 .word 0x000000c9
+.word 0x000000d2
 .word 0x35906de1
 .word 0x00000000
 .word 0x94301716

--- a/tests/rv32i/ZacasZabha/ZacasZabha-amocas.h-00.S
+++ b/tests/rv32i/ZacasZabha/ZacasZabha-amocas.h-00.S
@@ -36,6 +36,7 @@ RVTEST_BEGIN
 # Testcase cp_rs1_nx0 (Test source rs1 = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x27) # load value in memory: x27 = 0x00009f45
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x0000c666
+  RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rd compare value: x8 = 0x00009f45
   LA(x1, scratch) # load base address into rs1
   SREG x27, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b1_equal:
@@ -49,6 +50,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b1_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load value in memory: x14 = 0x00005688
   RVTEST_TESTDATA_LOAD_INT(x3, x25) # load rs2: x25 = 0x0000beef
+  RVTEST_TESTDATA_LOAD_INT(x3, x29) # load rd compare value: x29 = 0x000044ef
   LA(x1, scratch) # load base address into rs1
   SREG x14, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b1_not_equal:
@@ -63,6 +65,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b1_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x18) # load value in memory: x18 = 0x0000e10d
   RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0x00003d42
+  RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rd compare value: x8 = 0x0000e10d
   LA(x2, scratch) # load base address into rs1
   SREG x18, 0(x2) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b2_equal:
@@ -76,6 +79,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b2_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load value in memory: x10 = 0x0000f38e
   RVTEST_TESTDATA_LOAD_INT(x3, x16) # load rs2: x16 = 0x0000bd95
+  RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rd compare value: x0 = 0x00003481
   LA(x2, scratch) # load base address into rs1
   SREG x10, 0(x2) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b2_not_equal:
@@ -90,6 +94,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b2_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x31) # load value in memory: x31 = 0x0000b5d1
   RVTEST_TESTDATA_LOAD_INT(x20, x16) # load rs2: x16 = 0x0000911a
+  RVTEST_TESTDATA_LOAD_INT(x20, x12) # load rd compare value: x12 = 0x0000b5d1
   LA(x3, scratch) # load base address into rs1
   SREG x31, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b3_equal:
@@ -103,6 +108,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b3_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x7) # load value in memory: x7 = 0x000050e0
   RVTEST_TESTDATA_LOAD_INT(x20, x24) # load rs2: x24 = 0x000067ec
+  RVTEST_TESTDATA_LOAD_INT(x20, x29) # load rd compare value: x29 = 0x00006335
   LA(x3, scratch) # load base address into rs1
   SREG x7, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b3_not_equal:
@@ -118,6 +124,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b3_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x17) # load value in memory: x17 = 0x00003b4a
   RVTEST_TESTDATA_LOAD_INT(x20, x18) # load rs2: x18 = 0x00004f41
+  RVTEST_TESTDATA_LOAD_INT(x20, x31) # load rd compare value: x31 = 0x00003b4a
   LA(x4, scratch) # load base address into rs1
   SREG x17, 0(x4) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b4_equal:
@@ -131,6 +138,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b4_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x24) # load value in memory: x24 = 0x0000e32d
   RVTEST_TESTDATA_LOAD_INT(x20, x9) # load rs2: x9 = 0x0000c7d8
+  RVTEST_TESTDATA_LOAD_INT(x20, x16) # load rd compare value: x16 = 0x0000ff81
   LA(x4, scratch) # load base address into rs1
   SREG x24, 0(x4) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b4_not_equal:
@@ -144,6 +152,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b4_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x6) # load value in memory: x6 = 0x00000c17
   RVTEST_TESTDATA_LOAD_INT(x20, x28) # load rs2: x28 = 0x000064b7
+  RVTEST_TESTDATA_LOAD_INT(x20, x4) # load rd compare value: x4 = 0x00000c17
   LA(x5, scratch) # load base address into rs1
   SREG x6, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b5_equal:
@@ -157,6 +166,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b5_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x17) # load value in memory: x17 = 0x0000c2a8
   RVTEST_TESTDATA_LOAD_INT(x20, x16) # load rs2: x16 = 0x0000fbd6
+  RVTEST_TESTDATA_LOAD_INT(x20, x0) # load rd compare value: x0 = 0x00000101
   LA(x5, scratch) # load base address into rs1
   SREG x17, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b5_not_equal:
@@ -170,6 +180,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b5_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x17) # load value in memory: x17 = 0x00006d40
   RVTEST_TESTDATA_LOAD_INT(x20, x24) # load rs2: x24 = 0x0000def9
+  RVTEST_TESTDATA_LOAD_INT(x20, x21) # load rd compare value: x21 = 0x00006d40
   LA(x6, scratch) # load base address into rs1
   SREG x17, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b6_equal:
@@ -183,6 +194,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b6_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x24) # load value in memory: x24 = 0x000055c9
   RVTEST_TESTDATA_LOAD_INT(x20, x2) # load rs2: x2 = 0x00003a0e
+  RVTEST_TESTDATA_LOAD_INT(x20, x16) # load rd compare value: x16 = 0x0000eca3
   LA(x6, scratch) # load base address into rs1
   SREG x24, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b6_not_equal:
@@ -196,6 +208,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b6_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x1) # load value in memory: x1 = 0x00005adf
   RVTEST_TESTDATA_LOAD_INT(x20, x29) # load rs2: x29 = 0x0000b308
+  RVTEST_TESTDATA_LOAD_INT(x20, x23) # load rd compare value: x23 = 0x00005adf
   LA(x7, scratch) # load base address into rs1
   SREG x1, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b7_equal:
@@ -209,6 +222,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b7_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x28) # load value in memory: x28 = 0x0000d892
   RVTEST_TESTDATA_LOAD_INT(x20, x10) # load rs2: x10 = 0x0000adb5
+  RVTEST_TESTDATA_LOAD_INT(x20, x21) # load rd compare value: x21 = 0x0000c917
   LA(x7, scratch) # load base address into rs1
   SREG x28, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b7_not_equal:
@@ -222,6 +236,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b7_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x4) # load value in memory: x4 = 0x0000d44f
   RVTEST_TESTDATA_LOAD_INT(x20, x23) # load rs2: x23 = 0x0000726b
+  RVTEST_TESTDATA_LOAD_INT(x20, x6) # load rd compare value: x6 = 0x0000d44f
   LA(x8, scratch) # load base address into rs1
   SREG x4, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b8_equal:
@@ -235,6 +250,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b8_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x15) # load value in memory: x15 = 0x00006ce6
   RVTEST_TESTDATA_LOAD_INT(x20, x31) # load rs2: x31 = 0x0000e828
+  RVTEST_TESTDATA_LOAD_INT(x20, x11) # load rd compare value: x11 = 0x00002d67
   LA(x8, scratch) # load base address into rs1
   SREG x15, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b8_not_equal:
@@ -248,6 +264,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b8_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x22) # load value in memory: x22 = 0x00002eaf
   RVTEST_TESTDATA_LOAD_INT(x20, x16) # load rs2: x16 = 0x0000de7d
+  RVTEST_TESTDATA_LOAD_INT(x20, x4) # load rd compare value: x4 = 0x00002eaf
   LA(x9, scratch) # load base address into rs1
   SREG x22, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b9_equal:
@@ -261,6 +278,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b9_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x24) # load value in memory: x24 = 0x000024f9
   RVTEST_TESTDATA_LOAD_INT(x20, x28) # load rs2: x28 = 0x00004a25
+  RVTEST_TESTDATA_LOAD_INT(x20, x3) # load rd compare value: x3 = 0x00004052
   LA(x9, scratch) # load base address into rs1
   SREG x24, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b9_not_equal:
@@ -274,6 +292,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b9_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x1) # load value in memory: x1 = 0x00002cbe
   RVTEST_TESTDATA_LOAD_INT(x20, x22) # load rs2: x22 = 0x0000eca6
+  RVTEST_TESTDATA_LOAD_INT(x20, x12) # load rd compare value: x12 = 0x00002cbe
   LA(x10, scratch) # load base address into rs1
   SREG x1, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b10_equal:
@@ -287,6 +306,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b10_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x6) # load value in memory: x6 = 0x00007c98
   RVTEST_TESTDATA_LOAD_INT(x20, x8) # load rs2: x8 = 0x0000da89
+  RVTEST_TESTDATA_LOAD_INT(x20, x27) # load rd compare value: x27 = 0x0000e9a5
   LA(x10, scratch) # load base address into rs1
   SREG x6, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b10_not_equal:
@@ -300,6 +320,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b10_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x23) # load value in memory: x23 = 0x00007451
   RVTEST_TESTDATA_LOAD_INT(x20, x3) # load rs2: x3 = 0x0000cbaf
+  RVTEST_TESTDATA_LOAD_INT(x20, x9) # load rd compare value: x9 = 0x00007451
   LA(x11, scratch) # load base address into rs1
   SREG x23, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b11_equal:
@@ -313,6 +334,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b11_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x25) # load value in memory: x25 = 0x0000d729
   RVTEST_TESTDATA_LOAD_INT(x20, x0) # load rs2: x0 = 0x00009925
+  RVTEST_TESTDATA_LOAD_INT(x20, x17) # load rd compare value: x17 = 0x000076b8
   LA(x11, scratch) # load base address into rs1
   SREG x25, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b11_not_equal:
@@ -326,6 +348,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b11_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x23) # load value in memory: x23 = 0x0000e5dd
   RVTEST_TESTDATA_LOAD_INT(x20, x31) # load rs2: x31 = 0x0000c36f
+  RVTEST_TESTDATA_LOAD_INT(x20, x18) # load rd compare value: x18 = 0x0000e5dd
   LA(x12, scratch) # load base address into rs1
   SREG x23, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b12_equal:
@@ -339,6 +362,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b12_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x7) # load value in memory: x7 = 0x00008902
   RVTEST_TESTDATA_LOAD_INT(x20, x30) # load rs2: x30 = 0x0000d550
+  RVTEST_TESTDATA_LOAD_INT(x20, x1) # load rd compare value: x1 = 0x0000513d
   LA(x12, scratch) # load base address into rs1
   SREG x7, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b12_not_equal:
@@ -354,6 +378,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b12_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x4) # load value in memory: x4 = 0x0000dcf8
   RVTEST_TESTDATA_LOAD_INT(x20, x18) # load rs2: x18 = 0x0000244e
+  RVTEST_TESTDATA_LOAD_INT(x20, x16) # load rd compare value: x16 = 0x0000dcf8
   LA(x13, scratch) # load base address into rs1
   SREG x4, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b13_equal:
@@ -367,6 +392,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b13_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x21) # load value in memory: x21 = 0x00006319
   RVTEST_TESTDATA_LOAD_INT(x20, x18) # load rs2: x18 = 0x00002c06
+  RVTEST_TESTDATA_LOAD_INT(x20, x27) # load rd compare value: x27 = 0x00002a74
   LA(x13, scratch) # load base address into rs1
   SREG x21, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b13_not_equal:
@@ -380,6 +406,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b13_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x28) # load value in memory: x28 = 0x0000476b
   RVTEST_TESTDATA_LOAD_INT(x20, x22) # load rs2: x22 = 0x00009e6c
+  RVTEST_TESTDATA_LOAD_INT(x20, x9) # load rd compare value: x9 = 0x0000476b
   LA(x14, scratch) # load base address into rs1
   SREG x28, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b14_equal:
@@ -393,6 +420,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b14_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x26) # load value in memory: x26 = 0x00007c51
   RVTEST_TESTDATA_LOAD_INT(x20, x2) # load rs2: x2 = 0x0000db71
+  RVTEST_TESTDATA_LOAD_INT(x20, x5) # load rd compare value: x5 = 0x0000cf3c
   LA(x14, scratch) # load base address into rs1
   SREG x26, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b14_not_equal:
@@ -406,6 +434,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b14_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x23) # load value in memory: x23 = 0x0000bcfd
   RVTEST_TESTDATA_LOAD_INT(x20, x1) # load rs2: x1 = 0x0000d2e2
+  RVTEST_TESTDATA_LOAD_INT(x20, x10) # load rd compare value: x10 = 0x0000bcfd
   LA(x15, scratch) # load base address into rs1
   SREG x23, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b15_equal:
@@ -419,6 +448,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b15_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x30) # load value in memory: x30 = 0x0000e307
   RVTEST_TESTDATA_LOAD_INT(x20, x17) # load rs2: x17 = 0x00001486
+  RVTEST_TESTDATA_LOAD_INT(x20, x14) # load rd compare value: x14 = 0x00000944
   LA(x15, scratch) # load base address into rs1
   SREG x30, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b15_not_equal:
@@ -432,6 +462,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b15_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x28) # load value in memory: x28 = 0x0000014d
   RVTEST_TESTDATA_LOAD_INT(x20, x29) # load rs2: x29 = 0x00001afa
+  RVTEST_TESTDATA_LOAD_INT(x20, x27) # load rd compare value: x27 = 0x0000014d
   LA(x16, scratch) # load base address into rs1
   SREG x28, 0(x16) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b16_equal:
@@ -445,6 +476,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b16_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x17) # load value in memory: x17 = 0x0000bc2d
   RVTEST_TESTDATA_LOAD_INT(x20, x22) # load rs2: x22 = 0x0000c50b
+  RVTEST_TESTDATA_LOAD_INT(x20, x25) # load rd compare value: x25 = 0x0000c36d
   LA(x16, scratch) # load base address into rs1
   SREG x17, 0(x16) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b16_not_equal:
@@ -458,6 +490,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b16_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x16) # load value in memory: x16 = 0x0000c04e
   RVTEST_TESTDATA_LOAD_INT(x20, x25) # load rs2: x25 = 0x00000f2a
+  RVTEST_TESTDATA_LOAD_INT(x20, x13) # load rd compare value: x13 = 0x0000c04e
   LA(x17, scratch) # load base address into rs1
   SREG x16, 0(x17) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b17_equal:
@@ -471,6 +504,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b17_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x13) # load value in memory: x13 = 0x000077de
   RVTEST_TESTDATA_LOAD_INT(x20, x5) # load rs2: x5 = 0x000090db
+  RVTEST_TESTDATA_LOAD_INT(x20, x4) # load rd compare value: x4 = 0x00005015
   LA(x17, scratch) # load base address into rs1
   SREG x13, 0(x17) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b17_not_equal:
@@ -484,6 +518,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b17_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x28) # load value in memory: x28 = 0x00001a88
   RVTEST_TESTDATA_LOAD_INT(x20, x6) # load rs2: x6 = 0x00009206
+  RVTEST_TESTDATA_LOAD_INT(x20, x26) # load rd compare value: x26 = 0x00001a88
   LA(x18, scratch) # load base address into rs1
   SREG x28, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b18_equal:
@@ -497,6 +532,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b18_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x23) # load value in memory: x23 = 0x0000e698
   RVTEST_TESTDATA_LOAD_INT(x20, x29) # load rs2: x29 = 0x000042cb
+  RVTEST_TESTDATA_LOAD_INT(x20, x6) # load rd compare value: x6 = 0x000044b1
   LA(x18, scratch) # load base address into rs1
   SREG x23, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b18_not_equal:
@@ -511,6 +547,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b18_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x24) # load value in memory: x24 = 0x0000eb6f
   RVTEST_TESTDATA_LOAD_INT(x20, x28) # load rs2: x28 = 0x000072e3
+  RVTEST_TESTDATA_LOAD_INT(x20, x21) # load rd compare value: x21 = 0x0000eb6f
   LA(x19, scratch) # load base address into rs1
   SREG x24, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b19_equal:
@@ -524,6 +561,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b19_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x5) # load value in memory: x5 = 0x00000d30
   RVTEST_TESTDATA_LOAD_INT(x20, x27) # load rs2: x27 = 0x00005c8d
+  RVTEST_TESTDATA_LOAD_INT(x20, x4) # load rd compare value: x4 = 0x0000a478
   LA(x19, scratch) # load base address into rs1
   SREG x5, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b19_not_equal:
@@ -538,6 +576,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b19_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x24) # load value in memory: x24 = 0x00008d9b
   RVTEST_TESTDATA_LOAD_INT(x25, x15) # load rs2: x15 = 0x0000cfb2
+  RVTEST_TESTDATA_LOAD_INT(x25, x2) # load rd compare value: x2 = 0x00008d9b
   LA(x20, scratch) # load base address into rs1
   SREG x24, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b20_equal:
@@ -551,6 +590,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b20_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x12) # load value in memory: x12 = 0x0000baed
   RVTEST_TESTDATA_LOAD_INT(x25, x15) # load rs2: x15 = 0x00001afb
+  RVTEST_TESTDATA_LOAD_INT(x25, x17) # load rd compare value: x17 = 0x0000ccd8
   LA(x20, scratch) # load base address into rs1
   SREG x12, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b20_not_equal:
@@ -564,6 +604,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b20_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x10) # load value in memory: x10 = 0x0000cf5c
   RVTEST_TESTDATA_LOAD_INT(x25, x3) # load rs2: x3 = 0x00005bad
+  RVTEST_TESTDATA_LOAD_INT(x25, x14) # load rd compare value: x14 = 0x0000cf5c
   LA(x21, scratch) # load base address into rs1
   SREG x10, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b21_equal:
@@ -577,6 +618,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b21_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x9) # load value in memory: x9 = 0x000017e9
   RVTEST_TESTDATA_LOAD_INT(x25, x15) # load rs2: x15 = 0x000049d4
+  RVTEST_TESTDATA_LOAD_INT(x25, x0) # load rd compare value: x0 = 0x0000092c
   LA(x21, scratch) # load base address into rs1
   SREG x9, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b21_not_equal:
@@ -590,6 +632,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b21_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x11) # load value in memory: x11 = 0x0000bee0
   RVTEST_TESTDATA_LOAD_INT(x25, x28) # load rs2: x28 = 0x00005090
+  RVTEST_TESTDATA_LOAD_INT(x25, x12) # load rd compare value: x12 = 0x0000bee0
   LA(x22, scratch) # load base address into rs1
   SREG x11, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b22_equal:
@@ -603,6 +646,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b22_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x16) # load value in memory: x16 = 0x00009ac1
   RVTEST_TESTDATA_LOAD_INT(x25, x27) # load rs2: x27 = 0x000084e2
+  RVTEST_TESTDATA_LOAD_INT(x25, x5) # load rd compare value: x5 = 0x000028e8
   LA(x22, scratch) # load base address into rs1
   SREG x16, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b22_not_equal:
@@ -616,6 +660,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b22_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x19) # load value in memory: x19 = 0x0000d3f7
   RVTEST_TESTDATA_LOAD_INT(x25, x4) # load rs2: x4 = 0x00005b62
+  RVTEST_TESTDATA_LOAD_INT(x25, x20) # load rd compare value: x20 = 0x0000d3f7
   LA(x23, scratch) # load base address into rs1
   SREG x19, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b23_equal:
@@ -629,6 +674,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b23_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x20) # load value in memory: x20 = 0x00005a5b
   RVTEST_TESTDATA_LOAD_INT(x25, x4) # load rs2: x4 = 0x0000bbdb
+  RVTEST_TESTDATA_LOAD_INT(x25, x17) # load rd compare value: x17 = 0x0000a0f3
   LA(x23, scratch) # load base address into rs1
   SREG x20, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b23_not_equal:
@@ -642,6 +688,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b23_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x11) # load value in memory: x11 = 0x00000c05
   RVTEST_TESTDATA_LOAD_INT(x25, x14) # load rs2: x14 = 0x00005c4c
+  RVTEST_TESTDATA_LOAD_INT(x25, x18) # load rd compare value: x18 = 0x00000c05
   LA(x24, scratch) # load base address into rs1
   SREG x11, 0(x24) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b24_equal:
@@ -655,6 +702,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b24_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x17) # load value in memory: x17 = 0x00006309
   RVTEST_TESTDATA_LOAD_INT(x25, x27) # load rs2: x27 = 0x00009ab3
+  RVTEST_TESTDATA_LOAD_INT(x25, x14) # load rd compare value: x14 = 0x00000f9a
   LA(x24, scratch) # load base address into rs1
   SREG x17, 0(x24) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b24_not_equal:
@@ -669,6 +717,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b24_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x11) # load value in memory: x11 = 0x00005035
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load rs2: x3 = 0x00003563
+  RVTEST_TESTDATA_LOAD_INT(x24, x27) # load rd compare value: x27 = 0x00005035
   LA(x25, scratch) # load base address into rs1
   SREG x11, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b25_equal:
@@ -682,6 +731,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b25_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x27) # load value in memory: x27 = 0x00000e64
   RVTEST_TESTDATA_LOAD_INT(x24, x31) # load rs2: x31 = 0x0000fe78
+  RVTEST_TESTDATA_LOAD_INT(x24, x3) # load rd compare value: x3 = 0x0000175e
   LA(x25, scratch) # load base address into rs1
   SREG x27, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b25_not_equal:
@@ -695,6 +745,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b25_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load value in memory: x1 = 0x00006d3a
   RVTEST_TESTDATA_LOAD_INT(x24, x25) # load rs2: x25 = 0x000086a9
+  RVTEST_TESTDATA_LOAD_INT(x24, x10) # load rd compare value: x10 = 0x00006d3a
   LA(x26, scratch) # load base address into rs1
   SREG x1, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b26_equal:
@@ -708,6 +759,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b26_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x31) # load value in memory: x31 = 0x000093e6
   RVTEST_TESTDATA_LOAD_INT(x24, x29) # load rs2: x29 = 0x0000d238
+  RVTEST_TESTDATA_LOAD_INT(x24, x0) # load rd compare value: x0 = 0x00007b61
   LA(x26, scratch) # load base address into rs1
   SREG x31, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b26_not_equal:
@@ -721,6 +773,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b26_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load value in memory: x20 = 0x00006cec
   RVTEST_TESTDATA_LOAD_INT(x24, x30) # load rs2: x30 = 0x0000f5d4
+  RVTEST_TESTDATA_LOAD_INT(x24, x18) # load rd compare value: x18 = 0x00006cec
   LA(x27, scratch) # load base address into rs1
   SREG x20, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b27_equal:
@@ -734,6 +787,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b27_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x9) # load value in memory: x9 = 0x0000effa
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load rs2: x20 = 0x00004a9f
+  RVTEST_TESTDATA_LOAD_INT(x24, x15) # load rd compare value: x15 = 0x0000881b
   LA(x27, scratch) # load base address into rs1
   SREG x9, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b27_not_equal:
@@ -747,6 +801,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b27_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x22) # load value in memory: x22 = 0x00001d5a
   RVTEST_TESTDATA_LOAD_INT(x24, x0) # load rs2: x0 = 0x0000198d
+  RVTEST_TESTDATA_LOAD_INT(x24, x12) # load rd compare value: x12 = 0x00001d5a
   LA(x28, scratch) # load base address into rs1
   SREG x22, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b28_equal:
@@ -760,6 +815,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b28_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x11) # load value in memory: x11 = 0x00004dc0
   RVTEST_TESTDATA_LOAD_INT(x24, x27) # load rs2: x27 = 0x00003efd
+  RVTEST_TESTDATA_LOAD_INT(x24, x9) # load rd compare value: x9 = 0x000099aa
   LA(x28, scratch) # load base address into rs1
   SREG x11, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b28_not_equal:
@@ -773,6 +829,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b28_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load value in memory: x1 = 0x00005fd7
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rs2: x21 = 0x0000601f
+  RVTEST_TESTDATA_LOAD_INT(x24, x5) # load rd compare value: x5 = 0x00005fd7
   LA(x29, scratch) # load base address into rs1
   SREG x1, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b29_equal:
@@ -786,6 +843,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b29_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x22) # load value in memory: x22 = 0x0000f66c
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rs2: x21 = 0x0000647a
+  RVTEST_TESTDATA_LOAD_INT(x24, x5) # load rd compare value: x5 = 0x0000540f
   LA(x29, scratch) # load base address into rs1
   SREG x22, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b29_not_equal:
@@ -799,6 +857,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b29_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load value in memory: x17 = 0x0000c1e9
   RVTEST_TESTDATA_LOAD_INT(x24, x29) # load rs2: x29 = 0x00000599
+  RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rd compare value: x21 = 0x0000c1e9
   LA(x30, scratch) # load base address into rs1
   SREG x17, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b30_equal:
@@ -812,6 +871,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b30_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x27) # load value in memory: x27 = 0x0000a207
   RVTEST_TESTDATA_LOAD_INT(x24, x4) # load rs2: x4 = 0x00007a2e
+  RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rd compare value: x23 = 0x0000ca8a
   LA(x30, scratch) # load base address into rs1
   SREG x27, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b30_not_equal:
@@ -825,6 +885,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b30_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x28) # load value in memory: x28 = 0x0000f47c
   RVTEST_TESTDATA_LOAD_INT(x24, x13) # load rs2: x13 = 0x0000e7b8
+  RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rd compare value: x22 = 0x0000f47c
   LA(x31, scratch) # load base address into rs1
   SREG x28, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b31_equal:
@@ -838,6 +899,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b31_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x28) # load value in memory: x28 = 0x000015c1
   RVTEST_TESTDATA_LOAD_INT(x24, x9) # load rs2: x9 = 0x00008607
+  RVTEST_TESTDATA_LOAD_INT(x24, x4) # load rd compare value: x4 = 0x00000cf5
   LA(x31, scratch) # load base address into rs1
   SREG x28, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b31_not_equal:
@@ -855,6 +917,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b31_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x0, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x12) # load value in memory: x12 = 0x0000fac1
   RVTEST_TESTDATA_LOAD_INT(x24, x0) # load rs2: x0 = 0x000034b3
+  RVTEST_TESTDATA_LOAD_INT(x24, x15) # load rd compare value: x15 = 0x0000fac1
   LA(x16, scratch) # load base address into rs1
   SREG x12, 0(x16) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b0_equal:
@@ -868,6 +931,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b0_equal:
 # Testcase cp_rs2 (Test source rs2 = x0, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x4) # load value in memory: x4 = 0x0000ace4
   RVTEST_TESTDATA_LOAD_INT(x24, x0) # load rs2: x0 = 0x00001882
+  RVTEST_TESTDATA_LOAD_INT(x24, x28) # load rd compare value: x28 = 0x0000abc7
   LA(x1, scratch) # load base address into rs1
   SREG x4, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b0_not_equal:
@@ -881,6 +945,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b0_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x19) # load value in memory: x19 = 0x0000192d
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load rs2: x1 = 0x0000027b
+  RVTEST_TESTDATA_LOAD_INT(x24, x0) # load rd compare value: x0 = 0x0000192d
   LA(x31, scratch) # load base address into rs1
   SREG x19, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b1_equal:
@@ -894,6 +959,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b1_equal:
 # Testcase cp_rs2 (Test source rs2 = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load value in memory: x3 = 0x00001bd6
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load rs2: x1 = 0x00004ed0
+  RVTEST_TESTDATA_LOAD_INT(x24, x2) # load rd compare value: x2 = 0x00005351
   LA(x16, scratch) # load base address into rs1
   SREG x3, 0(x16) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b1_not_equal:
@@ -907,6 +973,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b1_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x23) # load value in memory: x23 = 0x0000bb46
   RVTEST_TESTDATA_LOAD_INT(x24, x2) # load rs2: x2 = 0x0000f515
+  RVTEST_TESTDATA_LOAD_INT(x24, x29) # load rd compare value: x29 = 0x0000bb46
   LA(x11, scratch) # load base address into rs1
   SREG x23, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b2_equal:
@@ -920,6 +987,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b2_equal:
 # Testcase cp_rs2 (Test source rs2 = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load value in memory: x21 = 0x0000bb3c
   RVTEST_TESTDATA_LOAD_INT(x24, x2) # load rs2: x2 = 0x0000455e
+  RVTEST_TESTDATA_LOAD_INT(x24, x18) # load rd compare value: x18 = 0x000028d9
   LA(x22, scratch) # load base address into rs1
   SREG x21, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b2_not_equal:
@@ -933,6 +1001,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b2_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x11) # load value in memory: x11 = 0x00000304
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load rs2: x3 = 0x00001e4f
+  RVTEST_TESTDATA_LOAD_INT(x24, x17) # load rd compare value: x17 = 0x00000304
   LA(x1, scratch) # load base address into rs1
   SREG x11, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b3_equal:
@@ -946,6 +1015,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b3_equal:
 # Testcase cp_rs2 (Test source rs2 = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x15) # load value in memory: x15 = 0x0000d9a4
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load rs2: x3 = 0x0000a8d0
+  RVTEST_TESTDATA_LOAD_INT(x24, x17) # load rd compare value: x17 = 0x00004dec
   LA(x26, scratch) # load base address into rs1
   SREG x15, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b3_not_equal:
@@ -959,6 +1029,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b3_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x9) # load value in memory: x9 = 0x00004eba
   RVTEST_TESTDATA_LOAD_INT(x24, x4) # load rs2: x4 = 0x00008822
+  RVTEST_TESTDATA_LOAD_INT(x24, x1) # load rd compare value: x1 = 0x00004eba
   LA(x30, scratch) # load base address into rs1
   SREG x9, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b4_equal:
@@ -972,6 +1043,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b4_equal:
 # Testcase cp_rs2 (Test source rs2 = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x12) # load value in memory: x12 = 0x0000f7a1
   RVTEST_TESTDATA_LOAD_INT(x24, x4) # load rs2: x4 = 0x0000cb7b
+  RVTEST_TESTDATA_LOAD_INT(x24, x27) # load rd compare value: x27 = 0x0000509d
   LA(x9, scratch) # load base address into rs1
   SREG x12, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b4_not_equal:
@@ -985,6 +1057,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b4_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x29) # load value in memory: x29 = 0x000015b6
   RVTEST_TESTDATA_LOAD_INT(x24, x5) # load rs2: x5 = 0x0000bf7a
+  RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rd compare value: x22 = 0x000015b6
   LA(x18, scratch) # load base address into rs1
   SREG x29, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b5_equal:
@@ -998,6 +1071,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b5_equal:
 # Testcase cp_rs2 (Test source rs2 = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x4) # load value in memory: x4 = 0x0000b809
   RVTEST_TESTDATA_LOAD_INT(x24, x5) # load rs2: x5 = 0x000052de
+  RVTEST_TESTDATA_LOAD_INT(x24, x1) # load rd compare value: x1 = 0x00002a4c
   LA(x20, scratch) # load base address into rs1
   SREG x4, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b5_not_equal:
@@ -1012,6 +1086,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b5_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load value in memory: x1 = 0x000098dc
   RVTEST_TESTDATA_LOAD_INT(x24, x6) # load rs2: x6 = 0x0000e878
+  RVTEST_TESTDATA_LOAD_INT(x24, x20) # load rd compare value: x20 = 0x000098dc
   LA(x26, scratch) # load base address into rs1
   SREG x1, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b6_equal:
@@ -1025,6 +1100,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b6_equal:
 # Testcase cp_rs2 (Test source rs2 = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x30) # load value in memory: x30 = 0x0000b0c5
   RVTEST_TESTDATA_LOAD_INT(x24, x6) # load rs2: x6 = 0x00007e69
+  RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rd compare value: x23 = 0x00000c78
   LA(x28, scratch) # load base address into rs1
   SREG x30, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b6_not_equal:
@@ -1040,6 +1116,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b6_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load value in memory: x17 = 0x0000469a
   RVTEST_TESTDATA_LOAD_INT(x24, x7) # load rs2: x7 = 0x0000f779
+  RVTEST_TESTDATA_LOAD_INT(x24, x25) # load rd compare value: x25 = 0x0000469a
   LA(x1, scratch) # load base address into rs1
   SREG x17, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b7_equal:
@@ -1053,6 +1130,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b7_equal:
 # Testcase cp_rs2 (Test source rs2 = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x10) # load value in memory: x10 = 0x00003208
   RVTEST_TESTDATA_LOAD_INT(x24, x7) # load rs2: x7 = 0x0000faa0
+  RVTEST_TESTDATA_LOAD_INT(x24, x0) # load rd compare value: x0 = 0x00005378
   LA(x20, scratch) # load base address into rs1
   SREG x10, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b7_not_equal:
@@ -1066,6 +1144,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b7_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x29) # load value in memory: x29 = 0x00005216
   RVTEST_TESTDATA_LOAD_INT(x24, x8) # load rs2: x8 = 0x0000ef9f
+  RVTEST_TESTDATA_LOAD_INT(x24, x27) # load rd compare value: x27 = 0x00005216
   LA(x19, scratch) # load base address into rs1
   SREG x29, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b8_equal:
@@ -1079,6 +1158,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b8_equal:
 # Testcase cp_rs2 (Test source rs2 = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x10) # load value in memory: x10 = 0x000089b5
   RVTEST_TESTDATA_LOAD_INT(x24, x8) # load rs2: x8 = 0x0000afae
+  RVTEST_TESTDATA_LOAD_INT(x24, x3) # load rd compare value: x3 = 0x000062a6
   LA(x28, scratch) # load base address into rs1
   SREG x10, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b8_not_equal:
@@ -1092,6 +1172,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b8_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x7) # load value in memory: x7 = 0x0000ade5
   RVTEST_TESTDATA_LOAD_INT(x24, x9) # load rs2: x9 = 0x00008751
+  RVTEST_TESTDATA_LOAD_INT(x24, x10) # load rd compare value: x10 = 0x0000ade5
   LA(x29, scratch) # load base address into rs1
   SREG x7, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b9_equal:
@@ -1105,6 +1186,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b9_equal:
 # Testcase cp_rs2 (Test source rs2 = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load value in memory: x17 = 0x0000bd99
   RVTEST_TESTDATA_LOAD_INT(x24, x9) # load rs2: x9 = 0x0000c13c
+  RVTEST_TESTDATA_LOAD_INT(x24, x2) # load rd compare value: x2 = 0x0000802d
   LA(x25, scratch) # load base address into rs1
   SREG x17, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b9_not_equal:
@@ -1118,6 +1200,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b9_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load value in memory: x3 = 0x00006cd5
   RVTEST_TESTDATA_LOAD_INT(x24, x10) # load rs2: x10 = 0x00006d1c
+  RVTEST_TESTDATA_LOAD_INT(x24, x27) # load rd compare value: x27 = 0x00006cd5
   LA(x12, scratch) # load base address into rs1
   SREG x3, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b10_equal:
@@ -1131,6 +1214,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b10_equal:
 # Testcase cp_rs2 (Test source rs2 = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x28) # load value in memory: x28 = 0x0000d412
   RVTEST_TESTDATA_LOAD_INT(x24, x10) # load rs2: x10 = 0x00007bea
+  RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rd compare value: x19 = 0x0000527b
   LA(x21, scratch) # load base address into rs1
   SREG x28, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b10_not_equal:
@@ -1144,6 +1228,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b10_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load value in memory: x1 = 0x0000b64f
   RVTEST_TESTDATA_LOAD_INT(x24, x11) # load rs2: x11 = 0x0000e2f3
+  RVTEST_TESTDATA_LOAD_INT(x24, x16) # load rd compare value: x16 = 0x0000b64f
   LA(x28, scratch) # load base address into rs1
   SREG x1, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b11_equal:
@@ -1157,6 +1242,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b11_equal:
 # Testcase cp_rs2 (Test source rs2 = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x19) # load value in memory: x19 = 0x00001150
   RVTEST_TESTDATA_LOAD_INT(x24, x11) # load rs2: x11 = 0x0000e8a1
+  RVTEST_TESTDATA_LOAD_INT(x24, x16) # load rd compare value: x16 = 0x000029d1
   LA(x22, scratch) # load base address into rs1
   SREG x19, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b11_not_equal:
@@ -1170,6 +1256,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b11_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load value in memory: x1 = 0x00009d3d
   RVTEST_TESTDATA_LOAD_INT(x24, x12) # load rs2: x12 = 0x0000bd1d
+  RVTEST_TESTDATA_LOAD_INT(x24, x5) # load rd compare value: x5 = 0x00009d3d
   LA(x16, scratch) # load base address into rs1
   SREG x1, 0(x16) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b12_equal:
@@ -1183,6 +1270,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b12_equal:
 # Testcase cp_rs2 (Test source rs2 = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x11) # load value in memory: x11 = 0x0000e6ff
   RVTEST_TESTDATA_LOAD_INT(x24, x12) # load rs2: x12 = 0x0000fd0f
+  RVTEST_TESTDATA_LOAD_INT(x24, x6) # load rd compare value: x6 = 0x0000ef01
   LA(x7, scratch) # load base address into rs1
   SREG x11, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b12_not_equal:
@@ -1198,6 +1286,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b12_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load value in memory: x3 = 0x0000f770
   RVTEST_TESTDATA_LOAD_INT(x24, x13) # load rs2: x13 = 0x000097e4
+  RVTEST_TESTDATA_LOAD_INT(x24, x31) # load rd compare value: x31 = 0x0000f770
   LA(x22, scratch) # load base address into rs1
   SREG x3, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b13_equal:
@@ -1211,6 +1300,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b13_equal:
 # Testcase cp_rs2 (Test source rs2 = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x8) # load value in memory: x8 = 0x00002830
   RVTEST_TESTDATA_LOAD_INT(x24, x13) # load rs2: x13 = 0x00009973
+  RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rd compare value: x23 = 0x0000bdeb
   LA(x2, scratch) # load base address into rs1
   SREG x8, 0(x2) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b13_not_equal:
@@ -1224,6 +1314,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b13_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x13) # load value in memory: x13 = 0x00000209
   RVTEST_TESTDATA_LOAD_INT(x24, x14) # load rs2: x14 = 0x00005e99
+  RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rd compare value: x22 = 0x00000209
   LA(x16, scratch) # load base address into rs1
   SREG x13, 0(x16) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b14_equal:
@@ -1237,6 +1328,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b14_equal:
 # Testcase cp_rs2 (Test source rs2 = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load value in memory: x3 = 0x0000cf92
   RVTEST_TESTDATA_LOAD_INT(x24, x14) # load rs2: x14 = 0x000080d4
+  RVTEST_TESTDATA_LOAD_INT(x24, x28) # load rd compare value: x28 = 0x00002b78
   LA(x20, scratch) # load base address into rs1
   SREG x3, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b14_not_equal:
@@ -1250,6 +1342,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b14_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x31) # load value in memory: x31 = 0x00003f13
   RVTEST_TESTDATA_LOAD_INT(x24, x15) # load rs2: x15 = 0x00005db6
+  RVTEST_TESTDATA_LOAD_INT(x24, x10) # load rd compare value: x10 = 0x00003f13
   LA(x3, scratch) # load base address into rs1
   SREG x31, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b15_equal:
@@ -1263,6 +1356,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b15_equal:
 # Testcase cp_rs2 (Test source rs2 = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load value in memory: x20 = 0x0000e5c0
   RVTEST_TESTDATA_LOAD_INT(x24, x15) # load rs2: x15 = 0x00006626
+  RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rd compare value: x23 = 0x0000a4be
   LA(x7, scratch) # load base address into rs1
   SREG x20, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b15_not_equal:
@@ -1276,6 +1370,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b15_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load value in memory: x1 = 0x00001567
   RVTEST_TESTDATA_LOAD_INT(x24, x16) # load rs2: x16 = 0x00001046
+  RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rd compare value: x19 = 0x00001567
   LA(x11, scratch) # load base address into rs1
   SREG x1, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b16_equal:
@@ -1289,6 +1384,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b16_equal:
 # Testcase cp_rs2 (Test source rs2 = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x12) # load value in memory: x12 = 0x000078e6
   RVTEST_TESTDATA_LOAD_INT(x24, x16) # load rs2: x16 = 0x00004a68
+  RVTEST_TESTDATA_LOAD_INT(x24, x0) # load rd compare value: x0 = 0x00000744
   LA(x14, scratch) # load base address into rs1
   SREG x12, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b16_not_equal:
@@ -1302,6 +1398,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b16_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x31) # load value in memory: x31 = 0x0000790b
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load rs2: x17 = 0x000070c6
+  RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rd compare value: x23 = 0x0000790b
   LA(x11, scratch) # load base address into rs1
   SREG x31, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b17_equal:
@@ -1315,6 +1412,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b17_equal:
 # Testcase cp_rs2 (Test source rs2 = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x26) # load value in memory: x26 = 0x00009ee3
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load rs2: x17 = 0x00007a75
+  RVTEST_TESTDATA_LOAD_INT(x24, x10) # load rd compare value: x10 = 0x0000c84e
   LA(x22, scratch) # load base address into rs1
   SREG x26, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b17_not_equal:
@@ -1329,6 +1427,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b17_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x6) # load value in memory: x6 = 0x00009308
   RVTEST_TESTDATA_LOAD_INT(x24, x18) # load rs2: x18 = 0x00000295
+  RVTEST_TESTDATA_LOAD_INT(x24, x0) # load rd compare value: x0 = 0x00009308
   LA(x12, scratch) # load base address into rs1
   SREG x6, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b18_equal:
@@ -1342,6 +1441,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b18_equal:
 # Testcase cp_rs2 (Test source rs2 = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x14) # load value in memory: x14 = 0x00007a8d
   RVTEST_TESTDATA_LOAD_INT(x24, x18) # load rs2: x18 = 0x0000ba3f
+  RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rd compare value: x21 = 0x0000b772
   LA(x26, scratch) # load base address into rs1
   SREG x14, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b18_not_equal:
@@ -1355,6 +1455,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b18_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x16) # load value in memory: x16 = 0x0000dcdd
   RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rs2: x19 = 0x00008b14
+  RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rd compare value: x22 = 0x0000dcdd
   LA(x11, scratch) # load base address into rs1
   SREG x16, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b19_equal:
@@ -1368,6 +1469,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b19_equal:
 # Testcase cp_rs2 (Test source rs2 = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x14) # load value in memory: x14 = 0x0000b72d
   RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rs2: x19 = 0x0000c8b5
+  RVTEST_TESTDATA_LOAD_INT(x24, x1) # load rd compare value: x1 = 0x00009d06
   LA(x20, scratch) # load base address into rs1
   SREG x14, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b19_not_equal:
@@ -1381,6 +1483,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b19_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x22) # load value in memory: x22 = 0x0000f964
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load rs2: x20 = 0x00006581
+  RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rd compare value: x23 = 0x0000f964
   LA(x31, scratch) # load base address into rs1
   SREG x22, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b20_equal:
@@ -1394,6 +1497,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b20_equal:
 # Testcase cp_rs2 (Test source rs2 = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x14) # load value in memory: x14 = 0x00007d55
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load rs2: x20 = 0x0000e272
+  RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rd compare value: x19 = 0x0000dd14
   LA(x8, scratch) # load base address into rs1
   SREG x14, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b20_not_equal:
@@ -1407,6 +1511,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b20_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x14) # load value in memory: x14 = 0x0000b0fa
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rs2: x21 = 0x0000860c
+  RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rd compare value: x19 = 0x0000b0fa
   LA(x12, scratch) # load base address into rs1
   SREG x14, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b21_equal:
@@ -1420,6 +1525,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b21_equal:
 # Testcase cp_rs2 (Test source rs2 = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load value in memory: x17 = 0x000028d6
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rs2: x21 = 0x0000c421
+  RVTEST_TESTDATA_LOAD_INT(x24, x7) # load rd compare value: x7 = 0x00005850
   LA(x27, scratch) # load base address into rs1
   SREG x17, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b21_not_equal:
@@ -1433,6 +1539,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b21_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x23) # load value in memory: x23 = 0x00005b39
   RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rs2: x22 = 0x0000b189
+  RVTEST_TESTDATA_LOAD_INT(x24, x27) # load rd compare value: x27 = 0x00005b39
   LA(x9, scratch) # load base address into rs1
   SREG x23, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b22_equal:
@@ -1446,6 +1553,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b22_equal:
 # Testcase cp_rs2 (Test source rs2 = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x25) # load value in memory: x25 = 0x0000afdc
   RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rs2: x22 = 0x00006773
+  RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rd compare value: x23 = 0x000064ad
   LA(x9, scratch) # load base address into rs1
   SREG x25, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b22_not_equal:
@@ -1459,6 +1567,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b22_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x29) # load value in memory: x29 = 0x0000b4ca
   RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rs2: x23 = 0x0000b609
+  RVTEST_TESTDATA_LOAD_INT(x24, x25) # load rd compare value: x25 = 0x0000b4ca
   LA(x27, scratch) # load base address into rs1
   SREG x29, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b23_equal:
@@ -1472,6 +1581,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b23_equal:
 # Testcase cp_rs2 (Test source rs2 = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x26) # load value in memory: x26 = 0x00007a41
   RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rs2: x23 = 0x0000e72c
+  RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rd compare value: x19 = 0x0000b050
   LA(x6, scratch) # load base address into rs1
   SREG x26, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b23_not_equal:
@@ -1486,6 +1596,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b23_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x17) # load value in memory: x17 = 0x00007a77
   RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0x0000ef0f
+  RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rd compare value: x29 = 0x00007a77
   LA(x10, scratch) # load base address into rs1
   SREG x17, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b24_equal:
@@ -1499,6 +1610,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b24_equal:
 # Testcase cp_rs2 (Test source rs2 = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load value in memory: x11 = 0x00004a4b
   RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0x00002a7c
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rd compare value: x14 = 0x0000bfca
   LA(x25, scratch) # load base address into rs1
   SREG x11, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b24_not_equal:
@@ -1512,6 +1624,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b24_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load value in memory: x11 = 0x00007345
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x000056d9
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rd compare value: x0 = 0x00007345
   LA(x26, scratch) # load base address into rs1
   SREG x11, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b25_equal:
@@ -1525,6 +1638,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b25_equal:
 # Testcase cp_rs2 (Test source rs2 = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load value in memory: x31 = 0x00008d6e
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x0000fac4
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rd compare value: x26 = 0x00006afa
   LA(x21, scratch) # load base address into rs1
   SREG x31, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b25_not_equal:
@@ -1538,6 +1652,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b25_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load value in memory: x21 = 0x0000b56c
   RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x000007da
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rd compare value: x6 = 0x0000b56c
   LA(x11, scratch) # load base address into rs1
   SREG x21, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b26_equal:
@@ -1551,6 +1666,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b26_equal:
 # Testcase cp_rs2 (Test source rs2 = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load value in memory: x22 = 0x0000f20d
   RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x0000fe09
+  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rd compare value: x3 = 0x0000fbe2
   LA(x23, scratch) # load base address into rs1
   SREG x22, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b26_not_equal:
@@ -1564,6 +1680,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b26_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load value in memory: x11 = 0x0000564b
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x0000dd4c
+  RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rd compare value: x18 = 0x0000564b
   LA(x7, scratch) # load base address into rs1
   SREG x11, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b27_equal:
@@ -1577,6 +1694,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b27_equal:
 # Testcase cp_rs2 (Test source rs2 = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load value in memory: x25 = 0x0000dc97
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x0000571f
+  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rd compare value: x23 = 0x0000508b
   LA(x13, scratch) # load base address into rs1
   SREG x25, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b27_not_equal:
@@ -1590,6 +1708,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b27_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load value in memory: x3 = 0x00000282
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x0000eae9
+  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rd compare value: x20 = 0x00000282
   LA(x10, scratch) # load base address into rs1
   SREG x3, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b28_equal:
@@ -1603,6 +1722,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b28_equal:
 # Testcase cp_rs2 (Test source rs2 = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load value in memory: x14 = 0x0000db13
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x0000f2fe
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rd compare value: x10 = 0x00006ea5
   LA(x29, scratch) # load base address into rs1
   SREG x14, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b28_not_equal:
@@ -1616,6 +1736,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b28_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load value in memory: x13 = 0x000018ae
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x00002996
+  RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rd compare value: x18 = 0x000018ae
   LA(x3, scratch) # load base address into rs1
   SREG x13, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b29_equal:
@@ -1629,6 +1750,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b29_equal:
 # Testcase cp_rs2 (Test source rs2 = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load value in memory: x28 = 0x0000e627
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x0000f626
+  RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rd compare value: x24 = 0x00005239
   LA(x30, scratch) # load base address into rs1
   SREG x28, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b29_not_equal:
@@ -1642,6 +1764,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b29_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load value in memory: x11 = 0x00000d9d
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x00007a4d
+  RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rd compare value: x17 = 0x00000d9d
   LA(x23, scratch) # load base address into rs1
   SREG x11, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b30_equal:
@@ -1655,6 +1778,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b30_equal:
 # Testcase cp_rs2 (Test source rs2 = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load value in memory: x9 = 0x0000b32d
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x0000f334
+  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rd compare value: x22 = 0x0000fdc9
   LA(x7, scratch) # load base address into rs1
   SREG x9, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b30_not_equal:
@@ -1668,6 +1792,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b30_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load value in memory: x27 = 0x0000f819
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x00003559
+  RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rd compare value: x17 = 0x0000f819
   LA(x28, scratch) # load base address into rs1
   SREG x27, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b31_equal:
@@ -1681,6 +1806,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b31_equal:
 # Testcase cp_rs2 (Test source rs2 = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x24) # load value in memory: x24 = 0x0000ca0c
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x0000d8f8
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rd compare value: x6 = 0x0000e2b6
   LA(x8, scratch) # load base address into rs1
   SREG x24, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b31_not_equal:
@@ -1698,6 +1824,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b31_not_equal:
 # Testcase cp_rd (Test destination rd = x0, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load value in memory: x19 = 0x00006d46
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x00006674
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rd compare value: x0 = 0x00006d46
   LA(x3, scratch) # load base address into rs1
   SREG x19, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b0_equal:
@@ -1711,6 +1838,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b0_equal:
 # Testcase cp_rd (Test destination rd = x0, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load value in memory: x3 = 0x00001eea
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0x0000c1ba
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rd compare value: x0 = 0x00009b03
   LA(x14, scratch) # load base address into rs1
   SREG x3, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b0_not_equal:
@@ -1725,6 +1853,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b0_not_equal:
 # Testcase cp_rd (Test destination rd = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load value in memory: x10 = 0x0000eafb
   RVTEST_TESTDATA_LOAD_INT(x27, x0) # load rs2: x0 = 0x00008329
+  RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rd compare value: x1 = 0x0000eafb
   LA(x9, scratch) # load base address into rs1
   SREG x10, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b1_equal:
@@ -1738,6 +1867,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b1_equal:
 # Testcase cp_rd (Test destination rd = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x18) # load value in memory: x18 = 0x0000dd8f
   RVTEST_TESTDATA_LOAD_INT(x27, x29) # load rs2: x29 = 0x0000dbb4
+  RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rd compare value: x1 = 0x000038ba
   LA(x28, scratch) # load base address into rs1
   SREG x18, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b1_not_equal:
@@ -1751,6 +1881,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b1_not_equal:
 # Testcase cp_rd (Test destination rd = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load value in memory: x31 = 0x000044c8
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rs2: x16 = 0x00000ebc
+  RVTEST_TESTDATA_LOAD_INT(x27, x2) # load rd compare value: x2 = 0x000044c8
   LA(x28, scratch) # load base address into rs1
   SREG x31, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b2_equal:
@@ -1764,6 +1895,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b2_equal:
 # Testcase cp_rd (Test destination rd = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load value in memory: x16 = 0x00004bde
   RVTEST_TESTDATA_LOAD_INT(x27, x3) # load rs2: x3 = 0x00005e9f
+  RVTEST_TESTDATA_LOAD_INT(x27, x2) # load rd compare value: x2 = 0x0000b841
   LA(x30, scratch) # load base address into rs1
   SREG x16, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b2_not_equal:
@@ -1777,6 +1909,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b2_not_equal:
 # Testcase cp_rd (Test destination rd = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x11) # load value in memory: x11 = 0x000018a7
   RVTEST_TESTDATA_LOAD_INT(x27, x29) # load rs2: x29 = 0x0000a4a1
+  RVTEST_TESTDATA_LOAD_INT(x27, x3) # load rd compare value: x3 = 0x000018a7
   LA(x10, scratch) # load base address into rs1
   SREG x11, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b3_equal:
@@ -1790,6 +1923,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b3_equal:
 # Testcase cp_rd (Test destination rd = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load value in memory: x8 = 0x00006999
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load rs2: x31 = 0x000020a3
+  RVTEST_TESTDATA_LOAD_INT(x27, x3) # load rd compare value: x3 = 0x0000f969
   LA(x10, scratch) # load base address into rs1
   SREG x8, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b3_not_equal:
@@ -1805,6 +1939,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b3_not_equal:
 # Testcase cp_rd (Test destination rd = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x5) # load value in memory: x5 = 0x0000b497
   RVTEST_TESTDATA_LOAD_INT(x27, x19) # load rs2: x19 = 0x00004840
+  RVTEST_TESTDATA_LOAD_INT(x27, x4) # load rd compare value: x4 = 0x0000b497
   LA(x26, scratch) # load base address into rs1
   SREG x5, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b4_equal:
@@ -1818,6 +1953,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b4_equal:
 # Testcase cp_rd (Test destination rd = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x26) # load value in memory: x26 = 0x0000f482
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rs2: x12 = 0x000018ce
+  RVTEST_TESTDATA_LOAD_INT(x27, x4) # load rd compare value: x4 = 0x0000f023
   LA(x29, scratch) # load base address into rs1
   SREG x26, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b4_not_equal:
@@ -1831,6 +1967,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b4_not_equal:
 # Testcase cp_rd (Test destination rd = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load value in memory: x31 = 0x0000d264
   RVTEST_TESTDATA_LOAD_INT(x27, x30) # load rs2: x30 = 0x0000274a
+  RVTEST_TESTDATA_LOAD_INT(x27, x5) # load rd compare value: x5 = 0x0000d264
   LA(x26, scratch) # load base address into rs1
   SREG x31, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b5_equal:
@@ -1844,6 +1981,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b5_equal:
 # Testcase cp_rd (Test destination rd = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load value in memory: x1 = 0x000098d7
   RVTEST_TESTDATA_LOAD_INT(x27, x26) # load rs2: x26 = 0x0000ddc6
+  RVTEST_TESTDATA_LOAD_INT(x27, x5) # load rd compare value: x5 = 0x00006321
   LA(x22, scratch) # load base address into rs1
   SREG x1, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b5_not_equal:
@@ -1857,6 +1995,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b5_not_equal:
 # Testcase cp_rd (Test destination rd = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x14) # load value in memory: x14 = 0x0000a213
   RVTEST_TESTDATA_LOAD_INT(x27, x24) # load rs2: x24 = 0x00004eca
+  RVTEST_TESTDATA_LOAD_INT(x27, x6) # load rd compare value: x6 = 0x0000a213
   LA(x4, scratch) # load base address into rs1
   SREG x14, 0(x4) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b6_equal:
@@ -1870,6 +2009,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b6_equal:
 # Testcase cp_rd (Test destination rd = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x5) # load value in memory: x5 = 0x0000a0cd
   RVTEST_TESTDATA_LOAD_INT(x27, x30) # load rs2: x30 = 0x00009b4d
+  RVTEST_TESTDATA_LOAD_INT(x27, x6) # load rd compare value: x6 = 0x00003074
   LA(x20, scratch) # load base address into rs1
   SREG x5, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b6_not_equal:
@@ -1885,6 +2025,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b6_not_equal:
 # Testcase cp_rd (Test destination rd = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x20) # load value in memory: x20 = 0x00003878
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load rs2: x8 = 0x00002fee
+  RVTEST_TESTDATA_LOAD_INT(x27, x7) # load rd compare value: x7 = 0x00003878
   LA(x29, scratch) # load base address into rs1
   SREG x20, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b7_equal:
@@ -1898,6 +2039,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b7_equal:
 # Testcase cp_rd (Test destination rd = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x19) # load value in memory: x19 = 0x00008850
   RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rs2: x20 = 0x0000df58
+  RVTEST_TESTDATA_LOAD_INT(x27, x7) # load rd compare value: x7 = 0x00000b37
   LA(x31, scratch) # load base address into rs1
   SREG x19, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b7_not_equal:
@@ -1911,6 +2053,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b7_not_equal:
 # Testcase cp_rd (Test destination rd = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x7) # load value in memory: x7 = 0x000019e9
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rs2: x13 = 0x00001ead
+  RVTEST_TESTDATA_LOAD_INT(x27, x8) # load rd compare value: x8 = 0x000019e9
   LA(x1, scratch) # load base address into rs1
   SREG x7, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b8_equal:
@@ -1924,6 +2067,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b8_equal:
 # Testcase cp_rd (Test destination rd = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load value in memory: x31 = 0x00005939
   RVTEST_TESTDATA_LOAD_INT(x27, x28) # load rs2: x28 = 0x0000194e
+  RVTEST_TESTDATA_LOAD_INT(x27, x8) # load rd compare value: x8 = 0x000018a2
   LA(x29, scratch) # load base address into rs1
   SREG x31, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b8_not_equal:
@@ -1937,6 +2081,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b8_not_equal:
 # Testcase cp_rd (Test destination rd = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load value in memory: x16 = 0x000039d7
   RVTEST_TESTDATA_LOAD_INT(x27, x25) # load rs2: x25 = 0x00007331
+  RVTEST_TESTDATA_LOAD_INT(x27, x9) # load rd compare value: x9 = 0x000039d7
   LA(x20, scratch) # load base address into rs1
   SREG x16, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b9_equal:
@@ -1950,6 +2095,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b9_equal:
 # Testcase cp_rd (Test destination rd = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x19) # load value in memory: x19 = 0x0000ac1a
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rs2: x1 = 0x0000a5fb
+  RVTEST_TESTDATA_LOAD_INT(x27, x9) # load rd compare value: x9 = 0x00004382
   LA(x24, scratch) # load base address into rs1
   SREG x19, 0(x24) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b9_not_equal:
@@ -1963,6 +2109,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b9_not_equal:
 # Testcase cp_rd (Test destination rd = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x21) # load value in memory: x21 = 0x0000b65a
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rs2: x1 = 0x00004b3c
+  RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rd compare value: x10 = 0x0000b65a
   LA(x17, scratch) # load base address into rs1
   SREG x21, 0(x17) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b10_equal:
@@ -1976,6 +2123,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b10_equal:
 # Testcase cp_rd (Test destination rd = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x25) # load value in memory: x25 = 0x00005356
   RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rs2: x20 = 0x00000cb2
+  RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rd compare value: x10 = 0x00007f07
   LA(x22, scratch) # load base address into rs1
   SREG x25, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b10_not_equal:
@@ -1989,6 +2137,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b10_not_equal:
 # Testcase cp_rd (Test destination rd = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x26) # load value in memory: x26 = 0x00003913
   RVTEST_TESTDATA_LOAD_INT(x27, x25) # load rs2: x25 = 0x0000ced3
+  RVTEST_TESTDATA_LOAD_INT(x27, x11) # load rd compare value: x11 = 0x00003913
   LA(x3, scratch) # load base address into rs1
   SREG x26, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b11_equal:
@@ -2002,6 +2151,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b11_equal:
 # Testcase cp_rd (Test destination rd = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x7) # load value in memory: x7 = 0x00007d75
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rs2: x16 = 0x0000043c
+  RVTEST_TESTDATA_LOAD_INT(x27, x11) # load rd compare value: x11 = 0x000038b9
   LA(x21, scratch) # load base address into rs1
   SREG x7, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b11_not_equal:
@@ -2015,6 +2165,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b11_not_equal:
 # Testcase cp_rd (Test destination rd = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load value in memory: x1 = 0x0000e3c6
   RVTEST_TESTDATA_LOAD_INT(x27, x6) # load rs2: x6 = 0x000051ed
+  RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rd compare value: x12 = 0x0000e3c6
   LA(x11, scratch) # load base address into rs1
   SREG x1, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b12_equal:
@@ -2028,6 +2179,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b12_equal:
 # Testcase cp_rd (Test destination rd = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x24) # load value in memory: x24 = 0x00009d1a
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rs2: x10 = 0x0000b5f7
+  RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rd compare value: x12 = 0x0000ce59
   LA(x31, scratch) # load base address into rs1
   SREG x24, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b12_not_equal:
@@ -2041,6 +2193,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b12_not_equal:
 # Testcase cp_rd (Test destination rd = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x3) # load value in memory: x3 = 0x000047a1
   RVTEST_TESTDATA_LOAD_INT(x27, x6) # load rs2: x6 = 0x00007640
+  RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rd compare value: x13 = 0x000047a1
   LA(x10, scratch) # load base address into rs1
   SREG x3, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b13_equal:
@@ -2054,6 +2207,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b13_equal:
 # Testcase cp_rd (Test destination rd = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load value in memory: x31 = 0x00002348
   RVTEST_TESTDATA_LOAD_INT(x27, x30) # load rs2: x30 = 0x0000eddc
+  RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rd compare value: x13 = 0x00008cbc
   LA(x10, scratch) # load base address into rs1
   SREG x31, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b13_not_equal:
@@ -2067,6 +2221,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b13_not_equal:
 # Testcase cp_rd (Test destination rd = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load value in memory: x8 = 0x00008f63
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rs2: x13 = 0x0000c25e
+  RVTEST_TESTDATA_LOAD_INT(x27, x14) # load rd compare value: x14 = 0x00008f63
   LA(x28, scratch) # load base address into rs1
   SREG x8, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b14_equal:
@@ -2080,6 +2235,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b14_equal:
 # Testcase cp_rd (Test destination rd = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x29) # load value in memory: x29 = 0x000043d9
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rs2: x1 = 0x0000122c
+  RVTEST_TESTDATA_LOAD_INT(x27, x14) # load rd compare value: x14 = 0x00005c7a
   LA(x18, scratch) # load base address into rs1
   SREG x29, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b14_not_equal:
@@ -2094,6 +2250,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b14_not_equal:
 # Testcase cp_rd (Test destination rd = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load value in memory: x13 = 0x00001e5a
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rs2: x10 = 0x00006a6c
+  RVTEST_TESTDATA_LOAD_INT(x27, x15) # load rd compare value: x15 = 0x00001e5a
   LA(x11, scratch) # load base address into rs1
   SREG x13, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b15_equal:
@@ -2107,6 +2264,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b15_equal:
 # Testcase cp_rd (Test destination rd = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x14) # load value in memory: x14 = 0x00009690
   RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rs2: x20 = 0x000005fb
+  RVTEST_TESTDATA_LOAD_INT(x27, x15) # load rd compare value: x15 = 0x00001df4
   LA(x8, scratch) # load base address into rs1
   SREG x14, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b15_not_equal:
@@ -2120,6 +2278,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b15_not_equal:
 # Testcase cp_rd (Test destination rd = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load value in memory: x1 = 0x00000b6a
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rs2: x10 = 0x00005dc7
+  RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rd compare value: x16 = 0x00000b6a
   LA(x24, scratch) # load base address into rs1
   SREG x1, 0(x24) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b16_equal:
@@ -2133,6 +2292,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b16_equal:
 # Testcase cp_rd (Test destination rd = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load value in memory: x8 = 0x00009524
   RVTEST_TESTDATA_LOAD_INT(x27, x15) # load rs2: x15 = 0x00003e2e
+  RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rd compare value: x16 = 0x0000986f
   LA(x10, scratch) # load base address into rs1
   SREG x8, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b16_not_equal:
@@ -2146,6 +2306,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b16_not_equal:
 # Testcase cp_rd (Test destination rd = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load value in memory: x12 = 0x000030a8
   RVTEST_TESTDATA_LOAD_INT(x27, x29) # load rs2: x29 = 0x0000bc15
+  RVTEST_TESTDATA_LOAD_INT(x27, x17) # load rd compare value: x17 = 0x000030a8
   LA(x3, scratch) # load base address into rs1
   SREG x12, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b17_equal:
@@ -2159,6 +2320,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b17_equal:
 # Testcase cp_rd (Test destination rd = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load value in memory: x13 = 0x00004995
   RVTEST_TESTDATA_LOAD_INT(x27, x14) # load rs2: x14 = 0x0000458c
+  RVTEST_TESTDATA_LOAD_INT(x27, x17) # load rd compare value: x17 = 0x00001d9e
   LA(x26, scratch) # load base address into rs1
   SREG x13, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b17_not_equal:
@@ -2172,6 +2334,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b17_not_equal:
 # Testcase cp_rd (Test destination rd = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x26) # load value in memory: x26 = 0x00008526
   RVTEST_TESTDATA_LOAD_INT(x27, x7) # load rs2: x7 = 0x00007815
+  RVTEST_TESTDATA_LOAD_INT(x27, x18) # load rd compare value: x18 = 0x00008526
   LA(x12, scratch) # load base address into rs1
   SREG x26, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b18_equal:
@@ -2185,6 +2348,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b18_equal:
 # Testcase cp_rd (Test destination rd = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load value in memory: x13 = 0x0000c76b
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load rs2: x8 = 0x00001f83
+  RVTEST_TESTDATA_LOAD_INT(x27, x18) # load rd compare value: x18 = 0x0000e114
   LA(x26, scratch) # load base address into rs1
   SREG x13, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b18_not_equal:
@@ -2198,6 +2362,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b18_not_equal:
 # Testcase cp_rd (Test destination rd = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load value in memory: x8 = 0x00003630
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rs2: x12 = 0x000009e0
+  RVTEST_TESTDATA_LOAD_INT(x27, x19) # load rd compare value: x19 = 0x00003630
   LA(x18, scratch) # load base address into rs1
   SREG x8, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b19_equal:
@@ -2211,6 +2376,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b19_equal:
 # Testcase cp_rd (Test destination rd = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x22) # load value in memory: x22 = 0x000039ed
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load rs2: x31 = 0x00000bda
+  RVTEST_TESTDATA_LOAD_INT(x27, x19) # load rd compare value: x19 = 0x0000296b
   LA(x3, scratch) # load base address into rs1
   SREG x22, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b19_not_equal:
@@ -2224,6 +2390,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b19_not_equal:
 # Testcase cp_rd (Test destination rd = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x30) # load value in memory: x30 = 0x00002b38
   RVTEST_TESTDATA_LOAD_INT(x27, x0) # load rs2: x0 = 0x0000133c
+  RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rd compare value: x20 = 0x00002b38
   LA(x23, scratch) # load base address into rs1
   SREG x30, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b20_equal:
@@ -2237,6 +2404,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b20_equal:
 # Testcase cp_rd (Test destination rd = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load value in memory: x8 = 0x0000a019
   RVTEST_TESTDATA_LOAD_INT(x27, x29) # load rs2: x29 = 0x000022a8
+  RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rd compare value: x20 = 0x00001187
   LA(x31, scratch) # load base address into rs1
   SREG x8, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b20_not_equal:
@@ -2251,6 +2419,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b20_not_equal:
 # Testcase cp_rd (Test destination rd = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load value in memory: x12 = 0x0000437e
   RVTEST_TESTDATA_LOAD_INT(x27, x17) # load rs2: x17 = 0x0000889b
+  RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rd compare value: x21 = 0x0000437e
   LA(x23, scratch) # load base address into rs1
   SREG x12, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b21_equal:
@@ -2264,6 +2433,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b21_equal:
 # Testcase cp_rd (Test destination rd = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load value in memory: x13 = 0x000027d9
   RVTEST_TESTDATA_LOAD_INT(x27, x6) # load rs2: x6 = 0x0000951c
+  RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rd compare value: x21 = 0x0000bd99
   LA(x30, scratch) # load base address into rs1
   SREG x13, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b21_not_equal:
@@ -2277,6 +2447,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b21_not_equal:
 # Testcase cp_rd (Test destination rd = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load value in memory: x8 = 0x00006b49
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load rs2: x31 = 0x00003d38
+  RVTEST_TESTDATA_LOAD_INT(x27, x22) # load rd compare value: x22 = 0x00006b49
   LA(x19, scratch) # load base address into rs1
   SREG x8, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b22_equal:
@@ -2290,6 +2461,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b22_equal:
 # Testcase cp_rd (Test destination rd = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load value in memory: x13 = 0x00004882
   RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rs2: x21 = 0x0000821f
+  RVTEST_TESTDATA_LOAD_INT(x27, x22) # load rd compare value: x22 = 0x00001cca
   LA(x18, scratch) # load base address into rs1
   SREG x13, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b22_not_equal:
@@ -2303,6 +2475,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b22_not_equal:
 # Testcase cp_rd (Test destination rd = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x19) # load value in memory: x19 = 0x000009a2
   RVTEST_TESTDATA_LOAD_INT(x27, x24) # load rs2: x24 = 0x0000dd5e
+  RVTEST_TESTDATA_LOAD_INT(x27, x23) # load rd compare value: x23 = 0x000009a2
   LA(x21, scratch) # load base address into rs1
   SREG x19, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b23_equal:
@@ -2316,6 +2489,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b23_equal:
 # Testcase cp_rd (Test destination rd = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load value in memory: x31 = 0x0000a193
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rs2: x13 = 0x0000b7a7
+  RVTEST_TESTDATA_LOAD_INT(x27, x23) # load rd compare value: x23 = 0x0000285b
   LA(x28, scratch) # load base address into rs1
   SREG x31, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b23_not_equal:
@@ -2329,6 +2503,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b23_not_equal:
 # Testcase cp_rd (Test destination rd = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load value in memory: x12 = 0x0000404e
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rs2: x10 = 0x0000e95e
+  RVTEST_TESTDATA_LOAD_INT(x27, x24) # load rd compare value: x24 = 0x0000404e
   LA(x7, scratch) # load base address into rs1
   SREG x12, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b24_equal:
@@ -2342,6 +2517,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b24_equal:
 # Testcase cp_rd (Test destination rd = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load value in memory: x10 = 0x000075bd
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rs2: x1 = 0x0000d7d1
+  RVTEST_TESTDATA_LOAD_INT(x27, x24) # load rd compare value: x24 = 0x0000b9bb
   LA(x14, scratch) # load base address into rs1
   SREG x10, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b24_not_equal:
@@ -2355,6 +2531,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b24_not_equal:
 # Testcase cp_rd (Test destination rd = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load value in memory: x12 = 0x00006b05
   RVTEST_TESTDATA_LOAD_INT(x27, x18) # load rs2: x18 = 0x00006ea7
+  RVTEST_TESTDATA_LOAD_INT(x27, x25) # load rd compare value: x25 = 0x00006b05
   LA(x31, scratch) # load base address into rs1
   SREG x12, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b25_equal:
@@ -2368,6 +2545,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b25_equal:
 # Testcase cp_rd (Test destination rd = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x11) # load value in memory: x11 = 0x0000d608
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rs2: x1 = 0x0000756b
+  RVTEST_TESTDATA_LOAD_INT(x27, x25) # load rd compare value: x25 = 0x00008f2e
   LA(x18, scratch) # load base address into rs1
   SREG x11, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b25_not_equal:
@@ -2381,6 +2559,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b25_not_equal:
 # Testcase cp_rd (Test destination rd = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x18) # load value in memory: x18 = 0x0000e9e5
   RVTEST_TESTDATA_LOAD_INT(x27, x14) # load rs2: x14 = 0x000036b8
+  RVTEST_TESTDATA_LOAD_INT(x27, x26) # load rd compare value: x26 = 0x0000e9e5
   LA(x15, scratch) # load base address into rs1
   SREG x18, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b26_equal:
@@ -2394,6 +2573,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b26_equal:
 # Testcase cp_rd (Test destination rd = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x29) # load value in memory: x29 = 0x0000d86b
   RVTEST_TESTDATA_LOAD_INT(x27, x23) # load rs2: x23 = 0x0000550e
+  RVTEST_TESTDATA_LOAD_INT(x27, x26) # load rd compare value: x26 = 0x00004723
   LA(x15, scratch) # load base address into rs1
   SREG x29, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b26_not_equal:
@@ -2408,6 +2588,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b26_not_equal:
 # Testcase cp_rd (Test destination rd = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x8) # load value in memory: x8 = 0x000039e7
   RVTEST_TESTDATA_LOAD_INT(x12, x18) # load rs2: x18 = 0x0000440e
+  RVTEST_TESTDATA_LOAD_INT(x12, x27) # load rd compare value: x27 = 0x000039e7
   LA(x14, scratch) # load base address into rs1
   SREG x8, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b27_equal:
@@ -2421,6 +2602,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b27_equal:
 # Testcase cp_rd (Test destination rd = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x7) # load value in memory: x7 = 0x00008b4f
   RVTEST_TESTDATA_LOAD_INT(x12, x23) # load rs2: x23 = 0x000045b9
+  RVTEST_TESTDATA_LOAD_INT(x12, x27) # load rd compare value: x27 = 0x00000b9f
   LA(x30, scratch) # load base address into rs1
   SREG x7, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b27_not_equal:
@@ -2434,6 +2616,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b27_not_equal:
 # Testcase cp_rd (Test destination rd = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x16) # load value in memory: x16 = 0x00005351
   RVTEST_TESTDATA_LOAD_INT(x12, x0) # load rs2: x0 = 0x0000044b
+  RVTEST_TESTDATA_LOAD_INT(x12, x28) # load rd compare value: x28 = 0x00005351
   LA(x26, scratch) # load base address into rs1
   SREG x16, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b28_equal:
@@ -2447,6 +2630,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b28_equal:
 # Testcase cp_rd (Test destination rd = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x27) # load value in memory: x27 = 0x000017cd
   RVTEST_TESTDATA_LOAD_INT(x12, x16) # load rs2: x16 = 0x000086a4
+  RVTEST_TESTDATA_LOAD_INT(x12, x28) # load rd compare value: x28 = 0x000064a5
   LA(x20, scratch) # load base address into rs1
   SREG x27, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b28_not_equal:
@@ -2460,6 +2644,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b28_not_equal:
 # Testcase cp_rd (Test destination rd = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x15) # load value in memory: x15 = 0x000074ce
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load rs2: x1 = 0x00001305
+  RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rd compare value: x29 = 0x000074ce
   LA(x11, scratch) # load base address into rs1
   SREG x15, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b29_equal:
@@ -2473,6 +2658,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b29_equal:
 # Testcase cp_rd (Test destination rd = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x25) # load value in memory: x25 = 0x000078c8
   RVTEST_TESTDATA_LOAD_INT(x12, x30) # load rs2: x30 = 0x00004e83
+  RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rd compare value: x29 = 0x0000ba80
   LA(x28, scratch) # load base address into rs1
   SREG x25, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b29_not_equal:
@@ -2486,6 +2672,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b29_not_equal:
 # Testcase cp_rd (Test destination rd = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x26) # load value in memory: x26 = 0x00005938
   RVTEST_TESTDATA_LOAD_INT(x12, x14) # load rs2: x14 = 0x0000e2ec
+  RVTEST_TESTDATA_LOAD_INT(x12, x30) # load rd compare value: x30 = 0x00005938
   LA(x19, scratch) # load base address into rs1
   SREG x26, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b30_equal:
@@ -2499,6 +2686,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b30_equal:
 # Testcase cp_rd (Test destination rd = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x14) # load value in memory: x14 = 0x0000721d
   RVTEST_TESTDATA_LOAD_INT(x12, x22) # load rs2: x22 = 0x000061ca
+  RVTEST_TESTDATA_LOAD_INT(x12, x30) # load rd compare value: x30 = 0x0000e0f6
   LA(x13, scratch) # load base address into rs1
   SREG x14, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b30_not_equal:
@@ -2512,6 +2700,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b30_not_equal:
 # Testcase cp_rd (Test destination rd = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x25) # load value in memory: x25 = 0x0000af92
   RVTEST_TESTDATA_LOAD_INT(x12, x23) # load rs2: x23 = 0x000030df
+  RVTEST_TESTDATA_LOAD_INT(x12, x31) # load rd compare value: x31 = 0x0000af92
   LA(x11, scratch) # load base address into rs1
   SREG x25, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b31_equal:
@@ -2525,6 +2714,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b31_equal:
 # Testcase cp_rd (Test destination rd = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x20) # load value in memory: x20 = 0x00005746
   RVTEST_TESTDATA_LOAD_INT(x12, x24) # load rs2: x24 = 0x00003a37
+  RVTEST_TESTDATA_LOAD_INT(x12, x31) # load rd compare value: x31 = 0x000086f5
   LA(x29, scratch) # load base address into rs1
   SREG x20, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b31_not_equal:
@@ -4501,384 +4691,574 @@ RVTEST_DATA_BEGIN
 // Test data
 .word 0x00009f45
 .word 0x0000c666
+.word 0x00009f45
 .word 0x00005688
 .word 0x0000beef
+.word 0x000044ef
 .word 0x0000e10d
 .word 0x00003d42
+.word 0x0000e10d
 .word 0x0000f38e
 .word 0x0000bd95
+.word 0x00003481
 .word 0x0000b5d1
 .word 0x0000911a
+.word 0x0000b5d1
 .word 0x000050e0
 .word 0x000067ec
+.word 0x00006335
 .word 0x00003b4a
 .word 0x00004f41
+.word 0x00003b4a
 .word 0x0000e32d
 .word 0x0000c7d8
+.word 0x0000ff81
 .word 0x00000c17
 .word 0x000064b7
+.word 0x00000c17
 .word 0x0000c2a8
 .word 0x0000fbd6
+.word 0x00000101
 .word 0x00006d40
 .word 0x0000def9
+.word 0x00006d40
 .word 0x000055c9
 .word 0x00003a0e
+.word 0x0000eca3
 .word 0x00005adf
 .word 0x0000b308
+.word 0x00005adf
 .word 0x0000d892
 .word 0x0000adb5
+.word 0x0000c917
 .word 0x0000d44f
 .word 0x0000726b
+.word 0x0000d44f
 .word 0x00006ce6
 .word 0x0000e828
+.word 0x00002d67
 .word 0x00002eaf
 .word 0x0000de7d
+.word 0x00002eaf
 .word 0x000024f9
 .word 0x00004a25
+.word 0x00004052
 .word 0x00002cbe
 .word 0x0000eca6
+.word 0x00002cbe
 .word 0x00007c98
 .word 0x0000da89
+.word 0x0000e9a5
 .word 0x00007451
 .word 0x0000cbaf
+.word 0x00007451
 .word 0x0000d729
 .word 0x00009925
+.word 0x000076b8
 .word 0x0000e5dd
 .word 0x0000c36f
+.word 0x0000e5dd
 .word 0x00008902
 .word 0x0000d550
+.word 0x0000513d
 .word 0x0000dcf8
 .word 0x0000244e
+.word 0x0000dcf8
 .word 0x00006319
 .word 0x00002c06
+.word 0x00002a74
 .word 0x0000476b
 .word 0x00009e6c
+.word 0x0000476b
 .word 0x00007c51
 .word 0x0000db71
+.word 0x0000cf3c
 .word 0x0000bcfd
 .word 0x0000d2e2
+.word 0x0000bcfd
 .word 0x0000e307
 .word 0x00001486
+.word 0x00000944
 .word 0x0000014d
 .word 0x00001afa
+.word 0x0000014d
 .word 0x0000bc2d
 .word 0x0000c50b
+.word 0x0000c36d
 .word 0x0000c04e
 .word 0x00000f2a
+.word 0x0000c04e
 .word 0x000077de
 .word 0x000090db
+.word 0x00005015
 .word 0x00001a88
 .word 0x00009206
+.word 0x00001a88
 .word 0x0000e698
 .word 0x000042cb
+.word 0x000044b1
 .word 0x0000eb6f
 .word 0x000072e3
+.word 0x0000eb6f
 .word 0x00000d30
 .word 0x00005c8d
+.word 0x0000a478
 .word 0x00008d9b
 .word 0x0000cfb2
+.word 0x00008d9b
 .word 0x0000baed
 .word 0x00001afb
+.word 0x0000ccd8
 .word 0x0000cf5c
 .word 0x00005bad
+.word 0x0000cf5c
 .word 0x000017e9
 .word 0x000049d4
+.word 0x0000092c
 .word 0x0000bee0
 .word 0x00005090
+.word 0x0000bee0
 .word 0x00009ac1
 .word 0x000084e2
+.word 0x000028e8
 .word 0x0000d3f7
 .word 0x00005b62
+.word 0x0000d3f7
 .word 0x00005a5b
 .word 0x0000bbdb
+.word 0x0000a0f3
 .word 0x00000c05
 .word 0x00005c4c
+.word 0x00000c05
 .word 0x00006309
 .word 0x00009ab3
+.word 0x00000f9a
 .word 0x00005035
 .word 0x00003563
+.word 0x00005035
 .word 0x00000e64
 .word 0x0000fe78
+.word 0x0000175e
 .word 0x00006d3a
 .word 0x000086a9
+.word 0x00006d3a
 .word 0x000093e6
 .word 0x0000d238
+.word 0x00007b61
 .word 0x00006cec
 .word 0x0000f5d4
+.word 0x00006cec
 .word 0x0000effa
 .word 0x00004a9f
+.word 0x0000881b
 .word 0x00001d5a
 .word 0x0000198d
+.word 0x00001d5a
 .word 0x00004dc0
 .word 0x00003efd
+.word 0x000099aa
 .word 0x00005fd7
 .word 0x0000601f
+.word 0x00005fd7
 .word 0x0000f66c
 .word 0x0000647a
+.word 0x0000540f
 .word 0x0000c1e9
 .word 0x00000599
+.word 0x0000c1e9
 .word 0x0000a207
 .word 0x00007a2e
+.word 0x0000ca8a
 .word 0x0000f47c
 .word 0x0000e7b8
+.word 0x0000f47c
 .word 0x000015c1
 .word 0x00008607
+.word 0x00000cf5
 .word 0x0000fac1
 .word 0x000034b3
+.word 0x0000fac1
 .word 0x0000ace4
 .word 0x00001882
+.word 0x0000abc7
 .word 0x0000192d
 .word 0x0000027b
+.word 0x0000192d
 .word 0x00001bd6
 .word 0x00004ed0
+.word 0x00005351
 .word 0x0000bb46
 .word 0x0000f515
+.word 0x0000bb46
 .word 0x0000bb3c
 .word 0x0000455e
+.word 0x000028d9
 .word 0x00000304
 .word 0x00001e4f
+.word 0x00000304
 .word 0x0000d9a4
 .word 0x0000a8d0
+.word 0x00004dec
 .word 0x00004eba
 .word 0x00008822
+.word 0x00004eba
 .word 0x0000f7a1
 .word 0x0000cb7b
+.word 0x0000509d
 .word 0x000015b6
 .word 0x0000bf7a
+.word 0x000015b6
 .word 0x0000b809
 .word 0x000052de
+.word 0x00002a4c
 .word 0x000098dc
 .word 0x0000e878
+.word 0x000098dc
 .word 0x0000b0c5
 .word 0x00007e69
+.word 0x00000c78
 .word 0x0000469a
 .word 0x0000f779
+.word 0x0000469a
 .word 0x00003208
 .word 0x0000faa0
+.word 0x00005378
 .word 0x00005216
 .word 0x0000ef9f
+.word 0x00005216
 .word 0x000089b5
 .word 0x0000afae
+.word 0x000062a6
 .word 0x0000ade5
 .word 0x00008751
+.word 0x0000ade5
 .word 0x0000bd99
 .word 0x0000c13c
+.word 0x0000802d
 .word 0x00006cd5
 .word 0x00006d1c
+.word 0x00006cd5
 .word 0x0000d412
 .word 0x00007bea
+.word 0x0000527b
 .word 0x0000b64f
 .word 0x0000e2f3
+.word 0x0000b64f
 .word 0x00001150
 .word 0x0000e8a1
+.word 0x000029d1
 .word 0x00009d3d
 .word 0x0000bd1d
+.word 0x00009d3d
 .word 0x0000e6ff
 .word 0x0000fd0f
+.word 0x0000ef01
 .word 0x0000f770
 .word 0x000097e4
+.word 0x0000f770
 .word 0x00002830
 .word 0x00009973
+.word 0x0000bdeb
 .word 0x00000209
 .word 0x00005e99
+.word 0x00000209
 .word 0x0000cf92
 .word 0x000080d4
+.word 0x00002b78
 .word 0x00003f13
 .word 0x00005db6
+.word 0x00003f13
 .word 0x0000e5c0
 .word 0x00006626
+.word 0x0000a4be
 .word 0x00001567
 .word 0x00001046
+.word 0x00001567
 .word 0x000078e6
 .word 0x00004a68
+.word 0x00000744
 .word 0x0000790b
 .word 0x000070c6
+.word 0x0000790b
 .word 0x00009ee3
 .word 0x00007a75
+.word 0x0000c84e
 .word 0x00009308
 .word 0x00000295
+.word 0x00009308
 .word 0x00007a8d
 .word 0x0000ba3f
+.word 0x0000b772
 .word 0x0000dcdd
 .word 0x00008b14
+.word 0x0000dcdd
 .word 0x0000b72d
 .word 0x0000c8b5
+.word 0x00009d06
 .word 0x0000f964
 .word 0x00006581
+.word 0x0000f964
 .word 0x00007d55
 .word 0x0000e272
+.word 0x0000dd14
 .word 0x0000b0fa
 .word 0x0000860c
+.word 0x0000b0fa
 .word 0x000028d6
 .word 0x0000c421
+.word 0x00005850
 .word 0x00005b39
 .word 0x0000b189
+.word 0x00005b39
 .word 0x0000afdc
 .word 0x00006773
+.word 0x000064ad
 .word 0x0000b4ca
 .word 0x0000b609
+.word 0x0000b4ca
 .word 0x00007a41
 .word 0x0000e72c
+.word 0x0000b050
 .word 0x00007a77
 .word 0x0000ef0f
+.word 0x00007a77
 .word 0x00004a4b
 .word 0x00002a7c
+.word 0x0000bfca
 .word 0x00007345
 .word 0x000056d9
+.word 0x00007345
 .word 0x00008d6e
 .word 0x0000fac4
+.word 0x00006afa
 .word 0x0000b56c
 .word 0x000007da
+.word 0x0000b56c
 .word 0x0000f20d
 .word 0x0000fe09
+.word 0x0000fbe2
 .word 0x0000564b
 .word 0x0000dd4c
+.word 0x0000564b
 .word 0x0000dc97
 .word 0x0000571f
+.word 0x0000508b
 .word 0x00000282
 .word 0x0000eae9
+.word 0x00000282
 .word 0x0000db13
 .word 0x0000f2fe
+.word 0x00006ea5
 .word 0x000018ae
 .word 0x00002996
+.word 0x000018ae
 .word 0x0000e627
 .word 0x0000f626
+.word 0x00005239
 .word 0x00000d9d
 .word 0x00007a4d
+.word 0x00000d9d
 .word 0x0000b32d
 .word 0x0000f334
+.word 0x0000fdc9
 .word 0x0000f819
 .word 0x00003559
+.word 0x0000f819
 .word 0x0000ca0c
 .word 0x0000d8f8
+.word 0x0000e2b6
 .word 0x00006d46
 .word 0x00006674
+.word 0x00006d46
 .word 0x00001eea
 .word 0x0000c1ba
+.word 0x00009b03
 .word 0x0000eafb
 .word 0x00008329
+.word 0x0000eafb
 .word 0x0000dd8f
 .word 0x0000dbb4
+.word 0x000038ba
 .word 0x000044c8
 .word 0x00000ebc
+.word 0x000044c8
 .word 0x00004bde
 .word 0x00005e9f
+.word 0x0000b841
 .word 0x000018a7
 .word 0x0000a4a1
+.word 0x000018a7
 .word 0x00006999
 .word 0x000020a3
+.word 0x0000f969
 .word 0x0000b497
 .word 0x00004840
+.word 0x0000b497
 .word 0x0000f482
 .word 0x000018ce
+.word 0x0000f023
 .word 0x0000d264
 .word 0x0000274a
+.word 0x0000d264
 .word 0x000098d7
 .word 0x0000ddc6
+.word 0x00006321
 .word 0x0000a213
 .word 0x00004eca
+.word 0x0000a213
 .word 0x0000a0cd
 .word 0x00009b4d
+.word 0x00003074
 .word 0x00003878
 .word 0x00002fee
+.word 0x00003878
 .word 0x00008850
 .word 0x0000df58
+.word 0x00000b37
 .word 0x000019e9
 .word 0x00001ead
+.word 0x000019e9
 .word 0x00005939
 .word 0x0000194e
+.word 0x000018a2
 .word 0x000039d7
 .word 0x00007331
+.word 0x000039d7
 .word 0x0000ac1a
 .word 0x0000a5fb
+.word 0x00004382
 .word 0x0000b65a
 .word 0x00004b3c
+.word 0x0000b65a
 .word 0x00005356
 .word 0x00000cb2
+.word 0x00007f07
 .word 0x00003913
 .word 0x0000ced3
+.word 0x00003913
 .word 0x00007d75
 .word 0x0000043c
+.word 0x000038b9
 .word 0x0000e3c6
 .word 0x000051ed
+.word 0x0000e3c6
 .word 0x00009d1a
 .word 0x0000b5f7
+.word 0x0000ce59
 .word 0x000047a1
 .word 0x00007640
+.word 0x000047a1
 .word 0x00002348
 .word 0x0000eddc
+.word 0x00008cbc
 .word 0x00008f63
 .word 0x0000c25e
+.word 0x00008f63
 .word 0x000043d9
 .word 0x0000122c
+.word 0x00005c7a
 .word 0x00001e5a
 .word 0x00006a6c
+.word 0x00001e5a
 .word 0x00009690
 .word 0x000005fb
+.word 0x00001df4
 .word 0x00000b6a
 .word 0x00005dc7
+.word 0x00000b6a
 .word 0x00009524
 .word 0x00003e2e
+.word 0x0000986f
 .word 0x000030a8
 .word 0x0000bc15
+.word 0x000030a8
 .word 0x00004995
 .word 0x0000458c
+.word 0x00001d9e
 .word 0x00008526
 .word 0x00007815
+.word 0x00008526
 .word 0x0000c76b
 .word 0x00001f83
+.word 0x0000e114
 .word 0x00003630
 .word 0x000009e0
+.word 0x00003630
 .word 0x000039ed
 .word 0x00000bda
+.word 0x0000296b
 .word 0x00002b38
 .word 0x0000133c
+.word 0x00002b38
 .word 0x0000a019
 .word 0x000022a8
+.word 0x00001187
 .word 0x0000437e
 .word 0x0000889b
+.word 0x0000437e
 .word 0x000027d9
 .word 0x0000951c
+.word 0x0000bd99
 .word 0x00006b49
 .word 0x00003d38
+.word 0x00006b49
 .word 0x00004882
 .word 0x0000821f
+.word 0x00001cca
 .word 0x000009a2
 .word 0x0000dd5e
+.word 0x000009a2
 .word 0x0000a193
 .word 0x0000b7a7
+.word 0x0000285b
 .word 0x0000404e
 .word 0x0000e95e
+.word 0x0000404e
 .word 0x000075bd
 .word 0x0000d7d1
+.word 0x0000b9bb
 .word 0x00006b05
 .word 0x00006ea7
+.word 0x00006b05
 .word 0x0000d608
 .word 0x0000756b
+.word 0x00008f2e
 .word 0x0000e9e5
 .word 0x000036b8
+.word 0x0000e9e5
 .word 0x0000d86b
 .word 0x0000550e
+.word 0x00004723
 .word 0x000039e7
 .word 0x0000440e
+.word 0x000039e7
 .word 0x00008b4f
 .word 0x000045b9
+.word 0x00000b9f
 .word 0x00005351
 .word 0x0000044b
+.word 0x00005351
 .word 0x000017cd
 .word 0x000086a4
+.word 0x000064a5
 .word 0x000074ce
 .word 0x00001305
+.word 0x000074ce
 .word 0x000078c8
 .word 0x00004e83
+.word 0x0000ba80
 .word 0x00005938
 .word 0x0000e2ec
+.word 0x00005938
 .word 0x0000721d
 .word 0x000061ca
+.word 0x0000e0f6
 .word 0x0000af92
 .word 0x000030df
+.word 0x0000af92
 .word 0x00005746
 .word 0x00003a37
+.word 0x000086f5
 .word 0x87c727bb
 .word 0x00000000
 .word 0x04b03944

--- a/tests/rv32i/Zca/Zca-c.mv-00.S
+++ b/tests/rv32i/Zca/Zca-c.mv-00.S
@@ -295,259 +295,259 @@ Zca_c_mv_cg_cp_rs2_nx0_b31:
 /////////////////////////////////
 
 # Testcase cp_rd_nx0 (Test destination rd = x1)
-  RVTEST_TESTDATA_LOAD_INT(x19, x27) # load rd/rs1: x27 = 0xb128dd9b
+  RVTEST_TESTDATA_LOAD_INT(x19, x1) # load rd/rs1: x1 = 0xb128dd9b
   RVTEST_TESTDATA_LOAD_INT(x19, x13) # load rs2: x13 = 0x5adcb918
 Zca_c_mv_cg_cp_rd_nx0_b1:
-  c.mv x27, x13 # perform operation
-  # Check if x27 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x12, x8, x7, x27, Zca_c_mv_cg_cp_rd_nx0_b1, Zca_c_mv_cg_cp_rd_nx0_b1_str)
+  c.mv x1, x13 # perform operation
+  # Check if x1 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x12, x8, x7, x1, Zca_c_mv_cg_cp_rd_nx0_b1, Zca_c_mv_cg_cp_rd_nx0_b1_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x2)
-  RVTEST_TESTDATA_LOAD_INT(x19, x24) # load rd/rs1: x24 = 0x9da3a605
+  RVTEST_TESTDATA_LOAD_INT(x19, x2) # load rd/rs1: x2 = 0x9da3a605
   RVTEST_TESTDATA_LOAD_INT(x19, x30) # load rs2: x30 = 0xa43be7ee
 Zca_c_mv_cg_cp_rd_nx0_b2:
-  c.mv x24, x30 # perform operation
-  # Check if x24 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x12, x8, x7, x24, Zca_c_mv_cg_cp_rd_nx0_b2, Zca_c_mv_cg_cp_rd_nx0_b2_str)
+  c.mv x2, x30 # perform operation
+  # Check if x2 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x12, x8, x7, x2, Zca_c_mv_cg_cp_rd_nx0_b2, Zca_c_mv_cg_cp_rd_nx0_b2_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x3)
-  RVTEST_TESTDATA_LOAD_INT(x19, x9) # load rd/rs1: x9 = 0x1ae58866
+  RVTEST_TESTDATA_LOAD_INT(x19, x3) # load rd/rs1: x3 = 0x1ae58866
   RVTEST_TESTDATA_LOAD_INT(x19, x20) # load rs2: x20 = 0xc3b256f0
 Zca_c_mv_cg_cp_rd_nx0_b3:
-  c.mv x9, x20 # perform operation
-  # Check if x9 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x12, x8, x7, x9, Zca_c_mv_cg_cp_rd_nx0_b3, Zca_c_mv_cg_cp_rd_nx0_b3_str)
+  c.mv x3, x20 # perform operation
+  # Check if x3 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x12, x8, x7, x3, Zca_c_mv_cg_cp_rd_nx0_b3, Zca_c_mv_cg_cp_rd_nx0_b3_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x4)
-  RVTEST_TESTDATA_LOAD_INT(x19, x21) # load rd/rs1: x21 = 0xccabf957
+  RVTEST_TESTDATA_LOAD_INT(x19, x4) # load rd/rs1: x4 = 0xccabf957
   RVTEST_TESTDATA_LOAD_INT(x19, x1) # load rs2: x1 = 0x331106ac
 Zca_c_mv_cg_cp_rd_nx0_b4:
-  c.mv x21, x1 # perform operation
-  # Check if x21 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x12, x8, x7, x21, Zca_c_mv_cg_cp_rd_nx0_b4, Zca_c_mv_cg_cp_rd_nx0_b4_str)
+  c.mv x4, x1 # perform operation
+  # Check if x4 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x12, x8, x7, x4, Zca_c_mv_cg_cp_rd_nx0_b4, Zca_c_mv_cg_cp_rd_nx0_b4_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x5)
-  RVTEST_TESTDATA_LOAD_INT(x19, x9) # load rd/rs1: x9 = 0x8035b2d7
+  RVTEST_TESTDATA_LOAD_INT(x19, x5) # load rd/rs1: x5 = 0x8035b2d7
   RVTEST_TESTDATA_LOAD_INT(x19, x23) # load rs2: x23 = 0xc04501f9
 Zca_c_mv_cg_cp_rd_nx0_b5:
-  c.mv x9, x23 # perform operation
-  # Check if x9 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x12, x8, x7, x9, Zca_c_mv_cg_cp_rd_nx0_b5, Zca_c_mv_cg_cp_rd_nx0_b5_str)
+  c.mv x5, x23 # perform operation
+  # Check if x5 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x12, x8, x7, x5, Zca_c_mv_cg_cp_rd_nx0_b5, Zca_c_mv_cg_cp_rd_nx0_b5_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x6)
-  RVTEST_TESTDATA_LOAD_INT(x19, x22) # load rd/rs1: x22 = 0xce8d6c12
+  RVTEST_TESTDATA_LOAD_INT(x19, x6) # load rd/rs1: x6 = 0xce8d6c12
   RVTEST_TESTDATA_LOAD_INT(x19, x20) # load rs2: x20 = 0x78cd8eba
 Zca_c_mv_cg_cp_rd_nx0_b6:
-  c.mv x22, x20 # perform operation
-  # Check if x22 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x12, x8, x7, x22, Zca_c_mv_cg_cp_rd_nx0_b6, Zca_c_mv_cg_cp_rd_nx0_b6_str)
+  c.mv x6, x20 # perform operation
+  # Check if x6 contains the expected result. x12 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x12, x8, x7, x6, Zca_c_mv_cg_cp_rd_nx0_b6, Zca_c_mv_cg_cp_rd_nx0_b6_str)
 
   mv x13, x7 # switch temp register to avoid conflict with test
   mv x14, x8 # switch link pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x7)
-  RVTEST_TESTDATA_LOAD_INT(x19, x27) # load rd/rs1: x27 = 0xaa571e2a
+  RVTEST_TESTDATA_LOAD_INT(x19, x7) # load rd/rs1: x7 = 0xaa571e2a
   RVTEST_TESTDATA_LOAD_INT(x19, x31) # load rs2: x31 = 0x67436e11
 Zca_c_mv_cg_cp_rd_nx0_b7:
-  c.mv x27, x31 # perform operation
-  # Check if x27 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x12, x14, x13, x27, Zca_c_mv_cg_cp_rd_nx0_b7, Zca_c_mv_cg_cp_rd_nx0_b7_str)
+  c.mv x7, x31 # perform operation
+  # Check if x7 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x12, x14, x13, x7, Zca_c_mv_cg_cp_rd_nx0_b7, Zca_c_mv_cg_cp_rd_nx0_b7_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x8)
-  RVTEST_TESTDATA_LOAD_INT(x19, x10) # load rd/rs1: x10 = 0xbba5aa6c
+  RVTEST_TESTDATA_LOAD_INT(x19, x8) # load rd/rs1: x8 = 0xbba5aa6c
   RVTEST_TESTDATA_LOAD_INT(x19, x23) # load rs2: x23 = 0xba2c9c19
 Zca_c_mv_cg_cp_rd_nx0_b8:
-  c.mv x10, x23 # perform operation
-  # Check if x10 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x12, x14, x13, x10, Zca_c_mv_cg_cp_rd_nx0_b8, Zca_c_mv_cg_cp_rd_nx0_b8_str)
+  c.mv x8, x23 # perform operation
+  # Check if x8 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x12, x14, x13, x8, Zca_c_mv_cg_cp_rd_nx0_b8, Zca_c_mv_cg_cp_rd_nx0_b8_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x9)
-  RVTEST_TESTDATA_LOAD_INT(x19, x22) # load rd/rs1: x22 = 0xd9934e6e
+  RVTEST_TESTDATA_LOAD_INT(x19, x9) # load rd/rs1: x9 = 0xd9934e6e
   RVTEST_TESTDATA_LOAD_INT(x19, x25) # load rs2: x25 = 0x093e8f51
 Zca_c_mv_cg_cp_rd_nx0_b9:
-  c.mv x22, x25 # perform operation
-  # Check if x22 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x12, x14, x13, x22, Zca_c_mv_cg_cp_rd_nx0_b9, Zca_c_mv_cg_cp_rd_nx0_b9_str)
+  c.mv x9, x25 # perform operation
+  # Check if x9 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x12, x14, x13, x9, Zca_c_mv_cg_cp_rd_nx0_b9, Zca_c_mv_cg_cp_rd_nx0_b9_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x10)
-  RVTEST_TESTDATA_LOAD_INT(x19, x25) # load rd/rs1: x25 = 0x4260f149
+  RVTEST_TESTDATA_LOAD_INT(x19, x10) # load rd/rs1: x10 = 0x4260f149
   RVTEST_TESTDATA_LOAD_INT(x19, x23) # load rs2: x23 = 0x68812222
 Zca_c_mv_cg_cp_rd_nx0_b10:
-  c.mv x25, x23 # perform operation
-  # Check if x25 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x12, x14, x13, x25, Zca_c_mv_cg_cp_rd_nx0_b10, Zca_c_mv_cg_cp_rd_nx0_b10_str)
+  c.mv x10, x23 # perform operation
+  # Check if x10 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x12, x14, x13, x10, Zca_c_mv_cg_cp_rd_nx0_b10, Zca_c_mv_cg_cp_rd_nx0_b10_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x11)
-  RVTEST_TESTDATA_LOAD_INT(x19, x9) # load rd/rs1: x9 = 0x14d8af6f
+  RVTEST_TESTDATA_LOAD_INT(x19, x11) # load rd/rs1: x11 = 0x14d8af6f
   RVTEST_TESTDATA_LOAD_INT(x19, x8) # load rs2: x8 = 0xcf215490
 Zca_c_mv_cg_cp_rd_nx0_b11:
-  c.mv x9, x8 # perform operation
-  # Check if x9 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x12, x14, x13, x9, Zca_c_mv_cg_cp_rd_nx0_b11, Zca_c_mv_cg_cp_rd_nx0_b11_str)
+  c.mv x11, x8 # perform operation
+  # Check if x11 contains the expected result. x12 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x12, x14, x13, x11, Zca_c_mv_cg_cp_rd_nx0_b11, Zca_c_mv_cg_cp_rd_nx0_b11_str)
 
   mv x28, x12 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x12)
-  RVTEST_TESTDATA_LOAD_INT(x19, x22) # load rd/rs1: x22 = 0x87a7d08d
+  RVTEST_TESTDATA_LOAD_INT(x19, x12) # load rd/rs1: x12 = 0x87a7d08d
   RVTEST_TESTDATA_LOAD_INT(x19, x20) # load rs2: x20 = 0x56d1ee33
 Zca_c_mv_cg_cp_rd_nx0_b12:
-  c.mv x22, x20 # perform operation
-  # Check if x22 contains the expected result. x28 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x28, x14, x13, x22, Zca_c_mv_cg_cp_rd_nx0_b12, Zca_c_mv_cg_cp_rd_nx0_b12_str)
+  c.mv x12, x20 # perform operation
+  # Check if x12 contains the expected result. x28 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x28, x14, x13, x12, Zca_c_mv_cg_cp_rd_nx0_b12, Zca_c_mv_cg_cp_rd_nx0_b12_str)
 
   mv x7, x13 # switch temp register to avoid conflict with test
   mv x8, x14 # switch link pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x13)
-  RVTEST_TESTDATA_LOAD_INT(x19, x23) # load rd/rs1: x23 = 0xab916e86
+  RVTEST_TESTDATA_LOAD_INT(x19, x13) # load rd/rs1: x13 = 0xab916e86
   RVTEST_TESTDATA_LOAD_INT(x19, x27) # load rs2: x27 = 0xd5d400ac
 Zca_c_mv_cg_cp_rd_nx0_b13:
-  c.mv x23, x27 # perform operation
-  # Check if x23 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x28, x8, x7, x23, Zca_c_mv_cg_cp_rd_nx0_b13, Zca_c_mv_cg_cp_rd_nx0_b13_str)
+  c.mv x13, x27 # perform operation
+  # Check if x13 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x28, x8, x7, x13, Zca_c_mv_cg_cp_rd_nx0_b13, Zca_c_mv_cg_cp_rd_nx0_b13_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x14)
-  RVTEST_TESTDATA_LOAD_INT(x19, x3) # load rd/rs1: x3 = 0x3c18542a
+  RVTEST_TESTDATA_LOAD_INT(x19, x14) # load rd/rs1: x14 = 0x3c18542a
   RVTEST_TESTDATA_LOAD_INT(x19, x4) # load rs2: x4 = 0x1e997a8a
 Zca_c_mv_cg_cp_rd_nx0_b14:
-  c.mv x3, x4 # perform operation
-  # Check if x3 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x28, x8, x7, x3, Zca_c_mv_cg_cp_rd_nx0_b14, Zca_c_mv_cg_cp_rd_nx0_b14_str)
+  c.mv x14, x4 # perform operation
+  # Check if x14 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x28, x8, x7, x14, Zca_c_mv_cg_cp_rd_nx0_b14, Zca_c_mv_cg_cp_rd_nx0_b14_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x15)
-  RVTEST_TESTDATA_LOAD_INT(x19, x23) # load rd/rs1: x23 = 0x0bf66be4
+  RVTEST_TESTDATA_LOAD_INT(x19, x15) # load rd/rs1: x15 = 0x0bf66be4
   RVTEST_TESTDATA_LOAD_INT(x19, x30) # load rs2: x30 = 0x45cff92c
 Zca_c_mv_cg_cp_rd_nx0_b15:
-  c.mv x23, x30 # perform operation
-  # Check if x23 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x28, x8, x7, x23, Zca_c_mv_cg_cp_rd_nx0_b15, Zca_c_mv_cg_cp_rd_nx0_b15_str)
+  c.mv x15, x30 # perform operation
+  # Check if x15 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x28, x8, x7, x15, Zca_c_mv_cg_cp_rd_nx0_b15, Zca_c_mv_cg_cp_rd_nx0_b15_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x16)
-  RVTEST_TESTDATA_LOAD_INT(x19, x3) # load rd/rs1: x3 = 0xd6267b29
+  RVTEST_TESTDATA_LOAD_INT(x19, x16) # load rd/rs1: x16 = 0xd6267b29
   RVTEST_TESTDATA_LOAD_INT(x19, x29) # load rs2: x29 = 0xb9723c03
 Zca_c_mv_cg_cp_rd_nx0_b16:
-  c.mv x3, x29 # perform operation
-  # Check if x3 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x28, x8, x7, x3, Zca_c_mv_cg_cp_rd_nx0_b16, Zca_c_mv_cg_cp_rd_nx0_b16_str)
+  c.mv x16, x29 # perform operation
+  # Check if x16 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x28, x8, x7, x16, Zca_c_mv_cg_cp_rd_nx0_b16, Zca_c_mv_cg_cp_rd_nx0_b16_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x17)
-  RVTEST_TESTDATA_LOAD_INT(x19, x9) # load rd/rs1: x9 = 0x63187e44
+  RVTEST_TESTDATA_LOAD_INT(x19, x17) # load rd/rs1: x17 = 0x63187e44
   RVTEST_TESTDATA_LOAD_INT(x19, x16) # load rs2: x16 = 0xe7d39a94
 Zca_c_mv_cg_cp_rd_nx0_b17:
-  c.mv x9, x16 # perform operation
-  # Check if x9 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x28, x8, x7, x9, Zca_c_mv_cg_cp_rd_nx0_b17, Zca_c_mv_cg_cp_rd_nx0_b17_str)
+  c.mv x17, x16 # perform operation
+  # Check if x17 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x28, x8, x7, x17, Zca_c_mv_cg_cp_rd_nx0_b17, Zca_c_mv_cg_cp_rd_nx0_b17_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x18)
-  RVTEST_TESTDATA_LOAD_INT(x19, x26) # load rd/rs1: x26 = 0x1e2052db
+  RVTEST_TESTDATA_LOAD_INT(x19, x18) # load rd/rs1: x18 = 0x1e2052db
   RVTEST_TESTDATA_LOAD_INT(x19, x9) # load rs2: x9 = 0xb8bc0a30
 Zca_c_mv_cg_cp_rd_nx0_b18:
-  c.mv x26, x9 # perform operation
-  # Check if x26 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x28, x8, x7, x26, Zca_c_mv_cg_cp_rd_nx0_b18, Zca_c_mv_cg_cp_rd_nx0_b18_str)
+  c.mv x18, x9 # perform operation
+  # Check if x18 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x28, x8, x7, x18, Zca_c_mv_cg_cp_rd_nx0_b18, Zca_c_mv_cg_cp_rd_nx0_b18_str)
 
   mv x10, x19 # switch data pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x19)
-  RVTEST_TESTDATA_LOAD_INT(x10, x3) # load rd/rs1: x3 = 0x3c885443
+  RVTEST_TESTDATA_LOAD_INT(x10, x19) # load rd/rs1: x19 = 0x3c885443
   RVTEST_TESTDATA_LOAD_INT(x10, x15) # load rs2: x15 = 0xc697e57d
 Zca_c_mv_cg_cp_rd_nx0_b19:
-  c.mv x3, x15 # perform operation
-  # Check if x3 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x28, x8, x7, x3, Zca_c_mv_cg_cp_rd_nx0_b19, Zca_c_mv_cg_cp_rd_nx0_b19_str)
+  c.mv x19, x15 # perform operation
+  # Check if x19 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x28, x8, x7, x19, Zca_c_mv_cg_cp_rd_nx0_b19, Zca_c_mv_cg_cp_rd_nx0_b19_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x20)
-  RVTEST_TESTDATA_LOAD_INT(x10, x12) # load rd/rs1: x12 = 0xe955b064
+  RVTEST_TESTDATA_LOAD_INT(x10, x20) # load rd/rs1: x20 = 0xe955b064
   RVTEST_TESTDATA_LOAD_INT(x10, x3) # load rs2: x3 = 0x66702d3c
 Zca_c_mv_cg_cp_rd_nx0_b20:
-  c.mv x12, x3 # perform operation
-  # Check if x12 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x28, x8, x7, x12, Zca_c_mv_cg_cp_rd_nx0_b20, Zca_c_mv_cg_cp_rd_nx0_b20_str)
+  c.mv x20, x3 # perform operation
+  # Check if x20 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x28, x8, x7, x20, Zca_c_mv_cg_cp_rd_nx0_b20, Zca_c_mv_cg_cp_rd_nx0_b20_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x21)
-  RVTEST_TESTDATA_LOAD_INT(x10, x30) # load rd/rs1: x30 = 0x615cffbf
+  RVTEST_TESTDATA_LOAD_INT(x10, x21) # load rd/rs1: x21 = 0x615cffbf
   RVTEST_TESTDATA_LOAD_INT(x10, x14) # load rs2: x14 = 0xcfee093b
 Zca_c_mv_cg_cp_rd_nx0_b21:
-  c.mv x30, x14 # perform operation
-  # Check if x30 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x28, x8, x7, x30, Zca_c_mv_cg_cp_rd_nx0_b21, Zca_c_mv_cg_cp_rd_nx0_b21_str)
+  c.mv x21, x14 # perform operation
+  # Check if x21 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x28, x8, x7, x21, Zca_c_mv_cg_cp_rd_nx0_b21, Zca_c_mv_cg_cp_rd_nx0_b21_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x22)
-  RVTEST_TESTDATA_LOAD_INT(x10, x27) # load rd/rs1: x27 = 0xc17b22d8
+  RVTEST_TESTDATA_LOAD_INT(x10, x22) # load rd/rs1: x22 = 0xc17b22d8
   RVTEST_TESTDATA_LOAD_INT(x10, x1) # load rs2: x1 = 0x3a03b9f3
 Zca_c_mv_cg_cp_rd_nx0_b22:
-  c.mv x27, x1 # perform operation
-  # Check if x27 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x28, x8, x7, x27, Zca_c_mv_cg_cp_rd_nx0_b22, Zca_c_mv_cg_cp_rd_nx0_b22_str)
+  c.mv x22, x1 # perform operation
+  # Check if x22 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x28, x8, x7, x22, Zca_c_mv_cg_cp_rd_nx0_b22, Zca_c_mv_cg_cp_rd_nx0_b22_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x23)
-  RVTEST_TESTDATA_LOAD_INT(x10, x26) # load rd/rs1: x26 = 0x50de2689
+  RVTEST_TESTDATA_LOAD_INT(x10, x23) # load rd/rs1: x23 = 0x50de2689
   RVTEST_TESTDATA_LOAD_INT(x10, x19) # load rs2: x19 = 0x84dfc369
 Zca_c_mv_cg_cp_rd_nx0_b23:
-  c.mv x26, x19 # perform operation
-  # Check if x26 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x28, x8, x7, x26, Zca_c_mv_cg_cp_rd_nx0_b23, Zca_c_mv_cg_cp_rd_nx0_b23_str)
+  c.mv x23, x19 # perform operation
+  # Check if x23 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x28, x8, x7, x23, Zca_c_mv_cg_cp_rd_nx0_b23, Zca_c_mv_cg_cp_rd_nx0_b23_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x24)
-  RVTEST_TESTDATA_LOAD_INT(x10, x14) # load rd/rs1: x14 = 0x70b66246
+  RVTEST_TESTDATA_LOAD_INT(x10, x24) # load rd/rs1: x24 = 0x70b66246
   RVTEST_TESTDATA_LOAD_INT(x10, x6) # load rs2: x6 = 0x345c596c
 Zca_c_mv_cg_cp_rd_nx0_b24:
-  c.mv x14, x6 # perform operation
-  # Check if x14 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x28, x8, x7, x14, Zca_c_mv_cg_cp_rd_nx0_b24, Zca_c_mv_cg_cp_rd_nx0_b24_str)
+  c.mv x24, x6 # perform operation
+  # Check if x24 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x28, x8, x7, x24, Zca_c_mv_cg_cp_rd_nx0_b24, Zca_c_mv_cg_cp_rd_nx0_b24_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x25)
-  RVTEST_TESTDATA_LOAD_INT(x10, x6) # load rd/rs1: x6 = 0x8108b2cf
+  RVTEST_TESTDATA_LOAD_INT(x10, x25) # load rd/rs1: x25 = 0x8108b2cf
   RVTEST_TESTDATA_LOAD_INT(x10, x18) # load rs2: x18 = 0xcc96da89
 Zca_c_mv_cg_cp_rd_nx0_b25:
-  c.mv x6, x18 # perform operation
-  # Check if x6 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x28, x8, x7, x6, Zca_c_mv_cg_cp_rd_nx0_b25, Zca_c_mv_cg_cp_rd_nx0_b25_str)
+  c.mv x25, x18 # perform operation
+  # Check if x25 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x28, x8, x7, x25, Zca_c_mv_cg_cp_rd_nx0_b25, Zca_c_mv_cg_cp_rd_nx0_b25_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x26)
-  RVTEST_TESTDATA_LOAD_INT(x10, x14) # load rd/rs1: x14 = 0xbf81834d
+  RVTEST_TESTDATA_LOAD_INT(x10, x26) # load rd/rs1: x26 = 0xbf81834d
   RVTEST_TESTDATA_LOAD_INT(x10, x6) # load rs2: x6 = 0xb10e1dc3
 Zca_c_mv_cg_cp_rd_nx0_b26:
-  c.mv x14, x6 # perform operation
-  # Check if x14 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x28, x8, x7, x14, Zca_c_mv_cg_cp_rd_nx0_b26, Zca_c_mv_cg_cp_rd_nx0_b26_str)
+  c.mv x26, x6 # perform operation
+  # Check if x26 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x28, x8, x7, x26, Zca_c_mv_cg_cp_rd_nx0_b26, Zca_c_mv_cg_cp_rd_nx0_b26_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x27)
-  RVTEST_TESTDATA_LOAD_INT(x10, x9) # load rd/rs1: x9 = 0xee35a1c3
+  RVTEST_TESTDATA_LOAD_INT(x10, x27) # load rd/rs1: x27 = 0xee35a1c3
   RVTEST_TESTDATA_LOAD_INT(x10, x19) # load rs2: x19 = 0x1e4c7066
 Zca_c_mv_cg_cp_rd_nx0_b27:
-  c.mv x9, x19 # perform operation
-  # Check if x9 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x28, x8, x7, x9, Zca_c_mv_cg_cp_rd_nx0_b27, Zca_c_mv_cg_cp_rd_nx0_b27_str)
+  c.mv x27, x19 # perform operation
+  # Check if x27 contains the expected result. x28 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x28, x8, x7, x27, Zca_c_mv_cg_cp_rd_nx0_b27, Zca_c_mv_cg_cp_rd_nx0_b27_str)
 
   mv x26, x28 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x28)
-  RVTEST_TESTDATA_LOAD_INT(x10, x27) # load rd/rs1: x27 = 0x599cb6fc
+  RVTEST_TESTDATA_LOAD_INT(x10, x28) # load rd/rs1: x28 = 0x599cb6fc
   RVTEST_TESTDATA_LOAD_INT(x10, x31) # load rs2: x31 = 0x08b6665a
 Zca_c_mv_cg_cp_rd_nx0_b28:
-  c.mv x27, x31 # perform operation
-  # Check if x27 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x26, x8, x7, x27, Zca_c_mv_cg_cp_rd_nx0_b28, Zca_c_mv_cg_cp_rd_nx0_b28_str)
+  c.mv x28, x31 # perform operation
+  # Check if x28 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x26, x8, x7, x28, Zca_c_mv_cg_cp_rd_nx0_b28, Zca_c_mv_cg_cp_rd_nx0_b28_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x29)
-  RVTEST_TESTDATA_LOAD_INT(x10, x24) # load rd/rs1: x24 = 0xa98afaaf
+  RVTEST_TESTDATA_LOAD_INT(x10, x29) # load rd/rs1: x29 = 0xa98afaaf
   RVTEST_TESTDATA_LOAD_INT(x10, x30) # load rs2: x30 = 0x20321420
 Zca_c_mv_cg_cp_rd_nx0_b29:
-  c.mv x24, x30 # perform operation
-  # Check if x24 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x26, x8, x7, x24, Zca_c_mv_cg_cp_rd_nx0_b29, Zca_c_mv_cg_cp_rd_nx0_b29_str)
+  c.mv x29, x30 # perform operation
+  # Check if x29 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x26, x8, x7, x29, Zca_c_mv_cg_cp_rd_nx0_b29, Zca_c_mv_cg_cp_rd_nx0_b29_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x30)
-  RVTEST_TESTDATA_LOAD_INT(x10, x22) # load rd/rs1: x22 = 0x5b23c730
+  RVTEST_TESTDATA_LOAD_INT(x10, x30) # load rd/rs1: x30 = 0x5b23c730
   RVTEST_TESTDATA_LOAD_INT(x10, x9) # load rs2: x9 = 0xfe73a467
 Zca_c_mv_cg_cp_rd_nx0_b30:
-  c.mv x22, x9 # perform operation
-  # Check if x22 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x26, x8, x7, x22, Zca_c_mv_cg_cp_rd_nx0_b30, Zca_c_mv_cg_cp_rd_nx0_b30_str)
+  c.mv x30, x9 # perform operation
+  # Check if x30 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x26, x8, x7, x30, Zca_c_mv_cg_cp_rd_nx0_b30, Zca_c_mv_cg_cp_rd_nx0_b30_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x31)
-  RVTEST_TESTDATA_LOAD_INT(x10, x17) # load rd/rs1: x17 = 0xd5471a44
+  RVTEST_TESTDATA_LOAD_INT(x10, x31) # load rd/rs1: x31 = 0xd5471a44
   RVTEST_TESTDATA_LOAD_INT(x10, x22) # load rs2: x22 = 0x87d82dfa
 Zca_c_mv_cg_cp_rd_nx0_b31:
-  c.mv x17, x22 # perform operation
-  # Check if x17 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x26, x8, x7, x17, Zca_c_mv_cg_cp_rd_nx0_b31, Zca_c_mv_cg_cp_rd_nx0_b31_str)
+  c.mv x31, x22 # perform operation
+  # Check if x31 contains the expected result. x26 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x26, x8, x7, x31, Zca_c_mv_cg_cp_rd_nx0_b31, Zca_c_mv_cg_cp_rd_nx0_b31_str)
 
 /////////////////////////////////
 // cp_rs2_edges

--- a/tests/rv64e/Zca/Zca-c.mv-00.S
+++ b/tests/rv64e/Zca/Zca-c.mv-00.S
@@ -168,133 +168,133 @@ Zca_c_mv_cg_cp_rs2_nx0_b15:
 
   mv x12, x1 # switch data pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x1)
-  RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rd/rs1: x7 = 0x5adcb918d3ffd4fd
+  RVTEST_TESTDATA_LOAD_INT(x12, x1) # load rd/rs1: x1 = 0x5adcb918d3ffd4fd
   RVTEST_TESTDATA_LOAD_INT(x12, x15) # load rs2: x15 = 0x95184c474cabf957
 Zca_c_mv_cg_cp_rd_nx0_b1:
-  c.mv x7, x15 # perform operation
-  # Check if x7 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x2, x5, x4, x7, Zca_c_mv_cg_cp_rd_nx0_b1, Zca_c_mv_cg_cp_rd_nx0_b1_str)
+  c.mv x1, x15 # perform operation
+  # Check if x1 contains the expected result. x2 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x2, x5, x4, x1, Zca_c_mv_cg_cp_rd_nx0_b1, Zca_c_mv_cg_cp_rd_nx0_b1_str)
 
   mv x9, x2 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x2)
-  RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rd/rs1: x6 = 0x331106ace3d326b0
+  RVTEST_TESTDATA_LOAD_INT(x12, x2) # load rd/rs1: x2 = 0x331106ace3d326b0
   RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rs2: x7 = 0xc04501f9d8228da5
 Zca_c_mv_cg_cp_rd_nx0_b2:
-  c.mv x6, x7 # perform operation
-  # Check if x6 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x6, Zca_c_mv_cg_cp_rd_nx0_b2, Zca_c_mv_cg_cp_rd_nx0_b2_str)
+  c.mv x2, x7 # perform operation
+  # Check if x2 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x2, Zca_c_mv_cg_cp_rd_nx0_b2, Zca_c_mv_cg_cp_rd_nx0_b2_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x3)
-  RVTEST_TESTDATA_LOAD_INT(x12, x13) # load rd/rs1: x13 = 0x57d2819f6fe6c6a4
+  RVTEST_TESTDATA_LOAD_INT(x12, x3) # load rd/rs1: x3 = 0x57d2819f6fe6c6a4
   RVTEST_TESTDATA_LOAD_INT(x12, x11) # load rs2: x11 = 0x78cd8eba7d2b4f44
 Zca_c_mv_cg_cp_rd_nx0_b3:
-  c.mv x13, x11 # perform operation
-  # Check if x13 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x9, x5, x4, x13, Zca_c_mv_cg_cp_rd_nx0_b3, Zca_c_mv_cg_cp_rd_nx0_b3_str)
+  c.mv x3, x11 # perform operation
+  # Check if x3 contains the expected result. x9 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x9, x5, x4, x3, Zca_c_mv_cg_cp_rd_nx0_b3, Zca_c_mv_cg_cp_rd_nx0_b3_str)
 
   mv x13, x4 # switch temp register to avoid conflict with test
   mv x14, x5 # switch link pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x4)
-  RVTEST_TESTDATA_LOAD_INT(x12, x2) # load rd/rs1: x2 = 0x1bb9494cd18a51f3
-  RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rs2: x7 = 0x093e8f519c82dddb
+  RVTEST_TESTDATA_LOAD_INT(x12, x4) # load rd/rs1: x4 = 0x1bb9494cd18a51f3
+  RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rs2: x6 = 0x093e8f519c82dddb
 Zca_c_mv_cg_cp_rd_nx0_b4:
-  c.mv x2, x7 # perform operation
-  # Check if x2 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x9, x14, x13, x2, Zca_c_mv_cg_cp_rd_nx0_b4, Zca_c_mv_cg_cp_rd_nx0_b4_str)
+  c.mv x4, x6 # perform operation
+  # Check if x4 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x9, x14, x13, x4, Zca_c_mv_cg_cp_rd_nx0_b4, Zca_c_mv_cg_cp_rd_nx0_b4_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x5)
-  RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rd/rs1: x10 = 0x795e92c02b177d87
+  RVTEST_TESTDATA_LOAD_INT(x12, x5) # load rd/rs1: x5 = 0x795e92c02b177d87
   RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rs2: x7 = 0x0606325f6a44d06d
 Zca_c_mv_cg_cp_rd_nx0_b5:
-  c.mv x10, x7 # perform operation
-  # Check if x10 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x9, x14, x13, x10, Zca_c_mv_cg_cp_rd_nx0_b5, Zca_c_mv_cg_cp_rd_nx0_b5_str)
+  c.mv x5, x7 # perform operation
+  # Check if x5 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x9, x14, x13, x5, Zca_c_mv_cg_cp_rd_nx0_b5, Zca_c_mv_cg_cp_rd_nx0_b5_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x6)
-  RVTEST_TESTDATA_LOAD_INT(x12, x11) # load rd/rs1: x11 = 0x68812222b5ac1524
+  RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rd/rs1: x6 = 0x68812222b5ac1524
   RVTEST_TESTDATA_LOAD_INT(x12, x4) # load rs2: x4 = 0xc1ee30964f1dc211
 Zca_c_mv_cg_cp_rd_nx0_b6:
-  c.mv x11, x4 # perform operation
-  # Check if x11 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x9, x14, x13, x11, Zca_c_mv_cg_cp_rd_nx0_b6, Zca_c_mv_cg_cp_rd_nx0_b6_str)
-
-# Testcase cp_rd_nx0 (Test destination rd = x7)
-  RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rd/rs1: x6 = 0x56d1ee33b3cd9991
-  RVTEST_TESTDATA_LOAD_INT(x12, x4) # load rs2: x4 = 0xab916e869c8b5007
-Zca_c_mv_cg_cp_rd_nx0_b7:
   c.mv x6, x4 # perform operation
   # Check if x6 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x9, x14, x13, x6, Zca_c_mv_cg_cp_rd_nx0_b7, Zca_c_mv_cg_cp_rd_nx0_b7_str)
+  RVTEST_SIGUPD(x9, x14, x13, x6, Zca_c_mv_cg_cp_rd_nx0_b6, Zca_c_mv_cg_cp_rd_nx0_b6_str)
+
+# Testcase cp_rd_nx0 (Test destination rd = x7)
+  RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rd/rs1: x7 = 0x56d1ee33b3cd9991
+  RVTEST_TESTDATA_LOAD_INT(x12, x4) # load rs2: x4 = 0xab916e869c8b5007
+Zca_c_mv_cg_cp_rd_nx0_b7:
+  c.mv x7, x4 # perform operation
+  # Check if x7 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x9, x14, x13, x7, Zca_c_mv_cg_cp_rd_nx0_b7, Zca_c_mv_cg_cp_rd_nx0_b7_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x8)
-  RVTEST_TESTDATA_LOAD_INT(x12, x5) # load rd/rs1: x5 = 0x5f5ac8810ec2b996
+  RVTEST_TESTDATA_LOAD_INT(x12, x8) # load rd/rs1: x8 = 0x5f5ac8810ec2b996
   RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rs2: x10 = 0x1e997a8a1e4fc34d
 Zca_c_mv_cg_cp_rd_nx0_b8:
-  c.mv x5, x10 # perform operation
-  # Check if x5 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x9, x14, x13, x5, Zca_c_mv_cg_cp_rd_nx0_b8, Zca_c_mv_cg_cp_rd_nx0_b8_str)
+  c.mv x8, x10 # perform operation
+  # Check if x8 contains the expected result. x9 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x9, x14, x13, x8, Zca_c_mv_cg_cp_rd_nx0_b8, Zca_c_mv_cg_cp_rd_nx0_b8_str)
 
   mv x10, x9 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x9)
-  RVTEST_TESTDATA_LOAD_INT(x12, x8) # load rd/rs1: x8 = 0x476feddb0eab18f6
+  RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rd/rs1: x9 = 0x476feddb0eab18f6
   RVTEST_TESTDATA_LOAD_INT(x12, x15) # load rs2: x15 = 0x830c7f98c5cff92c
 Zca_c_mv_cg_cp_rd_nx0_b9:
-  c.mv x8, x15 # perform operation
-  # Check if x8 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x10, x14, x13, x8, Zca_c_mv_cg_cp_rd_nx0_b9, Zca_c_mv_cg_cp_rd_nx0_b9_str)
+  c.mv x9, x15 # perform operation
+  # Check if x9 contains the expected result. x10 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x10, x14, x13, x9, Zca_c_mv_cg_cp_rd_nx0_b9, Zca_c_mv_cg_cp_rd_nx0_b9_str)
 
   mv x11, x10 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x10)
-  RVTEST_TESTDATA_LOAD_INT(x12, x4) # load rd/rs1: x4 = 0xd6267b29a7ec303d
+  RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rd/rs1: x10 = 0xd6267b29a7ec303d
   RVTEST_TESTDATA_LOAD_INT(x12, x5) # load rs2: x5 = 0xb9723c03ade0282a
 Zca_c_mv_cg_cp_rd_nx0_b10:
-  c.mv x4, x5 # perform operation
-  # Check if x4 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x11, x14, x13, x4, Zca_c_mv_cg_cp_rd_nx0_b10, Zca_c_mv_cg_cp_rd_nx0_b10_str)
+  c.mv x10, x5 # perform operation
+  # Check if x10 contains the expected result. x11 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x11, x14, x13, x10, Zca_c_mv_cg_cp_rd_nx0_b10, Zca_c_mv_cg_cp_rd_nx0_b10_str)
 
   mv x2, x11 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x11)
-  RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rd/rs1: x7 = 0x3c885443181d6bcf
+  RVTEST_TESTDATA_LOAD_INT(x12, x11) # load rd/rs1: x11 = 0x3c885443181d6bcf
   RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rs2: x6 = 0x61fa0fca3e1c07fb
 Zca_c_mv_cg_cp_rd_nx0_b11:
-  c.mv x7, x6 # perform operation
-  # Check if x7 contains the expected result. x2 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x2, x14, x13, x7, Zca_c_mv_cg_cp_rd_nx0_b11, Zca_c_mv_cg_cp_rd_nx0_b11_str)
+  c.mv x11, x6 # perform operation
+  # Check if x11 contains the expected result. x2 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x2, x14, x13, x11, Zca_c_mv_cg_cp_rd_nx0_b11, Zca_c_mv_cg_cp_rd_nx0_b11_str)
 
   mv x6, x12 # switch data pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x12)
-  RVTEST_TESTDATA_LOAD_INT(x6, x5) # load rd/rs1: x5 = 0xe0af8cee6955b064
+  RVTEST_TESTDATA_LOAD_INT(x6, x12) # load rd/rs1: x12 = 0xe0af8cee6955b064
   RVTEST_TESTDATA_LOAD_INT(x6, x8) # load rs2: x8 = 0x615cffbfcfdf3636
 Zca_c_mv_cg_cp_rd_nx0_b12:
-  c.mv x5, x8 # perform operation
-  # Check if x5 contains the expected result. x2 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
-  RVTEST_SIGUPD(x2, x14, x13, x5, Zca_c_mv_cg_cp_rd_nx0_b12, Zca_c_mv_cg_cp_rd_nx0_b12_str)
+  c.mv x12, x8 # perform operation
+  # Check if x12 contains the expected result. x2 is the signature ptr, x14 is the link ptr, x13 is a temp reg.
+  RVTEST_SIGUPD(x2, x14, x13, x12, Zca_c_mv_cg_cp_rd_nx0_b12, Zca_c_mv_cg_cp_rd_nx0_b12_str)
 
   mv x7, x13 # switch temp register to avoid conflict with test
   mv x8, x14 # switch link pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x13)
-  RVTEST_TESTDATA_LOAD_INT(x6, x14) # load rd/rs1: x14 = 0x1c529ac85e4bd2f2
+  RVTEST_TESTDATA_LOAD_INT(x6, x13) # load rd/rs1: x13 = 0x1c529ac85e4bd2f2
   RVTEST_TESTDATA_LOAD_INT(x6, x11) # load rs2: x11 = 0xdb03ec93417b22d8
 Zca_c_mv_cg_cp_rd_nx0_b13:
-  c.mv x14, x11 # perform operation
-  # Check if x14 contains the expected result. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x2, x8, x7, x14, Zca_c_mv_cg_cp_rd_nx0_b13, Zca_c_mv_cg_cp_rd_nx0_b13_str)
+  c.mv x13, x11 # perform operation
+  # Check if x13 contains the expected result. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x2, x8, x7, x13, Zca_c_mv_cg_cp_rd_nx0_b13, Zca_c_mv_cg_cp_rd_nx0_b13_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x14)
-  RVTEST_TESTDATA_LOAD_INT(x6, x11) # load rd/rs1: x11 = 0x50de2689b298b7ec
+  RVTEST_TESTDATA_LOAD_INT(x6, x14) # load rd/rs1: x14 = 0x50de2689b298b7ec
   RVTEST_TESTDATA_LOAD_INT(x6, x13) # load rs2: x13 = 0x84dfc3699dd663c2
 Zca_c_mv_cg_cp_rd_nx0_b14:
-  c.mv x11, x13 # perform operation
-  # Check if x11 contains the expected result. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x2, x8, x7, x11, Zca_c_mv_cg_cp_rd_nx0_b14, Zca_c_mv_cg_cp_rd_nx0_b14_str)
+  c.mv x14, x13 # perform operation
+  # Check if x14 contains the expected result. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x2, x8, x7, x14, Zca_c_mv_cg_cp_rd_nx0_b14, Zca_c_mv_cg_cp_rd_nx0_b14_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x15)
-  RVTEST_TESTDATA_LOAD_INT(x6, x9) # load rd/rs1: x9 = 0x7c0c914162d0d1b4
+  RVTEST_TESTDATA_LOAD_INT(x6, x15) # load rd/rs1: x15 = 0x7c0c914162d0d1b4
   RVTEST_TESTDATA_LOAD_INT(x6, x11) # load rs2: x11 = 0x96431584f0b66246
 Zca_c_mv_cg_cp_rd_nx0_b15:
-  c.mv x9, x11 # perform operation
-  # Check if x9 contains the expected result. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x2, x8, x7, x9, Zca_c_mv_cg_cp_rd_nx0_b15, Zca_c_mv_cg_cp_rd_nx0_b15_str)
+  c.mv x15, x11 # perform operation
+  # Check if x15 contains the expected result. x2 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x2, x8, x7, x15, Zca_c_mv_cg_cp_rd_nx0_b15, Zca_c_mv_cg_cp_rd_nx0_b15_str)
 
 /////////////////////////////////
 // cp_rs2_edges

--- a/tests/rv64i/Zacas/Zacas-amocas.d-00.S
+++ b/tests/rv64i/Zacas/Zacas-amocas.d-00.S
@@ -36,6 +36,7 @@ RVTEST_BEGIN
 # Testcase cp_rs1_nx0 (Test source rs1 = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x16) # load value in memory: x16 = 0x5613235ad98e94ef
   RVTEST_TESTDATA_LOAD_INT(x3, x23) # load rs2: x23 = 0x8e878410970b5e91
+  RVTEST_TESTDATA_LOAD_INT(x3, x18) # load rd compare value: x18 = 0x5613235ad98e94ef
   LA(x1, scratch) # load base address into rs1
   SREG x16, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b1_equal:
@@ -49,6 +50,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b1_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x25) # load value in memory: x25 = 0x7195dd57cdfdc2e7
   RVTEST_TESTDATA_LOAD_INT(x3, x23) # load rs2: x23 = 0x4ca44073103f6b15
+  RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rd compare value: x8 = 0x9f1d23eb1c067ac6
   LA(x1, scratch) # load base address into rs1
   SREG x25, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b1_not_equal:
@@ -63,6 +65,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b1_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load value in memory: x12 = 0xf2b49184967d1b1c
   RVTEST_TESTDATA_LOAD_INT(x3, x22) # load rs2: x22 = 0x2a58de902b54a60c
+  RVTEST_TESTDATA_LOAD_INT(x3, x17) # load rd compare value: x17 = 0xf2b49184967d1b1c
   LA(x2, scratch) # load base address into rs1
   SREG x12, 0(x2) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b2_equal:
@@ -76,6 +79,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b2_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load value in memory: x15 = 0x0e812955f255240a
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x52d5243a2e6228fd
+  RVTEST_TESTDATA_LOAD_INT(x3, x24) # load rd compare value: x24 = 0x9351db8a718e9e40
   LA(x2, scratch) # load base address into rs1
   SREG x15, 0(x2) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b2_not_equal:
@@ -90,6 +94,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b2_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x27) # load value in memory: x27 = 0x0fb0af504c9bf35a
   RVTEST_TESTDATA_LOAD_INT(x12, x0) # load rs2: x0 = 0xf2ab91c791b9c919
+  RVTEST_TESTDATA_LOAD_INT(x12, x14) # load rd compare value: x14 = 0x0fb0af504c9bf35a
   LA(x3, scratch) # load base address into rs1
   SREG x27, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b3_equal:
@@ -103,6 +108,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b3_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x20) # load value in memory: x20 = 0x3787500dfdce853c
   RVTEST_TESTDATA_LOAD_INT(x12, x30) # load rs2: x30 = 0xd0b18e7ea82a2b8b
+  RVTEST_TESTDATA_LOAD_INT(x12, x1) # load rd compare value: x1 = 0x32e6c977c0f2b37a
   LA(x3, scratch) # load base address into rs1
   SREG x20, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b3_not_equal:
@@ -118,6 +124,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b3_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x3) # load value in memory: x3 = 0xa7c4e8b6510af5a4
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rs2: x29 = 0x2aeb042d92d361e2
+  RVTEST_TESTDATA_LOAD_INT(x12, x11) # load rd compare value: x11 = 0xa7c4e8b6510af5a4
   LA(x4, scratch) # load base address into rs1
   SREG x3, 0(x4) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b4_equal:
@@ -131,6 +138,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b4_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x27) # load value in memory: x27 = 0x264463d78e1ced88
   RVTEST_TESTDATA_LOAD_INT(x12, x21) # load rs2: x21 = 0xe7630d6862f03018
+  RVTEST_TESTDATA_LOAD_INT(x12, x11) # load rd compare value: x11 = 0xe48826a6fd2b118f
   LA(x4, scratch) # load base address into rs1
   SREG x27, 0(x4) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b4_not_equal:
@@ -144,6 +152,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b4_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x26) # load value in memory: x26 = 0x39ae079e48075674
   RVTEST_TESTDATA_LOAD_INT(x12, x15) # load rs2: x15 = 0x1fa863051337c3d9
+  RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rd compare value: x6 = 0x39ae079e48075674
   LA(x5, scratch) # load base address into rs1
   SREG x26, 0(x5) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b5_equal:
@@ -157,6 +166,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b5_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x10) # load value in memory: x10 = 0x97c3694f645e3c9d
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load rs2: x1 = 0x1a3825458de04bda
+  RVTEST_TESTDATA_LOAD_INT(x12, x18) # load rd compare value: x18 = 0xeeff0df323a4adb7
   LA(x5, scratch) # load base address into rs1
   SREG x10, 0(x5) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b5_not_equal:
@@ -170,6 +180,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b5_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x4) # load value in memory: x4 = 0x4e692a1c19f7154b
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load rs2: x1 = 0xe3bdcb3e54ce43e3
+  RVTEST_TESTDATA_LOAD_INT(x12, x22) # load rd compare value: x22 = 0x4e692a1c19f7154b
   LA(x6, scratch) # load base address into rs1
   SREG x4, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b6_equal:
@@ -183,6 +194,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b6_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load value in memory: x29 = 0x5afd81ab1a8c26e8
   RVTEST_TESTDATA_LOAD_INT(x12, x23) # load rs2: x23 = 0x3a6cf73f3189bd44
+  RVTEST_TESTDATA_LOAD_INT(x12, x13) # load rd compare value: x13 = 0x535c5b9a6bbd11f3
   LA(x6, scratch) # load base address into rs1
   SREG x29, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b6_not_equal:
@@ -198,6 +210,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b6_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x31) # load value in memory: x31 = 0xec336a614d40488a
   RVTEST_TESTDATA_LOAD_INT(x12, x17) # load rs2: x17 = 0x26592254fb9c91ef
+  RVTEST_TESTDATA_LOAD_INT(x12, x3) # load rd compare value: x3 = 0xec336a614d40488a
   LA(x7, scratch) # load base address into rs1
   SREG x31, 0(x7) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b7_equal:
@@ -211,6 +224,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b7_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load value in memory: x29 = 0xbd7d73ada1578b10
   RVTEST_TESTDATA_LOAD_INT(x12, x25) # load rs2: x25 = 0xbf5980d481e0c906
+  RVTEST_TESTDATA_LOAD_INT(x12, x27) # load rd compare value: x27 = 0xd868bd3984ce4fe8
   LA(x7, scratch) # load base address into rs1
   SREG x29, 0(x7) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b7_not_equal:
@@ -224,6 +238,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b7_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x9) # load value in memory: x9 = 0x1363c9adfe7d4664
   RVTEST_TESTDATA_LOAD_INT(x12, x22) # load rs2: x22 = 0x862b50f11a475edd
+  RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rd compare value: x7 = 0x1363c9adfe7d4664
   LA(x8, scratch) # load base address into rs1
   SREG x9, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b8_equal:
@@ -237,6 +252,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b8_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x15) # load value in memory: x15 = 0x1821cca95dc6c3d6
   RVTEST_TESTDATA_LOAD_INT(x12, x21) # load rs2: x21 = 0x97b51eb1b0e32b6a
+  RVTEST_TESTDATA_LOAD_INT(x12, x4) # load rd compare value: x4 = 0x6c5b2dbbad451207
   LA(x8, scratch) # load base address into rs1
   SREG x15, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b8_not_equal:
@@ -250,6 +266,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b8_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x22) # load value in memory: x22 = 0x72c205fd6f1271c9
   RVTEST_TESTDATA_LOAD_INT(x12, x2) # load rs2: x2 = 0xcaf2ba455991f5b5
+  RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rd compare value: x10 = 0x72c205fd6f1271c9
   LA(x9, scratch) # load base address into rs1
   SREG x22, 0(x9) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b9_equal:
@@ -263,6 +280,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b9_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x23) # load value in memory: x23 = 0x029b94c335506719
   RVTEST_TESTDATA_LOAD_INT(x12, x18) # load rs2: x18 = 0xe5ff9a47f4549d17
+  RVTEST_TESTDATA_LOAD_INT(x12, x31) # load rd compare value: x31 = 0x337e4026f124c32c
   LA(x9, scratch) # load base address into rs1
   SREG x23, 0(x9) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b9_not_equal:
@@ -276,6 +294,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b9_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x5) # load value in memory: x5 = 0x42064e33c8af5f2b
   RVTEST_TESTDATA_LOAD_INT(x12, x8) # load rs2: x8 = 0xbd2b2a023bbb284b
+  RVTEST_TESTDATA_LOAD_INT(x12, x31) # load rd compare value: x31 = 0x42064e33c8af5f2b
   LA(x10, scratch) # load base address into rs1
   SREG x5, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b10_equal:
@@ -289,6 +308,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b10_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x17) # load value in memory: x17 = 0x46cee4b1d71e7d37
   RVTEST_TESTDATA_LOAD_INT(x12, x8) # load rs2: x8 = 0xe192161b472afab0
+  RVTEST_TESTDATA_LOAD_INT(x12, x0) # load rd compare value: x0 = 0x07388d746ca9a6c0
   LA(x10, scratch) # load base address into rs1
   SREG x17, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b10_not_equal:
@@ -302,6 +322,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b10_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x4) # load value in memory: x4 = 0xc379a366856159fd
   RVTEST_TESTDATA_LOAD_INT(x12, x17) # load rs2: x17 = 0x581c501b64817030
+  RVTEST_TESTDATA_LOAD_INT(x12, x20) # load rd compare value: x20 = 0xc379a366856159fd
   LA(x11, scratch) # load base address into rs1
   SREG x4, 0(x11) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b11_equal:
@@ -315,6 +336,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b11_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x16) # load value in memory: x16 = 0xaaf9f69ce87ae52e
   RVTEST_TESTDATA_LOAD_INT(x12, x30) # load rs2: x30 = 0x9fcd3ec679ee5fff
+  RVTEST_TESTDATA_LOAD_INT(x12, x26) # load rd compare value: x26 = 0x0f57081ba8fbea54
   LA(x11, scratch) # load base address into rs1
   SREG x16, 0(x11) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b11_not_equal:
@@ -329,6 +351,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b11_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x3) # load value in memory: x3 = 0xffbe278cf4646ed5
   RVTEST_TESTDATA_LOAD_INT(x21, x22) # load rs2: x22 = 0x026dfb70c78e74b7
+  RVTEST_TESTDATA_LOAD_INT(x21, x1) # load rd compare value: x1 = 0xffbe278cf4646ed5
   LA(x12, scratch) # load base address into rs1
   SREG x3, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b12_equal:
@@ -342,6 +365,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b12_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x6) # load value in memory: x6 = 0x96747d0179b88830
   RVTEST_TESTDATA_LOAD_INT(x21, x20) # load rs2: x20 = 0xd43e6a6ca52eb41c
+  RVTEST_TESTDATA_LOAD_INT(x21, x22) # load rd compare value: x22 = 0xf3a1b70b2dadba15
   LA(x12, scratch) # load base address into rs1
   SREG x6, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b12_not_equal:
@@ -357,6 +381,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b12_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x22) # load value in memory: x22 = 0x71bf3ea9f41c4764
   RVTEST_TESTDATA_LOAD_INT(x21, x29) # load rs2: x29 = 0x1aa894f42f53dee7
+  RVTEST_TESTDATA_LOAD_INT(x21, x17) # load rd compare value: x17 = 0x71bf3ea9f41c4764
   LA(x13, scratch) # load base address into rs1
   SREG x22, 0(x13) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b13_equal:
@@ -370,6 +395,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b13_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x10) # load value in memory: x10 = 0x9094e1fdfed0114a
   RVTEST_TESTDATA_LOAD_INT(x21, x6) # load rs2: x6 = 0xb8ae9297a3dc3597
+  RVTEST_TESTDATA_LOAD_INT(x21, x18) # load rd compare value: x18 = 0x86831e8d4f7dbb31
   LA(x13, scratch) # load base address into rs1
   SREG x10, 0(x13) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b13_not_equal:
@@ -383,6 +409,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b13_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x17) # load value in memory: x17 = 0xaf32c6ab0a2c53dc
   RVTEST_TESTDATA_LOAD_INT(x21, x23) # load rs2: x23 = 0xfebf214a06582ac9
+  RVTEST_TESTDATA_LOAD_INT(x21, x3) # load rd compare value: x3 = 0xaf32c6ab0a2c53dc
   LA(x14, scratch) # load base address into rs1
   SREG x17, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b14_equal:
@@ -396,6 +423,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b14_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x10) # load value in memory: x10 = 0x1466389dba76c951
   RVTEST_TESTDATA_LOAD_INT(x21, x17) # load rs2: x17 = 0x88185c1de8fcaf55
+  RVTEST_TESTDATA_LOAD_INT(x21, x8) # load rd compare value: x8 = 0x77e0648a6c439e59
   LA(x14, scratch) # load base address into rs1
   SREG x10, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b14_not_equal:
@@ -409,6 +437,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b14_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x26) # load value in memory: x26 = 0x31bd4adbc38dd70c
   RVTEST_TESTDATA_LOAD_INT(x21, x2) # load rs2: x2 = 0x6899bb3cad825714
+  RVTEST_TESTDATA_LOAD_INT(x21, x22) # load rd compare value: x22 = 0x31bd4adbc38dd70c
   LA(x15, scratch) # load base address into rs1
   SREG x26, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b15_equal:
@@ -422,6 +451,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b15_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x13) # load value in memory: x13 = 0x0b4207fc004e7cd2
   RVTEST_TESTDATA_LOAD_INT(x21, x20) # load rs2: x20 = 0x84231f95aab93fcb
+  RVTEST_TESTDATA_LOAD_INT(x21, x30) # load rd compare value: x30 = 0x4c2599184e185ba9
   LA(x15, scratch) # load base address into rs1
   SREG x13, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b15_not_equal:
@@ -435,6 +465,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b15_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x13) # load value in memory: x13 = 0x4dddc4c996b547e7
   RVTEST_TESTDATA_LOAD_INT(x21, x6) # load rs2: x6 = 0x5394b87059061263
+  RVTEST_TESTDATA_LOAD_INT(x21, x20) # load rd compare value: x20 = 0x4dddc4c996b547e7
   LA(x16, scratch) # load base address into rs1
   SREG x13, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b16_equal:
@@ -448,6 +479,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b16_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x6) # load value in memory: x6 = 0x6f6f381f821668d7
   RVTEST_TESTDATA_LOAD_INT(x21, x24) # load rs2: x24 = 0x947a3816b40028dd
+  RVTEST_TESTDATA_LOAD_INT(x21, x10) # load rd compare value: x10 = 0xbd9e5ce04ad8f3f3
   LA(x16, scratch) # load base address into rs1
   SREG x6, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b16_not_equal:
@@ -461,6 +493,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b16_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x20) # load value in memory: x20 = 0x853600164970dae4
   RVTEST_TESTDATA_LOAD_INT(x21, x13) # load rs2: x13 = 0x52bb92dad8a66dae
+  RVTEST_TESTDATA_LOAD_INT(x21, x30) # load rd compare value: x30 = 0x853600164970dae4
   LA(x17, scratch) # load base address into rs1
   SREG x20, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b17_equal:
@@ -474,6 +507,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b17_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x24) # load value in memory: x24 = 0x0b14bd3d350bf8d7
   RVTEST_TESTDATA_LOAD_INT(x21, x20) # load rs2: x20 = 0x216fb47e3292ddf4
+  RVTEST_TESTDATA_LOAD_INT(x21, x11) # load rd compare value: x11 = 0xacd6014f8ba20bae
   LA(x17, scratch) # load base address into rs1
   SREG x24, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b17_not_equal:
@@ -487,6 +521,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b17_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x9) # load value in memory: x9 = 0x9eadc030acc84ff2
   RVTEST_TESTDATA_LOAD_INT(x21, x6) # load rs2: x6 = 0x309b3a946846b33e
+  RVTEST_TESTDATA_LOAD_INT(x21, x1) # load rd compare value: x1 = 0x9eadc030acc84ff2
   LA(x18, scratch) # load base address into rs1
   SREG x9, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b18_equal:
@@ -500,6 +535,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b18_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x20) # load value in memory: x20 = 0x42062bd05a758a91
   RVTEST_TESTDATA_LOAD_INT(x21, x7) # load rs2: x7 = 0x4623fb93006e667e
+  RVTEST_TESTDATA_LOAD_INT(x21, x31) # load rd compare value: x31 = 0x781d1709fed0d551
   LA(x18, scratch) # load base address into rs1
   SREG x20, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b18_not_equal:
@@ -514,6 +550,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b18_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x23) # load value in memory: x23 = 0xf774da002fd10943
   RVTEST_TESTDATA_LOAD_INT(x21, x9) # load rs2: x9 = 0xc6fa9b0d938f3aae
+  RVTEST_TESTDATA_LOAD_INT(x21, x16) # load rd compare value: x16 = 0xf774da002fd10943
   LA(x19, scratch) # load base address into rs1
   SREG x23, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b19_equal:
@@ -527,6 +564,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b19_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x12) # load value in memory: x12 = 0x8be2685f98172afd
   RVTEST_TESTDATA_LOAD_INT(x21, x16) # load rs2: x16 = 0xfd158330d5923b04
+  RVTEST_TESTDATA_LOAD_INT(x21, x3) # load rd compare value: x3 = 0xea294d40a35199c7
   LA(x19, scratch) # load base address into rs1
   SREG x12, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b19_not_equal:
@@ -540,6 +578,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b19_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x1) # load value in memory: x1 = 0x6ff5459f500cccee
   RVTEST_TESTDATA_LOAD_INT(x21, x30) # load rs2: x30 = 0xb20c581a4cd46fce
+  RVTEST_TESTDATA_LOAD_INT(x21, x18) # load rd compare value: x18 = 0x6ff5459f500cccee
   LA(x20, scratch) # load base address into rs1
   SREG x1, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b20_equal:
@@ -553,6 +592,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b20_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x21, x8) # load value in memory: x8 = 0x82caa5d23c0b2c93
   RVTEST_TESTDATA_LOAD_INT(x21, x9) # load rs2: x9 = 0x754b0943639ae452
+  RVTEST_TESTDATA_LOAD_INT(x21, x1) # load rd compare value: x1 = 0x8b63fc4fd8a32a9d
   LA(x20, scratch) # load base address into rs1
   SREG x8, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b20_not_equal:
@@ -567,6 +607,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b20_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x12) # load value in memory: x12 = 0xeb214373d187b6b0
   RVTEST_TESTDATA_LOAD_INT(x16, x8) # load rs2: x8 = 0x1e0dbba1c5ba0a00
+  RVTEST_TESTDATA_LOAD_INT(x16, x15) # load rd compare value: x15 = 0xeb214373d187b6b0
   LA(x21, scratch) # load base address into rs1
   SREG x12, 0(x21) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b21_equal:
@@ -580,6 +621,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b21_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x25) # load value in memory: x25 = 0xcf433ae0165e8201
   RVTEST_TESTDATA_LOAD_INT(x16, x12) # load rs2: x12 = 0x6caa1cf9c655ed75
+  RVTEST_TESTDATA_LOAD_INT(x16, x28) # load rd compare value: x28 = 0x2070e483bef72c63
   LA(x21, scratch) # load base address into rs1
   SREG x25, 0(x21) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b21_not_equal:
@@ -593,6 +635,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b21_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x8) # load value in memory: x8 = 0xc471558509f990e0
   RVTEST_TESTDATA_LOAD_INT(x16, x9) # load rs2: x9 = 0x70799445dac10ca7
+  RVTEST_TESTDATA_LOAD_INT(x16, x6) # load rd compare value: x6 = 0xc471558509f990e0
   LA(x22, scratch) # load base address into rs1
   SREG x8, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b22_equal:
@@ -606,6 +649,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b22_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x15) # load value in memory: x15 = 0x314247473caf663e
   RVTEST_TESTDATA_LOAD_INT(x16, x29) # load rs2: x29 = 0x083b0b437ef800c2
+  RVTEST_TESTDATA_LOAD_INT(x16, x19) # load rd compare value: x19 = 0xe222141a6701abb0
   LA(x22, scratch) # load base address into rs1
   SREG x15, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b22_not_equal:
@@ -619,6 +663,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b22_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x8) # load value in memory: x8 = 0x81cf13788d4555fa
   RVTEST_TESTDATA_LOAD_INT(x16, x28) # load rs2: x28 = 0x932027574c832906
+  RVTEST_TESTDATA_LOAD_INT(x16, x26) # load rd compare value: x26 = 0x81cf13788d4555fa
   LA(x23, scratch) # load base address into rs1
   SREG x8, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b23_equal:
@@ -632,6 +677,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b23_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x14) # load value in memory: x14 = 0xf16e0a9b8e71854c
   RVTEST_TESTDATA_LOAD_INT(x16, x0) # load rs2: x0 = 0xb8e2c1d92b984fda
+  RVTEST_TESTDATA_LOAD_INT(x16, x26) # load rd compare value: x26 = 0x6bf3bf9ec7f1dd85
   LA(x23, scratch) # load base address into rs1
   SREG x14, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b23_not_equal:
@@ -645,6 +691,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b23_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x14) # load value in memory: x14 = 0x9215dceaf61433d5
   RVTEST_TESTDATA_LOAD_INT(x16, x28) # load rs2: x28 = 0x79e8644a1f91e85a
+  RVTEST_TESTDATA_LOAD_INT(x16, x15) # load rd compare value: x15 = 0x9215dceaf61433d5
   LA(x24, scratch) # load base address into rs1
   SREG x14, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b24_equal:
@@ -658,6 +705,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b24_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x1) # load value in memory: x1 = 0x20cef6da043888ff
   RVTEST_TESTDATA_LOAD_INT(x16, x10) # load rs2: x10 = 0x4516cbb61b431aff
+  RVTEST_TESTDATA_LOAD_INT(x16, x11) # load rd compare value: x11 = 0x582bd2afad8dda65
   LA(x24, scratch) # load base address into rs1
   SREG x1, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b24_not_equal:
@@ -671,6 +719,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b24_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x18) # load value in memory: x18 = 0x71a3d2ebc187d30b
   RVTEST_TESTDATA_LOAD_INT(x16, x29) # load rs2: x29 = 0xb9b93a3a7a64daf1
+  RVTEST_TESTDATA_LOAD_INT(x16, x20) # load rd compare value: x20 = 0x71a3d2ebc187d30b
   LA(x25, scratch) # load base address into rs1
   SREG x18, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b25_equal:
@@ -684,6 +733,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b25_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x27) # load value in memory: x27 = 0x60d46f265d155d27
   RVTEST_TESTDATA_LOAD_INT(x16, x20) # load rs2: x20 = 0x7405a57de6b814bf
+  RVTEST_TESTDATA_LOAD_INT(x16, x13) # load rd compare value: x13 = 0x2882bd97bc145c46
   LA(x25, scratch) # load base address into rs1
   SREG x27, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b25_not_equal:
@@ -697,6 +747,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b25_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x10) # load value in memory: x10 = 0xde06a34d578e1f62
   RVTEST_TESTDATA_LOAD_INT(x16, x7) # load rs2: x7 = 0x7fe6f02d6dd38820
+  RVTEST_TESTDATA_LOAD_INT(x16, x23) # load rd compare value: x23 = 0xde06a34d578e1f62
   LA(x26, scratch) # load base address into rs1
   SREG x10, 0(x26) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b26_equal:
@@ -710,6 +761,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b26_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x19) # load value in memory: x19 = 0x418e936f5975fae3
   RVTEST_TESTDATA_LOAD_INT(x16, x15) # load rs2: x15 = 0x9b467899680f537d
+  RVTEST_TESTDATA_LOAD_INT(x16, x14) # load rd compare value: x14 = 0xeab2f9dc760b4e9e
   LA(x26, scratch) # load base address into rs1
   SREG x19, 0(x26) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b26_not_equal:
@@ -723,6 +775,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b26_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x6) # load value in memory: x6 = 0xd3a697fdb22fccc7
   RVTEST_TESTDATA_LOAD_INT(x16, x28) # load rs2: x28 = 0x0c1f0ae6403bab84
+  RVTEST_TESTDATA_LOAD_INT(x16, x0) # load rd compare value: x0 = 0xd3a697fdb22fccc7
   LA(x27, scratch) # load base address into rs1
   SREG x6, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b27_equal:
@@ -736,6 +789,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b27_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x6) # load value in memory: x6 = 0x56e30b7fb40253cc
   RVTEST_TESTDATA_LOAD_INT(x16, x13) # load rs2: x13 = 0x405aa66cdecdc169
+  RVTEST_TESTDATA_LOAD_INT(x16, x29) # load rd compare value: x29 = 0xb75dee7cf59abbae
   LA(x27, scratch) # load base address into rs1
   SREG x6, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b27_not_equal:
@@ -749,6 +803,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b27_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x22) # load value in memory: x22 = 0x8971da1f6918a9d9
   RVTEST_TESTDATA_LOAD_INT(x16, x29) # load rs2: x29 = 0xe5aa367b1fa5b7a1
+  RVTEST_TESTDATA_LOAD_INT(x16, x14) # load rd compare value: x14 = 0x8971da1f6918a9d9
   LA(x28, scratch) # load base address into rs1
   SREG x22, 0(x28) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b28_equal:
@@ -762,6 +817,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b28_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x24) # load value in memory: x24 = 0x26c5c9bb3b7da224
   RVTEST_TESTDATA_LOAD_INT(x16, x26) # load rs2: x26 = 0x5f7ee85c8bd2e306
+  RVTEST_TESTDATA_LOAD_INT(x16, x21) # load rd compare value: x21 = 0xacf9a2508d83f9b7
   LA(x28, scratch) # load base address into rs1
   SREG x24, 0(x28) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b28_not_equal:
@@ -775,6 +831,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b28_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x13) # load value in memory: x13 = 0xe4775e6db2aa086d
   RVTEST_TESTDATA_LOAD_INT(x16, x7) # load rs2: x7 = 0x56651453b452f417
+  RVTEST_TESTDATA_LOAD_INT(x16, x11) # load rd compare value: x11 = 0xe4775e6db2aa086d
   LA(x29, scratch) # load base address into rs1
   SREG x13, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b29_equal:
@@ -788,6 +845,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b29_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x3) # load value in memory: x3 = 0x596fdba3ec965775
   RVTEST_TESTDATA_LOAD_INT(x16, x19) # load rs2: x19 = 0x612e3de85dab2c79
+  RVTEST_TESTDATA_LOAD_INT(x16, x0) # load rd compare value: x0 = 0xd4475a43d37b6c88
   LA(x29, scratch) # load base address into rs1
   SREG x3, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b29_not_equal:
@@ -801,6 +859,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b29_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x21) # load value in memory: x21 = 0x04cbd86a9b2e8843
   RVTEST_TESTDATA_LOAD_INT(x16, x3) # load rs2: x3 = 0xe8996d6f1e72ce31
+  RVTEST_TESTDATA_LOAD_INT(x16, x23) # load rd compare value: x23 = 0x04cbd86a9b2e8843
   LA(x30, scratch) # load base address into rs1
   SREG x21, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b30_equal:
@@ -814,6 +873,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b30_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x25) # load value in memory: x25 = 0x92b682e636259482
   RVTEST_TESTDATA_LOAD_INT(x16, x21) # load rs2: x21 = 0x98282439f8c9440a
+  RVTEST_TESTDATA_LOAD_INT(x16, x26) # load rd compare value: x26 = 0xdd370dba702b47de
   LA(x30, scratch) # load base address into rs1
   SREG x25, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b30_not_equal:
@@ -828,6 +888,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b30_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x6) # load value in memory: x6 = 0x9c38b505fb149ba6
   RVTEST_TESTDATA_LOAD_INT(x16, x14) # load rs2: x14 = 0xd1a2e0d5425b4c5c
+  RVTEST_TESTDATA_LOAD_INT(x16, x19) # load rd compare value: x19 = 0x9c38b505fb149ba6
   LA(x31, scratch) # load base address into rs1
   SREG x6, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b31_equal:
@@ -841,6 +902,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b31_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x30) # load value in memory: x30 = 0x1652d23e1221fffa
   RVTEST_TESTDATA_LOAD_INT(x16, x8) # load rs2: x8 = 0x9cf9ba58cf90f2c6
+  RVTEST_TESTDATA_LOAD_INT(x16, x15) # load rd compare value: x15 = 0x02a871fb7821c398
   LA(x31, scratch) # load base address into rs1
   SREG x30, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs1_nx0_b31_not_equal:
@@ -858,6 +920,7 @@ Zacas_amocas_d_cg_cp_rs1_nx0_b31_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x0, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x28) # load value in memory: x28 = 0xa747cc709ad7e038
   RVTEST_TESTDATA_LOAD_INT(x16, x0) # load rs2: x0 = 0x366069ce6cfc2be4
+  RVTEST_TESTDATA_LOAD_INT(x16, x24) # load rd compare value: x24 = 0xa747cc709ad7e038
   LA(x18, scratch) # load base address into rs1
   SREG x28, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b0_equal:
@@ -871,6 +934,7 @@ Zacas_amocas_d_cg_cp_rs2_b0_equal:
 # Testcase cp_rs2 (Test source rs2 = x0, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x22) # load value in memory: x22 = 0x71842a51f5352d7a
   RVTEST_TESTDATA_LOAD_INT(x16, x0) # load rs2: x0 = 0xb0f13b14c3304f0f
+  RVTEST_TESTDATA_LOAD_INT(x16, x29) # load rd compare value: x29 = 0x38ce6fe242b29058
   LA(x11, scratch) # load base address into rs1
   SREG x22, 0(x11) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b0_not_equal:
@@ -884,6 +948,7 @@ Zacas_amocas_d_cg_cp_rs2_b0_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x28) # load value in memory: x28 = 0x99f048c1e5851e91
   RVTEST_TESTDATA_LOAD_INT(x16, x1) # load rs2: x1 = 0x87a68db8aaf7d88b
+  RVTEST_TESTDATA_LOAD_INT(x16, x20) # load rd compare value: x20 = 0x99f048c1e5851e91
   LA(x10, scratch) # load base address into rs1
   SREG x28, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b1_equal:
@@ -897,6 +962,7 @@ Zacas_amocas_d_cg_cp_rs2_b1_equal:
 # Testcase cp_rs2 (Test source rs2 = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x27) # load value in memory: x27 = 0x444eb7064027664f
   RVTEST_TESTDATA_LOAD_INT(x16, x1) # load rs2: x1 = 0xf7bd4f8306e0ea4e
+  RVTEST_TESTDATA_LOAD_INT(x16, x12) # load rd compare value: x12 = 0x21260ecdde5bcb1b
   LA(x18, scratch) # load base address into rs1
   SREG x27, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b1_not_equal:
@@ -910,6 +976,7 @@ Zacas_amocas_d_cg_cp_rs2_b1_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x22) # load value in memory: x22 = 0xa4a210307a7542b8
   RVTEST_TESTDATA_LOAD_INT(x16, x2) # load rs2: x2 = 0x491faad2eb1bf5e6
+  RVTEST_TESTDATA_LOAD_INT(x16, x10) # load rd compare value: x10 = 0xa4a210307a7542b8
   LA(x24, scratch) # load base address into rs1
   SREG x22, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b2_equal:
@@ -923,6 +990,7 @@ Zacas_amocas_d_cg_cp_rs2_b2_equal:
 # Testcase cp_rs2 (Test source rs2 = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x22) # load value in memory: x22 = 0xde856c5a6dce5bb7
   RVTEST_TESTDATA_LOAD_INT(x16, x2) # load rs2: x2 = 0x7c4e09da61d48c77
+  RVTEST_TESTDATA_LOAD_INT(x16, x15) # load rd compare value: x15 = 0xc2bb979e54bd27fa
   LA(x8, scratch) # load base address into rs1
   SREG x22, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b2_not_equal:
@@ -936,6 +1004,7 @@ Zacas_amocas_d_cg_cp_rs2_b2_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x1) # load value in memory: x1 = 0xf71764c0ed83f9d1
   RVTEST_TESTDATA_LOAD_INT(x16, x3) # load rs2: x3 = 0x925cc16bb1d17733
+  RVTEST_TESTDATA_LOAD_INT(x16, x22) # load rd compare value: x22 = 0xf71764c0ed83f9d1
   LA(x14, scratch) # load base address into rs1
   SREG x1, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b3_equal:
@@ -949,6 +1018,7 @@ Zacas_amocas_d_cg_cp_rs2_b3_equal:
 # Testcase cp_rs2 (Test source rs2 = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x17) # load value in memory: x17 = 0x1937b6306b7379fc
   RVTEST_TESTDATA_LOAD_INT(x16, x3) # load rs2: x3 = 0x1c2ba61ac2c504a5
+  RVTEST_TESTDATA_LOAD_INT(x16, x2) # load rd compare value: x2 = 0x0dadced5787f219a
   LA(x20, scratch) # load base address into rs1
   SREG x17, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b3_not_equal:
@@ -964,6 +1034,7 @@ Zacas_amocas_d_cg_cp_rs2_b3_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x29) # load value in memory: x29 = 0x8f768de29b49de6e
   RVTEST_TESTDATA_LOAD_INT(x16, x4) # load rs2: x4 = 0xd1de4f6ee296e507
+  RVTEST_TESTDATA_LOAD_INT(x16, x2) # load rd compare value: x2 = 0x8f768de29b49de6e
   LA(x12, scratch) # load base address into rs1
   SREG x29, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b4_equal:
@@ -977,6 +1048,7 @@ Zacas_amocas_d_cg_cp_rs2_b4_equal:
 # Testcase cp_rs2 (Test source rs2 = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x24) # load value in memory: x24 = 0xad0a42168c2a16e6
   RVTEST_TESTDATA_LOAD_INT(x16, x4) # load rs2: x4 = 0xe968d405bd18e5f4
+  RVTEST_TESTDATA_LOAD_INT(x16, x25) # load rd compare value: x25 = 0x5b74529862734434
   LA(x19, scratch) # load base address into rs1
   SREG x24, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b4_not_equal:
@@ -990,6 +1062,7 @@ Zacas_amocas_d_cg_cp_rs2_b4_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x11) # load value in memory: x11 = 0x34df32bf2e93bc61
   RVTEST_TESTDATA_LOAD_INT(x16, x5) # load rs2: x5 = 0x82296dc5553d71b5
+  RVTEST_TESTDATA_LOAD_INT(x16, x1) # load rd compare value: x1 = 0x34df32bf2e93bc61
   LA(x26, scratch) # load base address into rs1
   SREG x11, 0(x26) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b5_equal:
@@ -1003,6 +1076,7 @@ Zacas_amocas_d_cg_cp_rs2_b5_equal:
 # Testcase cp_rs2 (Test source rs2 = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x27) # load value in memory: x27 = 0xbd6bfae6eb6a8b39
   RVTEST_TESTDATA_LOAD_INT(x16, x5) # load rs2: x5 = 0x3a849cced6289b29
+  RVTEST_TESTDATA_LOAD_INT(x16, x22) # load rd compare value: x22 = 0x5974bc8b6a730a25
   LA(x31, scratch) # load base address into rs1
   SREG x27, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b5_not_equal:
@@ -1016,6 +1090,7 @@ Zacas_amocas_d_cg_cp_rs2_b5_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x4) # load value in memory: x4 = 0xac6bf66c45d30330
   RVTEST_TESTDATA_LOAD_INT(x16, x6) # load rs2: x6 = 0x11af4251ee127d4c
+  RVTEST_TESTDATA_LOAD_INT(x16, x11) # load rd compare value: x11 = 0xac6bf66c45d30330
   LA(x1, scratch) # load base address into rs1
   SREG x4, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b6_equal:
@@ -1029,6 +1104,7 @@ Zacas_amocas_d_cg_cp_rs2_b6_equal:
 # Testcase cp_rs2 (Test source rs2 = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x13) # load value in memory: x13 = 0x6b66b1850a224142
   RVTEST_TESTDATA_LOAD_INT(x16, x6) # load rs2: x6 = 0x3fe09f64662c24aa
+  RVTEST_TESTDATA_LOAD_INT(x16, x0) # load rd compare value: x0 = 0xf6d7edb3aa2d0118
   LA(x22, scratch) # load base address into rs1
   SREG x13, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b6_not_equal:
@@ -1044,6 +1120,7 @@ Zacas_amocas_d_cg_cp_rs2_b6_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x13) # load value in memory: x13 = 0xb437eb14da325775
   RVTEST_TESTDATA_LOAD_INT(x16, x7) # load rs2: x7 = 0x335c47f4cd64e568
+  RVTEST_TESTDATA_LOAD_INT(x16, x1) # load rd compare value: x1 = 0xb437eb14da325775
   LA(x26, scratch) # load base address into rs1
   SREG x13, 0(x26) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b7_equal:
@@ -1057,6 +1134,7 @@ Zacas_amocas_d_cg_cp_rs2_b7_equal:
 # Testcase cp_rs2 (Test source rs2 = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x26) # load value in memory: x26 = 0x003d8d7e8449fa27
   RVTEST_TESTDATA_LOAD_INT(x16, x7) # load rs2: x7 = 0xc5a993157d771073
+  RVTEST_TESTDATA_LOAD_INT(x16, x27) # load rd compare value: x27 = 0xa44234c1d5580c4e
   LA(x14, scratch) # load base address into rs1
   SREG x26, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b7_not_equal:
@@ -1070,6 +1148,7 @@ Zacas_amocas_d_cg_cp_rs2_b7_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x9) # load value in memory: x9 = 0xdd0d4ce7dd07045b
   RVTEST_TESTDATA_LOAD_INT(x16, x8) # load rs2: x8 = 0x1c27999b8ea28295
+  RVTEST_TESTDATA_LOAD_INT(x16, x10) # load rd compare value: x10 = 0xdd0d4ce7dd07045b
   LA(x13, scratch) # load base address into rs1
   SREG x9, 0(x13) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b8_equal:
@@ -1083,6 +1162,7 @@ Zacas_amocas_d_cg_cp_rs2_b8_equal:
 # Testcase cp_rs2 (Test source rs2 = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x23) # load value in memory: x23 = 0x233b126329eef73a
   RVTEST_TESTDATA_LOAD_INT(x16, x8) # load rs2: x8 = 0x855cd9c68a667548
+  RVTEST_TESTDATA_LOAD_INT(x16, x29) # load rd compare value: x29 = 0x340def4633287c39
   LA(x18, scratch) # load base address into rs1
   SREG x23, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b8_not_equal:
@@ -1096,6 +1176,7 @@ Zacas_amocas_d_cg_cp_rs2_b8_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x29) # load value in memory: x29 = 0x910a99331c95d596
   RVTEST_TESTDATA_LOAD_INT(x16, x9) # load rs2: x9 = 0xef2a93d8bec34f36
+  RVTEST_TESTDATA_LOAD_INT(x16, x26) # load rd compare value: x26 = 0x910a99331c95d596
   LA(x2, scratch) # load base address into rs1
   SREG x29, 0(x2) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b9_equal:
@@ -1109,6 +1190,7 @@ Zacas_amocas_d_cg_cp_rs2_b9_equal:
 # Testcase cp_rs2 (Test source rs2 = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x18) # load value in memory: x18 = 0xd6f26c2e4c8d384c
   RVTEST_TESTDATA_LOAD_INT(x16, x9) # load rs2: x9 = 0xbe4d56c8b038d639
+  RVTEST_TESTDATA_LOAD_INT(x16, x25) # load rd compare value: x25 = 0x9178edbc55432025
   LA(x29, scratch) # load base address into rs1
   SREG x18, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b9_not_equal:
@@ -1122,6 +1204,7 @@ Zacas_amocas_d_cg_cp_rs2_b9_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x25) # load value in memory: x25 = 0x259177d36afe2d94
   RVTEST_TESTDATA_LOAD_INT(x16, x10) # load rs2: x10 = 0x851e506f08acca3f
+  RVTEST_TESTDATA_LOAD_INT(x16, x3) # load rd compare value: x3 = 0x259177d36afe2d94
   LA(x2, scratch) # load base address into rs1
   SREG x25, 0(x2) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b10_equal:
@@ -1135,6 +1218,7 @@ Zacas_amocas_d_cg_cp_rs2_b10_equal:
 # Testcase cp_rs2 (Test source rs2 = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x31) # load value in memory: x31 = 0x9191064c5de76f33
   RVTEST_TESTDATA_LOAD_INT(x16, x10) # load rs2: x10 = 0xc5bed2a1a927691a
+  RVTEST_TESTDATA_LOAD_INT(x16, x18) # load rd compare value: x18 = 0x8067cc50022e2934
   LA(x12, scratch) # load base address into rs1
   SREG x31, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b10_not_equal:
@@ -1148,6 +1232,7 @@ Zacas_amocas_d_cg_cp_rs2_b10_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x31) # load value in memory: x31 = 0xa68c073955c2c329
   RVTEST_TESTDATA_LOAD_INT(x16, x11) # load rs2: x11 = 0xf5098e6a31a7e13e
+  RVTEST_TESTDATA_LOAD_INT(x16, x15) # load rd compare value: x15 = 0xa68c073955c2c329
   LA(x23, scratch) # load base address into rs1
   SREG x31, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b11_equal:
@@ -1161,6 +1246,7 @@ Zacas_amocas_d_cg_cp_rs2_b11_equal:
 # Testcase cp_rs2 (Test source rs2 = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x25) # load value in memory: x25 = 0x66097b629a151d44
   RVTEST_TESTDATA_LOAD_INT(x16, x11) # load rs2: x11 = 0x41f07f1916bec132
+  RVTEST_TESTDATA_LOAD_INT(x16, x31) # load rd compare value: x31 = 0x37f216b5244fccf4
   LA(x19, scratch) # load base address into rs1
   SREG x25, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b11_not_equal:
@@ -1174,6 +1260,7 @@ Zacas_amocas_d_cg_cp_rs2_b11_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x14) # load value in memory: x14 = 0xe954d41b8f3ffbf7
   RVTEST_TESTDATA_LOAD_INT(x16, x12) # load rs2: x12 = 0x673cd515db27a3fa
+  RVTEST_TESTDATA_LOAD_INT(x16, x29) # load rd compare value: x29 = 0xe954d41b8f3ffbf7
   LA(x3, scratch) # load base address into rs1
   SREG x14, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b12_equal:
@@ -1187,6 +1274,7 @@ Zacas_amocas_d_cg_cp_rs2_b12_equal:
 # Testcase cp_rs2 (Test source rs2 = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x25) # load value in memory: x25 = 0xddb697b6db089ca8
   RVTEST_TESTDATA_LOAD_INT(x16, x12) # load rs2: x12 = 0xeb787f8696061c0b
+  RVTEST_TESTDATA_LOAD_INT(x16, x13) # load rd compare value: x13 = 0xb8e57a63c440600b
   LA(x10, scratch) # load base address into rs1
   SREG x25, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b12_not_equal:
@@ -1200,6 +1288,7 @@ Zacas_amocas_d_cg_cp_rs2_b12_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x22) # load value in memory: x22 = 0x64009ab53512f1f5
   RVTEST_TESTDATA_LOAD_INT(x16, x13) # load rs2: x13 = 0xce5198820437a165
+  RVTEST_TESTDATA_LOAD_INT(x16, x24) # load rd compare value: x24 = 0x64009ab53512f1f5
   LA(x10, scratch) # load base address into rs1
   SREG x22, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b13_equal:
@@ -1213,6 +1302,7 @@ Zacas_amocas_d_cg_cp_rs2_b13_equal:
 # Testcase cp_rs2 (Test source rs2 = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x18) # load value in memory: x18 = 0x2b906ab26cc50c46
   RVTEST_TESTDATA_LOAD_INT(x16, x13) # load rs2: x13 = 0xbe755129d94b3d26
+  RVTEST_TESTDATA_LOAD_INT(x16, x9) # load rd compare value: x9 = 0xe52299df533e8b2c
   LA(x19, scratch) # load base address into rs1
   SREG x18, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b13_not_equal:
@@ -1226,6 +1316,7 @@ Zacas_amocas_d_cg_cp_rs2_b13_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x3) # load value in memory: x3 = 0xf7caba8bf5448bc8
   RVTEST_TESTDATA_LOAD_INT(x16, x14) # load rs2: x14 = 0xc782b1f60ec2cded
+  RVTEST_TESTDATA_LOAD_INT(x16, x25) # load rd compare value: x25 = 0xf7caba8bf5448bc8
   LA(x26, scratch) # load base address into rs1
   SREG x3, 0(x26) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b14_equal:
@@ -1239,6 +1330,7 @@ Zacas_amocas_d_cg_cp_rs2_b14_equal:
 # Testcase cp_rs2 (Test source rs2 = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x1) # load value in memory: x1 = 0xee9e51a4df9f00b8
   RVTEST_TESTDATA_LOAD_INT(x16, x14) # load rs2: x14 = 0x1e31cb439d779d72
+  RVTEST_TESTDATA_LOAD_INT(x16, x13) # load rd compare value: x13 = 0x68f4165322c0be53
   LA(x19, scratch) # load base address into rs1
   SREG x1, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b14_not_equal:
@@ -1252,6 +1344,7 @@ Zacas_amocas_d_cg_cp_rs2_b14_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x1) # load value in memory: x1 = 0x59beef21a8d4dbf2
   RVTEST_TESTDATA_LOAD_INT(x16, x15) # load rs2: x15 = 0xae463bd7b768d563
+  RVTEST_TESTDATA_LOAD_INT(x16, x14) # load rd compare value: x14 = 0x59beef21a8d4dbf2
   LA(x8, scratch) # load base address into rs1
   SREG x1, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b15_equal:
@@ -1265,6 +1358,7 @@ Zacas_amocas_d_cg_cp_rs2_b15_equal:
 # Testcase cp_rs2 (Test source rs2 = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x16, x20) # load value in memory: x20 = 0x0be07308e24954ac
   RVTEST_TESTDATA_LOAD_INT(x16, x15) # load rs2: x15 = 0xb73c5e006e568633
+  RVTEST_TESTDATA_LOAD_INT(x16, x3) # load rd compare value: x3 = 0xc5dc514cda5dcb5d
   LA(x2, scratch) # load base address into rs1
   SREG x20, 0(x2) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b15_not_equal:
@@ -1279,6 +1373,7 @@ Zacas_amocas_d_cg_cp_rs2_b15_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x18) # load value in memory: x18 = 0xb4ce6fb3768abe5e
   RVTEST_TESTDATA_LOAD_INT(x10, x16) # load rs2: x16 = 0xfed4d6f17de57bce
+  RVTEST_TESTDATA_LOAD_INT(x10, x1) # load rd compare value: x1 = 0xb4ce6fb3768abe5e
   LA(x6, scratch) # load base address into rs1
   SREG x18, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b16_equal:
@@ -1292,6 +1387,7 @@ Zacas_amocas_d_cg_cp_rs2_b16_equal:
 # Testcase cp_rs2 (Test source rs2 = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x11) # load value in memory: x11 = 0x3418b78bfad18f5a
   RVTEST_TESTDATA_LOAD_INT(x10, x16) # load rs2: x16 = 0x9b790624b6b4d4ba
+  RVTEST_TESTDATA_LOAD_INT(x10, x18) # load rd compare value: x18 = 0xc27fd01d1c5c52f7
   LA(x30, scratch) # load base address into rs1
   SREG x11, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b16_not_equal:
@@ -1305,6 +1401,7 @@ Zacas_amocas_d_cg_cp_rs2_b16_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x9) # load value in memory: x9 = 0x2946a3c92ea5363a
   RVTEST_TESTDATA_LOAD_INT(x10, x17) # load rs2: x17 = 0xb462f971d384030c
+  RVTEST_TESTDATA_LOAD_INT(x10, x26) # load rd compare value: x26 = 0x2946a3c92ea5363a
   LA(x6, scratch) # load base address into rs1
   SREG x9, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b17_equal:
@@ -1318,6 +1415,7 @@ Zacas_amocas_d_cg_cp_rs2_b17_equal:
 # Testcase cp_rs2 (Test source rs2 = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x25) # load value in memory: x25 = 0x309a94623780b763
   RVTEST_TESTDATA_LOAD_INT(x10, x17) # load rs2: x17 = 0xbc0214a496b19d4f
+  RVTEST_TESTDATA_LOAD_INT(x10, x31) # load rd compare value: x31 = 0x1b2cd4ae25bce40f
   LA(x18, scratch) # load base address into rs1
   SREG x25, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b17_not_equal:
@@ -1331,6 +1429,7 @@ Zacas_amocas_d_cg_cp_rs2_b17_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x17) # load value in memory: x17 = 0x1d1c0a8fde0f090f
   RVTEST_TESTDATA_LOAD_INT(x10, x18) # load rs2: x18 = 0xbcfdd626df954e2c
+  RVTEST_TESTDATA_LOAD_INT(x10, x3) # load rd compare value: x3 = 0x1d1c0a8fde0f090f
   LA(x11, scratch) # load base address into rs1
   SREG x17, 0(x11) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b18_equal:
@@ -1344,6 +1443,7 @@ Zacas_amocas_d_cg_cp_rs2_b18_equal:
 # Testcase cp_rs2 (Test source rs2 = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x8) # load value in memory: x8 = 0x18bd3f73a067278d
   RVTEST_TESTDATA_LOAD_INT(x10, x18) # load rs2: x18 = 0x58353bba3da660db
+  RVTEST_TESTDATA_LOAD_INT(x10, x23) # load rd compare value: x23 = 0x0efe483aa49183dd
   LA(x16, scratch) # load base address into rs1
   SREG x8, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b18_not_equal:
@@ -1357,6 +1457,7 @@ Zacas_amocas_d_cg_cp_rs2_b18_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x28) # load value in memory: x28 = 0xdf680ae288e79e8e
   RVTEST_TESTDATA_LOAD_INT(x10, x19) # load rs2: x19 = 0x48c4ffa63043e312
+  RVTEST_TESTDATA_LOAD_INT(x10, x9) # load rd compare value: x9 = 0xdf680ae288e79e8e
   LA(x15, scratch) # load base address into rs1
   SREG x28, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b19_equal:
@@ -1370,6 +1471,7 @@ Zacas_amocas_d_cg_cp_rs2_b19_equal:
 # Testcase cp_rs2 (Test source rs2 = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x7) # load value in memory: x7 = 0x3f7d00bbae669ea7
   RVTEST_TESTDATA_LOAD_INT(x10, x19) # load rs2: x19 = 0x944b2d5a4b3bc019
+  RVTEST_TESTDATA_LOAD_INT(x10, x28) # load rd compare value: x28 = 0xff3d88b92c7a261a
   LA(x27, scratch) # load base address into rs1
   SREG x7, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b19_not_equal:
@@ -1383,6 +1485,7 @@ Zacas_amocas_d_cg_cp_rs2_b19_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x15) # load value in memory: x15 = 0x62b316a09b076300
   RVTEST_TESTDATA_LOAD_INT(x10, x20) # load rs2: x20 = 0x66d96488e7bd3510
+  RVTEST_TESTDATA_LOAD_INT(x10, x0) # load rd compare value: x0 = 0x62b316a09b076300
   LA(x12, scratch) # load base address into rs1
   SREG x15, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b20_equal:
@@ -1396,6 +1499,7 @@ Zacas_amocas_d_cg_cp_rs2_b20_equal:
 # Testcase cp_rs2 (Test source rs2 = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x31) # load value in memory: x31 = 0x057ed182163170b2
   RVTEST_TESTDATA_LOAD_INT(x10, x20) # load rs2: x20 = 0x565eeebceabb7dea
+  RVTEST_TESTDATA_LOAD_INT(x10, x12) # load rd compare value: x12 = 0xe809abc5bb1aafdc
   LA(x15, scratch) # load base address into rs1
   SREG x31, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b20_not_equal:
@@ -1410,6 +1514,7 @@ Zacas_amocas_d_cg_cp_rs2_b20_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x8) # load value in memory: x8 = 0x4e4bede5f0a7b03e
   RVTEST_TESTDATA_LOAD_INT(x10, x21) # load rs2: x21 = 0xb5846d0dd67bfcaf
+  RVTEST_TESTDATA_LOAD_INT(x10, x22) # load rd compare value: x22 = 0x4e4bede5f0a7b03e
   LA(x29, scratch) # load base address into rs1
   SREG x8, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b21_equal:
@@ -1423,6 +1528,7 @@ Zacas_amocas_d_cg_cp_rs2_b21_equal:
 # Testcase cp_rs2 (Test source rs2 = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x3) # load value in memory: x3 = 0x9a5c458cd66ab36b
   RVTEST_TESTDATA_LOAD_INT(x10, x21) # load rs2: x21 = 0x0544e49d7d95a4db
+  RVTEST_TESTDATA_LOAD_INT(x10, x6) # load rd compare value: x6 = 0x50cce4c210c83f18
   LA(x19, scratch) # load base address into rs1
   SREG x3, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b21_not_equal:
@@ -1436,6 +1542,7 @@ Zacas_amocas_d_cg_cp_rs2_b21_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x8) # load value in memory: x8 = 0x54b03031bb2c1509
   RVTEST_TESTDATA_LOAD_INT(x10, x22) # load rs2: x22 = 0x842b6634b2bae1cb
+  RVTEST_TESTDATA_LOAD_INT(x10, x17) # load rd compare value: x17 = 0x54b03031bb2c1509
   LA(x12, scratch) # load base address into rs1
   SREG x8, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b22_equal:
@@ -1449,6 +1556,7 @@ Zacas_amocas_d_cg_cp_rs2_b22_equal:
 # Testcase cp_rs2 (Test source rs2 = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x8) # load value in memory: x8 = 0x9b56dae44d25c462
   RVTEST_TESTDATA_LOAD_INT(x10, x22) # load rs2: x22 = 0x86a9472c2a87517e
+  RVTEST_TESTDATA_LOAD_INT(x10, x20) # load rd compare value: x20 = 0x8cb941e43c8ef15a
   LA(x12, scratch) # load base address into rs1
   SREG x8, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b22_not_equal:
@@ -1462,6 +1570,7 @@ Zacas_amocas_d_cg_cp_rs2_b22_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x28) # load value in memory: x28 = 0x5b7f64a1d6e04a4b
   RVTEST_TESTDATA_LOAD_INT(x10, x23) # load rs2: x23 = 0xf2b894d852cea0e7
+  RVTEST_TESTDATA_LOAD_INT(x10, x19) # load rd compare value: x19 = 0x5b7f64a1d6e04a4b
   LA(x16, scratch) # load base address into rs1
   SREG x28, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b23_equal:
@@ -1475,6 +1584,7 @@ Zacas_amocas_d_cg_cp_rs2_b23_equal:
 # Testcase cp_rs2 (Test source rs2 = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x21) # load value in memory: x21 = 0x7adc2f5cb3698016
   RVTEST_TESTDATA_LOAD_INT(x10, x23) # load rs2: x23 = 0xb041e7d16b415b28
+  RVTEST_TESTDATA_LOAD_INT(x10, x3) # load rd compare value: x3 = 0x11cd9ad64a7066ea
   LA(x16, scratch) # load base address into rs1
   SREG x21, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b23_not_equal:
@@ -1488,6 +1598,7 @@ Zacas_amocas_d_cg_cp_rs2_b23_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x21) # load value in memory: x21 = 0xae30f9cbd159d4d7
   RVTEST_TESTDATA_LOAD_INT(x10, x24) # load rs2: x24 = 0xf2e255949cb1575f
+  RVTEST_TESTDATA_LOAD_INT(x10, x17) # load rd compare value: x17 = 0xae30f9cbd159d4d7
   LA(x18, scratch) # load base address into rs1
   SREG x21, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b24_equal:
@@ -1501,6 +1612,7 @@ Zacas_amocas_d_cg_cp_rs2_b24_equal:
 # Testcase cp_rs2 (Test source rs2 = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x14) # load value in memory: x14 = 0x19d4498730cdd4e3
   RVTEST_TESTDATA_LOAD_INT(x10, x24) # load rs2: x24 = 0x8bc24744a834ce50
+  RVTEST_TESTDATA_LOAD_INT(x10, x25) # load rd compare value: x25 = 0x52877181fdbbb7c2
   LA(x20, scratch) # load base address into rs1
   SREG x14, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b24_not_equal:
@@ -1514,6 +1626,7 @@ Zacas_amocas_d_cg_cp_rs2_b24_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x3) # load value in memory: x3 = 0xfa168f1203ac3897
   RVTEST_TESTDATA_LOAD_INT(x10, x25) # load rs2: x25 = 0xf845fa5829650c35
+  RVTEST_TESTDATA_LOAD_INT(x10, x15) # load rd compare value: x15 = 0xfa168f1203ac3897
   LA(x11, scratch) # load base address into rs1
   SREG x3, 0(x11) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b25_equal:
@@ -1527,6 +1640,7 @@ Zacas_amocas_d_cg_cp_rs2_b25_equal:
 # Testcase cp_rs2 (Test source rs2 = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x19) # load value in memory: x19 = 0xf4dd27ced66192ad
   RVTEST_TESTDATA_LOAD_INT(x10, x25) # load rs2: x25 = 0xffb8fcbd3b60806d
+  RVTEST_TESTDATA_LOAD_INT(x10, x17) # load rd compare value: x17 = 0x66a74f0ccf860453
   LA(x18, scratch) # load base address into rs1
   SREG x19, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b25_not_equal:
@@ -1540,6 +1654,7 @@ Zacas_amocas_d_cg_cp_rs2_b25_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x23) # load value in memory: x23 = 0xa84733f737223968
   RVTEST_TESTDATA_LOAD_INT(x10, x26) # load rs2: x26 = 0xf687bdfbd67f2c12
+  RVTEST_TESTDATA_LOAD_INT(x10, x21) # load rd compare value: x21 = 0xa84733f737223968
   LA(x20, scratch) # load base address into rs1
   SREG x23, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b26_equal:
@@ -1553,6 +1668,7 @@ Zacas_amocas_d_cg_cp_rs2_b26_equal:
 # Testcase cp_rs2 (Test source rs2 = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x19) # load value in memory: x19 = 0xad9906c18182eb4a
   RVTEST_TESTDATA_LOAD_INT(x10, x26) # load rs2: x26 = 0x689f8b2469792c04
+  RVTEST_TESTDATA_LOAD_INT(x10, x7) # load rd compare value: x7 = 0xd9d778fa38be4805
   LA(x15, scratch) # load base address into rs1
   SREG x19, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b26_not_equal:
@@ -1566,6 +1682,7 @@ Zacas_amocas_d_cg_cp_rs2_b26_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x26) # load value in memory: x26 = 0xa3182ee384b1c48a
   RVTEST_TESTDATA_LOAD_INT(x10, x27) # load rs2: x27 = 0xb6ba006fe2b9a6a4
+  RVTEST_TESTDATA_LOAD_INT(x10, x18) # load rd compare value: x18 = 0xa3182ee384b1c48a
   LA(x12, scratch) # load base address into rs1
   SREG x26, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b27_equal:
@@ -1579,6 +1696,7 @@ Zacas_amocas_d_cg_cp_rs2_b27_equal:
 # Testcase cp_rs2 (Test source rs2 = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x28) # load value in memory: x28 = 0x4324ea6d4a7fea9f
   RVTEST_TESTDATA_LOAD_INT(x10, x27) # load rs2: x27 = 0xd561b1b988466c4b
+  RVTEST_TESTDATA_LOAD_INT(x10, x25) # load rd compare value: x25 = 0x4ce2ba8e68c7ced2
   LA(x7, scratch) # load base address into rs1
   SREG x28, 0(x7) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b27_not_equal:
@@ -1592,6 +1710,7 @@ Zacas_amocas_d_cg_cp_rs2_b27_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x25) # load value in memory: x25 = 0x8a153443cbe912ca
   RVTEST_TESTDATA_LOAD_INT(x10, x28) # load rs2: x28 = 0x6831a330035a3eab
+  RVTEST_TESTDATA_LOAD_INT(x10, x6) # load rd compare value: x6 = 0x8a153443cbe912ca
   LA(x26, scratch) # load base address into rs1
   SREG x25, 0(x26) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b28_equal:
@@ -1605,6 +1724,7 @@ Zacas_amocas_d_cg_cp_rs2_b28_equal:
 # Testcase cp_rs2 (Test source rs2 = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x15) # load value in memory: x15 = 0xd6662fd08aba8441
   RVTEST_TESTDATA_LOAD_INT(x10, x28) # load rs2: x28 = 0x3ba75eeba41d4f75
+  RVTEST_TESTDATA_LOAD_INT(x10, x19) # load rd compare value: x19 = 0xb48e1870b20574e5
   LA(x29, scratch) # load base address into rs1
   SREG x15, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b28_not_equal:
@@ -1618,6 +1738,7 @@ Zacas_amocas_d_cg_cp_rs2_b28_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x1) # load value in memory: x1 = 0x02437c14eba6a696
   RVTEST_TESTDATA_LOAD_INT(x10, x29) # load rs2: x29 = 0x760c3a224553abb1
+  RVTEST_TESTDATA_LOAD_INT(x10, x2) # load rd compare value: x2 = 0x02437c14eba6a696
   LA(x14, scratch) # load base address into rs1
   SREG x1, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b29_equal:
@@ -1631,6 +1752,7 @@ Zacas_amocas_d_cg_cp_rs2_b29_equal:
 # Testcase cp_rs2 (Test source rs2 = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x31) # load value in memory: x31 = 0x1d87e7687878ede8
   RVTEST_TESTDATA_LOAD_INT(x10, x29) # load rs2: x29 = 0xe445232d5ff8a875
+  RVTEST_TESTDATA_LOAD_INT(x10, x28) # load rd compare value: x28 = 0x3f6344517629bfc0
   LA(x19, scratch) # load base address into rs1
   SREG x31, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b29_not_equal:
@@ -1644,6 +1766,7 @@ Zacas_amocas_d_cg_cp_rs2_b29_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x12) # load value in memory: x12 = 0x775e4243567708b1
   RVTEST_TESTDATA_LOAD_INT(x10, x30) # load rs2: x30 = 0x4890676079136024
+  RVTEST_TESTDATA_LOAD_INT(x10, x27) # load rd compare value: x27 = 0x775e4243567708b1
   LA(x16, scratch) # load base address into rs1
   SREG x12, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b30_equal:
@@ -1657,6 +1780,7 @@ Zacas_amocas_d_cg_cp_rs2_b30_equal:
 # Testcase cp_rs2 (Test source rs2 = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x3) # load value in memory: x3 = 0x7c7dae0380e66680
   RVTEST_TESTDATA_LOAD_INT(x10, x30) # load rs2: x30 = 0x5122221b25da7be0
+  RVTEST_TESTDATA_LOAD_INT(x10, x23) # load rd compare value: x23 = 0x8c6b5e67c00e7863
   LA(x1, scratch) # load base address into rs1
   SREG x3, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b30_not_equal:
@@ -1670,6 +1794,7 @@ Zacas_amocas_d_cg_cp_rs2_b30_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x18) # load value in memory: x18 = 0x3ef9df5f32d87527
   RVTEST_TESTDATA_LOAD_INT(x10, x31) # load rs2: x31 = 0x3e48963bd6aad3de
+  RVTEST_TESTDATA_LOAD_INT(x10, x28) # load rd compare value: x28 = 0x3ef9df5f32d87527
   LA(x30, scratch) # load base address into rs1
   SREG x18, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b31_equal:
@@ -1683,6 +1808,7 @@ Zacas_amocas_d_cg_cp_rs2_b31_equal:
 # Testcase cp_rs2 (Test source rs2 = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x3) # load value in memory: x3 = 0x651e8f54432596fa
   RVTEST_TESTDATA_LOAD_INT(x10, x31) # load rs2: x31 = 0xbdbfd940429b75df
+  RVTEST_TESTDATA_LOAD_INT(x10, x29) # load rd compare value: x29 = 0x2da245790fd2cf9b
   LA(x15, scratch) # load base address into rs1
   SREG x3, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rs2_b31_not_equal:
@@ -1700,6 +1826,7 @@ Zacas_amocas_d_cg_cp_rs2_b31_not_equal:
 # Testcase cp_rd (Test destination rd = x0, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x26) # load value in memory: x26 = 0x0c5261562c0d5ea3
   RVTEST_TESTDATA_LOAD_INT(x10, x17) # load rs2: x17 = 0x56497044d69edce0
+  RVTEST_TESTDATA_LOAD_INT(x10, x0) # load rd compare value: x0 = 0x0c5261562c0d5ea3
   LA(x29, scratch) # load base address into rs1
   SREG x26, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b0_equal:
@@ -1713,6 +1840,7 @@ Zacas_amocas_d_cg_cp_rd_b0_equal:
 # Testcase cp_rd (Test destination rd = x0, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x31) # load value in memory: x31 = 0xc5819abb7a67c7f5
   RVTEST_TESTDATA_LOAD_INT(x10, x18) # load rs2: x18 = 0xa57fa1fa48c83411
+  RVTEST_TESTDATA_LOAD_INT(x10, x0) # load rd compare value: x0 = 0x3158c4279a03733e
   LA(x30, scratch) # load base address into rs1
   SREG x31, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b0_not_equal:
@@ -1726,6 +1854,7 @@ Zacas_amocas_d_cg_cp_rd_b0_not_equal:
 # Testcase cp_rd (Test destination rd = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x29) # load value in memory: x29 = 0x4d14fb62fa15e497
   RVTEST_TESTDATA_LOAD_INT(x10, x31) # load rs2: x31 = 0x4cec7fbf57adf1f9
+  RVTEST_TESTDATA_LOAD_INT(x10, x1) # load rd compare value: x1 = 0x4d14fb62fa15e497
   LA(x21, scratch) # load base address into rs1
   SREG x29, 0(x21) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b1_equal:
@@ -1739,6 +1868,7 @@ Zacas_amocas_d_cg_cp_rd_b1_equal:
 # Testcase cp_rd (Test destination rd = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x30) # load value in memory: x30 = 0x8562c652e55b1b82
   RVTEST_TESTDATA_LOAD_INT(x10, x3) # load rs2: x3 = 0xb79eb422e88cb259
+  RVTEST_TESTDATA_LOAD_INT(x10, x1) # load rd compare value: x1 = 0x13d93b25a6e338b3
   LA(x23, scratch) # load base address into rs1
   SREG x30, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b1_not_equal:
@@ -1752,6 +1882,7 @@ Zacas_amocas_d_cg_cp_rd_b1_not_equal:
 # Testcase cp_rd (Test destination rd = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x25) # load value in memory: x25 = 0x0eee930a8911e3cd
   RVTEST_TESTDATA_LOAD_INT(x10, x1) # load rs2: x1 = 0x24a90dacf57d172d
+  RVTEST_TESTDATA_LOAD_INT(x10, x2) # load rd compare value: x2 = 0x0eee930a8911e3cd
   LA(x23, scratch) # load base address into rs1
   SREG x25, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b2_equal:
@@ -1765,6 +1896,7 @@ Zacas_amocas_d_cg_cp_rd_b2_equal:
 # Testcase cp_rd (Test destination rd = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x16) # load value in memory: x16 = 0xa5c098661b179ca4
   RVTEST_TESTDATA_LOAD_INT(x10, x27) # load rs2: x27 = 0xe66b8b375ee33319
+  RVTEST_TESTDATA_LOAD_INT(x10, x2) # load rd compare value: x2 = 0x16b90eea6fd11a3b
   LA(x7, scratch) # load base address into rs1
   SREG x16, 0(x7) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b2_not_equal:
@@ -1778,6 +1910,7 @@ Zacas_amocas_d_cg_cp_rd_b2_not_equal:
 # Testcase cp_rd (Test destination rd = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x14) # load value in memory: x14 = 0x8af2b367d26834b2
   RVTEST_TESTDATA_LOAD_INT(x10, x13) # load rs2: x13 = 0x2d23497782b2e25b
+  RVTEST_TESTDATA_LOAD_INT(x10, x3) # load rd compare value: x3 = 0x8af2b367d26834b2
   LA(x24, scratch) # load base address into rs1
   SREG x14, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b3_equal:
@@ -1791,6 +1924,7 @@ Zacas_amocas_d_cg_cp_rd_b3_equal:
 # Testcase cp_rd (Test destination rd = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x29) # load value in memory: x29 = 0x399dd5e31b1d456f
   RVTEST_TESTDATA_LOAD_INT(x10, x21) # load rs2: x21 = 0xa4c6d872e880a9b5
+  RVTEST_TESTDATA_LOAD_INT(x10, x3) # load rd compare value: x3 = 0xc4bf5714dd646c96
   LA(x31, scratch) # load base address into rs1
   SREG x29, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b3_not_equal:
@@ -1806,6 +1940,7 @@ Zacas_amocas_d_cg_cp_rd_b3_not_equal:
 # Testcase cp_rd (Test destination rd = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x27) # load value in memory: x27 = 0x01293e681f536a1e
   RVTEST_TESTDATA_LOAD_INT(x10, x30) # load rs2: x30 = 0x52f3e1da9038520b
+  RVTEST_TESTDATA_LOAD_INT(x10, x4) # load rd compare value: x4 = 0x01293e681f536a1e
   LA(x26, scratch) # load base address into rs1
   SREG x27, 0(x26) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b4_equal:
@@ -1819,6 +1954,7 @@ Zacas_amocas_d_cg_cp_rd_b4_equal:
 # Testcase cp_rd (Test destination rd = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x31) # load value in memory: x31 = 0x23ea3cfdc3e41d23
   RVTEST_TESTDATA_LOAD_INT(x10, x12) # load rs2: x12 = 0x67676a73e22f70a1
+  RVTEST_TESTDATA_LOAD_INT(x10, x4) # load rd compare value: x4 = 0xe60128c3c8c744ad
   LA(x3, scratch) # load base address into rs1
   SREG x31, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b4_not_equal:
@@ -1832,6 +1968,7 @@ Zacas_amocas_d_cg_cp_rd_b4_not_equal:
 # Testcase cp_rd (Test destination rd = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x30) # load value in memory: x30 = 0x8c1c54c3f0567236
   RVTEST_TESTDATA_LOAD_INT(x10, x8) # load rs2: x8 = 0x9c4bcf3daadcf263
+  RVTEST_TESTDATA_LOAD_INT(x10, x5) # load rd compare value: x5 = 0x8c1c54c3f0567236
   LA(x25, scratch) # load base address into rs1
   SREG x30, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b5_equal:
@@ -1845,6 +1982,7 @@ Zacas_amocas_d_cg_cp_rd_b5_equal:
 # Testcase cp_rd (Test destination rd = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x24) # load value in memory: x24 = 0xe5ec86871c231655
   RVTEST_TESTDATA_LOAD_INT(x10, x12) # load rs2: x12 = 0xe5e2f9c97d754576
+  RVTEST_TESTDATA_LOAD_INT(x10, x5) # load rd compare value: x5 = 0xf67b6aeb694255cb
   LA(x31, scratch) # load base address into rs1
   SREG x24, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b5_not_equal:
@@ -1858,6 +1996,7 @@ Zacas_amocas_d_cg_cp_rd_b5_not_equal:
 # Testcase cp_rd (Test destination rd = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x7) # load value in memory: x7 = 0xbe423e44ad564943
   RVTEST_TESTDATA_LOAD_INT(x10, x24) # load rs2: x24 = 0xaad65694dfbbbd84
+  RVTEST_TESTDATA_LOAD_INT(x10, x6) # load rd compare value: x6 = 0xbe423e44ad564943
   LA(x29, scratch) # load base address into rs1
   SREG x7, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b6_equal:
@@ -1871,6 +2010,7 @@ Zacas_amocas_d_cg_cp_rd_b6_equal:
 # Testcase cp_rd (Test destination rd = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x8) # load value in memory: x8 = 0xd9bb68a6cd452e9b
   RVTEST_TESTDATA_LOAD_INT(x10, x31) # load rs2: x31 = 0x07fce15b3011efe2
+  RVTEST_TESTDATA_LOAD_INT(x10, x6) # load rd compare value: x6 = 0x5f39ff64a4ae6711
   LA(x4, scratch) # load base address into rs1
   SREG x8, 0(x4) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b6_not_equal:
@@ -1884,6 +2024,7 @@ Zacas_amocas_d_cg_cp_rd_b6_not_equal:
 # Testcase cp_rd (Test destination rd = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x19) # load value in memory: x19 = 0xadf0fa05f38f2827
   RVTEST_TESTDATA_LOAD_INT(x10, x27) # load rs2: x27 = 0xc64974a3cb0ee517
+  RVTEST_TESTDATA_LOAD_INT(x10, x7) # load rd compare value: x7 = 0xadf0fa05f38f2827
   LA(x16, scratch) # load base address into rs1
   SREG x19, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b7_equal:
@@ -1897,6 +2038,7 @@ Zacas_amocas_d_cg_cp_rd_b7_equal:
 # Testcase cp_rd (Test destination rd = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x12) # load value in memory: x12 = 0x93bd57ae9bf38f30
   RVTEST_TESTDATA_LOAD_INT(x10, x16) # load rs2: x16 = 0x86b603061cbce3b0
+  RVTEST_TESTDATA_LOAD_INT(x10, x7) # load rd compare value: x7 = 0x463bda96eecaf7c6
   LA(x28, scratch) # load base address into rs1
   SREG x12, 0(x28) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b7_not_equal:
@@ -1910,6 +2052,7 @@ Zacas_amocas_d_cg_cp_rd_b7_not_equal:
 # Testcase cp_rd (Test destination rd = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x30) # load value in memory: x30 = 0x6319fcc648893f3d
   RVTEST_TESTDATA_LOAD_INT(x10, x5) # load rs2: x5 = 0xadee9d629a66bf98
+  RVTEST_TESTDATA_LOAD_INT(x10, x8) # load rd compare value: x8 = 0x6319fcc648893f3d
   LA(x4, scratch) # load base address into rs1
   SREG x30, 0(x4) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b8_equal:
@@ -1923,6 +2066,7 @@ Zacas_amocas_d_cg_cp_rd_b8_equal:
 # Testcase cp_rd (Test destination rd = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x3) # load value in memory: x3 = 0xe9f1e310ad67ee2d
   RVTEST_TESTDATA_LOAD_INT(x10, x16) # load rs2: x16 = 0x38f11b19a7131ce3
+  RVTEST_TESTDATA_LOAD_INT(x10, x8) # load rd compare value: x8 = 0x633e4f78f58b7bc1
   LA(x28, scratch) # load base address into rs1
   SREG x3, 0(x28) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b8_not_equal:
@@ -1937,6 +2081,7 @@ Zacas_amocas_d_cg_cp_rd_b8_not_equal:
 # Testcase cp_rd (Test destination rd = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x17) # load value in memory: x17 = 0x41ce54ec5d4f7d4a
   RVTEST_TESTDATA_LOAD_INT(x10, x3) # load rs2: x3 = 0xfa60d8397ea988f4
+  RVTEST_TESTDATA_LOAD_INT(x10, x9) # load rd compare value: x9 = 0x41ce54ec5d4f7d4a
   LA(x1, scratch) # load base address into rs1
   SREG x17, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b9_equal:
@@ -1950,6 +2095,7 @@ Zacas_amocas_d_cg_cp_rd_b9_equal:
 # Testcase cp_rd (Test destination rd = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x10, x18) # load value in memory: x18 = 0x220c154b3462e9dc
   RVTEST_TESTDATA_LOAD_INT(x10, x7) # load rs2: x7 = 0x2bfc322b1115fb8b
+  RVTEST_TESTDATA_LOAD_INT(x10, x9) # load rd compare value: x9 = 0x44529ddddf8f3631
   LA(x19, scratch) # load base address into rs1
   SREG x18, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b9_not_equal:
@@ -1964,6 +2110,7 @@ Zacas_amocas_d_cg_cp_rd_b9_not_equal:
 # Testcase cp_rd (Test destination rd = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x5) # load value in memory: x5 = 0xb0056cda13908f9d
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x829457b08b2500b8
+  RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rd compare value: x10 = 0xb0056cda13908f9d
   LA(x12, scratch) # load base address into rs1
   SREG x5, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b10_equal:
@@ -1977,6 +2124,7 @@ Zacas_amocas_d_cg_cp_rd_b10_equal:
 # Testcase cp_rd (Test destination rd = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load value in memory: x9 = 0xe49f95fa5b1d9724
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x2efa5f4e2213b984
+  RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rd compare value: x10 = 0x25571ada972c44ba
   LA(x27, scratch) # load base address into rs1
   SREG x9, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b10_not_equal:
@@ -1990,6 +2138,7 @@ Zacas_amocas_d_cg_cp_rd_b10_not_equal:
 # Testcase cp_rd (Test destination rd = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x26) # load value in memory: x26 = 0xd80c7e8267da2352
   RVTEST_TESTDATA_LOAD_INT(x3, x24) # load rs2: x24 = 0x0112ecfd68db3f22
+  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rd compare value: x11 = 0xd80c7e8267da2352
   LA(x30, scratch) # load base address into rs1
   SREG x26, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b11_equal:
@@ -2003,6 +2152,7 @@ Zacas_amocas_d_cg_cp_rd_b11_equal:
 # Testcase cp_rd (Test destination rd = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x6) # load value in memory: x6 = 0xfc4bfbd42c1be5f5
   RVTEST_TESTDATA_LOAD_INT(x3, x30) # load rs2: x30 = 0x638b9ca846c309d0
+  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rd compare value: x11 = 0x232d978613bd2987
   LA(x29, scratch) # load base address into rs1
   SREG x6, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b11_not_equal:
@@ -2016,6 +2166,7 @@ Zacas_amocas_d_cg_cp_rd_b11_not_equal:
 # Testcase cp_rd (Test destination rd = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x17) # load value in memory: x17 = 0xf1a6f4a86821f170
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x7cbc33e69392c50d
+  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rd compare value: x12 = 0xf1a6f4a86821f170
   LA(x18, scratch) # load base address into rs1
   SREG x17, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b12_equal:
@@ -2029,6 +2180,7 @@ Zacas_amocas_d_cg_cp_rd_b12_equal:
 # Testcase cp_rd (Test destination rd = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x19) # load value in memory: x19 = 0x19ca861026b0e3dd
   RVTEST_TESTDATA_LOAD_INT(x3, x30) # load rs2: x30 = 0x5f5b3108a4789ac8
+  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rd compare value: x12 = 0x204439037bf9ab6c
   LA(x29, scratch) # load base address into rs1
   SREG x19, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b12_not_equal:
@@ -2044,6 +2196,7 @@ Zacas_amocas_d_cg_cp_rd_b12_not_equal:
 # Testcase cp_rd (Test destination rd = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x30) # load value in memory: x30 = 0x2a00256a872b2b64
   RVTEST_TESTDATA_LOAD_INT(x3, x27) # load rs2: x27 = 0x20d11d53a0c6d8b6
+  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rd compare value: x13 = 0x2a00256a872b2b64
   LA(x8, scratch) # load base address into rs1
   SREG x30, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b13_equal:
@@ -2057,6 +2210,7 @@ Zacas_amocas_d_cg_cp_rd_b13_equal:
 # Testcase cp_rd (Test destination rd = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load value in memory: x12 = 0xf3ee3b80b8d3521c
   RVTEST_TESTDATA_LOAD_INT(x3, x25) # load rs2: x25 = 0x2cc02731352cde38
+  RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rd compare value: x13 = 0xbe0316fd14465053
   LA(x28, scratch) # load base address into rs1
   SREG x12, 0(x28) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b13_not_equal:
@@ -2070,6 +2224,7 @@ Zacas_amocas_d_cg_cp_rd_b13_not_equal:
 # Testcase cp_rd (Test destination rd = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x29) # load value in memory: x29 = 0x7c02ec59b867aa10
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rs2: x11 = 0x7750588be7c6617b
+  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rd compare value: x14 = 0x7c02ec59b867aa10
   LA(x18, scratch) # load base address into rs1
   SREG x29, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b14_equal:
@@ -2083,6 +2238,7 @@ Zacas_amocas_d_cg_cp_rd_b14_equal:
 # Testcase cp_rd (Test destination rd = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x17) # load value in memory: x17 = 0x389dc6129ed28a84
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x45aea0f09ceccbd0
+  RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rd compare value: x14 = 0xbf6d26de6e59bbc5
   LA(x25, scratch) # load base address into rs1
   SREG x17, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b14_not_equal:
@@ -2096,6 +2252,7 @@ Zacas_amocas_d_cg_cp_rd_b14_not_equal:
 # Testcase cp_rd (Test destination rd = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x16) # load value in memory: x16 = 0x83db5bf71f338394
   RVTEST_TESTDATA_LOAD_INT(x3, x20) # load rs2: x20 = 0xb59e8df90016ef83
+  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rd compare value: x15 = 0x83db5bf71f338394
   LA(x31, scratch) # load base address into rs1
   SREG x16, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b15_equal:
@@ -2109,6 +2266,7 @@ Zacas_amocas_d_cg_cp_rd_b15_equal:
 # Testcase cp_rd (Test destination rd = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x26) # load value in memory: x26 = 0x4bedb88ece01d9e4
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xa0beceba72fbf399
+  RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rd compare value: x15 = 0x19ad00769de995ae
   LA(x22, scratch) # load base address into rs1
   SREG x26, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b15_not_equal:
@@ -2122,6 +2280,7 @@ Zacas_amocas_d_cg_cp_rd_b15_not_equal:
 # Testcase cp_rd (Test destination rd = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x30) # load value in memory: x30 = 0xa5b1be3d3d93a22a
   RVTEST_TESTDATA_LOAD_INT(x3, x18) # load rs2: x18 = 0xda3795669e6db3fc
+  RVTEST_TESTDATA_LOAD_INT(x3, x16) # load rd compare value: x16 = 0xa5b1be3d3d93a22a
   LA(x6, scratch) # load base address into rs1
   SREG x30, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b16_equal:
@@ -2135,6 +2294,7 @@ Zacas_amocas_d_cg_cp_rd_b16_equal:
 # Testcase cp_rd (Test destination rd = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load value in memory: x13 = 0x6cae33ef1140b719
   RVTEST_TESTDATA_LOAD_INT(x3, x17) # load rs2: x17 = 0xc9fba5b3ac6c4aec
+  RVTEST_TESTDATA_LOAD_INT(x3, x16) # load rd compare value: x16 = 0x5aa00beb061c08a2
   LA(x18, scratch) # load base address into rs1
   SREG x13, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b16_not_equal:
@@ -2148,6 +2308,7 @@ Zacas_amocas_d_cg_cp_rd_b16_not_equal:
 # Testcase cp_rd (Test destination rd = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x6) # load value in memory: x6 = 0xd52018ddf9b1a1f1
   RVTEST_TESTDATA_LOAD_INT(x3, x31) # load rs2: x31 = 0x80f72a93ae9a8675
+  RVTEST_TESTDATA_LOAD_INT(x3, x17) # load rd compare value: x17 = 0xd52018ddf9b1a1f1
   LA(x20, scratch) # load base address into rs1
   SREG x6, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b17_equal:
@@ -2161,6 +2322,7 @@ Zacas_amocas_d_cg_cp_rd_b17_equal:
 # Testcase cp_rd (Test destination rd = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load value in memory: x9 = 0xc1963178e24b9207
   RVTEST_TESTDATA_LOAD_INT(x3, x22) # load rs2: x22 = 0x40968344450db75f
+  RVTEST_TESTDATA_LOAD_INT(x3, x17) # load rd compare value: x17 = 0xcf2351d979472e44
   LA(x1, scratch) # load base address into rs1
   SREG x9, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b17_not_equal:
@@ -2174,6 +2336,7 @@ Zacas_amocas_d_cg_cp_rd_b17_not_equal:
 # Testcase cp_rd (Test destination rd = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x6) # load value in memory: x6 = 0xe6f550541faa32c5
   RVTEST_TESTDATA_LOAD_INT(x3, x31) # load rs2: x31 = 0xcdd3b8b5385fe683
+  RVTEST_TESTDATA_LOAD_INT(x3, x18) # load rd compare value: x18 = 0xe6f550541faa32c5
   LA(x27, scratch) # load base address into rs1
   SREG x6, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b18_equal:
@@ -2187,6 +2350,7 @@ Zacas_amocas_d_cg_cp_rd_b18_equal:
 # Testcase cp_rd (Test destination rd = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x7) # load value in memory: x7 = 0x2e593b0b746d102c
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rs2: x12 = 0x72198db0297317ea
+  RVTEST_TESTDATA_LOAD_INT(x3, x18) # load rd compare value: x18 = 0x1e3d54b5d245a3a1
   LA(x24, scratch) # load base address into rs1
   SREG x7, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b18_not_equal:
@@ -2200,6 +2364,7 @@ Zacas_amocas_d_cg_cp_rd_b18_not_equal:
 # Testcase cp_rd (Test destination rd = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x21) # load value in memory: x21 = 0xa886e853b1bbceaf
   RVTEST_TESTDATA_LOAD_INT(x3, x17) # load rs2: x17 = 0xb9f9e29ee414cd69
+  RVTEST_TESTDATA_LOAD_INT(x3, x19) # load rd compare value: x19 = 0xa886e853b1bbceaf
   LA(x16, scratch) # load base address into rs1
   SREG x21, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b19_equal:
@@ -2213,6 +2378,7 @@ Zacas_amocas_d_cg_cp_rd_b19_equal:
 # Testcase cp_rd (Test destination rd = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x31) # load value in memory: x31 = 0x9d4bfbfeec5ef2ee
   RVTEST_TESTDATA_LOAD_INT(x3, x25) # load rs2: x25 = 0x157f52d028f48d60
+  RVTEST_TESTDATA_LOAD_INT(x3, x19) # load rd compare value: x19 = 0x2e7a6d6345b065a7
   LA(x27, scratch) # load base address into rs1
   SREG x31, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b19_not_equal:
@@ -2226,6 +2392,7 @@ Zacas_amocas_d_cg_cp_rd_b19_not_equal:
 # Testcase cp_rd (Test destination rd = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x31) # load value in memory: x31 = 0xfc7b76652d9af8d3
   RVTEST_TESTDATA_LOAD_INT(x3, x18) # load rs2: x18 = 0x0ed24d3f2f2b9fb6
+  RVTEST_TESTDATA_LOAD_INT(x3, x20) # load rd compare value: x20 = 0xfc7b76652d9af8d3
   LA(x24, scratch) # load base address into rs1
   SREG x31, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b20_equal:
@@ -2239,6 +2406,7 @@ Zacas_amocas_d_cg_cp_rd_b20_equal:
 # Testcase cp_rd (Test destination rd = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x27) # load value in memory: x27 = 0x7732a4c5ed77de09
   RVTEST_TESTDATA_LOAD_INT(x3, x30) # load rs2: x30 = 0x29d240f3bcda3f91
+  RVTEST_TESTDATA_LOAD_INT(x3, x20) # load rd compare value: x20 = 0xdfb52fd3b4b29f57
   LA(x19, scratch) # load base address into rs1
   SREG x27, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b20_not_equal:
@@ -2252,6 +2420,7 @@ Zacas_amocas_d_cg_cp_rd_b20_not_equal:
 # Testcase cp_rd (Test destination rd = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load value in memory: x10 = 0x7f1cfa940f77074c
   RVTEST_TESTDATA_LOAD_INT(x3, x1) # load rs2: x1 = 0xa0d7920b0857ebd4
+  RVTEST_TESTDATA_LOAD_INT(x3, x21) # load rd compare value: x21 = 0x7f1cfa940f77074c
   LA(x24, scratch) # load base address into rs1
   SREG x10, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b21_equal:
@@ -2265,6 +2434,7 @@ Zacas_amocas_d_cg_cp_rd_b21_equal:
 # Testcase cp_rd (Test destination rd = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load value in memory: x11 = 0x7f044cf630de1f72
   RVTEST_TESTDATA_LOAD_INT(x3, x27) # load rs2: x27 = 0xbb26c444686b8485
+  RVTEST_TESTDATA_LOAD_INT(x3, x21) # load rd compare value: x21 = 0xa9b579ef94930c6c
   LA(x30, scratch) # load base address into rs1
   SREG x11, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b21_not_equal:
@@ -2278,6 +2448,7 @@ Zacas_amocas_d_cg_cp_rd_b21_not_equal:
 # Testcase cp_rd (Test destination rd = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x18) # load value in memory: x18 = 0x31d638c955f43cb0
   RVTEST_TESTDATA_LOAD_INT(x3, x24) # load rs2: x24 = 0x58639ca93efa8eae
+  RVTEST_TESTDATA_LOAD_INT(x3, x22) # load rd compare value: x22 = 0x31d638c955f43cb0
   LA(x13, scratch) # load base address into rs1
   SREG x18, 0(x13) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b22_equal:
@@ -2291,6 +2462,7 @@ Zacas_amocas_d_cg_cp_rd_b22_equal:
 # Testcase cp_rd (Test destination rd = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x29) # load value in memory: x29 = 0xa7b73e422324644e
   RVTEST_TESTDATA_LOAD_INT(x3, x26) # load rs2: x26 = 0x2de2cd8cba0daa50
+  RVTEST_TESTDATA_LOAD_INT(x3, x22) # load rd compare value: x22 = 0xbd4de29f199b8b93
   LA(x23, scratch) # load base address into rs1
   SREG x29, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b22_not_equal:
@@ -2304,6 +2476,7 @@ Zacas_amocas_d_cg_cp_rd_b22_not_equal:
 # Testcase cp_rd (Test destination rd = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x28) # load value in memory: x28 = 0xd0f71467a4b61647
   RVTEST_TESTDATA_LOAD_INT(x3, x19) # load rs2: x19 = 0x09062708aabaa05e
+  RVTEST_TESTDATA_LOAD_INT(x3, x23) # load rd compare value: x23 = 0xd0f71467a4b61647
   LA(x18, scratch) # load base address into rs1
   SREG x28, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b23_equal:
@@ -2317,6 +2490,7 @@ Zacas_amocas_d_cg_cp_rd_b23_equal:
 # Testcase cp_rd (Test destination rd = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x19) # load value in memory: x19 = 0x128b6e4f027005a6
   RVTEST_TESTDATA_LOAD_INT(x3, x22) # load rs2: x22 = 0x04b53c34cb7c0041
+  RVTEST_TESTDATA_LOAD_INT(x3, x23) # load rd compare value: x23 = 0xf8ce451f7e87a969
   LA(x20, scratch) # load base address into rs1
   SREG x19, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b23_not_equal:
@@ -2330,6 +2504,7 @@ Zacas_amocas_d_cg_cp_rd_b23_not_equal:
 # Testcase cp_rd (Test destination rd = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load value in memory: x15 = 0x27df56f830fef434
   RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0xc5486d756f54ee59
+  RVTEST_TESTDATA_LOAD_INT(x3, x24) # load rd compare value: x24 = 0x27df56f830fef434
   LA(x17, scratch) # load base address into rs1
   SREG x15, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b24_equal:
@@ -2343,6 +2518,7 @@ Zacas_amocas_d_cg_cp_rd_b24_equal:
 # Testcase cp_rd (Test destination rd = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x20) # load value in memory: x20 = 0x593a4727b135a6af
   RVTEST_TESTDATA_LOAD_INT(x3, x7) # load rs2: x7 = 0xc2c2011acdfad12b
+  RVTEST_TESTDATA_LOAD_INT(x3, x24) # load rd compare value: x24 = 0xd1ba76ab313bf9e1
   LA(x25, scratch) # load base address into rs1
   SREG x20, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b24_not_equal:
@@ -2356,6 +2532,7 @@ Zacas_amocas_d_cg_cp_rd_b24_not_equal:
 # Testcase cp_rd (Test destination rd = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x28) # load value in memory: x28 = 0xa242d7b6b90b452e
   RVTEST_TESTDATA_LOAD_INT(x3, x31) # load rs2: x31 = 0x31716bca327398e7
+  RVTEST_TESTDATA_LOAD_INT(x3, x25) # load rd compare value: x25 = 0xa242d7b6b90b452e
   LA(x24, scratch) # load base address into rs1
   SREG x28, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b25_equal:
@@ -2369,6 +2546,7 @@ Zacas_amocas_d_cg_cp_rd_b25_equal:
 # Testcase cp_rd (Test destination rd = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x20) # load value in memory: x20 = 0x0460651541a0b93e
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xcb65295ec07ad056
+  RVTEST_TESTDATA_LOAD_INT(x3, x25) # load rd compare value: x25 = 0x8e754ce9c6f661f4
   LA(x17, scratch) # load base address into rs1
   SREG x20, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b25_not_equal:
@@ -2382,6 +2560,7 @@ Zacas_amocas_d_cg_cp_rd_b25_not_equal:
 # Testcase cp_rd (Test destination rd = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x25) # load value in memory: x25 = 0x3e07c7db727f94cf
   RVTEST_TESTDATA_LOAD_INT(x3, x19) # load rs2: x19 = 0xd37a09530e4c33ed
+  RVTEST_TESTDATA_LOAD_INT(x3, x26) # load rd compare value: x26 = 0x3e07c7db727f94cf
   LA(x22, scratch) # load base address into rs1
   SREG x25, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b26_equal:
@@ -2395,6 +2574,7 @@ Zacas_amocas_d_cg_cp_rd_b26_equal:
 # Testcase cp_rd (Test destination rd = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x22) # load value in memory: x22 = 0x87e2f59dd7702228
   RVTEST_TESTDATA_LOAD_INT(x3, x7) # load rs2: x7 = 0xb501f5f481ac1a3b
+  RVTEST_TESTDATA_LOAD_INT(x3, x26) # load rd compare value: x26 = 0x1929cb259551893c
   LA(x12, scratch) # load base address into rs1
   SREG x22, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b26_not_equal:
@@ -2408,6 +2588,7 @@ Zacas_amocas_d_cg_cp_rd_b26_not_equal:
 # Testcase cp_rd (Test destination rd = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x19) # load value in memory: x19 = 0xd36ea9bebce3c544
   RVTEST_TESTDATA_LOAD_INT(x3, x16) # load rs2: x16 = 0xcc7d53b47c353add
+  RVTEST_TESTDATA_LOAD_INT(x3, x27) # load rd compare value: x27 = 0xd36ea9bebce3c544
   LA(x30, scratch) # load base address into rs1
   SREG x19, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b27_equal:
@@ -2421,6 +2602,7 @@ Zacas_amocas_d_cg_cp_rd_b27_equal:
 # Testcase cp_rd (Test destination rd = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x16) # load value in memory: x16 = 0x51b73f11b3ff2890
   RVTEST_TESTDATA_LOAD_INT(x3, x22) # load rs2: x22 = 0x4c84e66f1284fdb2
+  RVTEST_TESTDATA_LOAD_INT(x3, x27) # load rd compare value: x27 = 0x437efc08d081554a
   LA(x17, scratch) # load base address into rs1
   SREG x16, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b27_not_equal:
@@ -2434,6 +2616,7 @@ Zacas_amocas_d_cg_cp_rd_b27_not_equal:
 # Testcase cp_rd (Test destination rd = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x26) # load value in memory: x26 = 0xe8c9ce3fb0668b4f
   RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rs2: x8 = 0x633fb97e7472c449
+  RVTEST_TESTDATA_LOAD_INT(x3, x28) # load rd compare value: x28 = 0xe8c9ce3fb0668b4f
   LA(x9, scratch) # load base address into rs1
   SREG x26, 0(x9) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b28_equal:
@@ -2447,6 +2630,7 @@ Zacas_amocas_d_cg_cp_rd_b28_equal:
 # Testcase cp_rd (Test destination rd = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x26) # load value in memory: x26 = 0x6778001bfa64802e
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x74046b6a3b3db50e
+  RVTEST_TESTDATA_LOAD_INT(x3, x28) # load rd compare value: x28 = 0x01ea12e5e4110daf
   LA(x1, scratch) # load base address into rs1
   SREG x26, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b28_not_equal:
@@ -2460,6 +2644,7 @@ Zacas_amocas_d_cg_cp_rd_b28_not_equal:
 # Testcase cp_rd (Test destination rd = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load value in memory: x9 = 0x8d0e36545549af71
   RVTEST_TESTDATA_LOAD_INT(x3, x30) # load rs2: x30 = 0x1326133addff8e4d
+  RVTEST_TESTDATA_LOAD_INT(x3, x29) # load rd compare value: x29 = 0x8d0e36545549af71
   LA(x17, scratch) # load base address into rs1
   SREG x9, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b29_equal:
@@ -2473,6 +2658,7 @@ Zacas_amocas_d_cg_cp_rd_b29_equal:
 # Testcase cp_rd (Test destination rd = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x18) # load value in memory: x18 = 0xff18573ce4b036f4
   RVTEST_TESTDATA_LOAD_INT(x3, x26) # load rs2: x26 = 0xb7e4d71147a0cae3
+  RVTEST_TESTDATA_LOAD_INT(x3, x29) # load rd compare value: x29 = 0x857be7646c33aee7
   LA(x12, scratch) # load base address into rs1
   SREG x18, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b29_not_equal:
@@ -2486,6 +2672,7 @@ Zacas_amocas_d_cg_cp_rd_b29_not_equal:
 # Testcase cp_rd (Test destination rd = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x20) # load value in memory: x20 = 0x9941d51ee3820acb
   RVTEST_TESTDATA_LOAD_INT(x3, x28) # load rs2: x28 = 0x64341bca5d149c5c
+  RVTEST_TESTDATA_LOAD_INT(x3, x30) # load rd compare value: x30 = 0x9941d51ee3820acb
   LA(x23, scratch) # load base address into rs1
   SREG x20, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b30_equal:
@@ -2499,6 +2686,7 @@ Zacas_amocas_d_cg_cp_rd_b30_equal:
 # Testcase cp_rd (Test destination rd = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load value in memory: x9 = 0x177b71be27ea54ba
   RVTEST_TESTDATA_LOAD_INT(x3, x24) # load rs2: x24 = 0x00ea5edd3105efed
+  RVTEST_TESTDATA_LOAD_INT(x3, x30) # load rd compare value: x30 = 0x99552f2cadd80849
   LA(x26, scratch) # load base address into rs1
   SREG x9, 0(x26) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b30_not_equal:
@@ -2512,6 +2700,7 @@ Zacas_amocas_d_cg_cp_rd_b30_not_equal:
 # Testcase cp_rd (Test destination rd = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load value in memory: x9 = 0xce4795e8f81d2391
   RVTEST_TESTDATA_LOAD_INT(x3, x17) # load rs2: x17 = 0x4613a314c16a98e5
+  RVTEST_TESTDATA_LOAD_INT(x3, x31) # load rd compare value: x31 = 0xce4795e8f81d2391
   LA(x29, scratch) # load base address into rs1
   SREG x9, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b31_equal:
@@ -2525,6 +2714,7 @@ Zacas_amocas_d_cg_cp_rd_b31_equal:
 # Testcase cp_rd (Test destination rd = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x12) # load value in memory: x12 = 0xe827b50cc6e752f0
   RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rs2: x0 = 0xa074da22c85d469d
+  RVTEST_TESTDATA_LOAD_INT(x3, x31) # load rd compare value: x31 = 0x609d06250a24120a
   LA(x26, scratch) # load base address into rs1
   SREG x12, 0(x26) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cp_rd_b31_not_equal:
@@ -4486,9 +4676,9 @@ Zacas_amocas_d_cg_cmp_rd_rs1_rs2_nx0_b31:
 /////////////////////////////////
 
 # Testcase cmp_rd_rs1_val_eq (rd_val == mem_val)
-  RVTEST_TESTDATA_LOAD_INT(x3, x21) # load rd compare value: x21 = 0xeaefe57b62be275e
   RVTEST_TESTDATA_LOAD_INT(x3, x7) # load value in memory: x7 = 0xeaefe57b62be275e
   RVTEST_TESTDATA_LOAD_INT(x3, x22) # load rs2: x22 = 0x15cffa3b120f4371
+  RVTEST_TESTDATA_LOAD_INT(x3, x21) # load rd compare value: x21 = 0xeaefe57b62be275e
   LA(x17, scratch) # load base address into rs1
   SREG x7, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cmp_rd_rs1_val_eq_equal:
@@ -4500,9 +4690,9 @@ Zacas_amocas_d_cg_cmp_rd_rs1_val_eq_equal:
   RVTEST_SIGUPD(x1, x5, x4, x17, Zacas_amocas_d_cg_cmp_rd_rs1_val_eq_equal, Zacas_amocas_d_cg_cmp_rd_rs1_val_eq_equal_str)
 
 # Testcase cmp_rd_rs1_val_eq (rd_val != mem_val)
-  RVTEST_TESTDATA_LOAD_INT(x3, x25) # load rd compare value: x25 = 0x6e7cba557756c87e
   RVTEST_TESTDATA_LOAD_INT(x3, x22) # load value in memory: x22 = 0xa6d9cc313edc2c56
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0xcefc7f763ec0cc61
+  RVTEST_TESTDATA_LOAD_INT(x3, x25) # load rd compare value: x25 = 0x6e7cba557756c87e
   LA(x8, scratch) # load base address into rs1
   SREG x22, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cmp_rd_rs1_val_eq_not_equal:
@@ -4518,9 +4708,9 @@ Zacas_amocas_d_cg_cmp_rd_rs1_val_eq_not_equal:
 /////////////////////////////////
 
 # Testcase cmp_rd_rs1_val_lsb (rd_val[7:0] == mem_val[7:0])
-  RVTEST_TESTDATA_LOAD_INT(x3, x31) # load rd compare value: x31 = 0xaca850d5ca07cff2
   RVTEST_TESTDATA_LOAD_INT(x3, x25) # load value in memory: x25 = 0xb63a66e52414a9f2
   RVTEST_TESTDATA_LOAD_INT(x3, x22) # load rs2: x22 = 0xc6b9bdcea76fe88c
+  RVTEST_TESTDATA_LOAD_INT(x3, x31) # load rd compare value: x31 = 0xaca850d5ca07cff2
   LA(x7, scratch) # load base address into rs1
   SREG x25, 0(x7) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cmp_rd_rs1_val_lsb_equal:
@@ -4532,9 +4722,9 @@ Zacas_amocas_d_cg_cmp_rd_rs1_val_lsb_equal:
   RVTEST_SIGUPD(x1, x5, x4, x7, Zacas_amocas_d_cg_cmp_rd_rs1_val_lsb_equal, Zacas_amocas_d_cg_cmp_rd_rs1_val_lsb_equal_str)
 
 # Testcase cmp_rd_rs1_val_lsb (rd_val[7:0] != mem_val[7:0])
-  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rd compare value: x6 = 0xb9f037d521a9055f
   RVTEST_TESTDATA_LOAD_INT(x3, x22) # load value in memory: x22 = 0xb9f037d521a905e8
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load rs2: x14 = 0xd4c3d68f59c6c49a
+  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rd compare value: x6 = 0xb9f037d521a9055f
   LA(x8, scratch) # load base address into rs1
   SREG x22, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cmp_rd_rs1_val_lsb_not_equal:
@@ -4550,9 +4740,9 @@ Zacas_amocas_d_cg_cmp_rd_rs1_val_lsb_not_equal:
 /////////////////////////////////
 
 # Testcase cmp_rd_rs1_val_hw (rd_val[15:0] == mem_val[15:0])
-  RVTEST_TESTDATA_LOAD_INT(x3, x31) # load rd compare value: x31 = 0x10317ae2e5810619
   RVTEST_TESTDATA_LOAD_INT(x3, x16) # load value in memory: x16 = 0x987ee7a96b9c0619
   RVTEST_TESTDATA_LOAD_INT(x3, x24) # load rs2: x24 = 0x5408835923a7b116
+  RVTEST_TESTDATA_LOAD_INT(x3, x31) # load rd compare value: x31 = 0x10317ae2e5810619
   LA(x27, scratch) # load base address into rs1
   SREG x16, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cmp_rd_rs1_val_hw_equal:
@@ -4564,9 +4754,9 @@ Zacas_amocas_d_cg_cmp_rd_rs1_val_hw_equal:
   RVTEST_SIGUPD(x1, x5, x4, x27, Zacas_amocas_d_cg_cmp_rd_rs1_val_hw_equal, Zacas_amocas_d_cg_cmp_rd_rs1_val_hw_equal_str)
 
 # Testcase cmp_rd_rs1_val_hw (rd_val[15:0] != mem_val[15:0])
-  RVTEST_TESTDATA_LOAD_INT(x3, x29) # load rd compare value: x29 = 0x8ec71c4d470295e0
   RVTEST_TESTDATA_LOAD_INT(x3, x22) # load value in memory: x22 = 0x8ec71c4d4702aa7d
   RVTEST_TESTDATA_LOAD_INT(x3, x20) # load rs2: x20 = 0xc878841cbddc64cf
+  RVTEST_TESTDATA_LOAD_INT(x3, x29) # load rd compare value: x29 = 0x8ec71c4d470295e0
   LA(x28, scratch) # load base address into rs1
   SREG x22, 0(x28) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cmp_rd_rs1_val_hw_not_equal:
@@ -4582,9 +4772,9 @@ Zacas_amocas_d_cg_cmp_rd_rs1_val_hw_not_equal:
 /////////////////////////////////
 
 # Testcase cmp_rd_rs1_val_w (rd_val[31:0] == mem_val[31:0])
-  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rd compare value: x12 = 0xf3b66f8b392788a0
   RVTEST_TESTDATA_LOAD_INT(x3, x24) # load value in memory: x24 = 0xe638f048392788a0
   RVTEST_TESTDATA_LOAD_INT(x3, x29) # load rs2: x29 = 0x5428995c29d5112b
+  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rd compare value: x12 = 0xf3b66f8b392788a0
   LA(x8, scratch) # load base address into rs1
   SREG x24, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cmp_rd_rs1_val_w_equal:
@@ -4596,9 +4786,9 @@ Zacas_amocas_d_cg_cmp_rd_rs1_val_w_equal:
   RVTEST_SIGUPD(x1, x5, x4, x8, Zacas_amocas_d_cg_cmp_rd_rs1_val_w_equal, Zacas_amocas_d_cg_cmp_rd_rs1_val_w_equal_str)
 
 # Testcase cmp_rd_rs1_val_w (rd_val[31:0] != mem_val[31:0])
-  RVTEST_TESTDATA_LOAD_INT(x3, x19) # load rd compare value: x19 = 0xc70fa268e404a4c6
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load value in memory: x13 = 0xc70fa268774c93ef
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load rs2: x10 = 0xc3d8070738635803
+  RVTEST_TESTDATA_LOAD_INT(x3, x19) # load rd compare value: x19 = 0xc70fa268e404a4c6
   LA(x25, scratch) # load base address into rs1
   SREG x13, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_d_cg_cmp_rd_rs1_val_w_not_equal:
@@ -4620,384 +4810,574 @@ RVTEST_DATA_BEGIN
 // Test data
 .dword 0x5613235ad98e94ef
 .dword 0x8e878410970b5e91
+.dword 0x5613235ad98e94ef
 .dword 0x7195dd57cdfdc2e7
 .dword 0x4ca44073103f6b15
+.dword 0x9f1d23eb1c067ac6
 .dword 0xf2b49184967d1b1c
 .dword 0x2a58de902b54a60c
+.dword 0xf2b49184967d1b1c
 .dword 0x0e812955f255240a
 .dword 0x52d5243a2e6228fd
+.dword 0x9351db8a718e9e40
 .dword 0x0fb0af504c9bf35a
 .dword 0xf2ab91c791b9c919
+.dword 0x0fb0af504c9bf35a
 .dword 0x3787500dfdce853c
 .dword 0xd0b18e7ea82a2b8b
+.dword 0x32e6c977c0f2b37a
 .dword 0xa7c4e8b6510af5a4
 .dword 0x2aeb042d92d361e2
+.dword 0xa7c4e8b6510af5a4
 .dword 0x264463d78e1ced88
 .dword 0xe7630d6862f03018
+.dword 0xe48826a6fd2b118f
 .dword 0x39ae079e48075674
 .dword 0x1fa863051337c3d9
+.dword 0x39ae079e48075674
 .dword 0x97c3694f645e3c9d
 .dword 0x1a3825458de04bda
+.dword 0xeeff0df323a4adb7
 .dword 0x4e692a1c19f7154b
 .dword 0xe3bdcb3e54ce43e3
+.dword 0x4e692a1c19f7154b
 .dword 0x5afd81ab1a8c26e8
 .dword 0x3a6cf73f3189bd44
+.dword 0x535c5b9a6bbd11f3
 .dword 0xec336a614d40488a
 .dword 0x26592254fb9c91ef
+.dword 0xec336a614d40488a
 .dword 0xbd7d73ada1578b10
 .dword 0xbf5980d481e0c906
+.dword 0xd868bd3984ce4fe8
 .dword 0x1363c9adfe7d4664
 .dword 0x862b50f11a475edd
+.dword 0x1363c9adfe7d4664
 .dword 0x1821cca95dc6c3d6
 .dword 0x97b51eb1b0e32b6a
+.dword 0x6c5b2dbbad451207
 .dword 0x72c205fd6f1271c9
 .dword 0xcaf2ba455991f5b5
+.dword 0x72c205fd6f1271c9
 .dword 0x029b94c335506719
 .dword 0xe5ff9a47f4549d17
+.dword 0x337e4026f124c32c
 .dword 0x42064e33c8af5f2b
 .dword 0xbd2b2a023bbb284b
+.dword 0x42064e33c8af5f2b
 .dword 0x46cee4b1d71e7d37
 .dword 0xe192161b472afab0
+.dword 0x07388d746ca9a6c0
 .dword 0xc379a366856159fd
 .dword 0x581c501b64817030
+.dword 0xc379a366856159fd
 .dword 0xaaf9f69ce87ae52e
 .dword 0x9fcd3ec679ee5fff
+.dword 0x0f57081ba8fbea54
 .dword 0xffbe278cf4646ed5
 .dword 0x026dfb70c78e74b7
+.dword 0xffbe278cf4646ed5
 .dword 0x96747d0179b88830
 .dword 0xd43e6a6ca52eb41c
+.dword 0xf3a1b70b2dadba15
 .dword 0x71bf3ea9f41c4764
 .dword 0x1aa894f42f53dee7
+.dword 0x71bf3ea9f41c4764
 .dword 0x9094e1fdfed0114a
 .dword 0xb8ae9297a3dc3597
+.dword 0x86831e8d4f7dbb31
 .dword 0xaf32c6ab0a2c53dc
 .dword 0xfebf214a06582ac9
+.dword 0xaf32c6ab0a2c53dc
 .dword 0x1466389dba76c951
 .dword 0x88185c1de8fcaf55
+.dword 0x77e0648a6c439e59
 .dword 0x31bd4adbc38dd70c
 .dword 0x6899bb3cad825714
+.dword 0x31bd4adbc38dd70c
 .dword 0x0b4207fc004e7cd2
 .dword 0x84231f95aab93fcb
+.dword 0x4c2599184e185ba9
 .dword 0x4dddc4c996b547e7
 .dword 0x5394b87059061263
+.dword 0x4dddc4c996b547e7
 .dword 0x6f6f381f821668d7
 .dword 0x947a3816b40028dd
+.dword 0xbd9e5ce04ad8f3f3
 .dword 0x853600164970dae4
 .dword 0x52bb92dad8a66dae
+.dword 0x853600164970dae4
 .dword 0x0b14bd3d350bf8d7
 .dword 0x216fb47e3292ddf4
+.dword 0xacd6014f8ba20bae
 .dword 0x9eadc030acc84ff2
 .dword 0x309b3a946846b33e
+.dword 0x9eadc030acc84ff2
 .dword 0x42062bd05a758a91
 .dword 0x4623fb93006e667e
+.dword 0x781d1709fed0d551
 .dword 0xf774da002fd10943
 .dword 0xc6fa9b0d938f3aae
+.dword 0xf774da002fd10943
 .dword 0x8be2685f98172afd
 .dword 0xfd158330d5923b04
+.dword 0xea294d40a35199c7
 .dword 0x6ff5459f500cccee
 .dword 0xb20c581a4cd46fce
+.dword 0x6ff5459f500cccee
 .dword 0x82caa5d23c0b2c93
 .dword 0x754b0943639ae452
+.dword 0x8b63fc4fd8a32a9d
 .dword 0xeb214373d187b6b0
 .dword 0x1e0dbba1c5ba0a00
+.dword 0xeb214373d187b6b0
 .dword 0xcf433ae0165e8201
 .dword 0x6caa1cf9c655ed75
+.dword 0x2070e483bef72c63
 .dword 0xc471558509f990e0
 .dword 0x70799445dac10ca7
+.dword 0xc471558509f990e0
 .dword 0x314247473caf663e
 .dword 0x083b0b437ef800c2
+.dword 0xe222141a6701abb0
 .dword 0x81cf13788d4555fa
 .dword 0x932027574c832906
+.dword 0x81cf13788d4555fa
 .dword 0xf16e0a9b8e71854c
 .dword 0xb8e2c1d92b984fda
+.dword 0x6bf3bf9ec7f1dd85
 .dword 0x9215dceaf61433d5
 .dword 0x79e8644a1f91e85a
+.dword 0x9215dceaf61433d5
 .dword 0x20cef6da043888ff
 .dword 0x4516cbb61b431aff
+.dword 0x582bd2afad8dda65
 .dword 0x71a3d2ebc187d30b
 .dword 0xb9b93a3a7a64daf1
+.dword 0x71a3d2ebc187d30b
 .dword 0x60d46f265d155d27
 .dword 0x7405a57de6b814bf
+.dword 0x2882bd97bc145c46
 .dword 0xde06a34d578e1f62
 .dword 0x7fe6f02d6dd38820
+.dword 0xde06a34d578e1f62
 .dword 0x418e936f5975fae3
 .dword 0x9b467899680f537d
+.dword 0xeab2f9dc760b4e9e
 .dword 0xd3a697fdb22fccc7
 .dword 0x0c1f0ae6403bab84
+.dword 0xd3a697fdb22fccc7
 .dword 0x56e30b7fb40253cc
 .dword 0x405aa66cdecdc169
+.dword 0xb75dee7cf59abbae
 .dword 0x8971da1f6918a9d9
 .dword 0xe5aa367b1fa5b7a1
+.dword 0x8971da1f6918a9d9
 .dword 0x26c5c9bb3b7da224
 .dword 0x5f7ee85c8bd2e306
+.dword 0xacf9a2508d83f9b7
 .dword 0xe4775e6db2aa086d
 .dword 0x56651453b452f417
+.dword 0xe4775e6db2aa086d
 .dword 0x596fdba3ec965775
 .dword 0x612e3de85dab2c79
+.dword 0xd4475a43d37b6c88
 .dword 0x04cbd86a9b2e8843
 .dword 0xe8996d6f1e72ce31
+.dword 0x04cbd86a9b2e8843
 .dword 0x92b682e636259482
 .dword 0x98282439f8c9440a
+.dword 0xdd370dba702b47de
 .dword 0x9c38b505fb149ba6
 .dword 0xd1a2e0d5425b4c5c
+.dword 0x9c38b505fb149ba6
 .dword 0x1652d23e1221fffa
 .dword 0x9cf9ba58cf90f2c6
+.dword 0x02a871fb7821c398
 .dword 0xa747cc709ad7e038
 .dword 0x366069ce6cfc2be4
+.dword 0xa747cc709ad7e038
 .dword 0x71842a51f5352d7a
 .dword 0xb0f13b14c3304f0f
+.dword 0x38ce6fe242b29058
 .dword 0x99f048c1e5851e91
 .dword 0x87a68db8aaf7d88b
+.dword 0x99f048c1e5851e91
 .dword 0x444eb7064027664f
 .dword 0xf7bd4f8306e0ea4e
+.dword 0x21260ecdde5bcb1b
 .dword 0xa4a210307a7542b8
 .dword 0x491faad2eb1bf5e6
+.dword 0xa4a210307a7542b8
 .dword 0xde856c5a6dce5bb7
 .dword 0x7c4e09da61d48c77
+.dword 0xc2bb979e54bd27fa
 .dword 0xf71764c0ed83f9d1
 .dword 0x925cc16bb1d17733
+.dword 0xf71764c0ed83f9d1
 .dword 0x1937b6306b7379fc
 .dword 0x1c2ba61ac2c504a5
+.dword 0x0dadced5787f219a
 .dword 0x8f768de29b49de6e
 .dword 0xd1de4f6ee296e507
+.dword 0x8f768de29b49de6e
 .dword 0xad0a42168c2a16e6
 .dword 0xe968d405bd18e5f4
+.dword 0x5b74529862734434
 .dword 0x34df32bf2e93bc61
 .dword 0x82296dc5553d71b5
+.dword 0x34df32bf2e93bc61
 .dword 0xbd6bfae6eb6a8b39
 .dword 0x3a849cced6289b29
+.dword 0x5974bc8b6a730a25
 .dword 0xac6bf66c45d30330
 .dword 0x11af4251ee127d4c
+.dword 0xac6bf66c45d30330
 .dword 0x6b66b1850a224142
 .dword 0x3fe09f64662c24aa
+.dword 0xf6d7edb3aa2d0118
 .dword 0xb437eb14da325775
 .dword 0x335c47f4cd64e568
+.dword 0xb437eb14da325775
 .dword 0x003d8d7e8449fa27
 .dword 0xc5a993157d771073
+.dword 0xa44234c1d5580c4e
 .dword 0xdd0d4ce7dd07045b
 .dword 0x1c27999b8ea28295
+.dword 0xdd0d4ce7dd07045b
 .dword 0x233b126329eef73a
 .dword 0x855cd9c68a667548
+.dword 0x340def4633287c39
 .dword 0x910a99331c95d596
 .dword 0xef2a93d8bec34f36
+.dword 0x910a99331c95d596
 .dword 0xd6f26c2e4c8d384c
 .dword 0xbe4d56c8b038d639
+.dword 0x9178edbc55432025
 .dword 0x259177d36afe2d94
 .dword 0x851e506f08acca3f
+.dword 0x259177d36afe2d94
 .dword 0x9191064c5de76f33
 .dword 0xc5bed2a1a927691a
+.dword 0x8067cc50022e2934
 .dword 0xa68c073955c2c329
 .dword 0xf5098e6a31a7e13e
+.dword 0xa68c073955c2c329
 .dword 0x66097b629a151d44
 .dword 0x41f07f1916bec132
+.dword 0x37f216b5244fccf4
 .dword 0xe954d41b8f3ffbf7
 .dword 0x673cd515db27a3fa
+.dword 0xe954d41b8f3ffbf7
 .dword 0xddb697b6db089ca8
 .dword 0xeb787f8696061c0b
+.dword 0xb8e57a63c440600b
 .dword 0x64009ab53512f1f5
 .dword 0xce5198820437a165
+.dword 0x64009ab53512f1f5
 .dword 0x2b906ab26cc50c46
 .dword 0xbe755129d94b3d26
+.dword 0xe52299df533e8b2c
 .dword 0xf7caba8bf5448bc8
 .dword 0xc782b1f60ec2cded
+.dword 0xf7caba8bf5448bc8
 .dword 0xee9e51a4df9f00b8
 .dword 0x1e31cb439d779d72
+.dword 0x68f4165322c0be53
 .dword 0x59beef21a8d4dbf2
 .dword 0xae463bd7b768d563
+.dword 0x59beef21a8d4dbf2
 .dword 0x0be07308e24954ac
 .dword 0xb73c5e006e568633
+.dword 0xc5dc514cda5dcb5d
 .dword 0xb4ce6fb3768abe5e
 .dword 0xfed4d6f17de57bce
+.dword 0xb4ce6fb3768abe5e
 .dword 0x3418b78bfad18f5a
 .dword 0x9b790624b6b4d4ba
+.dword 0xc27fd01d1c5c52f7
 .dword 0x2946a3c92ea5363a
 .dword 0xb462f971d384030c
+.dword 0x2946a3c92ea5363a
 .dword 0x309a94623780b763
 .dword 0xbc0214a496b19d4f
+.dword 0x1b2cd4ae25bce40f
 .dword 0x1d1c0a8fde0f090f
 .dword 0xbcfdd626df954e2c
+.dword 0x1d1c0a8fde0f090f
 .dword 0x18bd3f73a067278d
 .dword 0x58353bba3da660db
+.dword 0x0efe483aa49183dd
 .dword 0xdf680ae288e79e8e
 .dword 0x48c4ffa63043e312
+.dword 0xdf680ae288e79e8e
 .dword 0x3f7d00bbae669ea7
 .dword 0x944b2d5a4b3bc019
+.dword 0xff3d88b92c7a261a
 .dword 0x62b316a09b076300
 .dword 0x66d96488e7bd3510
+.dword 0x62b316a09b076300
 .dword 0x057ed182163170b2
 .dword 0x565eeebceabb7dea
+.dword 0xe809abc5bb1aafdc
 .dword 0x4e4bede5f0a7b03e
 .dword 0xb5846d0dd67bfcaf
+.dword 0x4e4bede5f0a7b03e
 .dword 0x9a5c458cd66ab36b
 .dword 0x0544e49d7d95a4db
+.dword 0x50cce4c210c83f18
 .dword 0x54b03031bb2c1509
 .dword 0x842b6634b2bae1cb
+.dword 0x54b03031bb2c1509
 .dword 0x9b56dae44d25c462
 .dword 0x86a9472c2a87517e
+.dword 0x8cb941e43c8ef15a
 .dword 0x5b7f64a1d6e04a4b
 .dword 0xf2b894d852cea0e7
+.dword 0x5b7f64a1d6e04a4b
 .dword 0x7adc2f5cb3698016
 .dword 0xb041e7d16b415b28
+.dword 0x11cd9ad64a7066ea
 .dword 0xae30f9cbd159d4d7
 .dword 0xf2e255949cb1575f
+.dword 0xae30f9cbd159d4d7
 .dword 0x19d4498730cdd4e3
 .dword 0x8bc24744a834ce50
+.dword 0x52877181fdbbb7c2
 .dword 0xfa168f1203ac3897
 .dword 0xf845fa5829650c35
+.dword 0xfa168f1203ac3897
 .dword 0xf4dd27ced66192ad
 .dword 0xffb8fcbd3b60806d
+.dword 0x66a74f0ccf860453
 .dword 0xa84733f737223968
 .dword 0xf687bdfbd67f2c12
+.dword 0xa84733f737223968
 .dword 0xad9906c18182eb4a
 .dword 0x689f8b2469792c04
+.dword 0xd9d778fa38be4805
 .dword 0xa3182ee384b1c48a
 .dword 0xb6ba006fe2b9a6a4
+.dword 0xa3182ee384b1c48a
 .dword 0x4324ea6d4a7fea9f
 .dword 0xd561b1b988466c4b
+.dword 0x4ce2ba8e68c7ced2
 .dword 0x8a153443cbe912ca
 .dword 0x6831a330035a3eab
+.dword 0x8a153443cbe912ca
 .dword 0xd6662fd08aba8441
 .dword 0x3ba75eeba41d4f75
+.dword 0xb48e1870b20574e5
 .dword 0x02437c14eba6a696
 .dword 0x760c3a224553abb1
+.dword 0x02437c14eba6a696
 .dword 0x1d87e7687878ede8
 .dword 0xe445232d5ff8a875
+.dword 0x3f6344517629bfc0
 .dword 0x775e4243567708b1
 .dword 0x4890676079136024
+.dword 0x775e4243567708b1
 .dword 0x7c7dae0380e66680
 .dword 0x5122221b25da7be0
+.dword 0x8c6b5e67c00e7863
 .dword 0x3ef9df5f32d87527
 .dword 0x3e48963bd6aad3de
+.dword 0x3ef9df5f32d87527
 .dword 0x651e8f54432596fa
 .dword 0xbdbfd940429b75df
+.dword 0x2da245790fd2cf9b
 .dword 0x0c5261562c0d5ea3
 .dword 0x56497044d69edce0
+.dword 0x0c5261562c0d5ea3
 .dword 0xc5819abb7a67c7f5
 .dword 0xa57fa1fa48c83411
+.dword 0x3158c4279a03733e
 .dword 0x4d14fb62fa15e497
 .dword 0x4cec7fbf57adf1f9
+.dword 0x4d14fb62fa15e497
 .dword 0x8562c652e55b1b82
 .dword 0xb79eb422e88cb259
+.dword 0x13d93b25a6e338b3
 .dword 0x0eee930a8911e3cd
 .dword 0x24a90dacf57d172d
+.dword 0x0eee930a8911e3cd
 .dword 0xa5c098661b179ca4
 .dword 0xe66b8b375ee33319
+.dword 0x16b90eea6fd11a3b
 .dword 0x8af2b367d26834b2
 .dword 0x2d23497782b2e25b
+.dword 0x8af2b367d26834b2
 .dword 0x399dd5e31b1d456f
 .dword 0xa4c6d872e880a9b5
+.dword 0xc4bf5714dd646c96
 .dword 0x01293e681f536a1e
 .dword 0x52f3e1da9038520b
+.dword 0x01293e681f536a1e
 .dword 0x23ea3cfdc3e41d23
 .dword 0x67676a73e22f70a1
+.dword 0xe60128c3c8c744ad
 .dword 0x8c1c54c3f0567236
 .dword 0x9c4bcf3daadcf263
+.dword 0x8c1c54c3f0567236
 .dword 0xe5ec86871c231655
 .dword 0xe5e2f9c97d754576
+.dword 0xf67b6aeb694255cb
 .dword 0xbe423e44ad564943
 .dword 0xaad65694dfbbbd84
+.dword 0xbe423e44ad564943
 .dword 0xd9bb68a6cd452e9b
 .dword 0x07fce15b3011efe2
+.dword 0x5f39ff64a4ae6711
 .dword 0xadf0fa05f38f2827
 .dword 0xc64974a3cb0ee517
+.dword 0xadf0fa05f38f2827
 .dword 0x93bd57ae9bf38f30
 .dword 0x86b603061cbce3b0
+.dword 0x463bda96eecaf7c6
 .dword 0x6319fcc648893f3d
 .dword 0xadee9d629a66bf98
+.dword 0x6319fcc648893f3d
 .dword 0xe9f1e310ad67ee2d
 .dword 0x38f11b19a7131ce3
+.dword 0x633e4f78f58b7bc1
 .dword 0x41ce54ec5d4f7d4a
 .dword 0xfa60d8397ea988f4
+.dword 0x41ce54ec5d4f7d4a
 .dword 0x220c154b3462e9dc
 .dword 0x2bfc322b1115fb8b
+.dword 0x44529ddddf8f3631
 .dword 0xb0056cda13908f9d
 .dword 0x829457b08b2500b8
+.dword 0xb0056cda13908f9d
 .dword 0xe49f95fa5b1d9724
 .dword 0x2efa5f4e2213b984
+.dword 0x25571ada972c44ba
 .dword 0xd80c7e8267da2352
 .dword 0x0112ecfd68db3f22
+.dword 0xd80c7e8267da2352
 .dword 0xfc4bfbd42c1be5f5
 .dword 0x638b9ca846c309d0
+.dword 0x232d978613bd2987
 .dword 0xf1a6f4a86821f170
 .dword 0x7cbc33e69392c50d
+.dword 0xf1a6f4a86821f170
 .dword 0x19ca861026b0e3dd
 .dword 0x5f5b3108a4789ac8
+.dword 0x204439037bf9ab6c
 .dword 0x2a00256a872b2b64
 .dword 0x20d11d53a0c6d8b6
+.dword 0x2a00256a872b2b64
 .dword 0xf3ee3b80b8d3521c
 .dword 0x2cc02731352cde38
+.dword 0xbe0316fd14465053
 .dword 0x7c02ec59b867aa10
 .dword 0x7750588be7c6617b
+.dword 0x7c02ec59b867aa10
 .dword 0x389dc6129ed28a84
 .dword 0x45aea0f09ceccbd0
+.dword 0xbf6d26de6e59bbc5
 .dword 0x83db5bf71f338394
 .dword 0xb59e8df90016ef83
+.dword 0x83db5bf71f338394
 .dword 0x4bedb88ece01d9e4
 .dword 0xa0beceba72fbf399
+.dword 0x19ad00769de995ae
 .dword 0xa5b1be3d3d93a22a
 .dword 0xda3795669e6db3fc
+.dword 0xa5b1be3d3d93a22a
 .dword 0x6cae33ef1140b719
 .dword 0xc9fba5b3ac6c4aec
+.dword 0x5aa00beb061c08a2
 .dword 0xd52018ddf9b1a1f1
 .dword 0x80f72a93ae9a8675
+.dword 0xd52018ddf9b1a1f1
 .dword 0xc1963178e24b9207
 .dword 0x40968344450db75f
+.dword 0xcf2351d979472e44
 .dword 0xe6f550541faa32c5
 .dword 0xcdd3b8b5385fe683
+.dword 0xe6f550541faa32c5
 .dword 0x2e593b0b746d102c
 .dword 0x72198db0297317ea
+.dword 0x1e3d54b5d245a3a1
 .dword 0xa886e853b1bbceaf
 .dword 0xb9f9e29ee414cd69
+.dword 0xa886e853b1bbceaf
 .dword 0x9d4bfbfeec5ef2ee
 .dword 0x157f52d028f48d60
+.dword 0x2e7a6d6345b065a7
 .dword 0xfc7b76652d9af8d3
 .dword 0x0ed24d3f2f2b9fb6
+.dword 0xfc7b76652d9af8d3
 .dword 0x7732a4c5ed77de09
 .dword 0x29d240f3bcda3f91
+.dword 0xdfb52fd3b4b29f57
 .dword 0x7f1cfa940f77074c
 .dword 0xa0d7920b0857ebd4
+.dword 0x7f1cfa940f77074c
 .dword 0x7f044cf630de1f72
 .dword 0xbb26c444686b8485
+.dword 0xa9b579ef94930c6c
 .dword 0x31d638c955f43cb0
 .dword 0x58639ca93efa8eae
+.dword 0x31d638c955f43cb0
 .dword 0xa7b73e422324644e
 .dword 0x2de2cd8cba0daa50
+.dword 0xbd4de29f199b8b93
 .dword 0xd0f71467a4b61647
 .dword 0x09062708aabaa05e
+.dword 0xd0f71467a4b61647
 .dword 0x128b6e4f027005a6
 .dword 0x04b53c34cb7c0041
+.dword 0xf8ce451f7e87a969
 .dword 0x27df56f830fef434
 .dword 0xc5486d756f54ee59
+.dword 0x27df56f830fef434
 .dword 0x593a4727b135a6af
 .dword 0xc2c2011acdfad12b
+.dword 0xd1ba76ab313bf9e1
 .dword 0xa242d7b6b90b452e
 .dword 0x31716bca327398e7
+.dword 0xa242d7b6b90b452e
 .dword 0x0460651541a0b93e
 .dword 0xcb65295ec07ad056
+.dword 0x8e754ce9c6f661f4
 .dword 0x3e07c7db727f94cf
 .dword 0xd37a09530e4c33ed
+.dword 0x3e07c7db727f94cf
 .dword 0x87e2f59dd7702228
 .dword 0xb501f5f481ac1a3b
+.dword 0x1929cb259551893c
 .dword 0xd36ea9bebce3c544
 .dword 0xcc7d53b47c353add
+.dword 0xd36ea9bebce3c544
 .dword 0x51b73f11b3ff2890
 .dword 0x4c84e66f1284fdb2
+.dword 0x437efc08d081554a
 .dword 0xe8c9ce3fb0668b4f
 .dword 0x633fb97e7472c449
+.dword 0xe8c9ce3fb0668b4f
 .dword 0x6778001bfa64802e
 .dword 0x74046b6a3b3db50e
+.dword 0x01ea12e5e4110daf
 .dword 0x8d0e36545549af71
 .dword 0x1326133addff8e4d
+.dword 0x8d0e36545549af71
 .dword 0xff18573ce4b036f4
 .dword 0xb7e4d71147a0cae3
+.dword 0x857be7646c33aee7
 .dword 0x9941d51ee3820acb
 .dword 0x64341bca5d149c5c
+.dword 0x9941d51ee3820acb
 .dword 0x177b71be27ea54ba
 .dword 0x00ea5edd3105efed
+.dword 0x99552f2cadd80849
 .dword 0xce4795e8f81d2391
 .dword 0x4613a314c16a98e5
+.dword 0xce4795e8f81d2391
 .dword 0xe827b50cc6e752f0
 .dword 0xa074da22c85d469d
+.dword 0x609d06250a24120a
 .dword 0x2f8618976631e34d
 .dword 0x0000000000000000
 .dword 0x1e68b004200e1e8b
@@ -5281,29 +5661,29 @@ RVTEST_DATA_BEGIN
 .dword 0x44465ef460a1a6dd
 .dword 0x9bd784d3e0cafd92
 .dword 0xeaefe57b62be275e
-.dword 0xeaefe57b62be275e
 .dword 0x15cffa3b120f4371
-.dword 0x6e7cba557756c87e
+.dword 0xeaefe57b62be275e
 .dword 0xa6d9cc313edc2c56
 .dword 0xcefc7f763ec0cc61
-.dword 0xaca850d5ca07cff2
+.dword 0x6e7cba557756c87e
 .dword 0xb63a66e52414a9f2
 .dword 0xc6b9bdcea76fe88c
-.dword 0xb9f037d521a9055f
+.dword 0xaca850d5ca07cff2
 .dword 0xb9f037d521a905e8
 .dword 0xd4c3d68f59c6c49a
-.dword 0x10317ae2e5810619
+.dword 0xb9f037d521a9055f
 .dword 0x987ee7a96b9c0619
 .dword 0x5408835923a7b116
-.dword 0x8ec71c4d470295e0
+.dword 0x10317ae2e5810619
 .dword 0x8ec71c4d4702aa7d
 .dword 0xc878841cbddc64cf
-.dword 0xf3b66f8b392788a0
+.dword 0x8ec71c4d470295e0
 .dword 0xe638f048392788a0
 .dword 0x5428995c29d5112b
-.dword 0xc70fa268e404a4c6
+.dword 0xf3b66f8b392788a0
 .dword 0xc70fa268774c93ef
 .dword 0xc3d8070738635803
+.dword 0xc70fa268e404a4c6
 
 // Testcase strings
 Zacas_amocas_d_cg_cp_rs1_nx0_b1_equal_str: .string "\"test: 1; cg: Zacas_amocas.d_cg; cp: cp_rs1_nx0; bin: b1_equal\""

--- a/tests/rv64i/Zacas/Zacas-amocas.w-00.S
+++ b/tests/rv64i/Zacas/Zacas-amocas.w-00.S
@@ -36,6 +36,7 @@ RVTEST_BEGIN
 # Testcase cp_rs1_nx0 (Test source rs1 = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x11) # load value in memory: x11 = 0x000000004ffc9eb6
   RVTEST_TESTDATA_LOAD_INT(x3, x7) # load rs2: x7 = 0x00000000a05a7a33
+  RVTEST_TESTDATA_LOAD_INT(x3, x12) # load rd compare value: x12 = 0x000000004ffc9eb6
   LA(x1, scratch) # load base address into rs1
   SREG x11, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b1_equal:
@@ -49,6 +50,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b1_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x26) # load value in memory: x26 = 0x00000000ff00fd95
   RVTEST_TESTDATA_LOAD_INT(x3, x7) # load rs2: x7 = 0x000000005f58e971
+  RVTEST_TESTDATA_LOAD_INT(x3, x29) # load rd compare value: x29 = 0x000000008a1d8aed
   LA(x1, scratch) # load base address into rs1
   SREG x26, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b1_not_equal:
@@ -63,6 +65,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b1_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x29) # load value in memory: x29 = 0x00000000a73918b7
   RVTEST_TESTDATA_LOAD_INT(x3, x18) # load rs2: x18 = 0x000000004cdcba92
+  RVTEST_TESTDATA_LOAD_INT(x3, x23) # load rd compare value: x23 = 0x00000000a73918b7
   LA(x2, scratch) # load base address into rs1
   SREG x29, 0(x2) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b2_equal:
@@ -76,6 +79,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b2_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x16) # load value in memory: x16 = 0x000000006c982925
   RVTEST_TESTDATA_LOAD_INT(x3, x9) # load rs2: x9 = 0x000000007bc624fd
+  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rd compare value: x6 = 0x000000007f4abe45
   LA(x2, scratch) # load base address into rs1
   SREG x16, 0(x2) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b2_not_equal:
@@ -90,6 +94,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b2_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x11) # load value in memory: x11 = 0x00000000f6ad3329
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load rs2: x6 = 0x0000000006ff2c16
+  RVTEST_TESTDATA_LOAD_INT(x17, x23) # load rd compare value: x23 = 0x00000000f6ad3329
   LA(x3, scratch) # load base address into rs1
   SREG x11, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b3_equal:
@@ -103,6 +108,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b3_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load value in memory: x13 = 0x00000000c6a0f366
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load rs2: x15 = 0x00000000e26424c3
+  RVTEST_TESTDATA_LOAD_INT(x17, x20) # load rd compare value: x20 = 0x000000004bd34dad
   LA(x3, scratch) # load base address into rs1
   SREG x13, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b3_not_equal:
@@ -118,6 +124,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b3_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x11) # load value in memory: x11 = 0x000000005de6dea0
   RVTEST_TESTDATA_LOAD_INT(x17, x20) # load rs2: x20 = 0x000000001711f4d2
+  RVTEST_TESTDATA_LOAD_INT(x17, x18) # load rd compare value: x18 = 0x000000005de6dea0
   LA(x4, scratch) # load base address into rs1
   SREG x11, 0(x4) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b4_equal:
@@ -131,6 +138,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b4_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load value in memory: x1 = 0x00000000726baf91
   RVTEST_TESTDATA_LOAD_INT(x17, x16) # load rs2: x16 = 0x00000000a42e7e46
+  RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rd compare value: x14 = 0x00000000181a77a4
   LA(x4, scratch) # load base address into rs1
   SREG x1, 0(x4) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b4_not_equal:
@@ -144,6 +152,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b4_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x18) # load value in memory: x18 = 0x000000003543d5ff
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rs2: x9 = 0x00000000852cf4b5
+  RVTEST_TESTDATA_LOAD_INT(x17, x31) # load rd compare value: x31 = 0x000000003543d5ff
   LA(x5, scratch) # load base address into rs1
   SREG x18, 0(x5) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b5_equal:
@@ -157,6 +166,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b5_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load value in memory: x15 = 0x000000003bca9813
   RVTEST_TESTDATA_LOAD_INT(x17, x4) # load rs2: x4 = 0x0000000004bef3f4
+  RVTEST_TESTDATA_LOAD_INT(x17, x20) # load rd compare value: x20 = 0x0000000078c1ff64
   LA(x5, scratch) # load base address into rs1
   SREG x15, 0(x5) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b5_not_equal:
@@ -170,6 +180,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b5_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load value in memory: x14 = 0x0000000087d0bb55
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load rs2: x15 = 0x000000006fbe5b74
+  RVTEST_TESTDATA_LOAD_INT(x17, x3) # load rd compare value: x3 = 0x0000000087d0bb55
   LA(x6, scratch) # load base address into rs1
   SREG x14, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b6_equal:
@@ -183,6 +194,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b6_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x5) # load value in memory: x5 = 0x000000002906c7e7
   RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rs2: x0 = 0x000000006bd6ab30
+  RVTEST_TESTDATA_LOAD_INT(x17, x24) # load rd compare value: x24 = 0x000000000f938295
   LA(x6, scratch) # load base address into rs1
   SREG x5, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b6_not_equal:
@@ -198,6 +210,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b6_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load value in memory: x13 = 0x0000000045c86b14
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load rs2: x1 = 0x00000000b997c936
+  RVTEST_TESTDATA_LOAD_INT(x17, x29) # load rd compare value: x29 = 0x0000000045c86b14
   LA(x7, scratch) # load base address into rs1
   SREG x13, 0(x7) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b7_equal:
@@ -211,6 +224,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b7_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x19) # load value in memory: x19 = 0x000000000d14fab2
   RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rs2: x0 = 0x0000000076ad8f69
+  RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rd compare value: x2 = 0x0000000014d3e5ff
   LA(x7, scratch) # load base address into rs1
   SREG x19, 0(x7) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b7_not_equal:
@@ -224,6 +238,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b7_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load value in memory: x14 = 0x00000000aeb1b3a2
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rs2: x9 = 0x000000005b52bd50
+  RVTEST_TESTDATA_LOAD_INT(x17, x18) # load rd compare value: x18 = 0x00000000aeb1b3a2
   LA(x8, scratch) # load base address into rs1
   SREG x14, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b8_equal:
@@ -237,6 +252,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b8_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x30) # load value in memory: x30 = 0x00000000587ac726
   RVTEST_TESTDATA_LOAD_INT(x17, x23) # load rs2: x23 = 0x00000000d47b5863
+  RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rd compare value: x14 = 0x0000000022dbffff
   LA(x8, scratch) # load base address into rs1
   SREG x30, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b8_not_equal:
@@ -250,6 +266,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b8_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x31) # load value in memory: x31 = 0x00000000df3be6ab
   RVTEST_TESTDATA_LOAD_INT(x17, x27) # load rs2: x27 = 0x00000000f8237ec0
+  RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rd compare value: x2 = 0x00000000df3be6ab
   LA(x9, scratch) # load base address into rs1
   SREG x31, 0(x9) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b9_equal:
@@ -263,6 +280,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b9_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load value in memory: x6 = 0x0000000058a3c29b
   RVTEST_TESTDATA_LOAD_INT(x17, x22) # load rs2: x22 = 0x000000000ad3d73b
+  RVTEST_TESTDATA_LOAD_INT(x17, x21) # load rd compare value: x21 = 0x000000007dfc586b
   LA(x9, scratch) # load base address into rs1
   SREG x6, 0(x9) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b9_not_equal:
@@ -276,6 +294,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b9_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x26) # load value in memory: x26 = 0x0000000056ee66fa
   RVTEST_TESTDATA_LOAD_INT(x17, x28) # load rs2: x28 = 0x00000000f073f8a2
+  RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rd compare value: x2 = 0x0000000056ee66fa
   LA(x10, scratch) # load base address into rs1
   SREG x26, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b10_equal:
@@ -289,6 +308,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b10_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x19) # load value in memory: x19 = 0x0000000032322776
   RVTEST_TESTDATA_LOAD_INT(x17, x7) # load rs2: x7 = 0x0000000053faa5d0
+  RVTEST_TESTDATA_LOAD_INT(x17, x24) # load rd compare value: x24 = 0x0000000083414d7c
   LA(x10, scratch) # load base address into rs1
   SREG x19, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b10_not_equal:
@@ -302,6 +322,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b10_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load value in memory: x6 = 0x0000000084b72a64
   RVTEST_TESTDATA_LOAD_INT(x17, x10) # load rs2: x10 = 0x00000000a0f054c1
+  RVTEST_TESTDATA_LOAD_INT(x17, x8) # load rd compare value: x8 = 0x0000000084b72a64
   LA(x11, scratch) # load base address into rs1
   SREG x6, 0(x11) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b11_equal:
@@ -315,6 +336,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b11_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load value in memory: x1 = 0x00000000937c76d9
   RVTEST_TESTDATA_LOAD_INT(x17, x10) # load rs2: x10 = 0x000000007b56846a
+  RVTEST_TESTDATA_LOAD_INT(x17, x8) # load rd compare value: x8 = 0x0000000072eab756
   LA(x11, scratch) # load base address into rs1
   SREG x1, 0(x11) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b11_not_equal:
@@ -329,6 +351,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b11_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x3) # load value in memory: x3 = 0x00000000354cb6ae
   RVTEST_TESTDATA_LOAD_INT(x17, x23) # load rs2: x23 = 0x00000000346f685b
+  RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rd compare value: x0 = 0x00000000354cb6ae
   LA(x12, scratch) # load base address into rs1
   SREG x3, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b12_equal:
@@ -342,6 +365,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b12_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load value in memory: x13 = 0x00000000018899a6
   RVTEST_TESTDATA_LOAD_INT(x17, x24) # load rs2: x24 = 0x00000000a5ef20cc
+  RVTEST_TESTDATA_LOAD_INT(x17, x15) # load rd compare value: x15 = 0x00000000257768fe
   LA(x12, scratch) # load base address into rs1
   SREG x13, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b12_not_equal:
@@ -355,6 +379,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b12_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load value in memory: x6 = 0x00000000bffeda35
   RVTEST_TESTDATA_LOAD_INT(x17, x28) # load rs2: x28 = 0x000000000cbd8f1e
+  RVTEST_TESTDATA_LOAD_INT(x17, x11) # load rd compare value: x11 = 0x00000000bffeda35
   LA(x13, scratch) # load base address into rs1
   SREG x6, 0(x13) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b13_equal:
@@ -368,6 +393,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b13_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x7) # load value in memory: x7 = 0x00000000dac793c6
   RVTEST_TESTDATA_LOAD_INT(x17, x30) # load rs2: x30 = 0x00000000cb05efea
+  RVTEST_TESTDATA_LOAD_INT(x17, x10) # load rd compare value: x10 = 0x00000000c6a59de9
   LA(x13, scratch) # load base address into rs1
   SREG x7, 0(x13) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b13_not_equal:
@@ -381,6 +407,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b13_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x12) # load value in memory: x12 = 0x00000000627e075a
   RVTEST_TESTDATA_LOAD_INT(x17, x16) # load rs2: x16 = 0x00000000917e1f3a
+  RVTEST_TESTDATA_LOAD_INT(x17, x3) # load rd compare value: x3 = 0x00000000627e075a
   LA(x14, scratch) # load base address into rs1
   SREG x12, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b14_equal:
@@ -394,6 +421,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b14_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x18) # load value in memory: x18 = 0x00000000f6e56fbe
   RVTEST_TESTDATA_LOAD_INT(x17, x22) # load rs2: x22 = 0x000000005435bce2
+  RVTEST_TESTDATA_LOAD_INT(x17, x8) # load rd compare value: x8 = 0x0000000084b2620d
   LA(x14, scratch) # load base address into rs1
   SREG x18, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b14_not_equal:
@@ -407,6 +435,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b14_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x27) # load value in memory: x27 = 0x00000000866c2c45
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rs2: x9 = 0x00000000adb5330b
+  RVTEST_TESTDATA_LOAD_INT(x17, x22) # load rd compare value: x22 = 0x00000000866c2c45
   LA(x15, scratch) # load base address into rs1
   SREG x27, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b15_equal:
@@ -420,6 +449,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b15_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x29) # load value in memory: x29 = 0x00000000abae2a0d
   RVTEST_TESTDATA_LOAD_INT(x17, x24) # load rs2: x24 = 0x00000000399061be
+  RVTEST_TESTDATA_LOAD_INT(x17, x13) # load rd compare value: x13 = 0x00000000a9f01df4
   LA(x15, scratch) # load base address into rs1
   SREG x29, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b15_not_equal:
@@ -433,6 +463,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b15_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x10) # load value in memory: x10 = 0x00000000582c96c1
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rs2: x9 = 0x00000000e8524c8c
+  RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rd compare value: x14 = 0x00000000582c96c1
   LA(x16, scratch) # load base address into rs1
   SREG x10, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b16_equal:
@@ -446,6 +477,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b16_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x19) # load value in memory: x19 = 0x00000000d0d0ce74
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load rs2: x13 = 0x0000000014f28ef4
+  RVTEST_TESTDATA_LOAD_INT(x17, x3) # load rd compare value: x3 = 0x00000000e23703ef
   LA(x16, scratch) # load base address into rs1
   SREG x19, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b16_not_equal:
@@ -460,6 +492,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b16_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load value in memory: x6 = 0x00000000d465601f
   RVTEST_TESTDATA_LOAD_INT(x2, x31) # load rs2: x31 = 0x000000000f66fd14
+  RVTEST_TESTDATA_LOAD_INT(x2, x0) # load rd compare value: x0 = 0x00000000d465601f
   LA(x17, scratch) # load base address into rs1
   SREG x6, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b17_equal:
@@ -473,6 +506,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b17_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x21) # load value in memory: x21 = 0x00000000f035054e
   RVTEST_TESTDATA_LOAD_INT(x2, x9) # load rs2: x9 = 0x000000002bd8acb1
+  RVTEST_TESTDATA_LOAD_INT(x2, x8) # load rd compare value: x8 = 0x00000000785e2550
   LA(x17, scratch) # load base address into rs1
   SREG x21, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b17_not_equal:
@@ -486,6 +520,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b17_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x25) # load value in memory: x25 = 0x000000007e090d3d
   RVTEST_TESTDATA_LOAD_INT(x2, x31) # load rs2: x31 = 0x00000000e44d6bb5
+  RVTEST_TESTDATA_LOAD_INT(x2, x21) # load rd compare value: x21 = 0x000000007e090d3d
   LA(x18, scratch) # load base address into rs1
   SREG x25, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b18_equal:
@@ -499,6 +534,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b18_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x19) # load value in memory: x19 = 0x000000002fa54925
   RVTEST_TESTDATA_LOAD_INT(x2, x14) # load rs2: x14 = 0x00000000b8875162
+  RVTEST_TESTDATA_LOAD_INT(x2, x15) # load rd compare value: x15 = 0x00000000daaf0c88
   LA(x18, scratch) # load base address into rs1
   SREG x19, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b18_not_equal:
@@ -512,6 +548,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b18_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x18) # load value in memory: x18 = 0x000000001be89d3e
   RVTEST_TESTDATA_LOAD_INT(x2, x9) # load rs2: x9 = 0x0000000001f6b985
+  RVTEST_TESTDATA_LOAD_INT(x2, x12) # load rd compare value: x12 = 0x000000001be89d3e
   LA(x19, scratch) # load base address into rs1
   SREG x18, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b19_equal:
@@ -525,6 +562,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b19_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x31) # load value in memory: x31 = 0x00000000c9912fe7
   RVTEST_TESTDATA_LOAD_INT(x2, x15) # load rs2: x15 = 0x00000000a4d5116c
+  RVTEST_TESTDATA_LOAD_INT(x2, x8) # load rd compare value: x8 = 0x000000002823dfef
   LA(x19, scratch) # load base address into rs1
   SREG x31, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b19_not_equal:
@@ -538,6 +576,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b19_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x27) # load value in memory: x27 = 0x000000004755077d
   RVTEST_TESTDATA_LOAD_INT(x2, x25) # load rs2: x25 = 0x000000004f4c2a47
+  RVTEST_TESTDATA_LOAD_INT(x2, x29) # load rd compare value: x29 = 0x000000004755077d
   LA(x20, scratch) # load base address into rs1
   SREG x27, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b20_equal:
@@ -551,6 +590,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b20_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x9) # load value in memory: x9 = 0x00000000dcef1a91
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load rs2: x6 = 0x000000000be4be86
+  RVTEST_TESTDATA_LOAD_INT(x2, x3) # load rd compare value: x3 = 0x000000002eca0de0
   LA(x20, scratch) # load base address into rs1
   SREG x9, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b20_not_equal:
@@ -564,6 +604,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b20_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x17) # load value in memory: x17 = 0x00000000af6b6460
   RVTEST_TESTDATA_LOAD_INT(x2, x22) # load rs2: x22 = 0x000000002de4f9fa
+  RVTEST_TESTDATA_LOAD_INT(x2, x14) # load rd compare value: x14 = 0x00000000af6b6460
   LA(x21, scratch) # load base address into rs1
   SREG x17, 0(x21) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b21_equal:
@@ -577,6 +618,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b21_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load value in memory: x6 = 0x00000000262263c8
   RVTEST_TESTDATA_LOAD_INT(x2, x3) # load rs2: x3 = 0x000000002c0ca0c9
+  RVTEST_TESTDATA_LOAD_INT(x2, x31) # load rd compare value: x31 = 0x00000000d6455b4a
   LA(x21, scratch) # load base address into rs1
   SREG x6, 0(x21) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b21_not_equal:
@@ -590,6 +632,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b21_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x21) # load value in memory: x21 = 0x00000000cb9d4eb2
   RVTEST_TESTDATA_LOAD_INT(x2, x0) # load rs2: x0 = 0x000000001ceda7e0
+  RVTEST_TESTDATA_LOAD_INT(x2, x6) # load rd compare value: x6 = 0x00000000cb9d4eb2
   LA(x22, scratch) # load base address into rs1
   SREG x21, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b22_equal:
@@ -603,6 +646,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b22_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x18) # load value in memory: x18 = 0x00000000f9da4cae
   RVTEST_TESTDATA_LOAD_INT(x2, x30) # load rs2: x30 = 0x00000000c20d2cfd
+  RVTEST_TESTDATA_LOAD_INT(x2, x17) # load rd compare value: x17 = 0x000000007d3dbd0c
   LA(x22, scratch) # load base address into rs1
   SREG x18, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b22_not_equal:
@@ -616,6 +660,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b22_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load value in memory: x11 = 0x00000000dc7ec8d5
   RVTEST_TESTDATA_LOAD_INT(x2, x20) # load rs2: x20 = 0x00000000f15f5225
+  RVTEST_TESTDATA_LOAD_INT(x2, x22) # load rd compare value: x22 = 0x00000000dc7ec8d5
   LA(x23, scratch) # load base address into rs1
   SREG x11, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b23_equal:
@@ -629,6 +674,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b23_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x9) # load value in memory: x9 = 0x000000008dc361fd
   RVTEST_TESTDATA_LOAD_INT(x2, x19) # load rs2: x19 = 0x00000000cb6dadf5
+  RVTEST_TESTDATA_LOAD_INT(x2, x0) # load rd compare value: x0 = 0x00000000283b582e
   LA(x23, scratch) # load base address into rs1
   SREG x9, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b23_not_equal:
@@ -642,6 +688,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b23_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x9) # load value in memory: x9 = 0x0000000071d35cfc
   RVTEST_TESTDATA_LOAD_INT(x2, x27) # load rs2: x27 = 0x00000000b9b36cd4
+  RVTEST_TESTDATA_LOAD_INT(x2, x16) # load rd compare value: x16 = 0x0000000071d35cfc
   LA(x24, scratch) # load base address into rs1
   SREG x9, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b24_equal:
@@ -655,6 +702,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b24_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x20) # load value in memory: x20 = 0x000000005cbc5931
   RVTEST_TESTDATA_LOAD_INT(x2, x22) # load rs2: x22 = 0x0000000001c8efef
+  RVTEST_TESTDATA_LOAD_INT(x2, x19) # load rd compare value: x19 = 0x0000000071e929eb
   LA(x24, scratch) # load base address into rs1
   SREG x20, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b24_not_equal:
@@ -668,6 +716,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b24_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x8) # load value in memory: x8 = 0x00000000e01a8476
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load rs2: x6 = 0x0000000005035c34
+  RVTEST_TESTDATA_LOAD_INT(x2, x7) # load rd compare value: x7 = 0x00000000e01a8476
   LA(x25, scratch) # load base address into rs1
   SREG x8, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b25_equal:
@@ -681,6 +730,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b25_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load value in memory: x6 = 0x0000000075276317
   RVTEST_TESTDATA_LOAD_INT(x2, x19) # load rs2: x19 = 0x0000000092865dec
+  RVTEST_TESTDATA_LOAD_INT(x2, x17) # load rd compare value: x17 = 0x000000003db7c437
   LA(x25, scratch) # load base address into rs1
   SREG x6, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b25_not_equal:
@@ -694,6 +744,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b25_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x8) # load value in memory: x8 = 0x00000000a769f328
   RVTEST_TESTDATA_LOAD_INT(x2, x10) # load rs2: x10 = 0x00000000fd07adce
+  RVTEST_TESTDATA_LOAD_INT(x2, x15) # load rd compare value: x15 = 0x00000000a769f328
   LA(x26, scratch) # load base address into rs1
   SREG x8, 0(x26) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b26_equal:
@@ -707,6 +758,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b26_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x8) # load value in memory: x8 = 0x00000000dfa9c4d7
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load rs2: x6 = 0x00000000aa1a05af
+  RVTEST_TESTDATA_LOAD_INT(x2, x10) # load rd compare value: x10 = 0x000000000c4dd600
   LA(x26, scratch) # load base address into rs1
   SREG x8, 0(x26) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b26_not_equal:
@@ -720,6 +772,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b26_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x28) # load value in memory: x28 = 0x000000007c33a440
   RVTEST_TESTDATA_LOAD_INT(x2, x7) # load rs2: x7 = 0x0000000085782b0a
+  RVTEST_TESTDATA_LOAD_INT(x2, x21) # load rd compare value: x21 = 0x000000007c33a440
   LA(x27, scratch) # load base address into rs1
   SREG x28, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b27_equal:
@@ -733,6 +786,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b27_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x7) # load value in memory: x7 = 0x000000009075d8c6
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load rs2: x11 = 0x00000000581df4d2
+  RVTEST_TESTDATA_LOAD_INT(x2, x24) # load rd compare value: x24 = 0x00000000aac1ba47
   LA(x27, scratch) # load base address into rs1
   SREG x7, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b27_not_equal:
@@ -746,6 +800,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b27_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x20) # load value in memory: x20 = 0x00000000a77d5fe8
   RVTEST_TESTDATA_LOAD_INT(x2, x23) # load rs2: x23 = 0x0000000023b1ed93
+  RVTEST_TESTDATA_LOAD_INT(x2, x27) # load rd compare value: x27 = 0x00000000a77d5fe8
   LA(x28, scratch) # load base address into rs1
   SREG x20, 0(x28) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b28_equal:
@@ -759,6 +814,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b28_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load value in memory: x11 = 0x000000007fe74641
   RVTEST_TESTDATA_LOAD_INT(x2, x15) # load rs2: x15 = 0x00000000fb58b964
+  RVTEST_TESTDATA_LOAD_INT(x2, x21) # load rd compare value: x21 = 0x00000000f6350794
   LA(x28, scratch) # load base address into rs1
   SREG x11, 0(x28) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b28_not_equal:
@@ -772,6 +828,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b28_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x17) # load value in memory: x17 = 0x00000000e749a1ce
   RVTEST_TESTDATA_LOAD_INT(x2, x24) # load rs2: x24 = 0x00000000a972ef64
+  RVTEST_TESTDATA_LOAD_INT(x2, x18) # load rd compare value: x18 = 0x00000000e749a1ce
   LA(x29, scratch) # load base address into rs1
   SREG x17, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b29_equal:
@@ -785,6 +842,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b29_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x14) # load value in memory: x14 = 0x00000000d0055a9e
   RVTEST_TESTDATA_LOAD_INT(x2, x22) # load rs2: x22 = 0x000000000f3c0a10
+  RVTEST_TESTDATA_LOAD_INT(x2, x0) # load rd compare value: x0 = 0x000000003ad18ecb
   LA(x29, scratch) # load base address into rs1
   SREG x14, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b29_not_equal:
@@ -798,6 +856,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b29_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x25) # load value in memory: x25 = 0x00000000b185629f
   RVTEST_TESTDATA_LOAD_INT(x2, x11) # load rs2: x11 = 0x000000006d1aa8e3
+  RVTEST_TESTDATA_LOAD_INT(x2, x3) # load rd compare value: x3 = 0x00000000b185629f
   LA(x30, scratch) # load base address into rs1
   SREG x25, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b30_equal:
@@ -811,6 +870,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b30_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x19) # load value in memory: x19 = 0x00000000d17f48d2
   RVTEST_TESTDATA_LOAD_INT(x2, x28) # load rs2: x28 = 0x000000000981e070
+  RVTEST_TESTDATA_LOAD_INT(x2, x17) # load rd compare value: x17 = 0x000000004273dd23
   LA(x30, scratch) # load base address into rs1
   SREG x19, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b30_not_equal:
@@ -824,6 +884,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b30_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x24) # load value in memory: x24 = 0x00000000d83b9bfb
   RVTEST_TESTDATA_LOAD_INT(x2, x29) # load rs2: x29 = 0x00000000126eab4c
+  RVTEST_TESTDATA_LOAD_INT(x2, x14) # load rd compare value: x14 = 0x00000000d83b9bfb
   LA(x31, scratch) # load base address into rs1
   SREG x24, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b31_equal:
@@ -837,6 +898,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b31_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x13) # load value in memory: x13 = 0x000000007a1cf6b7
   RVTEST_TESTDATA_LOAD_INT(x2, x28) # load rs2: x28 = 0x000000005b9bed96
+  RVTEST_TESTDATA_LOAD_INT(x2, x8) # load rd compare value: x8 = 0x00000000d465db21
   LA(x31, scratch) # load base address into rs1
   SREG x13, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs1_nx0_b31_not_equal:
@@ -854,6 +916,7 @@ Zacas_amocas_w_cg_cp_rs1_nx0_b31_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x0, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x17) # load value in memory: x17 = 0x00000000bd34b68d
   RVTEST_TESTDATA_LOAD_INT(x2, x0) # load rs2: x0 = 0x00000000444cc2d2
+  RVTEST_TESTDATA_LOAD_INT(x2, x15) # load rd compare value: x15 = 0x00000000bd34b68d
   LA(x13, scratch) # load base address into rs1
   SREG x17, 0(x13) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b0_equal:
@@ -867,6 +930,7 @@ Zacas_amocas_w_cg_cp_rs2_b0_equal:
 # Testcase cp_rs2 (Test source rs2 = x0, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x7) # load value in memory: x7 = 0x00000000dbeade6c
   RVTEST_TESTDATA_LOAD_INT(x2, x0) # load rs2: x0 = 0x0000000061f08ccb
+  RVTEST_TESTDATA_LOAD_INT(x2, x14) # load rd compare value: x14 = 0x0000000070d95352
   LA(x11, scratch) # load base address into rs1
   SREG x7, 0(x11) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b0_not_equal:
@@ -881,6 +945,7 @@ Zacas_amocas_w_cg_cp_rs2_b0_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x15) # load value in memory: x15 = 0x00000000505de7cb
   RVTEST_TESTDATA_LOAD_INT(x2, x1) # load rs2: x1 = 0x000000007c8436ec
+  RVTEST_TESTDATA_LOAD_INT(x2, x30) # load rd compare value: x30 = 0x00000000505de7cb
   LA(x31, scratch) # load base address into rs1
   SREG x15, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b1_equal:
@@ -894,6 +959,7 @@ Zacas_amocas_w_cg_cp_rs2_b1_equal:
 # Testcase cp_rs2 (Test source rs2 = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x2, x6) # load value in memory: x6 = 0x00000000d29ff27b
   RVTEST_TESTDATA_LOAD_INT(x2, x1) # load rs2: x1 = 0x000000002da4e199
+  RVTEST_TESTDATA_LOAD_INT(x2, x22) # load rd compare value: x22 = 0x000000005b4887b6
   LA(x10, scratch) # load base address into rs1
   SREG x6, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b1_not_equal:
@@ -908,6 +974,7 @@ Zacas_amocas_w_cg_cp_rs2_b1_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x9) # load value in memory: x9 = 0x00000000e10fa38f
   RVTEST_TESTDATA_LOAD_INT(x28, x2) # load rs2: x2 = 0x00000000a66f401b
+  RVTEST_TESTDATA_LOAD_INT(x28, x24) # load rd compare value: x24 = 0x00000000e10fa38f
   LA(x3, scratch) # load base address into rs1
   SREG x9, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b2_equal:
@@ -921,6 +988,7 @@ Zacas_amocas_w_cg_cp_rs2_b2_equal:
 # Testcase cp_rs2 (Test source rs2 = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x27) # load value in memory: x27 = 0x000000000e65c3ed
   RVTEST_TESTDATA_LOAD_INT(x28, x2) # load rs2: x2 = 0x00000000bae87016
+  RVTEST_TESTDATA_LOAD_INT(x28, x23) # load rd compare value: x23 = 0x0000000009b372c8
   LA(x16, scratch) # load base address into rs1
   SREG x27, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b2_not_equal:
@@ -934,6 +1002,7 @@ Zacas_amocas_w_cg_cp_rs2_b2_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x16) # load value in memory: x16 = 0x00000000f49beb03
   RVTEST_TESTDATA_LOAD_INT(x28, x3) # load rs2: x3 = 0x0000000096eaf810
+  RVTEST_TESTDATA_LOAD_INT(x28, x10) # load rd compare value: x10 = 0x00000000f49beb03
   LA(x23, scratch) # load base address into rs1
   SREG x16, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b3_equal:
@@ -947,6 +1016,7 @@ Zacas_amocas_w_cg_cp_rs2_b3_equal:
 # Testcase cp_rs2 (Test source rs2 = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load value in memory: x24 = 0x00000000745d5331
   RVTEST_TESTDATA_LOAD_INT(x28, x3) # load rs2: x3 = 0x0000000052db7da1
+  RVTEST_TESTDATA_LOAD_INT(x28, x12) # load rd compare value: x12 = 0x000000004dee1585
   LA(x15, scratch) # load base address into rs1
   SREG x24, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b3_not_equal:
@@ -962,6 +1032,7 @@ Zacas_amocas_w_cg_cp_rs2_b3_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x9) # load value in memory: x9 = 0x00000000c4352d96
   RVTEST_TESTDATA_LOAD_INT(x28, x4) # load rs2: x4 = 0x00000000850fb30e
+  RVTEST_TESTDATA_LOAD_INT(x28, x26) # load rd compare value: x26 = 0x00000000c4352d96
   LA(x8, scratch) # load base address into rs1
   SREG x9, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b4_equal:
@@ -975,6 +1046,7 @@ Zacas_amocas_w_cg_cp_rs2_b4_equal:
 # Testcase cp_rs2 (Test source rs2 = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x17) # load value in memory: x17 = 0x00000000792b14bd
   RVTEST_TESTDATA_LOAD_INT(x28, x4) # load rs2: x4 = 0x00000000eccbc3d3
+  RVTEST_TESTDATA_LOAD_INT(x28, x15) # load rd compare value: x15 = 0x00000000d093c73a
   LA(x24, scratch) # load base address into rs1
   SREG x17, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b4_not_equal:
@@ -988,6 +1060,7 @@ Zacas_amocas_w_cg_cp_rs2_b4_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x4) # load value in memory: x4 = 0x00000000306f039b
   RVTEST_TESTDATA_LOAD_INT(x28, x5) # load rs2: x5 = 0x00000000541bb67e
+  RVTEST_TESTDATA_LOAD_INT(x28, x17) # load rd compare value: x17 = 0x00000000306f039b
   LA(x16, scratch) # load base address into rs1
   SREG x4, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b5_equal:
@@ -1001,6 +1074,7 @@ Zacas_amocas_w_cg_cp_rs2_b5_equal:
 # Testcase cp_rs2 (Test source rs2 = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x11) # load value in memory: x11 = 0x00000000fdf11d25
   RVTEST_TESTDATA_LOAD_INT(x28, x5) # load rs2: x5 = 0x000000003c5ade38
+  RVTEST_TESTDATA_LOAD_INT(x28, x17) # load rd compare value: x17 = 0x000000002e070f88
   LA(x25, scratch) # load base address into rs1
   SREG x11, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b5_not_equal:
@@ -1014,6 +1088,7 @@ Zacas_amocas_w_cg_cp_rs2_b5_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x27) # load value in memory: x27 = 0x00000000b40e737a
   RVTEST_TESTDATA_LOAD_INT(x28, x6) # load rs2: x6 = 0x00000000f3adc13b
+  RVTEST_TESTDATA_LOAD_INT(x28, x31) # load rd compare value: x31 = 0x00000000b40e737a
   LA(x20, scratch) # load base address into rs1
   SREG x27, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b6_equal:
@@ -1027,6 +1102,7 @@ Zacas_amocas_w_cg_cp_rs2_b6_equal:
 # Testcase cp_rs2 (Test source rs2 = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x8) # load value in memory: x8 = 0x00000000aa613e5d
   RVTEST_TESTDATA_LOAD_INT(x28, x6) # load rs2: x6 = 0x00000000aa4380fe
+  RVTEST_TESTDATA_LOAD_INT(x28, x16) # load rd compare value: x16 = 0x00000000bf0ce552
   LA(x15, scratch) # load base address into rs1
   SREG x8, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b6_not_equal:
@@ -1040,6 +1116,7 @@ Zacas_amocas_w_cg_cp_rs2_b6_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x22) # load value in memory: x22 = 0x0000000061f2dbba
   RVTEST_TESTDATA_LOAD_INT(x28, x7) # load rs2: x7 = 0x00000000723883c1
+  RVTEST_TESTDATA_LOAD_INT(x28, x3) # load rd compare value: x3 = 0x0000000061f2dbba
   LA(x9, scratch) # load base address into rs1
   SREG x22, 0(x9) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b7_equal:
@@ -1053,6 +1130,7 @@ Zacas_amocas_w_cg_cp_rs2_b7_equal:
 # Testcase cp_rs2 (Test source rs2 = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x27) # load value in memory: x27 = 0x00000000141b1f57
   RVTEST_TESTDATA_LOAD_INT(x28, x7) # load rs2: x7 = 0x000000006a7df2b0
+  RVTEST_TESTDATA_LOAD_INT(x28, x1) # load rd compare value: x1 = 0x00000000981e18e4
   LA(x8, scratch) # load base address into rs1
   SREG x27, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b7_not_equal:
@@ -1066,6 +1144,7 @@ Zacas_amocas_w_cg_cp_rs2_b7_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x12) # load value in memory: x12 = 0x0000000012c40312
   RVTEST_TESTDATA_LOAD_INT(x28, x8) # load rs2: x8 = 0x00000000dbce53a8
+  RVTEST_TESTDATA_LOAD_INT(x28, x2) # load rd compare value: x2 = 0x0000000012c40312
   LA(x24, scratch) # load base address into rs1
   SREG x12, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b8_equal:
@@ -1079,6 +1158,7 @@ Zacas_amocas_w_cg_cp_rs2_b8_equal:
 # Testcase cp_rs2 (Test source rs2 = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x7) # load value in memory: x7 = 0x00000000e3ce7c1e
   RVTEST_TESTDATA_LOAD_INT(x28, x8) # load rs2: x8 = 0x00000000850e3b56
+  RVTEST_TESTDATA_LOAD_INT(x28, x25) # load rd compare value: x25 = 0x00000000e326bc08
   LA(x20, scratch) # load base address into rs1
   SREG x7, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b8_not_equal:
@@ -1092,6 +1172,7 @@ Zacas_amocas_w_cg_cp_rs2_b8_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x4) # load value in memory: x4 = 0x00000000d015530f
   RVTEST_TESTDATA_LOAD_INT(x28, x9) # load rs2: x9 = 0x00000000269bb8f8
+  RVTEST_TESTDATA_LOAD_INT(x28, x22) # load rd compare value: x22 = 0x00000000d015530f
   LA(x25, scratch) # load base address into rs1
   SREG x4, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b9_equal:
@@ -1105,6 +1186,7 @@ Zacas_amocas_w_cg_cp_rs2_b9_equal:
 # Testcase cp_rs2 (Test source rs2 = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x16) # load value in memory: x16 = 0x00000000aacfecec
   RVTEST_TESTDATA_LOAD_INT(x28, x9) # load rs2: x9 = 0x0000000001a2d481
+  RVTEST_TESTDATA_LOAD_INT(x28, x30) # load rd compare value: x30 = 0x000000002a0366e5
   LA(x1, scratch) # load base address into rs1
   SREG x16, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b9_not_equal:
@@ -1118,6 +1200,7 @@ Zacas_amocas_w_cg_cp_rs2_b9_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x26) # load value in memory: x26 = 0x000000001a1e07ef
   RVTEST_TESTDATA_LOAD_INT(x28, x10) # load rs2: x10 = 0x00000000c6c46f8b
+  RVTEST_TESTDATA_LOAD_INT(x28, x4) # load rd compare value: x4 = 0x000000001a1e07ef
   LA(x27, scratch) # load base address into rs1
   SREG x26, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b10_equal:
@@ -1131,6 +1214,7 @@ Zacas_amocas_w_cg_cp_rs2_b10_equal:
 # Testcase cp_rs2 (Test source rs2 = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x3) # load value in memory: x3 = 0x0000000057a49263
   RVTEST_TESTDATA_LOAD_INT(x28, x10) # load rs2: x10 = 0x00000000678dc17e
+  RVTEST_TESTDATA_LOAD_INT(x28, x11) # load rd compare value: x11 = 0x00000000367b6462
   LA(x23, scratch) # load base address into rs1
   SREG x3, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b10_not_equal:
@@ -1144,6 +1228,7 @@ Zacas_amocas_w_cg_cp_rs2_b10_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x7) # load value in memory: x7 = 0x000000001cff4035
   RVTEST_TESTDATA_LOAD_INT(x28, x11) # load rs2: x11 = 0x00000000a4f42b7f
+  RVTEST_TESTDATA_LOAD_INT(x28, x1) # load rd compare value: x1 = 0x000000001cff4035
   LA(x26, scratch) # load base address into rs1
   SREG x7, 0(x26) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b11_equal:
@@ -1157,6 +1242,7 @@ Zacas_amocas_w_cg_cp_rs2_b11_equal:
 # Testcase cp_rs2 (Test source rs2 = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x18) # load value in memory: x18 = 0x00000000a31275aa
   RVTEST_TESTDATA_LOAD_INT(x28, x11) # load rs2: x11 = 0x00000000299e4754
+  RVTEST_TESTDATA_LOAD_INT(x28, x10) # load rd compare value: x10 = 0x000000002ab0d0d3
   LA(x21, scratch) # load base address into rs1
   SREG x18, 0(x21) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b11_not_equal:
@@ -1170,6 +1256,7 @@ Zacas_amocas_w_cg_cp_rs2_b11_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x6) # load value in memory: x6 = 0x0000000078ac69eb
   RVTEST_TESTDATA_LOAD_INT(x28, x12) # load rs2: x12 = 0x00000000efdd2ca2
+  RVTEST_TESTDATA_LOAD_INT(x28, x16) # load rd compare value: x16 = 0x0000000078ac69eb
   LA(x5, scratch) # load base address into rs1
   SREG x6, 0(x5) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b12_equal:
@@ -1183,6 +1270,7 @@ Zacas_amocas_w_cg_cp_rs2_b12_equal:
 # Testcase cp_rs2 (Test source rs2 = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x27) # load value in memory: x27 = 0x00000000074461fa
   RVTEST_TESTDATA_LOAD_INT(x28, x12) # load rs2: x12 = 0x00000000cc2863a6
+  RVTEST_TESTDATA_LOAD_INT(x28, x26) # load rd compare value: x26 = 0x0000000003839b36
   LA(x3, scratch) # load base address into rs1
   SREG x27, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b12_not_equal:
@@ -1198,6 +1286,7 @@ Zacas_amocas_w_cg_cp_rs2_b12_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x1) # load value in memory: x1 = 0x00000000fb57c386
   RVTEST_TESTDATA_LOAD_INT(x28, x13) # load rs2: x13 = 0x0000000040fd72a9
+  RVTEST_TESTDATA_LOAD_INT(x28, x29) # load rd compare value: x29 = 0x00000000fb57c386
   LA(x2, scratch) # load base address into rs1
   SREG x1, 0(x2) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b13_equal:
@@ -1211,6 +1300,7 @@ Zacas_amocas_w_cg_cp_rs2_b13_equal:
 # Testcase cp_rs2 (Test source rs2 = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x12) # load value in memory: x12 = 0x000000000a18316c
   RVTEST_TESTDATA_LOAD_INT(x28, x13) # load rs2: x13 = 0x000000009da6aa75
+  RVTEST_TESTDATA_LOAD_INT(x28, x2) # load rd compare value: x2 = 0x000000007e4cf42a
   LA(x6, scratch) # load base address into rs1
   SREG x12, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b13_not_equal:
@@ -1224,6 +1314,7 @@ Zacas_amocas_w_cg_cp_rs2_b13_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x15) # load value in memory: x15 = 0x0000000076de738b
   RVTEST_TESTDATA_LOAD_INT(x28, x14) # load rs2: x14 = 0x00000000551274a3
+  RVTEST_TESTDATA_LOAD_INT(x28, x21) # load rd compare value: x21 = 0x0000000076de738b
   LA(x1, scratch) # load base address into rs1
   SREG x15, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b14_equal:
@@ -1237,6 +1328,7 @@ Zacas_amocas_w_cg_cp_rs2_b14_equal:
 # Testcase cp_rs2 (Test source rs2 = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x9) # load value in memory: x9 = 0x00000000ec8ce1a3
   RVTEST_TESTDATA_LOAD_INT(x28, x14) # load rs2: x14 = 0x00000000ec8dbfef
+  RVTEST_TESTDATA_LOAD_INT(x28, x30) # load rd compare value: x30 = 0x00000000770d352c
   LA(x31, scratch) # load base address into rs1
   SREG x9, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b14_not_equal:
@@ -1250,6 +1342,7 @@ Zacas_amocas_w_cg_cp_rs2_b14_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x1) # load value in memory: x1 = 0x0000000062067f08
   RVTEST_TESTDATA_LOAD_INT(x28, x15) # load rs2: x15 = 0x000000006a97c92a
+  RVTEST_TESTDATA_LOAD_INT(x28, x6) # load rd compare value: x6 = 0x0000000062067f08
   LA(x12, scratch) # load base address into rs1
   SREG x1, 0(x12) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b15_equal:
@@ -1263,6 +1356,7 @@ Zacas_amocas_w_cg_cp_rs2_b15_equal:
 # Testcase cp_rs2 (Test source rs2 = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x30) # load value in memory: x30 = 0x0000000040403d9f
   RVTEST_TESTDATA_LOAD_INT(x28, x15) # load rs2: x15 = 0x0000000099955ff9
+  RVTEST_TESTDATA_LOAD_INT(x28, x9) # load rd compare value: x9 = 0x0000000049ef8140
   LA(x31, scratch) # load base address into rs1
   SREG x30, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b15_not_equal:
@@ -1276,6 +1370,7 @@ Zacas_amocas_w_cg_cp_rs2_b15_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x21) # load value in memory: x21 = 0x00000000ca961d07
   RVTEST_TESTDATA_LOAD_INT(x28, x16) # load rs2: x16 = 0x000000005bc0bdc6
+  RVTEST_TESTDATA_LOAD_INT(x28, x10) # load rd compare value: x10 = 0x00000000ca961d07
   LA(x25, scratch) # load base address into rs1
   SREG x21, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b16_equal:
@@ -1289,6 +1384,7 @@ Zacas_amocas_w_cg_cp_rs2_b16_equal:
 # Testcase cp_rs2 (Test source rs2 = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x26) # load value in memory: x26 = 0x00000000678c1f61
   RVTEST_TESTDATA_LOAD_INT(x28, x16) # load rs2: x16 = 0x000000003cbe5fa4
+  RVTEST_TESTDATA_LOAD_INT(x28, x24) # load rd compare value: x24 = 0x0000000019c52536
   LA(x4, scratch) # load base address into rs1
   SREG x26, 0(x4) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b16_not_equal:
@@ -1302,6 +1398,7 @@ Zacas_amocas_w_cg_cp_rs2_b16_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x29) # load value in memory: x29 = 0x00000000408878d0
   RVTEST_TESTDATA_LOAD_INT(x28, x17) # load rs2: x17 = 0x000000002ef3c18c
+  RVTEST_TESTDATA_LOAD_INT(x28, x6) # load rd compare value: x6 = 0x00000000408878d0
   LA(x30, scratch) # load base address into rs1
   SREG x29, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b17_equal:
@@ -1315,6 +1412,7 @@ Zacas_amocas_w_cg_cp_rs2_b17_equal:
 # Testcase cp_rs2 (Test source rs2 = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x4) # load value in memory: x4 = 0x00000000ad51b420
   RVTEST_TESTDATA_LOAD_INT(x28, x17) # load rs2: x17 = 0x00000000dae4152a
+  RVTEST_TESTDATA_LOAD_INT(x28, x16) # load rd compare value: x16 = 0x00000000ee69d061
   LA(x23, scratch) # load base address into rs1
   SREG x4, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b17_not_equal:
@@ -1328,6 +1426,7 @@ Zacas_amocas_w_cg_cp_rs2_b17_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x21) # load value in memory: x21 = 0x00000000f48ece8a
   RVTEST_TESTDATA_LOAD_INT(x28, x18) # load rs2: x18 = 0x00000000609d9cfa
+  RVTEST_TESTDATA_LOAD_INT(x28, x25) # load rd compare value: x25 = 0x00000000f48ece8a
   LA(x14, scratch) # load base address into rs1
   SREG x21, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b18_equal:
@@ -1341,6 +1440,7 @@ Zacas_amocas_w_cg_cp_rs2_b18_equal:
 # Testcase cp_rs2 (Test source rs2 = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x13) # load value in memory: x13 = 0x00000000ef794004
   RVTEST_TESTDATA_LOAD_INT(x28, x18) # load rs2: x18 = 0x00000000270d88f1
+  RVTEST_TESTDATA_LOAD_INT(x28, x27) # load rd compare value: x27 = 0x00000000cebb1f8d
   LA(x30, scratch) # load base address into rs1
   SREG x13, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b18_not_equal:
@@ -1355,6 +1455,7 @@ Zacas_amocas_w_cg_cp_rs2_b18_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x20) # load value in memory: x20 = 0x000000001cbeadfc
   RVTEST_TESTDATA_LOAD_INT(x28, x19) # load rs2: x19 = 0x000000006401d72b
+  RVTEST_TESTDATA_LOAD_INT(x28, x26) # load rd compare value: x26 = 0x000000001cbeadfc
   LA(x23, scratch) # load base address into rs1
   SREG x20, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b19_equal:
@@ -1368,6 +1469,7 @@ Zacas_amocas_w_cg_cp_rs2_b19_equal:
 # Testcase cp_rs2 (Test source rs2 = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x29) # load value in memory: x29 = 0x00000000cb96557a
   RVTEST_TESTDATA_LOAD_INT(x28, x19) # load rs2: x19 = 0x000000009705d985
+  RVTEST_TESTDATA_LOAD_INT(x28, x18) # load rd compare value: x18 = 0x00000000c38bc6cc
   LA(x24, scratch) # load base address into rs1
   SREG x29, 0(x24) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b19_not_equal:
@@ -1381,6 +1483,7 @@ Zacas_amocas_w_cg_cp_rs2_b19_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x29) # load value in memory: x29 = 0x000000000b751a67
   RVTEST_TESTDATA_LOAD_INT(x28, x20) # load rs2: x20 = 0x0000000069b3b0a1
+  RVTEST_TESTDATA_LOAD_INT(x28, x19) # load rd compare value: x19 = 0x000000000b751a67
   LA(x17, scratch) # load base address into rs1
   SREG x29, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b20_equal:
@@ -1394,6 +1497,7 @@ Zacas_amocas_w_cg_cp_rs2_b20_equal:
 # Testcase cp_rs2 (Test source rs2 = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x14) # load value in memory: x14 = 0x00000000d3a3770c
   RVTEST_TESTDATA_LOAD_INT(x28, x20) # load rs2: x20 = 0x00000000feb7b05a
+  RVTEST_TESTDATA_LOAD_INT(x28, x15) # load rd compare value: x15 = 0x000000008457f556
   LA(x27, scratch) # load base address into rs1
   SREG x14, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b20_not_equal:
@@ -1407,6 +1511,7 @@ Zacas_amocas_w_cg_cp_rs2_b20_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load value in memory: x24 = 0x000000007d3c8a1d
   RVTEST_TESTDATA_LOAD_INT(x28, x21) # load rs2: x21 = 0x00000000a427dbe3
+  RVTEST_TESTDATA_LOAD_INT(x28, x15) # load rd compare value: x15 = 0x000000007d3c8a1d
   LA(x23, scratch) # load base address into rs1
   SREG x24, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b21_equal:
@@ -1420,6 +1525,7 @@ Zacas_amocas_w_cg_cp_rs2_b21_equal:
 # Testcase cp_rs2 (Test source rs2 = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x17) # load value in memory: x17 = 0x00000000a9f502e9
   RVTEST_TESTDATA_LOAD_INT(x28, x21) # load rs2: x21 = 0x00000000743e7a5e
+  RVTEST_TESTDATA_LOAD_INT(x28, x4) # load rd compare value: x4 = 0x00000000479803e3
   LA(x25, scratch) # load base address into rs1
   SREG x17, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b21_not_equal:
@@ -1433,6 +1539,7 @@ Zacas_amocas_w_cg_cp_rs2_b21_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x25) # load value in memory: x25 = 0x000000000e3ed6e1
   RVTEST_TESTDATA_LOAD_INT(x28, x22) # load rs2: x22 = 0x0000000041a98612
+  RVTEST_TESTDATA_LOAD_INT(x28, x14) # load rd compare value: x14 = 0x000000000e3ed6e1
   LA(x15, scratch) # load base address into rs1
   SREG x25, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b22_equal:
@@ -1446,6 +1553,7 @@ Zacas_amocas_w_cg_cp_rs2_b22_equal:
 # Testcase cp_rs2 (Test source rs2 = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x12) # load value in memory: x12 = 0x00000000350609d8
   RVTEST_TESTDATA_LOAD_INT(x28, x22) # load rs2: x22 = 0x00000000af9361de
+  RVTEST_TESTDATA_LOAD_INT(x28, x3) # load rd compare value: x3 = 0x0000000047b76478
   LA(x17, scratch) # load base address into rs1
   SREG x12, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b22_not_equal:
@@ -1459,6 +1567,7 @@ Zacas_amocas_w_cg_cp_rs2_b22_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x4) # load value in memory: x4 = 0x00000000312fd0ee
   RVTEST_TESTDATA_LOAD_INT(x28, x23) # load rs2: x23 = 0x00000000bdfb0b4c
+  RVTEST_TESTDATA_LOAD_INT(x28, x2) # load rd compare value: x2 = 0x00000000312fd0ee
   LA(x15, scratch) # load base address into rs1
   SREG x4, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b23_equal:
@@ -1472,6 +1581,7 @@ Zacas_amocas_w_cg_cp_rs2_b23_equal:
 # Testcase cp_rs2 (Test source rs2 = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x17) # load value in memory: x17 = 0x000000006b3cdcbf
   RVTEST_TESTDATA_LOAD_INT(x28, x23) # load rs2: x23 = 0x00000000cb60db2c
+  RVTEST_TESTDATA_LOAD_INT(x28, x9) # load rd compare value: x9 = 0x000000002a40bd55
   LA(x30, scratch) # load base address into rs1
   SREG x17, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b23_not_equal:
@@ -1485,6 +1595,7 @@ Zacas_amocas_w_cg_cp_rs2_b23_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x17) # load value in memory: x17 = 0x00000000be4de47e
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load rs2: x24 = 0x0000000021c70762
+  RVTEST_TESTDATA_LOAD_INT(x28, x2) # load rd compare value: x2 = 0x00000000be4de47e
   LA(x15, scratch) # load base address into rs1
   SREG x17, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b24_equal:
@@ -1498,6 +1609,7 @@ Zacas_amocas_w_cg_cp_rs2_b24_equal:
 # Testcase cp_rs2 (Test source rs2 = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x1) # load value in memory: x1 = 0x00000000b96d7e32
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load rs2: x24 = 0x000000001debc09f
+  RVTEST_TESTDATA_LOAD_INT(x28, x12) # load rd compare value: x12 = 0x00000000a4cefebc
   LA(x16, scratch) # load base address into rs1
   SREG x1, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b24_not_equal:
@@ -1511,6 +1623,7 @@ Zacas_amocas_w_cg_cp_rs2_b24_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load value in memory: x24 = 0x00000000a1a5f156
   RVTEST_TESTDATA_LOAD_INT(x28, x25) # load rs2: x25 = 0x000000001508bb45
+  RVTEST_TESTDATA_LOAD_INT(x28, x9) # load rd compare value: x9 = 0x00000000a1a5f156
   LA(x13, scratch) # load base address into rs1
   SREG x24, 0(x13) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b25_equal:
@@ -1524,6 +1637,7 @@ Zacas_amocas_w_cg_cp_rs2_b25_equal:
 # Testcase cp_rs2 (Test source rs2 = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load value in memory: x24 = 0x00000000b6cffdc6
   RVTEST_TESTDATA_LOAD_INT(x28, x25) # load rs2: x25 = 0x00000000919bd39a
+  RVTEST_TESTDATA_LOAD_INT(x28, x22) # load rd compare value: x22 = 0x000000005cdf0412
   LA(x5, scratch) # load base address into rs1
   SREG x24, 0(x5) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b25_not_equal:
@@ -1537,6 +1651,7 @@ Zacas_amocas_w_cg_cp_rs2_b25_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x5) # load value in memory: x5 = 0x00000000effd3c3d
   RVTEST_TESTDATA_LOAD_INT(x28, x26) # load rs2: x26 = 0x0000000075c393fb
+  RVTEST_TESTDATA_LOAD_INT(x28, x2) # load rd compare value: x2 = 0x00000000effd3c3d
   LA(x10, scratch) # load base address into rs1
   SREG x5, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b26_equal:
@@ -1550,6 +1665,7 @@ Zacas_amocas_w_cg_cp_rs2_b26_equal:
 # Testcase cp_rs2 (Test source rs2 = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x15) # load value in memory: x15 = 0x000000001c2e183e
   RVTEST_TESTDATA_LOAD_INT(x28, x26) # load rs2: x26 = 0x00000000c80066c2
+  RVTEST_TESTDATA_LOAD_INT(x28, x21) # load rd compare value: x21 = 0x00000000d2c4cd8c
   LA(x30, scratch) # load base address into rs1
   SREG x15, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b26_not_equal:
@@ -1563,6 +1679,7 @@ Zacas_amocas_w_cg_cp_rs2_b26_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x16) # load value in memory: x16 = 0x00000000b102eaf1
   RVTEST_TESTDATA_LOAD_INT(x28, x27) # load rs2: x27 = 0x00000000bc0e5884
+  RVTEST_TESTDATA_LOAD_INT(x28, x24) # load rd compare value: x24 = 0x00000000b102eaf1
   LA(x4, scratch) # load base address into rs1
   SREG x16, 0(x4) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b27_equal:
@@ -1576,6 +1693,7 @@ Zacas_amocas_w_cg_cp_rs2_b27_equal:
 # Testcase cp_rs2 (Test source rs2 = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x28, x4) # load value in memory: x4 = 0x00000000d050b55b
   RVTEST_TESTDATA_LOAD_INT(x28, x27) # load rs2: x27 = 0x000000008c64f1aa
+  RVTEST_TESTDATA_LOAD_INT(x28, x20) # load rd compare value: x20 = 0x000000006fb1956b
   LA(x13, scratch) # load base address into rs1
   SREG x4, 0(x13) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b27_not_equal:
@@ -1590,6 +1708,7 @@ Zacas_amocas_w_cg_cp_rs2_b27_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x29, x19) # load value in memory: x19 = 0x00000000e8894296
   RVTEST_TESTDATA_LOAD_INT(x29, x28) # load rs2: x28 = 0x00000000042f1cf8
+  RVTEST_TESTDATA_LOAD_INT(x29, x13) # load rd compare value: x13 = 0x00000000e8894296
   LA(x18, scratch) # load base address into rs1
   SREG x19, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b28_equal:
@@ -1603,6 +1722,7 @@ Zacas_amocas_w_cg_cp_rs2_b28_equal:
 # Testcase cp_rs2 (Test source rs2 = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x29, x18) # load value in memory: x18 = 0x00000000f259fe2b
   RVTEST_TESTDATA_LOAD_INT(x29, x28) # load rs2: x28 = 0x000000005be58383
+  RVTEST_TESTDATA_LOAD_INT(x29, x26) # load rd compare value: x26 = 0x000000001bfcd829
   LA(x15, scratch) # load base address into rs1
   SREG x18, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b28_not_equal:
@@ -1617,6 +1737,7 @@ Zacas_amocas_w_cg_cp_rs2_b28_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x27) # load value in memory: x27 = 0x000000009ad5244a
   RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rs2: x29 = 0x0000000060ea4a62
+  RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rd compare value: x12 = 0x000000009ad5244a
   LA(x9, scratch) # load base address into rs1
   SREG x27, 0(x9) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b29_equal:
@@ -1630,6 +1751,7 @@ Zacas_amocas_w_cg_cp_rs2_b29_equal:
 # Testcase cp_rs2 (Test source rs2 = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x19) # load value in memory: x19 = 0x00000000cfac4d7a
   RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rs2: x29 = 0x00000000420ed58e
+  RVTEST_TESTDATA_LOAD_INT(x15, x31) # load rd compare value: x31 = 0x000000005097d0e2
   LA(x14, scratch) # load base address into rs1
   SREG x19, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b29_not_equal:
@@ -1643,6 +1765,7 @@ Zacas_amocas_w_cg_cp_rs2_b29_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x1) # load value in memory: x1 = 0x000000006fe6aa73
   RVTEST_TESTDATA_LOAD_INT(x15, x30) # load rs2: x30 = 0x00000000b171535b
+  RVTEST_TESTDATA_LOAD_INT(x15, x4) # load rd compare value: x4 = 0x000000006fe6aa73
   LA(x3, scratch) # load base address into rs1
   SREG x1, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b30_equal:
@@ -1656,6 +1779,7 @@ Zacas_amocas_w_cg_cp_rs2_b30_equal:
 # Testcase cp_rs2 (Test source rs2 = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x18) # load value in memory: x18 = 0x000000009052838b
   RVTEST_TESTDATA_LOAD_INT(x15, x30) # load rs2: x30 = 0x00000000920ef9f4
+  RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rd compare value: x9 = 0x00000000b6b83c74
   LA(x14, scratch) # load base address into rs1
   SREG x18, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b30_not_equal:
@@ -1669,6 +1793,7 @@ Zacas_amocas_w_cg_cp_rs2_b30_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x14) # load value in memory: x14 = 0x0000000094a8e5ef
   RVTEST_TESTDATA_LOAD_INT(x15, x31) # load rs2: x31 = 0x000000001705fb6a
+  RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rd compare value: x29 = 0x0000000094a8e5ef
   LA(x25, scratch) # load base address into rs1
   SREG x14, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b31_equal:
@@ -1682,6 +1807,7 @@ Zacas_amocas_w_cg_cp_rs2_b31_equal:
 # Testcase cp_rs2 (Test source rs2 = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x21) # load value in memory: x21 = 0x000000006dcc574f
   RVTEST_TESTDATA_LOAD_INT(x15, x31) # load rs2: x31 = 0x000000008631068a
+  RVTEST_TESTDATA_LOAD_INT(x15, x2) # load rd compare value: x2 = 0x00000000aa951675
   LA(x28, scratch) # load base address into rs1
   SREG x21, 0(x28) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rs2_b31_not_equal:
@@ -1699,6 +1825,7 @@ Zacas_amocas_w_cg_cp_rs2_b31_not_equal:
 # Testcase cp_rd (Test destination rd = x0, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x25) # load value in memory: x25 = 0x00000000d6331454
   RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rs2: x9 = 0x00000000c28961f3
+  RVTEST_TESTDATA_LOAD_INT(x15, x0) # load rd compare value: x0 = 0x00000000d6331454
   LA(x27, scratch) # load base address into rs1
   SREG x25, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b0_equal:
@@ -1712,6 +1839,7 @@ Zacas_amocas_w_cg_cp_rd_b0_equal:
 # Testcase cp_rd (Test destination rd = x0, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x30) # load value in memory: x30 = 0x000000000ff5b6d6
   RVTEST_TESTDATA_LOAD_INT(x15, x17) # load rs2: x17 = 0x00000000853515e3
+  RVTEST_TESTDATA_LOAD_INT(x15, x0) # load rd compare value: x0 = 0x00000000d8674601
   LA(x23, scratch) # load base address into rs1
   SREG x30, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b0_not_equal:
@@ -1725,6 +1853,7 @@ Zacas_amocas_w_cg_cp_rd_b0_not_equal:
 # Testcase cp_rd (Test destination rd = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x18) # load value in memory: x18 = 0x00000000d6e34586
   RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rs2: x12 = 0x000000008d5e2e05
+  RVTEST_TESTDATA_LOAD_INT(x15, x1) # load rd compare value: x1 = 0x00000000d6e34586
   LA(x2, scratch) # load base address into rs1
   SREG x18, 0(x2) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b1_equal:
@@ -1738,6 +1867,7 @@ Zacas_amocas_w_cg_cp_rd_b1_equal:
 # Testcase cp_rd (Test destination rd = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x13) # load value in memory: x13 = 0x00000000ca79b6e8
   RVTEST_TESTDATA_LOAD_INT(x15, x25) # load rs2: x25 = 0x0000000049fdb31d
+  RVTEST_TESTDATA_LOAD_INT(x15, x1) # load rd compare value: x1 = 0x000000006c2950fe
   LA(x10, scratch) # load base address into rs1
   SREG x13, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b1_not_equal:
@@ -1751,6 +1881,7 @@ Zacas_amocas_w_cg_cp_rd_b1_not_equal:
 # Testcase cp_rd (Test destination rd = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x22) # load value in memory: x22 = 0x00000000c3ff0de0
   RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rs2: x29 = 0x00000000522001a7
+  RVTEST_TESTDATA_LOAD_INT(x15, x2) # load rd compare value: x2 = 0x00000000c3ff0de0
   LA(x30, scratch) # load base address into rs1
   SREG x22, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b2_equal:
@@ -1764,6 +1895,7 @@ Zacas_amocas_w_cg_cp_rd_b2_equal:
 # Testcase cp_rd (Test destination rd = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x1) # load value in memory: x1 = 0x00000000a40024e5
   RVTEST_TESTDATA_LOAD_INT(x15, x20) # load rs2: x20 = 0x0000000087b5c092
+  RVTEST_TESTDATA_LOAD_INT(x15, x2) # load rd compare value: x2 = 0x00000000e9dae6a3
   LA(x9, scratch) # load base address into rs1
   SREG x1, 0(x9) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b2_not_equal:
@@ -1777,6 +1909,7 @@ Zacas_amocas_w_cg_cp_rd_b2_not_equal:
 # Testcase cp_rd (Test destination rd = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x13) # load value in memory: x13 = 0x00000000c7f326ef
   RVTEST_TESTDATA_LOAD_INT(x15, x19) # load rs2: x19 = 0x00000000ab24373f
+  RVTEST_TESTDATA_LOAD_INT(x15, x3) # load rd compare value: x3 = 0x00000000c7f326ef
   LA(x22, scratch) # load base address into rs1
   SREG x13, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b3_equal:
@@ -1790,6 +1923,7 @@ Zacas_amocas_w_cg_cp_rd_b3_equal:
 # Testcase cp_rd (Test destination rd = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x13) # load value in memory: x13 = 0x00000000b5cc81b1
   RVTEST_TESTDATA_LOAD_INT(x15, x28) # load rs2: x28 = 0x0000000025b3c30e
+  RVTEST_TESTDATA_LOAD_INT(x15, x3) # load rd compare value: x3 = 0x000000006accb197
   LA(x16, scratch) # load base address into rs1
   SREG x13, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b3_not_equal:
@@ -1803,6 +1937,7 @@ Zacas_amocas_w_cg_cp_rd_b3_not_equal:
 # Testcase cp_rd (Test destination rd = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x10) # load value in memory: x10 = 0x000000008f17f15c
   RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rs2: x9 = 0x00000000848170bb
+  RVTEST_TESTDATA_LOAD_INT(x15, x4) # load rd compare value: x4 = 0x000000008f17f15c
   LA(x25, scratch) # load base address into rs1
   SREG x10, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b4_equal:
@@ -1816,6 +1951,7 @@ Zacas_amocas_w_cg_cp_rd_b4_equal:
 # Testcase cp_rd (Test destination rd = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x25) # load value in memory: x25 = 0x00000000ff5e8bb0
   RVTEST_TESTDATA_LOAD_INT(x15, x11) # load rs2: x11 = 0x0000000053c3f6bc
+  RVTEST_TESTDATA_LOAD_INT(x15, x4) # load rd compare value: x4 = 0x00000000c004d0f3
   LA(x19, scratch) # load base address into rs1
   SREG x25, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b4_not_equal:
@@ -1829,6 +1965,7 @@ Zacas_amocas_w_cg_cp_rd_b4_not_equal:
 # Testcase cp_rd (Test destination rd = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x22) # load value in memory: x22 = 0x00000000dacbee00
   RVTEST_TESTDATA_LOAD_INT(x15, x3) # load rs2: x3 = 0x0000000019830e86
+  RVTEST_TESTDATA_LOAD_INT(x15, x5) # load rd compare value: x5 = 0x00000000dacbee00
   LA(x30, scratch) # load base address into rs1
   SREG x22, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b5_equal:
@@ -1842,6 +1979,7 @@ Zacas_amocas_w_cg_cp_rd_b5_equal:
 # Testcase cp_rd (Test destination rd = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x29) # load value in memory: x29 = 0x00000000b06f9892
   RVTEST_TESTDATA_LOAD_INT(x15, x4) # load rs2: x4 = 0x00000000522d21ae
+  RVTEST_TESTDATA_LOAD_INT(x15, x5) # load rd compare value: x5 = 0x000000008042963b
   LA(x21, scratch) # load base address into rs1
   SREG x29, 0(x21) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b5_not_equal:
@@ -1856,6 +1994,7 @@ Zacas_amocas_w_cg_cp_rd_b5_not_equal:
 # Testcase cp_rd (Test destination rd = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x5) # load value in memory: x5 = 0x00000000cfd6e8b2
   RVTEST_TESTDATA_LOAD_INT(x15, x20) # load rs2: x20 = 0x000000001b98c6b9
+  RVTEST_TESTDATA_LOAD_INT(x15, x6) # load rd compare value: x6 = 0x00000000cfd6e8b2
   LA(x21, scratch) # load base address into rs1
   SREG x5, 0(x21) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b6_equal:
@@ -1869,6 +2008,7 @@ Zacas_amocas_w_cg_cp_rd_b6_equal:
 # Testcase cp_rd (Test destination rd = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x3) # load value in memory: x3 = 0x000000007f288fc3
   RVTEST_TESTDATA_LOAD_INT(x15, x16) # load rs2: x16 = 0x00000000728f3d74
+  RVTEST_TESTDATA_LOAD_INT(x15, x6) # load rd compare value: x6 = 0x00000000afb07251
   LA(x18, scratch) # load base address into rs1
   SREG x3, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b6_not_equal:
@@ -1884,6 +2024,7 @@ Zacas_amocas_w_cg_cp_rd_b6_not_equal:
 # Testcase cp_rd (Test destination rd = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x3) # load value in memory: x3 = 0x00000000b3849b55
   RVTEST_TESTDATA_LOAD_INT(x15, x31) # load rs2: x31 = 0x00000000d4842674
+  RVTEST_TESTDATA_LOAD_INT(x15, x7) # load rd compare value: x7 = 0x00000000b3849b55
   LA(x29, scratch) # load base address into rs1
   SREG x3, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b7_equal:
@@ -1897,6 +2038,7 @@ Zacas_amocas_w_cg_cp_rd_b7_equal:
 # Testcase cp_rd (Test destination rd = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x31) # load value in memory: x31 = 0x000000005a38ca6c
   RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rs2: x9 = 0x00000000cb42e73e
+  RVTEST_TESTDATA_LOAD_INT(x15, x7) # load rd compare value: x7 = 0x00000000a2e175be
   LA(x25, scratch) # load base address into rs1
   SREG x31, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b7_not_equal:
@@ -1910,6 +2052,7 @@ Zacas_amocas_w_cg_cp_rd_b7_not_equal:
 # Testcase cp_rd (Test destination rd = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x1) # load value in memory: x1 = 0x000000009301493e
   RVTEST_TESTDATA_LOAD_INT(x15, x20) # load rs2: x20 = 0x00000000ed8d7433
+  RVTEST_TESTDATA_LOAD_INT(x15, x8) # load rd compare value: x8 = 0x000000009301493e
   LA(x23, scratch) # load base address into rs1
   SREG x1, 0(x23) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b8_equal:
@@ -1923,6 +2066,7 @@ Zacas_amocas_w_cg_cp_rd_b8_equal:
 # Testcase cp_rd (Test destination rd = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x11) # load value in memory: x11 = 0x000000008efa1d8f
   RVTEST_TESTDATA_LOAD_INT(x15, x18) # load rs2: x18 = 0x0000000055ea3982
+  RVTEST_TESTDATA_LOAD_INT(x15, x8) # load rd compare value: x8 = 0x00000000625098bd
   LA(x25, scratch) # load base address into rs1
   SREG x11, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b8_not_equal:
@@ -1936,6 +2080,7 @@ Zacas_amocas_w_cg_cp_rd_b8_not_equal:
 # Testcase cp_rd (Test destination rd = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x10) # load value in memory: x10 = 0x000000003b50cc74
   RVTEST_TESTDATA_LOAD_INT(x15, x20) # load rs2: x20 = 0x00000000df49096b
+  RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rd compare value: x9 = 0x000000003b50cc74
   LA(x30, scratch) # load base address into rs1
   SREG x10, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b9_equal:
@@ -1949,6 +2094,7 @@ Zacas_amocas_w_cg_cp_rd_b9_equal:
 # Testcase cp_rd (Test destination rd = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x10) # load value in memory: x10 = 0x0000000053999bd6
   RVTEST_TESTDATA_LOAD_INT(x15, x4) # load rs2: x4 = 0x0000000011c2ccdb
+  RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rd compare value: x9 = 0x000000008a74865c
   LA(x8, scratch) # load base address into rs1
   SREG x10, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b9_not_equal:
@@ -1962,6 +2108,7 @@ Zacas_amocas_w_cg_cp_rd_b9_not_equal:
 # Testcase cp_rd (Test destination rd = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x27) # load value in memory: x27 = 0x0000000015680d94
   RVTEST_TESTDATA_LOAD_INT(x15, x30) # load rs2: x30 = 0x000000007dd4aebe
+  RVTEST_TESTDATA_LOAD_INT(x15, x10) # load rd compare value: x10 = 0x0000000015680d94
   LA(x6, scratch) # load base address into rs1
   SREG x27, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b10_equal:
@@ -1975,6 +2122,7 @@ Zacas_amocas_w_cg_cp_rd_b10_equal:
 # Testcase cp_rd (Test destination rd = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x4) # load value in memory: x4 = 0x00000000aa6f1d34
   RVTEST_TESTDATA_LOAD_INT(x15, x19) # load rs2: x19 = 0x0000000050285057
+  RVTEST_TESTDATA_LOAD_INT(x15, x10) # load rd compare value: x10 = 0x00000000f0ad8501
   LA(x29, scratch) # load base address into rs1
   SREG x4, 0(x29) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b10_not_equal:
@@ -1988,6 +2136,7 @@ Zacas_amocas_w_cg_cp_rd_b10_not_equal:
 # Testcase cp_rd (Test destination rd = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x7) # load value in memory: x7 = 0x00000000238016f7
   RVTEST_TESTDATA_LOAD_INT(x15, x8) # load rs2: x8 = 0x00000000583c8fac
+  RVTEST_TESTDATA_LOAD_INT(x15, x11) # load rd compare value: x11 = 0x00000000238016f7
   LA(x4, scratch) # load base address into rs1
   SREG x7, 0(x4) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b11_equal:
@@ -2001,6 +2150,7 @@ Zacas_amocas_w_cg_cp_rd_b11_equal:
 # Testcase cp_rd (Test destination rd = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x29) # load value in memory: x29 = 0x00000000cbe48d8d
   RVTEST_TESTDATA_LOAD_INT(x15, x1) # load rs2: x1 = 0x000000007a073099
+  RVTEST_TESTDATA_LOAD_INT(x15, x11) # load rd compare value: x11 = 0x000000005300b1b2
   LA(x6, scratch) # load base address into rs1
   SREG x29, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b11_not_equal:
@@ -2014,6 +2164,7 @@ Zacas_amocas_w_cg_cp_rd_b11_not_equal:
 # Testcase cp_rd (Test destination rd = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x22) # load value in memory: x22 = 0x000000000e10721a
   RVTEST_TESTDATA_LOAD_INT(x15, x1) # load rs2: x1 = 0x00000000594d3170
+  RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rd compare value: x12 = 0x000000000e10721a
   LA(x27, scratch) # load base address into rs1
   SREG x22, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b12_equal:
@@ -2027,6 +2178,7 @@ Zacas_amocas_w_cg_cp_rd_b12_equal:
 # Testcase cp_rd (Test destination rd = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x3) # load value in memory: x3 = 0x00000000c658b92f
   RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rs2: x29 = 0x00000000f18c8384
+  RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rd compare value: x12 = 0x000000001c196d2b
   LA(x27, scratch) # load base address into rs1
   SREG x3, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b12_not_equal:
@@ -2042,6 +2194,7 @@ Zacas_amocas_w_cg_cp_rd_b12_not_equal:
 # Testcase cp_rd (Test destination rd = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x21) # load value in memory: x21 = 0x00000000d8acd1a6
   RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rs2: x12 = 0x00000000c4594ae3
+  RVTEST_TESTDATA_LOAD_INT(x15, x13) # load rd compare value: x13 = 0x00000000d8acd1a6
   LA(x1, scratch) # load base address into rs1
   SREG x21, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b13_equal:
@@ -2055,6 +2208,7 @@ Zacas_amocas_w_cg_cp_rd_b13_equal:
 # Testcase cp_rd (Test destination rd = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x7) # load value in memory: x7 = 0x0000000058dfa105
   RVTEST_TESTDATA_LOAD_INT(x15, x19) # load rs2: x19 = 0x000000002de2ff7f
+  RVTEST_TESTDATA_LOAD_INT(x15, x13) # load rd compare value: x13 = 0x00000000a8e327c0
   LA(x20, scratch) # load base address into rs1
   SREG x7, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b13_not_equal:
@@ -2068,6 +2222,7 @@ Zacas_amocas_w_cg_cp_rd_b13_not_equal:
 # Testcase cp_rd (Test destination rd = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x19) # load value in memory: x19 = 0x00000000860357f5
   RVTEST_TESTDATA_LOAD_INT(x15, x30) # load rs2: x30 = 0x00000000d9b03afe
+  RVTEST_TESTDATA_LOAD_INT(x15, x14) # load rd compare value: x14 = 0x00000000860357f5
   LA(x10, scratch) # load base address into rs1
   SREG x19, 0(x10) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b14_equal:
@@ -2081,6 +2236,7 @@ Zacas_amocas_w_cg_cp_rd_b14_equal:
 # Testcase cp_rd (Test destination rd = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x28) # load value in memory: x28 = 0x00000000485ee413
   RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rs2: x12 = 0x00000000f5cb62d5
+  RVTEST_TESTDATA_LOAD_INT(x15, x14) # load rd compare value: x14 = 0x00000000e1afbf7a
   LA(x6, scratch) # load base address into rs1
   SREG x28, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b14_not_equal:
@@ -2095,6 +2251,7 @@ Zacas_amocas_w_cg_cp_rd_b14_not_equal:
 # Testcase cp_rd (Test destination rd = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load value in memory: x19 = 0x000000004cf0591d
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x000000007f28e4d6
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rd compare value: x15 = 0x000000004cf0591d
   LA(x27, scratch) # load base address into rs1
   SREG x19, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b15_equal:
@@ -2108,6 +2265,7 @@ Zacas_amocas_w_cg_cp_rd_b15_equal:
 # Testcase cp_rd (Test destination rd = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load value in memory: x25 = 0x000000006862e75b
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x00000000eae88d41
+  RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rd compare value: x15 = 0x000000007ef4ffd8
   LA(x22, scratch) # load base address into rs1
   SREG x25, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b15_not_equal:
@@ -2121,6 +2279,7 @@ Zacas_amocas_w_cg_cp_rd_b15_not_equal:
 # Testcase cp_rd (Test destination rd = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load value in memory: x21 = 0x00000000790957c6
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0x0000000072159ef6
+  RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rd compare value: x16 = 0x00000000790957c6
   LA(x30, scratch) # load base address into rs1
   SREG x21, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b16_equal:
@@ -2134,6 +2293,7 @@ Zacas_amocas_w_cg_cp_rd_b16_equal:
 # Testcase cp_rd (Test destination rd = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load value in memory: x25 = 0x00000000f9cd5e5f
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x000000001ad8bf39
+  RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rd compare value: x16 = 0x000000001c249807
   LA(x3, scratch) # load base address into rs1
   SREG x25, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b16_not_equal:
@@ -2147,6 +2307,7 @@ Zacas_amocas_w_cg_cp_rd_b16_not_equal:
 # Testcase cp_rd (Test destination rd = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load value in memory: x11 = 0x00000000c47f5a46
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x000000004879e492
+  RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rd compare value: x17 = 0x00000000c47f5a46
   LA(x25, scratch) # load base address into rs1
   SREG x11, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b17_equal:
@@ -2160,6 +2321,7 @@ Zacas_amocas_w_cg_cp_rd_b17_equal:
 # Testcase cp_rd (Test destination rd = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load value in memory: x13 = 0x00000000d6928f8e
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x00000000f227e004
+  RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rd compare value: x17 = 0x00000000ec2f58f2
   LA(x11, scratch) # load base address into rs1
   SREG x13, 0(x11) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b17_not_equal:
@@ -2173,6 +2335,7 @@ Zacas_amocas_w_cg_cp_rd_b17_not_equal:
 # Testcase cp_rd (Test destination rd = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load value in memory: x10 = 0x000000004a39ca34
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rs2: x21 = 0x0000000063233351
+  RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rd compare value: x18 = 0x000000004a39ca34
   LA(x2, scratch) # load base address into rs1
   SREG x10, 0(x2) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b18_equal:
@@ -2186,6 +2349,7 @@ Zacas_amocas_w_cg_cp_rd_b18_equal:
 # Testcase cp_rd (Test destination rd = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load value in memory: x6 = 0x00000000f5277d88
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load rs2: x15 = 0x000000008be65d23
+  RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rd compare value: x18 = 0x000000008c92e5a3
   LA(x22, scratch) # load base address into rs1
   SREG x6, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b18_not_equal:
@@ -2199,6 +2363,7 @@ Zacas_amocas_w_cg_cp_rd_b18_not_equal:
 # Testcase cp_rd (Test destination rd = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load value in memory: x31 = 0x0000000090022404
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x00000000d2f3ffd4
+  RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rd compare value: x19 = 0x0000000090022404
   LA(x11, scratch) # load base address into rs1
   SREG x31, 0(x11) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b19_equal:
@@ -2212,6 +2377,7 @@ Zacas_amocas_w_cg_cp_rd_b19_equal:
 # Testcase cp_rd (Test destination rd = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load value in memory: x6 = 0x00000000babe58f1
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rs2: x14 = 0x00000000217b4c5d
+  RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rd compare value: x19 = 0x000000006af19230
   LA(x16, scratch) # load base address into rs1
   SREG x6, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b19_not_equal:
@@ -2225,6 +2391,7 @@ Zacas_amocas_w_cg_cp_rd_b19_not_equal:
 # Testcase cp_rd (Test destination rd = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load value in memory: x13 = 0x000000009d015e6a
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x000000007aff4913
+  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rd compare value: x20 = 0x000000009d015e6a
   LA(x16, scratch) # load base address into rs1
   SREG x13, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b20_equal:
@@ -2238,6 +2405,7 @@ Zacas_amocas_w_cg_cp_rd_b20_equal:
 # Testcase cp_rd (Test destination rd = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load value in memory: x28 = 0x0000000027f7132e
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x00000000102bc516
+  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rd compare value: x20 = 0x0000000019b4169f
   LA(x19, scratch) # load base address into rs1
   SREG x28, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b20_not_equal:
@@ -2251,6 +2419,7 @@ Zacas_amocas_w_cg_cp_rd_b20_not_equal:
 # Testcase cp_rd (Test destination rd = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load value in memory: x27 = 0x000000005f930393
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0x00000000fda2afe6
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rd compare value: x21 = 0x000000005f930393
   LA(x14, scratch) # load base address into rs1
   SREG x27, 0(x14) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b21_equal:
@@ -2264,6 +2433,7 @@ Zacas_amocas_w_cg_cp_rd_b21_equal:
 # Testcase cp_rd (Test destination rd = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load value in memory: x7 = 0x0000000050d9f349
   RVTEST_TESTDATA_LOAD_INT(x1, x16) # load rs2: x16 = 0x0000000034477649
+  RVTEST_TESTDATA_LOAD_INT(x1, x21) # load rd compare value: x21 = 0x0000000079b6ce9b
   LA(x31, scratch) # load base address into rs1
   SREG x7, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b21_not_equal:
@@ -2277,6 +2447,7 @@ Zacas_amocas_w_cg_cp_rd_b21_not_equal:
 # Testcase cp_rd (Test destination rd = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load value in memory: x14 = 0x00000000b9590ae0
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load rs2: x7 = 0x00000000e5bf0236
+  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rd compare value: x22 = 0x00000000b9590ae0
   LA(x16, scratch) # load base address into rs1
   SREG x14, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b22_equal:
@@ -2290,6 +2461,7 @@ Zacas_amocas_w_cg_cp_rd_b22_equal:
 # Testcase cp_rd (Test destination rd = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load value in memory: x6 = 0x00000000b6fcc608
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x000000006003de25
+  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rd compare value: x22 = 0x000000000560abb4
   LA(x17, scratch) # load base address into rs1
   SREG x6, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b22_not_equal:
@@ -2303,6 +2475,7 @@ Zacas_amocas_w_cg_cp_rd_b22_not_equal:
 # Testcase cp_rd (Test destination rd = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load value in memory: x9 = 0x00000000db383518
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load rs2: x19 = 0x00000000c0c49817
+  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rd compare value: x23 = 0x00000000db383518
   LA(x3, scratch) # load base address into rs1
   SREG x9, 0(x3) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b23_equal:
@@ -2316,6 +2489,7 @@ Zacas_amocas_w_cg_cp_rd_b23_equal:
 # Testcase cp_rd (Test destination rd = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load value in memory: x3 = 0x000000007c319a2b
   RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rs2: x0 = 0x0000000017799c6d
+  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rd compare value: x23 = 0x000000005899e179
   LA(x31, scratch) # load base address into rs1
   SREG x3, 0(x31) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b23_not_equal:
@@ -2329,6 +2503,7 @@ Zacas_amocas_w_cg_cp_rd_b23_not_equal:
 # Testcase cp_rd (Test destination rd = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load value in memory: x31 = 0x00000000cfce1aa3
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x000000008afc45b9
+  RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rd compare value: x24 = 0x00000000cfce1aa3
   LA(x6, scratch) # load base address into rs1
   SREG x31, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b24_equal:
@@ -2342,6 +2517,7 @@ Zacas_amocas_w_cg_cp_rd_b24_equal:
 # Testcase cp_rd (Test destination rd = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x7) # load value in memory: x7 = 0x0000000018bf5e52
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x0000000099288ffa
+  RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rd compare value: x24 = 0x00000000214ca299
   LA(x27, scratch) # load base address into rs1
   SREG x7, 0(x27) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b24_not_equal:
@@ -2355,6 +2531,7 @@ Zacas_amocas_w_cg_cp_rd_b24_not_equal:
 # Testcase cp_rd (Test destination rd = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load value in memory: x13 = 0x00000000225e1cd2
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x00000000aba66973
+  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rd compare value: x25 = 0x00000000225e1cd2
   LA(x30, scratch) # load base address into rs1
   SREG x13, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b25_equal:
@@ -2368,6 +2545,7 @@ Zacas_amocas_w_cg_cp_rd_b25_equal:
 # Testcase cp_rd (Test destination rd = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load value in memory: x23 = 0x00000000e4efb0bf
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x00000000702d4a82
+  RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rd compare value: x25 = 0x00000000f2615aa3
   LA(x16, scratch) # load base address into rs1
   SREG x23, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b25_not_equal:
@@ -2382,6 +2560,7 @@ Zacas_amocas_w_cg_cp_rd_b25_not_equal:
 # Testcase cp_rd (Test destination rd = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load value in memory: x8 = 0x0000000069266b77
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rs2: x3 = 0x000000002e1d99eb
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rd compare value: x26 = 0x0000000069266b77
   LA(x22, scratch) # load base address into rs1
   SREG x8, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b26_equal:
@@ -2395,6 +2574,7 @@ Zacas_amocas_w_cg_cp_rd_b26_equal:
 # Testcase cp_rd (Test destination rd = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x15) # load value in memory: x15 = 0x00000000384b7875
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load rs2: x9 = 0x0000000075eac200
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rd compare value: x26 = 0x000000007e8b786f
   LA(x22, scratch) # load base address into rs1
   SREG x15, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b26_not_equal:
@@ -2408,6 +2588,7 @@ Zacas_amocas_w_cg_cp_rd_b26_not_equal:
 # Testcase cp_rd (Test destination rd = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load value in memory: x6 = 0x00000000e1365c2a
   RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x00000000138feef2
+  RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rd compare value: x27 = 0x00000000e1365c2a
   LA(x8, scratch) # load base address into rs1
   SREG x6, 0(x8) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b27_equal:
@@ -2421,6 +2602,7 @@ Zacas_amocas_w_cg_cp_rd_b27_equal:
 # Testcase cp_rd (Test destination rd = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load value in memory: x22 = 0x00000000a17a6a46
   RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rs2: x17 = 0x00000000ad131e05
+  RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rd compare value: x27 = 0x00000000e27b88aa
   LA(x19, scratch) # load base address into rs1
   SREG x22, 0(x19) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b27_not_equal:
@@ -2434,6 +2616,7 @@ Zacas_amocas_w_cg_cp_rd_b27_not_equal:
 # Testcase cp_rd (Test destination rd = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load value in memory: x6 = 0x00000000adeb9c47
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load rs2: x12 = 0x00000000192cf1ba
+  RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rd compare value: x28 = 0x00000000adeb9c47
   LA(x20, scratch) # load base address into rs1
   SREG x6, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b28_equal:
@@ -2447,6 +2630,7 @@ Zacas_amocas_w_cg_cp_rd_b28_equal:
 # Testcase cp_rd (Test destination rd = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x18) # load value in memory: x18 = 0x000000001b588ff7
   RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rs2: x23 = 0x00000000bb7cbe78
+  RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rd compare value: x28 = 0x00000000d2da4750
   LA(x25, scratch) # load base address into rs1
   SREG x18, 0(x25) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b28_not_equal:
@@ -2460,6 +2644,7 @@ Zacas_amocas_w_cg_cp_rd_b28_not_equal:
 # Testcase cp_rd (Test destination rd = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x12) # load value in memory: x12 = 0x000000002a40cb61
   RVTEST_TESTDATA_LOAD_INT(x1, x8) # load rs2: x8 = 0x000000000fc5cd1e
+  RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rd compare value: x29 = 0x000000002a40cb61
   LA(x20, scratch) # load base address into rs1
   SREG x12, 0(x20) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b29_equal:
@@ -2473,6 +2658,7 @@ Zacas_amocas_w_cg_cp_rd_b29_equal:
 # Testcase cp_rd (Test destination rd = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load value in memory: x31 = 0x000000000e49dc88
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rs2: x10 = 0x0000000059d39b01
+  RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rd compare value: x29 = 0x000000006f0b7de9
   LA(x18, scratch) # load base address into rs1
   SREG x31, 0(x18) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b29_not_equal:
@@ -2486,6 +2672,7 @@ Zacas_amocas_w_cg_cp_rd_b29_not_equal:
 # Testcase cp_rd (Test destination rd = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x10) # load value in memory: x10 = 0x000000009c994a82
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x00000000be78931b
+  RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rd compare value: x30 = 0x000000009c994a82
   LA(x21, scratch) # load base address into rs1
   SREG x10, 0(x21) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b30_equal:
@@ -2499,6 +2686,7 @@ Zacas_amocas_w_cg_cp_rd_b30_equal:
 # Testcase cp_rd (Test destination rd = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load value in memory: x22 = 0x000000007a96ef97
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x00000000722ee0b2
+  RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rd compare value: x30 = 0x000000005b72cc26
   LA(x15, scratch) # load base address into rs1
   SREG x22, 0(x15) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b30_not_equal:
@@ -2512,6 +2700,7 @@ Zacas_amocas_w_cg_cp_rd_b30_not_equal:
 # Testcase cp_rd (Test destination rd = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x17) # load value in memory: x17 = 0x00000000346e7364
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load rs2: x13 = 0x00000000d701d09d
+  RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rd compare value: x31 = 0x00000000346e7364
   LA(x30, scratch) # load base address into rs1
   SREG x17, 0(x30) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b31_equal:
@@ -2525,6 +2714,7 @@ Zacas_amocas_w_cg_cp_rd_b31_equal:
 # Testcase cp_rd (Test destination rd = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x18) # load value in memory: x18 = 0x000000007d1246cd
   RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rs2: x6 = 0x00000000dadfa95e
+  RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rd compare value: x31 = 0x00000000f102be78
   LA(x28, scratch) # load base address into rs1
   SREG x18, 0(x28) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cp_rd_b31_not_equal:
@@ -4518,9 +4708,9 @@ Zacas_amocas_w_cg_cp_align_word_b4:
 /////////////////////////////////
 
 # Testcase cmp_rd_rs1_val_eq (rd_val == mem_val)
-  RVTEST_TESTDATA_LOAD_INT(x18, x19) # load rd compare value: x19 = 0x29156d208bb185da
   RVTEST_TESTDATA_LOAD_INT(x18, x6) # load value in memory: x6 = 0x29156d208bb185da
   RVTEST_TESTDATA_LOAD_INT(x18, x12) # load rs2: x12 = 0x8646c310e09a8531
+  RVTEST_TESTDATA_LOAD_INT(x18, x19) # load rd compare value: x19 = 0x29156d208bb185da
   LA(x17, scratch) # load base address into rs1
   SREG x6, 0(x17) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cmp_rd_rs1_val_eq_equal:
@@ -4532,9 +4722,9 @@ Zacas_amocas_w_cg_cmp_rd_rs1_val_eq_equal:
   RVTEST_SIGUPD(x3, x5, x4, x17, Zacas_amocas_w_cg_cmp_rd_rs1_val_eq_equal, Zacas_amocas_w_cg_cmp_rd_rs1_val_eq_equal_str)
 
 # Testcase cmp_rd_rs1_val_eq (rd_val != mem_val)
-  RVTEST_TESTDATA_LOAD_INT(x18, x29) # load rd compare value: x29 = 0x4b3475cdac2b2906
   RVTEST_TESTDATA_LOAD_INT(x18, x30) # load value in memory: x30 = 0xbd6d1b12124f7289
   RVTEST_TESTDATA_LOAD_INT(x18, x16) # load rs2: x16 = 0xc2ea307245c8e8cb
+  RVTEST_TESTDATA_LOAD_INT(x18, x29) # load rd compare value: x29 = 0x4b3475cdac2b2906
   LA(x7, scratch) # load base address into rs1
   SREG x30, 0(x7) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cmp_rd_rs1_val_eq_not_equal:
@@ -4550,9 +4740,9 @@ Zacas_amocas_w_cg_cmp_rd_rs1_val_eq_not_equal:
 /////////////////////////////////
 
 # Testcase cmp_rd_rs1_val_lsb (rd_val[7:0] == mem_val[7:0])
-  RVTEST_TESTDATA_LOAD_INT(x18, x25) # load rd compare value: x25 = 0x49f2b0fcec07c80d
   RVTEST_TESTDATA_LOAD_INT(x18, x16) # load value in memory: x16 = 0xf09eb0c1f8e66f0d
   RVTEST_TESTDATA_LOAD_INT(x18, x26) # load rs2: x26 = 0xedb2b05b38b799fd
+  RVTEST_TESTDATA_LOAD_INT(x18, x25) # load rd compare value: x25 = 0x49f2b0fcec07c80d
   LA(x6, scratch) # load base address into rs1
   SREG x16, 0(x6) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cmp_rd_rs1_val_lsb_equal:
@@ -4564,9 +4754,9 @@ Zacas_amocas_w_cg_cmp_rd_rs1_val_lsb_equal:
   RVTEST_SIGUPD(x3, x5, x4, x6, Zacas_amocas_w_cg_cmp_rd_rs1_val_lsb_equal, Zacas_amocas_w_cg_cmp_rd_rs1_val_lsb_equal_str)
 
 # Testcase cmp_rd_rs1_val_lsb (rd_val[7:0] != mem_val[7:0])
-  RVTEST_TESTDATA_LOAD_INT(x18, x22) # load rd compare value: x22 = 0x9de77799f06b590c
   RVTEST_TESTDATA_LOAD_INT(x18, x19) # load value in memory: x19 = 0x9de77799f06b599d
   RVTEST_TESTDATA_LOAD_INT(x18, x27) # load rs2: x27 = 0x417903ad2eea210e
+  RVTEST_TESTDATA_LOAD_INT(x18, x22) # load rd compare value: x22 = 0x9de77799f06b590c
   LA(x16, scratch) # load base address into rs1
   SREG x19, 0(x16) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cmp_rd_rs1_val_lsb_not_equal:
@@ -4582,9 +4772,9 @@ Zacas_amocas_w_cg_cmp_rd_rs1_val_lsb_not_equal:
 /////////////////////////////////
 
 # Testcase cmp_rd_rs1_val_hw (rd_val[15:0] == mem_val[15:0])
-  RVTEST_TESTDATA_LOAD_INT(x18, x26) # load rd compare value: x26 = 0x59e361346f603142
   RVTEST_TESTDATA_LOAD_INT(x18, x14) # load value in memory: x14 = 0x4a6c5a166ad13142
   RVTEST_TESTDATA_LOAD_INT(x18, x25) # load rs2: x25 = 0x4afd1146a063a741
+  RVTEST_TESTDATA_LOAD_INT(x18, x26) # load rd compare value: x26 = 0x59e361346f603142
   LA(x22, scratch) # load base address into rs1
   SREG x14, 0(x22) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cmp_rd_rs1_val_hw_equal:
@@ -4596,9 +4786,9 @@ Zacas_amocas_w_cg_cmp_rd_rs1_val_hw_equal:
   RVTEST_SIGUPD(x3, x5, x4, x22, Zacas_amocas_w_cg_cmp_rd_rs1_val_hw_equal, Zacas_amocas_w_cg_cmp_rd_rs1_val_hw_equal_str)
 
 # Testcase cmp_rd_rs1_val_hw (rd_val[15:0] != mem_val[15:0])
-  RVTEST_TESTDATA_LOAD_INT(x18, x13) # load rd compare value: x13 = 0xbac6d8dc951f3383
   RVTEST_TESTDATA_LOAD_INT(x18, x27) # load value in memory: x27 = 0xbac6d8dc951f5749
   RVTEST_TESTDATA_LOAD_INT(x18, x7) # load rs2: x7 = 0x4e2572e68d95f270
+  RVTEST_TESTDATA_LOAD_INT(x18, x13) # load rd compare value: x13 = 0xbac6d8dc951f3383
   LA(x1, scratch) # load base address into rs1
   SREG x27, 0(x1) # store value into memory at address in rs1
 Zacas_amocas_w_cg_cmp_rd_rs1_val_hw_not_equal:
@@ -4676,384 +4866,574 @@ RVTEST_DATA_BEGIN
 // Test data
 .dword 0x000000004ffc9eb6
 .dword 0x00000000a05a7a33
+.dword 0x000000004ffc9eb6
 .dword 0x00000000ff00fd95
 .dword 0x000000005f58e971
+.dword 0x000000008a1d8aed
 .dword 0x00000000a73918b7
 .dword 0x000000004cdcba92
+.dword 0x00000000a73918b7
 .dword 0x000000006c982925
 .dword 0x000000007bc624fd
+.dword 0x000000007f4abe45
 .dword 0x00000000f6ad3329
 .dword 0x0000000006ff2c16
+.dword 0x00000000f6ad3329
 .dword 0x00000000c6a0f366
 .dword 0x00000000e26424c3
+.dword 0x000000004bd34dad
 .dword 0x000000005de6dea0
 .dword 0x000000001711f4d2
+.dword 0x000000005de6dea0
 .dword 0x00000000726baf91
 .dword 0x00000000a42e7e46
+.dword 0x00000000181a77a4
 .dword 0x000000003543d5ff
 .dword 0x00000000852cf4b5
+.dword 0x000000003543d5ff
 .dword 0x000000003bca9813
 .dword 0x0000000004bef3f4
+.dword 0x0000000078c1ff64
 .dword 0x0000000087d0bb55
 .dword 0x000000006fbe5b74
+.dword 0x0000000087d0bb55
 .dword 0x000000002906c7e7
 .dword 0x000000006bd6ab30
+.dword 0x000000000f938295
 .dword 0x0000000045c86b14
 .dword 0x00000000b997c936
+.dword 0x0000000045c86b14
 .dword 0x000000000d14fab2
 .dword 0x0000000076ad8f69
+.dword 0x0000000014d3e5ff
 .dword 0x00000000aeb1b3a2
 .dword 0x000000005b52bd50
+.dword 0x00000000aeb1b3a2
 .dword 0x00000000587ac726
 .dword 0x00000000d47b5863
+.dword 0x0000000022dbffff
 .dword 0x00000000df3be6ab
 .dword 0x00000000f8237ec0
+.dword 0x00000000df3be6ab
 .dword 0x0000000058a3c29b
 .dword 0x000000000ad3d73b
+.dword 0x000000007dfc586b
 .dword 0x0000000056ee66fa
 .dword 0x00000000f073f8a2
+.dword 0x0000000056ee66fa
 .dword 0x0000000032322776
 .dword 0x0000000053faa5d0
+.dword 0x0000000083414d7c
 .dword 0x0000000084b72a64
 .dword 0x00000000a0f054c1
+.dword 0x0000000084b72a64
 .dword 0x00000000937c76d9
 .dword 0x000000007b56846a
+.dword 0x0000000072eab756
 .dword 0x00000000354cb6ae
 .dword 0x00000000346f685b
+.dword 0x00000000354cb6ae
 .dword 0x00000000018899a6
 .dword 0x00000000a5ef20cc
+.dword 0x00000000257768fe
 .dword 0x00000000bffeda35
 .dword 0x000000000cbd8f1e
+.dword 0x00000000bffeda35
 .dword 0x00000000dac793c6
 .dword 0x00000000cb05efea
+.dword 0x00000000c6a59de9
 .dword 0x00000000627e075a
 .dword 0x00000000917e1f3a
+.dword 0x00000000627e075a
 .dword 0x00000000f6e56fbe
 .dword 0x000000005435bce2
+.dword 0x0000000084b2620d
 .dword 0x00000000866c2c45
 .dword 0x00000000adb5330b
+.dword 0x00000000866c2c45
 .dword 0x00000000abae2a0d
 .dword 0x00000000399061be
+.dword 0x00000000a9f01df4
 .dword 0x00000000582c96c1
 .dword 0x00000000e8524c8c
+.dword 0x00000000582c96c1
 .dword 0x00000000d0d0ce74
 .dword 0x0000000014f28ef4
+.dword 0x00000000e23703ef
 .dword 0x00000000d465601f
 .dword 0x000000000f66fd14
+.dword 0x00000000d465601f
 .dword 0x00000000f035054e
 .dword 0x000000002bd8acb1
+.dword 0x00000000785e2550
 .dword 0x000000007e090d3d
 .dword 0x00000000e44d6bb5
+.dword 0x000000007e090d3d
 .dword 0x000000002fa54925
 .dword 0x00000000b8875162
+.dword 0x00000000daaf0c88
 .dword 0x000000001be89d3e
 .dword 0x0000000001f6b985
+.dword 0x000000001be89d3e
 .dword 0x00000000c9912fe7
 .dword 0x00000000a4d5116c
+.dword 0x000000002823dfef
 .dword 0x000000004755077d
 .dword 0x000000004f4c2a47
+.dword 0x000000004755077d
 .dword 0x00000000dcef1a91
 .dword 0x000000000be4be86
+.dword 0x000000002eca0de0
 .dword 0x00000000af6b6460
 .dword 0x000000002de4f9fa
+.dword 0x00000000af6b6460
 .dword 0x00000000262263c8
 .dword 0x000000002c0ca0c9
+.dword 0x00000000d6455b4a
 .dword 0x00000000cb9d4eb2
 .dword 0x000000001ceda7e0
+.dword 0x00000000cb9d4eb2
 .dword 0x00000000f9da4cae
 .dword 0x00000000c20d2cfd
+.dword 0x000000007d3dbd0c
 .dword 0x00000000dc7ec8d5
 .dword 0x00000000f15f5225
+.dword 0x00000000dc7ec8d5
 .dword 0x000000008dc361fd
 .dword 0x00000000cb6dadf5
+.dword 0x00000000283b582e
 .dword 0x0000000071d35cfc
 .dword 0x00000000b9b36cd4
+.dword 0x0000000071d35cfc
 .dword 0x000000005cbc5931
 .dword 0x0000000001c8efef
+.dword 0x0000000071e929eb
 .dword 0x00000000e01a8476
 .dword 0x0000000005035c34
+.dword 0x00000000e01a8476
 .dword 0x0000000075276317
 .dword 0x0000000092865dec
+.dword 0x000000003db7c437
 .dword 0x00000000a769f328
 .dword 0x00000000fd07adce
+.dword 0x00000000a769f328
 .dword 0x00000000dfa9c4d7
 .dword 0x00000000aa1a05af
+.dword 0x000000000c4dd600
 .dword 0x000000007c33a440
 .dword 0x0000000085782b0a
+.dword 0x000000007c33a440
 .dword 0x000000009075d8c6
 .dword 0x00000000581df4d2
+.dword 0x00000000aac1ba47
 .dword 0x00000000a77d5fe8
 .dword 0x0000000023b1ed93
+.dword 0x00000000a77d5fe8
 .dword 0x000000007fe74641
 .dword 0x00000000fb58b964
+.dword 0x00000000f6350794
 .dword 0x00000000e749a1ce
 .dword 0x00000000a972ef64
+.dword 0x00000000e749a1ce
 .dword 0x00000000d0055a9e
 .dword 0x000000000f3c0a10
+.dword 0x000000003ad18ecb
 .dword 0x00000000b185629f
 .dword 0x000000006d1aa8e3
+.dword 0x00000000b185629f
 .dword 0x00000000d17f48d2
 .dword 0x000000000981e070
+.dword 0x000000004273dd23
 .dword 0x00000000d83b9bfb
 .dword 0x00000000126eab4c
+.dword 0x00000000d83b9bfb
 .dword 0x000000007a1cf6b7
 .dword 0x000000005b9bed96
+.dword 0x00000000d465db21
 .dword 0x00000000bd34b68d
 .dword 0x00000000444cc2d2
+.dword 0x00000000bd34b68d
 .dword 0x00000000dbeade6c
 .dword 0x0000000061f08ccb
+.dword 0x0000000070d95352
 .dword 0x00000000505de7cb
 .dword 0x000000007c8436ec
+.dword 0x00000000505de7cb
 .dword 0x00000000d29ff27b
 .dword 0x000000002da4e199
+.dword 0x000000005b4887b6
 .dword 0x00000000e10fa38f
 .dword 0x00000000a66f401b
+.dword 0x00000000e10fa38f
 .dword 0x000000000e65c3ed
 .dword 0x00000000bae87016
+.dword 0x0000000009b372c8
 .dword 0x00000000f49beb03
 .dword 0x0000000096eaf810
+.dword 0x00000000f49beb03
 .dword 0x00000000745d5331
 .dword 0x0000000052db7da1
+.dword 0x000000004dee1585
 .dword 0x00000000c4352d96
 .dword 0x00000000850fb30e
+.dword 0x00000000c4352d96
 .dword 0x00000000792b14bd
 .dword 0x00000000eccbc3d3
+.dword 0x00000000d093c73a
 .dword 0x00000000306f039b
 .dword 0x00000000541bb67e
+.dword 0x00000000306f039b
 .dword 0x00000000fdf11d25
 .dword 0x000000003c5ade38
+.dword 0x000000002e070f88
 .dword 0x00000000b40e737a
 .dword 0x00000000f3adc13b
+.dword 0x00000000b40e737a
 .dword 0x00000000aa613e5d
 .dword 0x00000000aa4380fe
+.dword 0x00000000bf0ce552
 .dword 0x0000000061f2dbba
 .dword 0x00000000723883c1
+.dword 0x0000000061f2dbba
 .dword 0x00000000141b1f57
 .dword 0x000000006a7df2b0
+.dword 0x00000000981e18e4
 .dword 0x0000000012c40312
 .dword 0x00000000dbce53a8
+.dword 0x0000000012c40312
 .dword 0x00000000e3ce7c1e
 .dword 0x00000000850e3b56
+.dword 0x00000000e326bc08
 .dword 0x00000000d015530f
 .dword 0x00000000269bb8f8
+.dword 0x00000000d015530f
 .dword 0x00000000aacfecec
 .dword 0x0000000001a2d481
+.dword 0x000000002a0366e5
 .dword 0x000000001a1e07ef
 .dword 0x00000000c6c46f8b
+.dword 0x000000001a1e07ef
 .dword 0x0000000057a49263
 .dword 0x00000000678dc17e
+.dword 0x00000000367b6462
 .dword 0x000000001cff4035
 .dword 0x00000000a4f42b7f
+.dword 0x000000001cff4035
 .dword 0x00000000a31275aa
 .dword 0x00000000299e4754
+.dword 0x000000002ab0d0d3
 .dword 0x0000000078ac69eb
 .dword 0x00000000efdd2ca2
+.dword 0x0000000078ac69eb
 .dword 0x00000000074461fa
 .dword 0x00000000cc2863a6
+.dword 0x0000000003839b36
 .dword 0x00000000fb57c386
 .dword 0x0000000040fd72a9
+.dword 0x00000000fb57c386
 .dword 0x000000000a18316c
 .dword 0x000000009da6aa75
+.dword 0x000000007e4cf42a
 .dword 0x0000000076de738b
 .dword 0x00000000551274a3
+.dword 0x0000000076de738b
 .dword 0x00000000ec8ce1a3
 .dword 0x00000000ec8dbfef
+.dword 0x00000000770d352c
 .dword 0x0000000062067f08
 .dword 0x000000006a97c92a
+.dword 0x0000000062067f08
 .dword 0x0000000040403d9f
 .dword 0x0000000099955ff9
+.dword 0x0000000049ef8140
 .dword 0x00000000ca961d07
 .dword 0x000000005bc0bdc6
+.dword 0x00000000ca961d07
 .dword 0x00000000678c1f61
 .dword 0x000000003cbe5fa4
+.dword 0x0000000019c52536
 .dword 0x00000000408878d0
 .dword 0x000000002ef3c18c
+.dword 0x00000000408878d0
 .dword 0x00000000ad51b420
 .dword 0x00000000dae4152a
+.dword 0x00000000ee69d061
 .dword 0x00000000f48ece8a
 .dword 0x00000000609d9cfa
+.dword 0x00000000f48ece8a
 .dword 0x00000000ef794004
 .dword 0x00000000270d88f1
+.dword 0x00000000cebb1f8d
 .dword 0x000000001cbeadfc
 .dword 0x000000006401d72b
+.dword 0x000000001cbeadfc
 .dword 0x00000000cb96557a
 .dword 0x000000009705d985
+.dword 0x00000000c38bc6cc
 .dword 0x000000000b751a67
 .dword 0x0000000069b3b0a1
+.dword 0x000000000b751a67
 .dword 0x00000000d3a3770c
 .dword 0x00000000feb7b05a
+.dword 0x000000008457f556
 .dword 0x000000007d3c8a1d
 .dword 0x00000000a427dbe3
+.dword 0x000000007d3c8a1d
 .dword 0x00000000a9f502e9
 .dword 0x00000000743e7a5e
+.dword 0x00000000479803e3
 .dword 0x000000000e3ed6e1
 .dword 0x0000000041a98612
+.dword 0x000000000e3ed6e1
 .dword 0x00000000350609d8
 .dword 0x00000000af9361de
+.dword 0x0000000047b76478
 .dword 0x00000000312fd0ee
 .dword 0x00000000bdfb0b4c
+.dword 0x00000000312fd0ee
 .dword 0x000000006b3cdcbf
 .dword 0x00000000cb60db2c
+.dword 0x000000002a40bd55
 .dword 0x00000000be4de47e
 .dword 0x0000000021c70762
+.dword 0x00000000be4de47e
 .dword 0x00000000b96d7e32
 .dword 0x000000001debc09f
+.dword 0x00000000a4cefebc
 .dword 0x00000000a1a5f156
 .dword 0x000000001508bb45
+.dword 0x00000000a1a5f156
 .dword 0x00000000b6cffdc6
 .dword 0x00000000919bd39a
+.dword 0x000000005cdf0412
 .dword 0x00000000effd3c3d
 .dword 0x0000000075c393fb
+.dword 0x00000000effd3c3d
 .dword 0x000000001c2e183e
 .dword 0x00000000c80066c2
+.dword 0x00000000d2c4cd8c
 .dword 0x00000000b102eaf1
 .dword 0x00000000bc0e5884
+.dword 0x00000000b102eaf1
 .dword 0x00000000d050b55b
 .dword 0x000000008c64f1aa
+.dword 0x000000006fb1956b
 .dword 0x00000000e8894296
 .dword 0x00000000042f1cf8
+.dword 0x00000000e8894296
 .dword 0x00000000f259fe2b
 .dword 0x000000005be58383
+.dword 0x000000001bfcd829
 .dword 0x000000009ad5244a
 .dword 0x0000000060ea4a62
+.dword 0x000000009ad5244a
 .dword 0x00000000cfac4d7a
 .dword 0x00000000420ed58e
+.dword 0x000000005097d0e2
 .dword 0x000000006fe6aa73
 .dword 0x00000000b171535b
+.dword 0x000000006fe6aa73
 .dword 0x000000009052838b
 .dword 0x00000000920ef9f4
+.dword 0x00000000b6b83c74
 .dword 0x0000000094a8e5ef
 .dword 0x000000001705fb6a
+.dword 0x0000000094a8e5ef
 .dword 0x000000006dcc574f
 .dword 0x000000008631068a
+.dword 0x00000000aa951675
 .dword 0x00000000d6331454
 .dword 0x00000000c28961f3
+.dword 0x00000000d6331454
 .dword 0x000000000ff5b6d6
 .dword 0x00000000853515e3
+.dword 0x00000000d8674601
 .dword 0x00000000d6e34586
 .dword 0x000000008d5e2e05
+.dword 0x00000000d6e34586
 .dword 0x00000000ca79b6e8
 .dword 0x0000000049fdb31d
+.dword 0x000000006c2950fe
 .dword 0x00000000c3ff0de0
 .dword 0x00000000522001a7
+.dword 0x00000000c3ff0de0
 .dword 0x00000000a40024e5
 .dword 0x0000000087b5c092
+.dword 0x00000000e9dae6a3
 .dword 0x00000000c7f326ef
 .dword 0x00000000ab24373f
+.dword 0x00000000c7f326ef
 .dword 0x00000000b5cc81b1
 .dword 0x0000000025b3c30e
+.dword 0x000000006accb197
 .dword 0x000000008f17f15c
 .dword 0x00000000848170bb
+.dword 0x000000008f17f15c
 .dword 0x00000000ff5e8bb0
 .dword 0x0000000053c3f6bc
+.dword 0x00000000c004d0f3
 .dword 0x00000000dacbee00
 .dword 0x0000000019830e86
+.dword 0x00000000dacbee00
 .dword 0x00000000b06f9892
 .dword 0x00000000522d21ae
+.dword 0x000000008042963b
 .dword 0x00000000cfd6e8b2
 .dword 0x000000001b98c6b9
+.dword 0x00000000cfd6e8b2
 .dword 0x000000007f288fc3
 .dword 0x00000000728f3d74
+.dword 0x00000000afb07251
 .dword 0x00000000b3849b55
 .dword 0x00000000d4842674
+.dword 0x00000000b3849b55
 .dword 0x000000005a38ca6c
 .dword 0x00000000cb42e73e
+.dword 0x00000000a2e175be
 .dword 0x000000009301493e
 .dword 0x00000000ed8d7433
+.dword 0x000000009301493e
 .dword 0x000000008efa1d8f
 .dword 0x0000000055ea3982
+.dword 0x00000000625098bd
 .dword 0x000000003b50cc74
 .dword 0x00000000df49096b
+.dword 0x000000003b50cc74
 .dword 0x0000000053999bd6
 .dword 0x0000000011c2ccdb
+.dword 0x000000008a74865c
 .dword 0x0000000015680d94
 .dword 0x000000007dd4aebe
+.dword 0x0000000015680d94
 .dword 0x00000000aa6f1d34
 .dword 0x0000000050285057
+.dword 0x00000000f0ad8501
 .dword 0x00000000238016f7
 .dword 0x00000000583c8fac
+.dword 0x00000000238016f7
 .dword 0x00000000cbe48d8d
 .dword 0x000000007a073099
+.dword 0x000000005300b1b2
 .dword 0x000000000e10721a
 .dword 0x00000000594d3170
+.dword 0x000000000e10721a
 .dword 0x00000000c658b92f
 .dword 0x00000000f18c8384
+.dword 0x000000001c196d2b
 .dword 0x00000000d8acd1a6
 .dword 0x00000000c4594ae3
+.dword 0x00000000d8acd1a6
 .dword 0x0000000058dfa105
 .dword 0x000000002de2ff7f
+.dword 0x00000000a8e327c0
 .dword 0x00000000860357f5
 .dword 0x00000000d9b03afe
+.dword 0x00000000860357f5
 .dword 0x00000000485ee413
 .dword 0x00000000f5cb62d5
+.dword 0x00000000e1afbf7a
 .dword 0x000000004cf0591d
 .dword 0x000000007f28e4d6
+.dword 0x000000004cf0591d
 .dword 0x000000006862e75b
 .dword 0x00000000eae88d41
+.dword 0x000000007ef4ffd8
 .dword 0x00000000790957c6
 .dword 0x0000000072159ef6
+.dword 0x00000000790957c6
 .dword 0x00000000f9cd5e5f
 .dword 0x000000001ad8bf39
+.dword 0x000000001c249807
 .dword 0x00000000c47f5a46
 .dword 0x000000004879e492
+.dword 0x00000000c47f5a46
 .dword 0x00000000d6928f8e
 .dword 0x00000000f227e004
+.dword 0x00000000ec2f58f2
 .dword 0x000000004a39ca34
 .dword 0x0000000063233351
+.dword 0x000000004a39ca34
 .dword 0x00000000f5277d88
 .dword 0x000000008be65d23
+.dword 0x000000008c92e5a3
 .dword 0x0000000090022404
 .dword 0x00000000d2f3ffd4
+.dword 0x0000000090022404
 .dword 0x00000000babe58f1
 .dword 0x00000000217b4c5d
+.dword 0x000000006af19230
 .dword 0x000000009d015e6a
 .dword 0x000000007aff4913
+.dword 0x000000009d015e6a
 .dword 0x0000000027f7132e
 .dword 0x00000000102bc516
+.dword 0x0000000019b4169f
 .dword 0x000000005f930393
 .dword 0x00000000fda2afe6
+.dword 0x000000005f930393
 .dword 0x0000000050d9f349
 .dword 0x0000000034477649
+.dword 0x0000000079b6ce9b
 .dword 0x00000000b9590ae0
 .dword 0x00000000e5bf0236
+.dword 0x00000000b9590ae0
 .dword 0x00000000b6fcc608
 .dword 0x000000006003de25
+.dword 0x000000000560abb4
 .dword 0x00000000db383518
 .dword 0x00000000c0c49817
+.dword 0x00000000db383518
 .dword 0x000000007c319a2b
 .dword 0x0000000017799c6d
+.dword 0x000000005899e179
 .dword 0x00000000cfce1aa3
 .dword 0x000000008afc45b9
+.dword 0x00000000cfce1aa3
 .dword 0x0000000018bf5e52
 .dword 0x0000000099288ffa
+.dword 0x00000000214ca299
 .dword 0x00000000225e1cd2
 .dword 0x00000000aba66973
+.dword 0x00000000225e1cd2
 .dword 0x00000000e4efb0bf
 .dword 0x00000000702d4a82
+.dword 0x00000000f2615aa3
 .dword 0x0000000069266b77
 .dword 0x000000002e1d99eb
+.dword 0x0000000069266b77
 .dword 0x00000000384b7875
 .dword 0x0000000075eac200
+.dword 0x000000007e8b786f
 .dword 0x00000000e1365c2a
 .dword 0x00000000138feef2
+.dword 0x00000000e1365c2a
 .dword 0x00000000a17a6a46
 .dword 0x00000000ad131e05
+.dword 0x00000000e27b88aa
 .dword 0x00000000adeb9c47
 .dword 0x00000000192cf1ba
+.dword 0x00000000adeb9c47
 .dword 0x000000001b588ff7
 .dword 0x00000000bb7cbe78
+.dword 0x00000000d2da4750
 .dword 0x000000002a40cb61
 .dword 0x000000000fc5cd1e
+.dword 0x000000002a40cb61
 .dword 0x000000000e49dc88
 .dword 0x0000000059d39b01
+.dword 0x000000006f0b7de9
 .dword 0x000000009c994a82
 .dword 0x00000000be78931b
+.dword 0x000000009c994a82
 .dword 0x000000007a96ef97
 .dword 0x00000000722ee0b2
+.dword 0x000000005b72cc26
 .dword 0x00000000346e7364
 .dword 0x00000000d701d09d
+.dword 0x00000000346e7364
 .dword 0x000000007d1246cd
 .dword 0x00000000dadfa95e
+.dword 0x00000000f102be78
 .dword 0x31dfb3ad1be93313
 .dword 0x0000000000000000
 .dword 0x93a9f5dc46b777c6
@@ -5341,23 +5721,23 @@ RVTEST_DATA_BEGIN
 .dword 0x751c848e675e6a7f
 .dword 0x7209957928960ece
 .dword 0x29156d208bb185da
-.dword 0x29156d208bb185da
 .dword 0x8646c310e09a8531
-.dword 0x4b3475cdac2b2906
+.dword 0x29156d208bb185da
 .dword 0xbd6d1b12124f7289
 .dword 0xc2ea307245c8e8cb
-.dword 0x49f2b0fcec07c80d
+.dword 0x4b3475cdac2b2906
 .dword 0xf09eb0c1f8e66f0d
 .dword 0xedb2b05b38b799fd
-.dword 0x9de77799f06b590c
+.dword 0x49f2b0fcec07c80d
 .dword 0x9de77799f06b599d
 .dword 0x417903ad2eea210e
-.dword 0x59e361346f603142
+.dword 0x9de77799f06b590c
 .dword 0x4a6c5a166ad13142
 .dword 0x4afd1146a063a741
-.dword 0xbac6d8dc951f3383
+.dword 0x59e361346f603142
 .dword 0xbac6d8dc951f5749
 .dword 0x4e2572e68d95f270
+.dword 0xbac6d8dc951f3383
 .dword 0x0000000000000000
 .dword 0x0000000000000000
 .dword 0x000000007fffffff

--- a/tests/rv64i/ZacasZabha/ZacasZabha-amocas.b-00.S
+++ b/tests/rv64i/ZacasZabha/ZacasZabha-amocas.b-00.S
@@ -36,6 +36,7 @@ RVTEST_BEGIN
 # Testcase cp_rs1_nx0 (Test source rs1 = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x20) # load value in memory: x20 = 0x00000000000000cd
   RVTEST_TESTDATA_LOAD_INT(x3, x21) # load rs2: x21 = 0x0000000000000098
+  RVTEST_TESTDATA_LOAD_INT(x3, x29) # load rd compare value: x29 = 0x00000000000000cd
   LA(x1, scratch) # load base address into rs1
   SREG x20, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b1_equal:
@@ -49,6 +50,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b1_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x21) # load value in memory: x21 = 0x000000000000002d
   RVTEST_TESTDATA_LOAD_INT(x3, x13) # load rs2: x13 = 0x00000000000000dd
+  RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rd compare value: x6 = 0x000000000000009c
   LA(x1, scratch) # load base address into rs1
   SREG x21, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b1_not_equal:
@@ -63,6 +65,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b1_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x28) # load value in memory: x28 = 0x0000000000000002
   RVTEST_TESTDATA_LOAD_INT(x3, x21) # load rs2: x21 = 0x0000000000000061
+  RVTEST_TESTDATA_LOAD_INT(x3, x11) # load rd compare value: x11 = 0x0000000000000002
   LA(x2, scratch) # load base address into rs1
   SREG x28, 0(x2) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b2_equal:
@@ -76,6 +79,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b2_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x19) # load value in memory: x19 = 0x000000000000009b
   RVTEST_TESTDATA_LOAD_INT(x3, x29) # load rs2: x29 = 0x00000000000000c9
+  RVTEST_TESTDATA_LOAD_INT(x3, x21) # load rd compare value: x21 = 0x0000000000000016
   LA(x2, scratch) # load base address into rs1
   SREG x19, 0(x2) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b2_not_equal:
@@ -90,6 +94,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b2_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x14) # load value in memory: x14 = 0x0000000000000043
   RVTEST_TESTDATA_LOAD_INT(x15, x25) # load rs2: x25 = 0x0000000000000078
+  RVTEST_TESTDATA_LOAD_INT(x15, x26) # load rd compare value: x26 = 0x0000000000000043
   LA(x3, scratch) # load base address into rs1
   SREG x14, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b3_equal:
@@ -103,6 +108,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b3_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x23) # load value in memory: x23 = 0x0000000000000093
   RVTEST_TESTDATA_LOAD_INT(x15, x22) # load rs2: x22 = 0x000000000000008c
+  RVTEST_TESTDATA_LOAD_INT(x15, x18) # load rd compare value: x18 = 0x00000000000000fe
   LA(x3, scratch) # load base address into rs1
   SREG x23, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b3_not_equal:
@@ -118,6 +124,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b3_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x21) # load value in memory: x21 = 0x00000000000000f7
   RVTEST_TESTDATA_LOAD_INT(x15, x10) # load rs2: x10 = 0x00000000000000d3
+  RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rd compare value: x29 = 0x00000000000000f7
   LA(x4, scratch) # load base address into rs1
   SREG x21, 0(x4) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b4_equal:
@@ -131,6 +138,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b4_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x11) # load value in memory: x11 = 0x00000000000000c3
   RVTEST_TESTDATA_LOAD_INT(x15, x10) # load rs2: x10 = 0x00000000000000c3
+  RVTEST_TESTDATA_LOAD_INT(x15, x30) # load rd compare value: x30 = 0x00000000000000dc
   LA(x4, scratch) # load base address into rs1
   SREG x11, 0(x4) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b4_not_equal:
@@ -144,6 +152,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b4_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x6) # load value in memory: x6 = 0x0000000000000047
   RVTEST_TESTDATA_LOAD_INT(x15, x22) # load rs2: x22 = 0x0000000000000069
+  RVTEST_TESTDATA_LOAD_INT(x15, x1) # load rd compare value: x1 = 0x0000000000000047
   LA(x5, scratch) # load base address into rs1
   SREG x6, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b5_equal:
@@ -157,6 +166,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b5_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x30) # load value in memory: x30 = 0x00000000000000df
   RVTEST_TESTDATA_LOAD_INT(x15, x27) # load rs2: x27 = 0x000000000000008e
+  RVTEST_TESTDATA_LOAD_INT(x15, x19) # load rd compare value: x19 = 0x0000000000000070
   LA(x5, scratch) # load base address into rs1
   SREG x30, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b5_not_equal:
@@ -170,6 +180,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b5_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x11) # load value in memory: x11 = 0x0000000000000027
   RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rs2: x29 = 0x00000000000000a0
+  RVTEST_TESTDATA_LOAD_INT(x15, x0) # load rd compare value: x0 = 0x0000000000000027
   LA(x6, scratch) # load base address into rs1
   SREG x11, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b6_equal:
@@ -183,6 +194,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b6_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x24) # load value in memory: x24 = 0x00000000000000bc
   RVTEST_TESTDATA_LOAD_INT(x15, x8) # load rs2: x8 = 0x00000000000000f8
+  RVTEST_TESTDATA_LOAD_INT(x15, x2) # load rd compare value: x2 = 0x0000000000000065
   LA(x6, scratch) # load base address into rs1
   SREG x24, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b6_not_equal:
@@ -196,6 +208,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b6_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x31) # load value in memory: x31 = 0x00000000000000bc
   RVTEST_TESTDATA_LOAD_INT(x15, x3) # load rs2: x3 = 0x0000000000000052
+  RVTEST_TESTDATA_LOAD_INT(x15, x5) # load rd compare value: x5 = 0x00000000000000bc
   LA(x7, scratch) # load base address into rs1
   SREG x31, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b7_equal:
@@ -209,6 +222,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b7_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x16) # load value in memory: x16 = 0x00000000000000f0
   RVTEST_TESTDATA_LOAD_INT(x15, x11) # load rs2: x11 = 0x0000000000000054
+  RVTEST_TESTDATA_LOAD_INT(x15, x2) # load rd compare value: x2 = 0x0000000000000003
   LA(x7, scratch) # load base address into rs1
   SREG x16, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b7_not_equal:
@@ -222,6 +236,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b7_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x25) # load value in memory: x25 = 0x00000000000000c5
   RVTEST_TESTDATA_LOAD_INT(x15, x23) # load rs2: x23 = 0x0000000000000097
+  RVTEST_TESTDATA_LOAD_INT(x15, x30) # load rd compare value: x30 = 0x00000000000000c5
   LA(x8, scratch) # load base address into rs1
   SREG x25, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b8_equal:
@@ -235,6 +250,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b8_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x16) # load value in memory: x16 = 0x000000000000007c
   RVTEST_TESTDATA_LOAD_INT(x15, x4) # load rs2: x4 = 0x00000000000000c4
+  RVTEST_TESTDATA_LOAD_INT(x15, x30) # load rd compare value: x30 = 0x0000000000000037
   LA(x8, scratch) # load base address into rs1
   SREG x16, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b8_not_equal:
@@ -248,6 +264,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b8_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x25) # load value in memory: x25 = 0x000000000000000a
   RVTEST_TESTDATA_LOAD_INT(x15, x24) # load rs2: x24 = 0x00000000000000d2
+  RVTEST_TESTDATA_LOAD_INT(x15, x7) # load rd compare value: x7 = 0x000000000000000a
   LA(x9, scratch) # load base address into rs1
   SREG x25, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b9_equal:
@@ -261,6 +278,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b9_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x8) # load value in memory: x8 = 0x00000000000000e7
   RVTEST_TESTDATA_LOAD_INT(x15, x28) # load rs2: x28 = 0x0000000000000059
+  RVTEST_TESTDATA_LOAD_INT(x15, x6) # load rd compare value: x6 = 0x00000000000000a5
   LA(x9, scratch) # load base address into rs1
   SREG x8, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b9_not_equal:
@@ -274,6 +292,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b9_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x27) # load value in memory: x27 = 0x00000000000000c4
   RVTEST_TESTDATA_LOAD_INT(x15, x31) # load rs2: x31 = 0x00000000000000eb
+  RVTEST_TESTDATA_LOAD_INT(x15, x16) # load rd compare value: x16 = 0x00000000000000c4
   LA(x10, scratch) # load base address into rs1
   SREG x27, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b10_equal:
@@ -287,6 +306,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b10_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x16) # load value in memory: x16 = 0x0000000000000064
   RVTEST_TESTDATA_LOAD_INT(x15, x22) # load rs2: x22 = 0x000000000000007e
+  RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rd compare value: x29 = 0x0000000000000045
   LA(x10, scratch) # load base address into rs1
   SREG x16, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b10_not_equal:
@@ -300,6 +320,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b10_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x19) # load value in memory: x19 = 0x000000000000005f
   RVTEST_TESTDATA_LOAD_INT(x15, x1) # load rs2: x1 = 0x000000000000007b
+  RVTEST_TESTDATA_LOAD_INT(x15, x8) # load rd compare value: x8 = 0x000000000000005f
   LA(x11, scratch) # load base address into rs1
   SREG x19, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b11_equal:
@@ -313,6 +334,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b11_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x19) # load value in memory: x19 = 0x0000000000000089
   RVTEST_TESTDATA_LOAD_INT(x15, x2) # load rs2: x2 = 0x000000000000008d
+  RVTEST_TESTDATA_LOAD_INT(x15, x27) # load rd compare value: x27 = 0x00000000000000b6
   LA(x11, scratch) # load base address into rs1
   SREG x19, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b11_not_equal:
@@ -326,6 +348,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b11_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x17) # load value in memory: x17 = 0x0000000000000051
   RVTEST_TESTDATA_LOAD_INT(x15, x10) # load rs2: x10 = 0x000000000000004d
+  RVTEST_TESTDATA_LOAD_INT(x15, x0) # load rd compare value: x0 = 0x0000000000000051
   LA(x12, scratch) # load base address into rs1
   SREG x17, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b12_equal:
@@ -339,6 +362,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b12_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x21) # load value in memory: x21 = 0x00000000000000b7
   RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rs2: x9 = 0x00000000000000a6
+  RVTEST_TESTDATA_LOAD_INT(x15, x3) # load rd compare value: x3 = 0x000000000000009e
   LA(x12, scratch) # load base address into rs1
   SREG x21, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b12_not_equal:
@@ -354,6 +378,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b12_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x18) # load value in memory: x18 = 0x00000000000000ae
   RVTEST_TESTDATA_LOAD_INT(x15, x9) # load rs2: x9 = 0x00000000000000e7
+  RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rd compare value: x29 = 0x00000000000000ae
   LA(x13, scratch) # load base address into rs1
   SREG x18, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b13_equal:
@@ -367,6 +392,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b13_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x23) # load value in memory: x23 = 0x000000000000004a
   RVTEST_TESTDATA_LOAD_INT(x15, x24) # load rs2: x24 = 0x000000000000004e
+  RVTEST_TESTDATA_LOAD_INT(x15, x29) # load rd compare value: x29 = 0x00000000000000b8
   LA(x13, scratch) # load base address into rs1
   SREG x23, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b13_not_equal:
@@ -380,6 +406,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b13_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x18) # load value in memory: x18 = 0x0000000000000070
   RVTEST_TESTDATA_LOAD_INT(x15, x12) # load rs2: x12 = 0x00000000000000f2
+  RVTEST_TESTDATA_LOAD_INT(x15, x3) # load rd compare value: x3 = 0x0000000000000070
   LA(x14, scratch) # load base address into rs1
   SREG x18, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b14_equal:
@@ -393,6 +420,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b14_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x15, x5) # load value in memory: x5 = 0x00000000000000dd
   RVTEST_TESTDATA_LOAD_INT(x15, x1) # load rs2: x1 = 0x00000000000000e7
+  RVTEST_TESTDATA_LOAD_INT(x15, x25) # load rd compare value: x25 = 0x00000000000000c9
   LA(x14, scratch) # load base address into rs1
   SREG x5, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b14_not_equal:
@@ -407,6 +435,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b14_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x21) # load value in memory: x21 = 0x0000000000000095
   RVTEST_TESTDATA_LOAD_INT(x23, x25) # load rs2: x25 = 0x000000000000009b
+  RVTEST_TESTDATA_LOAD_INT(x23, x22) # load rd compare value: x22 = 0x0000000000000095
   LA(x15, scratch) # load base address into rs1
   SREG x21, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b15_equal:
@@ -420,6 +449,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b15_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x11) # load value in memory: x11 = 0x0000000000000064
   RVTEST_TESTDATA_LOAD_INT(x23, x10) # load rs2: x10 = 0x00000000000000da
+  RVTEST_TESTDATA_LOAD_INT(x23, x25) # load rd compare value: x25 = 0x0000000000000086
   LA(x15, scratch) # load base address into rs1
   SREG x11, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b15_not_equal:
@@ -433,6 +463,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b15_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x18) # load value in memory: x18 = 0x000000000000007d
   RVTEST_TESTDATA_LOAD_INT(x23, x12) # load rs2: x12 = 0x0000000000000056
+  RVTEST_TESTDATA_LOAD_INT(x23, x30) # load rd compare value: x30 = 0x000000000000007d
   LA(x16, scratch) # load base address into rs1
   SREG x18, 0(x16) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b16_equal:
@@ -446,6 +477,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b16_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x18) # load value in memory: x18 = 0x00000000000000ab
   RVTEST_TESTDATA_LOAD_INT(x23, x4) # load rs2: x4 = 0x00000000000000dc
+  RVTEST_TESTDATA_LOAD_INT(x23, x3) # load rd compare value: x3 = 0x0000000000000056
   LA(x16, scratch) # load base address into rs1
   SREG x18, 0(x16) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b16_not_equal:
@@ -459,6 +491,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b16_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x30) # load value in memory: x30 = 0x000000000000005f
   RVTEST_TESTDATA_LOAD_INT(x23, x28) # load rs2: x28 = 0x000000000000009d
+  RVTEST_TESTDATA_LOAD_INT(x23, x1) # load rd compare value: x1 = 0x000000000000005f
   LA(x17, scratch) # load base address into rs1
   SREG x30, 0(x17) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b17_equal:
@@ -472,6 +505,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b17_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x15) # load value in memory: x15 = 0x0000000000000074
   RVTEST_TESTDATA_LOAD_INT(x23, x27) # load rs2: x27 = 0x0000000000000000
+  RVTEST_TESTDATA_LOAD_INT(x23, x5) # load rd compare value: x5 = 0x0000000000000041
   LA(x17, scratch) # load base address into rs1
   SREG x15, 0(x17) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b17_not_equal:
@@ -485,6 +519,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b17_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x13) # load value in memory: x13 = 0x0000000000000031
   RVTEST_TESTDATA_LOAD_INT(x23, x21) # load rs2: x21 = 0x0000000000000065
+  RVTEST_TESTDATA_LOAD_INT(x23, x10) # load rd compare value: x10 = 0x0000000000000031
   LA(x18, scratch) # load base address into rs1
   SREG x13, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b18_equal:
@@ -498,6 +533,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b18_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x12) # load value in memory: x12 = 0x000000000000005f
   RVTEST_TESTDATA_LOAD_INT(x23, x13) # load rs2: x13 = 0x0000000000000037
+  RVTEST_TESTDATA_LOAD_INT(x23, x21) # load rd compare value: x21 = 0x0000000000000079
   LA(x18, scratch) # load base address into rs1
   SREG x12, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b18_not_equal:
@@ -511,6 +547,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b18_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x27) # load value in memory: x27 = 0x000000000000007a
   RVTEST_TESTDATA_LOAD_INT(x23, x14) # load rs2: x14 = 0x0000000000000003
+  RVTEST_TESTDATA_LOAD_INT(x23, x13) # load rd compare value: x13 = 0x000000000000007a
   LA(x19, scratch) # load base address into rs1
   SREG x27, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b19_equal:
@@ -524,6 +561,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b19_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x29) # load value in memory: x29 = 0x000000000000002c
   RVTEST_TESTDATA_LOAD_INT(x23, x1) # load rs2: x1 = 0x00000000000000bf
+  RVTEST_TESTDATA_LOAD_INT(x23, x26) # load rd compare value: x26 = 0x00000000000000e5
   LA(x19, scratch) # load base address into rs1
   SREG x29, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b19_not_equal:
@@ -538,6 +576,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b19_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x4) # load value in memory: x4 = 0x000000000000005b
   RVTEST_TESTDATA_LOAD_INT(x23, x15) # load rs2: x15 = 0x00000000000000ec
+  RVTEST_TESTDATA_LOAD_INT(x23, x13) # load rd compare value: x13 = 0x000000000000005b
   LA(x20, scratch) # load base address into rs1
   SREG x4, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b20_equal:
@@ -551,6 +590,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b20_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x26) # load value in memory: x26 = 0x00000000000000eb
   RVTEST_TESTDATA_LOAD_INT(x23, x14) # load rs2: x14 = 0x00000000000000c2
+  RVTEST_TESTDATA_LOAD_INT(x23, x24) # load rd compare value: x24 = 0x0000000000000038
   LA(x20, scratch) # load base address into rs1
   SREG x26, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b20_not_equal:
@@ -564,6 +604,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b20_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x27) # load value in memory: x27 = 0x000000000000001e
   RVTEST_TESTDATA_LOAD_INT(x23, x1) # load rs2: x1 = 0x000000000000006a
+  RVTEST_TESTDATA_LOAD_INT(x23, x24) # load rd compare value: x24 = 0x000000000000001e
   LA(x21, scratch) # load base address into rs1
   SREG x27, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b21_equal:
@@ -577,6 +618,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b21_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x16) # load value in memory: x16 = 0x000000000000007d
   RVTEST_TESTDATA_LOAD_INT(x23, x9) # load rs2: x9 = 0x000000000000004d
+  RVTEST_TESTDATA_LOAD_INT(x23, x1) # load rd compare value: x1 = 0x0000000000000034
   LA(x21, scratch) # load base address into rs1
   SREG x16, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b21_not_equal:
@@ -591,6 +633,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b21_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x31) # load value in memory: x31 = 0x0000000000000052
   RVTEST_TESTDATA_LOAD_INT(x23, x5) # load rs2: x5 = 0x0000000000000058
+  RVTEST_TESTDATA_LOAD_INT(x23, x4) # load rd compare value: x4 = 0x0000000000000052
   LA(x22, scratch) # load base address into rs1
   SREG x31, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b22_equal:
@@ -604,6 +647,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b22_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x23, x21) # load value in memory: x21 = 0x0000000000000061
   RVTEST_TESTDATA_LOAD_INT(x23, x11) # load rs2: x11 = 0x00000000000000a4
+  RVTEST_TESTDATA_LOAD_INT(x23, x31) # load rd compare value: x31 = 0x00000000000000c8
   LA(x22, scratch) # load base address into rs1
   SREG x21, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b22_not_equal:
@@ -618,6 +662,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b22_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x20) # load value in memory: x20 = 0x000000000000000b
   RVTEST_TESTDATA_LOAD_INT(x17, x3) # load rs2: x3 = 0x000000000000007e
+  RVTEST_TESTDATA_LOAD_INT(x17, x11) # load rd compare value: x11 = 0x000000000000000b
   LA(x23, scratch) # load base address into rs1
   SREG x20, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b23_equal:
@@ -631,6 +676,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b23_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load value in memory: x13 = 0x0000000000000077
   RVTEST_TESTDATA_LOAD_INT(x17, x19) # load rs2: x19 = 0x00000000000000be
+  RVTEST_TESTDATA_LOAD_INT(x17, x6) # load rd compare value: x6 = 0x000000000000008f
   LA(x23, scratch) # load base address into rs1
   SREG x13, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b23_not_equal:
@@ -644,6 +690,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b23_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load value in memory: x13 = 0x0000000000000032
   RVTEST_TESTDATA_LOAD_INT(x17, x26) # load rs2: x26 = 0x000000000000008d
+  RVTEST_TESTDATA_LOAD_INT(x17, x29) # load rd compare value: x29 = 0x0000000000000032
   LA(x24, scratch) # load base address into rs1
   SREG x13, 0(x24) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b24_equal:
@@ -657,6 +704,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b24_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x29) # load value in memory: x29 = 0x000000000000008e
   RVTEST_TESTDATA_LOAD_INT(x17, x4) # load rs2: x4 = 0x000000000000006a
+  RVTEST_TESTDATA_LOAD_INT(x17, x25) # load rd compare value: x25 = 0x00000000000000c3
   LA(x24, scratch) # load base address into rs1
   SREG x29, 0(x24) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b24_not_equal:
@@ -670,6 +718,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b24_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load value in memory: x13 = 0x0000000000000073
   RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rs2: x2 = 0x00000000000000c3
+  RVTEST_TESTDATA_LOAD_INT(x17, x18) # load rd compare value: x18 = 0x0000000000000073
   LA(x25, scratch) # load base address into rs1
   SREG x13, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b25_equal:
@@ -683,6 +732,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b25_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load value in memory: x9 = 0x00000000000000fc
   RVTEST_TESTDATA_LOAD_INT(x17, x23) # load rs2: x23 = 0x0000000000000093
+  RVTEST_TESTDATA_LOAD_INT(x17, x5) # load rd compare value: x5 = 0x0000000000000008
   LA(x25, scratch) # load base address into rs1
   SREG x9, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b25_not_equal:
@@ -696,6 +746,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b25_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x21) # load value in memory: x21 = 0x0000000000000064
   RVTEST_TESTDATA_LOAD_INT(x17, x29) # load rs2: x29 = 0x00000000000000d6
+  RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rd compare value: x14 = 0x0000000000000064
   LA(x26, scratch) # load base address into rs1
   SREG x21, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b26_equal:
@@ -709,6 +760,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b26_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x28) # load value in memory: x28 = 0x000000000000002d
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rs2: x14 = 0x00000000000000ee
+  RVTEST_TESTDATA_LOAD_INT(x17, x24) # load rd compare value: x24 = 0x00000000000000ac
   LA(x26, scratch) # load base address into rs1
   SREG x28, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b26_not_equal:
@@ -723,6 +775,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b26_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x25) # load value in memory: x25 = 0x000000000000003b
   RVTEST_TESTDATA_LOAD_INT(x17, x18) # load rs2: x18 = 0x00000000000000d4
+  RVTEST_TESTDATA_LOAD_INT(x17, x16) # load rd compare value: x16 = 0x000000000000003b
   LA(x27, scratch) # load base address into rs1
   SREG x25, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b27_equal:
@@ -736,6 +789,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b27_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x22) # load value in memory: x22 = 0x00000000000000fb
   RVTEST_TESTDATA_LOAD_INT(x17, x30) # load rs2: x30 = 0x000000000000003e
+  RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rd compare value: x2 = 0x000000000000006e
   LA(x27, scratch) # load base address into rs1
   SREG x22, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b27_not_equal:
@@ -749,6 +803,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b27_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load value in memory: x14 = 0x0000000000000032
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load rs2: x15 = 0x00000000000000c0
+  RVTEST_TESTDATA_LOAD_INT(x17, x10) # load rd compare value: x10 = 0x0000000000000032
   LA(x28, scratch) # load base address into rs1
   SREG x14, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b28_equal:
@@ -762,6 +817,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b28_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x12) # load value in memory: x12 = 0x000000000000006c
   RVTEST_TESTDATA_LOAD_INT(x17, x20) # load rs2: x20 = 0x0000000000000053
+  RVTEST_TESTDATA_LOAD_INT(x17, x18) # load rd compare value: x18 = 0x0000000000000081
   LA(x28, scratch) # load base address into rs1
   SREG x12, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b28_not_equal:
@@ -775,6 +831,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b28_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x27) # load value in memory: x27 = 0x000000000000008b
   RVTEST_TESTDATA_LOAD_INT(x17, x28) # load rs2: x28 = 0x0000000000000080
+  RVTEST_TESTDATA_LOAD_INT(x17, x10) # load rd compare value: x10 = 0x000000000000008b
   LA(x29, scratch) # load base address into rs1
   SREG x27, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b29_equal:
@@ -788,6 +845,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b29_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x3) # load value in memory: x3 = 0x00000000000000ec
   RVTEST_TESTDATA_LOAD_INT(x17, x11) # load rs2: x11 = 0x0000000000000047
+  RVTEST_TESTDATA_LOAD_INT(x17, x23) # load rd compare value: x23 = 0x0000000000000031
   LA(x29, scratch) # load base address into rs1
   SREG x3, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b29_not_equal:
@@ -801,6 +859,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b29_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x31) # load value in memory: x31 = 0x0000000000000078
   RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rs2: x0 = 0x00000000000000e3
+  RVTEST_TESTDATA_LOAD_INT(x17, x18) # load rd compare value: x18 = 0x0000000000000078
   LA(x30, scratch) # load base address into rs1
   SREG x31, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b30_equal:
@@ -814,6 +873,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b30_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x19) # load value in memory: x19 = 0x000000000000005c
   RVTEST_TESTDATA_LOAD_INT(x17, x29) # load rs2: x29 = 0x0000000000000090
+  RVTEST_TESTDATA_LOAD_INT(x17, x4) # load rd compare value: x4 = 0x00000000000000a5
   LA(x30, scratch) # load base address into rs1
   SREG x19, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b30_not_equal:
@@ -827,6 +887,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b30_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x4) # load value in memory: x4 = 0x00000000000000df
   RVTEST_TESTDATA_LOAD_INT(x17, x5) # load rs2: x5 = 0x0000000000000039
+  RVTEST_TESTDATA_LOAD_INT(x17, x22) # load rd compare value: x22 = 0x00000000000000df
   LA(x31, scratch) # load base address into rs1
   SREG x4, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b31_equal:
@@ -840,6 +901,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b31_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load value in memory: x1 = 0x0000000000000089
   RVTEST_TESTDATA_LOAD_INT(x17, x26) # load rs2: x26 = 0x00000000000000d0
+  RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rd compare value: x0 = 0x000000000000009f
   LA(x31, scratch) # load base address into rs1
   SREG x1, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs1_nx0_b31_not_equal:
@@ -857,6 +919,7 @@ ZacasZabha_amocas_b_cg_cp_rs1_nx0_b31_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x0, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x16) # load value in memory: x16 = 0x00000000000000b3
   RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rs2: x0 = 0x00000000000000a4
+  RVTEST_TESTDATA_LOAD_INT(x17, x15) # load rd compare value: x15 = 0x00000000000000b3
   LA(x13, scratch) # load base address into rs1
   SREG x16, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b0_equal:
@@ -870,6 +933,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b0_equal:
 # Testcase cp_rs2 (Test source rs2 = x0, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x12) # load value in memory: x12 = 0x0000000000000005
   RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rs2: x0 = 0x00000000000000f6
+  RVTEST_TESTDATA_LOAD_INT(x17, x13) # load rd compare value: x13 = 0x00000000000000c5
   LA(x1, scratch) # load base address into rs1
   SREG x12, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b0_not_equal:
@@ -883,6 +947,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b0_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load value in memory: x15 = 0x0000000000000015
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load rs2: x1 = 0x0000000000000033
+  RVTEST_TESTDATA_LOAD_INT(x17, x4) # load rd compare value: x4 = 0x0000000000000015
   LA(x25, scratch) # load base address into rs1
   SREG x15, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b1_equal:
@@ -896,6 +961,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b1_equal:
 # Testcase cp_rs2 (Test source rs2 = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x10) # load value in memory: x10 = 0x0000000000000023
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load rs2: x1 = 0x000000000000002f
+  RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rd compare value: x0 = 0x000000000000003a
   LA(x26, scratch) # load base address into rs1
   SREG x10, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b1_not_equal:
@@ -909,6 +975,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b1_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x30) # load value in memory: x30 = 0x0000000000000030
   RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rs2: x2 = 0x000000000000009d
+  RVTEST_TESTDATA_LOAD_INT(x17, x28) # load rd compare value: x28 = 0x0000000000000030
   LA(x11, scratch) # load base address into rs1
   SREG x30, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b2_equal:
@@ -922,6 +989,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b2_equal:
 # Testcase cp_rs2 (Test source rs2 = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x10) # load value in memory: x10 = 0x0000000000000097
   RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rs2: x2 = 0x0000000000000072
+  RVTEST_TESTDATA_LOAD_INT(x17, x0) # load rd compare value: x0 = 0x000000000000002c
   LA(x31, scratch) # load base address into rs1
   SREG x10, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b2_not_equal:
@@ -935,6 +1003,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b2_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x22) # load value in memory: x22 = 0x0000000000000052
   RVTEST_TESTDATA_LOAD_INT(x17, x3) # load rs2: x3 = 0x0000000000000060
+  RVTEST_TESTDATA_LOAD_INT(x17, x21) # load rd compare value: x21 = 0x0000000000000052
   LA(x11, scratch) # load base address into rs1
   SREG x22, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b3_equal:
@@ -948,6 +1017,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b3_equal:
 # Testcase cp_rs2 (Test source rs2 = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x5) # load value in memory: x5 = 0x0000000000000067
   RVTEST_TESTDATA_LOAD_INT(x17, x3) # load rs2: x3 = 0x0000000000000077
+  RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rd compare value: x9 = 0x0000000000000089
   LA(x1, scratch) # load base address into rs1
   SREG x5, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b3_not_equal:
@@ -961,6 +1031,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b3_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load value in memory: x9 = 0x00000000000000cf
   RVTEST_TESTDATA_LOAD_INT(x17, x4) # load rs2: x4 = 0x0000000000000003
+  RVTEST_TESTDATA_LOAD_INT(x17, x19) # load rd compare value: x19 = 0x00000000000000cf
   LA(x15, scratch) # load base address into rs1
   SREG x9, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b4_equal:
@@ -974,6 +1045,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b4_equal:
 # Testcase cp_rs2 (Test source rs2 = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x26) # load value in memory: x26 = 0x0000000000000031
   RVTEST_TESTDATA_LOAD_INT(x17, x4) # load rs2: x4 = 0x0000000000000065
+  RVTEST_TESTDATA_LOAD_INT(x17, x30) # load rd compare value: x30 = 0x00000000000000f9
   LA(x20, scratch) # load base address into rs1
   SREG x26, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b4_not_equal:
@@ -987,6 +1059,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b4_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x21) # load value in memory: x21 = 0x00000000000000c8
   RVTEST_TESTDATA_LOAD_INT(x17, x5) # load rs2: x5 = 0x0000000000000098
+  RVTEST_TESTDATA_LOAD_INT(x17, x29) # load rd compare value: x29 = 0x00000000000000c8
   LA(x20, scratch) # load base address into rs1
   SREG x21, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b5_equal:
@@ -1000,6 +1073,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b5_equal:
 # Testcase cp_rs2 (Test source rs2 = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x18) # load value in memory: x18 = 0x00000000000000fc
   RVTEST_TESTDATA_LOAD_INT(x17, x5) # load rs2: x5 = 0x0000000000000075
+  RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rd compare value: x9 = 0x0000000000000027
   LA(x11, scratch) # load base address into rs1
   SREG x18, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b5_not_equal:
@@ -1014,6 +1088,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b5_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x19) # load value in memory: x19 = 0x0000000000000040
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load rs2: x6 = 0x0000000000000089
+  RVTEST_TESTDATA_LOAD_INT(x17, x3) # load rd compare value: x3 = 0x0000000000000040
   LA(x11, scratch) # load base address into rs1
   SREG x19, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b6_equal:
@@ -1027,6 +1102,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b6_equal:
 # Testcase cp_rs2 (Test source rs2 = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x31) # load value in memory: x31 = 0x0000000000000090
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load rs2: x6 = 0x00000000000000ea
+  RVTEST_TESTDATA_LOAD_INT(x17, x22) # load rd compare value: x22 = 0x000000000000002f
   LA(x13, scratch) # load base address into rs1
   SREG x31, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b6_not_equal:
@@ -1042,6 +1118,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b6_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x31) # load value in memory: x31 = 0x00000000000000f8
   RVTEST_TESTDATA_LOAD_INT(x17, x7) # load rs2: x7 = 0x00000000000000fe
+  RVTEST_TESTDATA_LOAD_INT(x17, x29) # load rd compare value: x29 = 0x00000000000000f8
   LA(x14, scratch) # load base address into rs1
   SREG x31, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b7_equal:
@@ -1055,6 +1132,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b7_equal:
 # Testcase cp_rs2 (Test source rs2 = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x22) # load value in memory: x22 = 0x0000000000000009
   RVTEST_TESTDATA_LOAD_INT(x17, x7) # load rs2: x7 = 0x00000000000000ec
+  RVTEST_TESTDATA_LOAD_INT(x17, x1) # load rd compare value: x1 = 0x0000000000000075
   LA(x30, scratch) # load base address into rs1
   SREG x22, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b7_not_equal:
@@ -1068,6 +1146,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b7_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x1) # load value in memory: x1 = 0x00000000000000dd
   RVTEST_TESTDATA_LOAD_INT(x17, x8) # load rs2: x8 = 0x000000000000003e
+  RVTEST_TESTDATA_LOAD_INT(x17, x29) # load rd compare value: x29 = 0x00000000000000dd
   LA(x28, scratch) # load base address into rs1
   SREG x1, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b8_equal:
@@ -1081,6 +1160,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b8_equal:
 # Testcase cp_rs2 (Test source rs2 = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load value in memory: x14 = 0x0000000000000039
   RVTEST_TESTDATA_LOAD_INT(x17, x8) # load rs2: x8 = 0x0000000000000073
+  RVTEST_TESTDATA_LOAD_INT(x17, x7) # load rd compare value: x7 = 0x00000000000000f0
   LA(x22, scratch) # load base address into rs1
   SREG x14, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b8_not_equal:
@@ -1094,6 +1174,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b8_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x3) # load value in memory: x3 = 0x00000000000000e5
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rs2: x9 = 0x0000000000000054
+  RVTEST_TESTDATA_LOAD_INT(x17, x1) # load rd compare value: x1 = 0x00000000000000e5
   LA(x18, scratch) # load base address into rs1
   SREG x3, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b9_equal:
@@ -1107,6 +1188,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b9_equal:
 # Testcase cp_rs2 (Test source rs2 = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x28) # load value in memory: x28 = 0x0000000000000070
   RVTEST_TESTDATA_LOAD_INT(x17, x9) # load rs2: x9 = 0x000000000000003d
+  RVTEST_TESTDATA_LOAD_INT(x17, x20) # load rd compare value: x20 = 0x00000000000000d4
   LA(x29, scratch) # load base address into rs1
   SREG x28, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b9_not_equal:
@@ -1120,6 +1202,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b9_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x29) # load value in memory: x29 = 0x0000000000000052
   RVTEST_TESTDATA_LOAD_INT(x17, x10) # load rs2: x10 = 0x0000000000000035
+  RVTEST_TESTDATA_LOAD_INT(x17, x2) # load rd compare value: x2 = 0x0000000000000052
   LA(x14, scratch) # load base address into rs1
   SREG x29, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b10_equal:
@@ -1133,6 +1216,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b10_equal:
 # Testcase cp_rs2 (Test source rs2 = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load value in memory: x15 = 0x00000000000000fb
   RVTEST_TESTDATA_LOAD_INT(x17, x10) # load rs2: x10 = 0x00000000000000fc
+  RVTEST_TESTDATA_LOAD_INT(x17, x6) # load rd compare value: x6 = 0x000000000000006b
   LA(x21, scratch) # load base address into rs1
   SREG x15, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b10_not_equal:
@@ -1146,6 +1230,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b10_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load value in memory: x14 = 0x00000000000000d9
   RVTEST_TESTDATA_LOAD_INT(x17, x11) # load rs2: x11 = 0x00000000000000eb
+  RVTEST_TESTDATA_LOAD_INT(x17, x7) # load rd compare value: x7 = 0x00000000000000d9
   LA(x29, scratch) # load base address into rs1
   SREG x14, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b11_equal:
@@ -1159,6 +1244,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b11_equal:
 # Testcase cp_rs2 (Test source rs2 = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load value in memory: x6 = 0x00000000000000b3
   RVTEST_TESTDATA_LOAD_INT(x17, x11) # load rs2: x11 = 0x00000000000000e5
+  RVTEST_TESTDATA_LOAD_INT(x17, x20) # load rd compare value: x20 = 0x00000000000000fd
   LA(x30, scratch) # load base address into rs1
   SREG x6, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b11_not_equal:
@@ -1172,6 +1258,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b11_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x16) # load value in memory: x16 = 0x0000000000000068
   RVTEST_TESTDATA_LOAD_INT(x17, x12) # load rs2: x12 = 0x00000000000000c6
+  RVTEST_TESTDATA_LOAD_INT(x17, x21) # load rd compare value: x21 = 0x0000000000000068
   LA(x30, scratch) # load base address into rs1
   SREG x16, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b12_equal:
@@ -1185,6 +1272,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b12_equal:
 # Testcase cp_rs2 (Test source rs2 = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x22) # load value in memory: x22 = 0x000000000000004f
   RVTEST_TESTDATA_LOAD_INT(x17, x12) # load rs2: x12 = 0x0000000000000065
+  RVTEST_TESTDATA_LOAD_INT(x17, x27) # load rd compare value: x27 = 0x0000000000000023
   LA(x14, scratch) # load base address into rs1
   SREG x22, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b12_not_equal:
@@ -1198,6 +1286,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b12_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load value in memory: x14 = 0x00000000000000b2
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load rs2: x13 = 0x00000000000000f8
+  RVTEST_TESTDATA_LOAD_INT(x17, x18) # load rd compare value: x18 = 0x00000000000000b2
   LA(x7, scratch) # load base address into rs1
   SREG x14, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b13_equal:
@@ -1211,6 +1300,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b13_equal:
 # Testcase cp_rs2 (Test source rs2 = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x18) # load value in memory: x18 = 0x0000000000000003
   RVTEST_TESTDATA_LOAD_INT(x17, x13) # load rs2: x13 = 0x00000000000000f4
+  RVTEST_TESTDATA_LOAD_INT(x17, x24) # load rd compare value: x24 = 0x00000000000000b7
   LA(x2, scratch) # load base address into rs1
   SREG x18, 0(x2) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b13_not_equal:
@@ -1224,6 +1314,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b13_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x12) # load value in memory: x12 = 0x0000000000000040
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rs2: x14 = 0x0000000000000052
+  RVTEST_TESTDATA_LOAD_INT(x17, x22) # load rd compare value: x22 = 0x0000000000000040
   LA(x7, scratch) # load base address into rs1
   SREG x12, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b14_equal:
@@ -1237,6 +1328,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b14_equal:
 # Testcase cp_rs2 (Test source rs2 = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x16) # load value in memory: x16 = 0x00000000000000b9
   RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rs2: x14 = 0x0000000000000074
+  RVTEST_TESTDATA_LOAD_INT(x17, x11) # load rd compare value: x11 = 0x0000000000000035
   LA(x3, scratch) # load base address into rs1
   SREG x16, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b14_not_equal:
@@ -1250,6 +1342,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b14_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x8) # load value in memory: x8 = 0x0000000000000067
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load rs2: x15 = 0x00000000000000bd
+  RVTEST_TESTDATA_LOAD_INT(x17, x24) # load rd compare value: x24 = 0x0000000000000067
   LA(x13, scratch) # load base address into rs1
   SREG x8, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b15_equal:
@@ -1263,6 +1356,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b15_equal:
 # Testcase cp_rs2 (Test source rs2 = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x6) # load value in memory: x6 = 0x000000000000009c
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load rs2: x15 = 0x00000000000000b4
+  RVTEST_TESTDATA_LOAD_INT(x17, x12) # load rd compare value: x12 = 0x0000000000000058
   LA(x18, scratch) # load base address into rs1
   SREG x6, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b15_not_equal:
@@ -1276,6 +1370,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b15_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x15) # load value in memory: x15 = 0x0000000000000049
   RVTEST_TESTDATA_LOAD_INT(x17, x16) # load rs2: x16 = 0x0000000000000050
+  RVTEST_TESTDATA_LOAD_INT(x17, x14) # load rd compare value: x14 = 0x0000000000000049
   LA(x25, scratch) # load base address into rs1
   SREG x15, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b16_equal:
@@ -1289,6 +1384,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b16_equal:
 # Testcase cp_rs2 (Test source rs2 = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x17, x21) # load value in memory: x21 = 0x000000000000009a
   RVTEST_TESTDATA_LOAD_INT(x17, x16) # load rs2: x16 = 0x0000000000000025
+  RVTEST_TESTDATA_LOAD_INT(x17, x24) # load rd compare value: x24 = 0x000000000000005a
   LA(x30, scratch) # load base address into rs1
   SREG x21, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b16_not_equal:
@@ -1303,6 +1399,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b16_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x12) # load value in memory: x12 = 0x00000000000000a2
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load rs2: x17 = 0x00000000000000c3
+  RVTEST_TESTDATA_LOAD_INT(x24, x6) # load rd compare value: x6 = 0x00000000000000a2
   LA(x7, scratch) # load base address into rs1
   SREG x12, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b17_equal:
@@ -1316,6 +1413,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b17_equal:
 # Testcase cp_rs2 (Test source rs2 = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x16) # load value in memory: x16 = 0x00000000000000d1
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load rs2: x17 = 0x000000000000004c
+  RVTEST_TESTDATA_LOAD_INT(x24, x26) # load rd compare value: x26 = 0x00000000000000af
   LA(x6, scratch) # load base address into rs1
   SREG x16, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b17_not_equal:
@@ -1329,6 +1427,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b17_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x8) # load value in memory: x8 = 0x000000000000003d
   RVTEST_TESTDATA_LOAD_INT(x24, x18) # load rs2: x18 = 0x0000000000000063
+  RVTEST_TESTDATA_LOAD_INT(x24, x31) # load rd compare value: x31 = 0x000000000000003d
   LA(x6, scratch) # load base address into rs1
   SREG x8, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b18_equal:
@@ -1342,6 +1441,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b18_equal:
 # Testcase cp_rs2 (Test source rs2 = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x8) # load value in memory: x8 = 0x000000000000009c
   RVTEST_TESTDATA_LOAD_INT(x24, x18) # load rs2: x18 = 0x0000000000000090
+  RVTEST_TESTDATA_LOAD_INT(x24, x25) # load rd compare value: x25 = 0x000000000000002b
   LA(x12, scratch) # load base address into rs1
   SREG x8, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b18_not_equal:
@@ -1355,6 +1455,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b18_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x11) # load value in memory: x11 = 0x0000000000000002
   RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rs2: x19 = 0x00000000000000c3
+  RVTEST_TESTDATA_LOAD_INT(x24, x13) # load rd compare value: x13 = 0x0000000000000002
   LA(x25, scratch) # load base address into rs1
   SREG x11, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b19_equal:
@@ -1368,6 +1469,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b19_equal:
 # Testcase cp_rs2 (Test source rs2 = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load value in memory: x20 = 0x00000000000000ee
   RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rs2: x19 = 0x00000000000000f6
+  RVTEST_TESTDATA_LOAD_INT(x24, x25) # load rd compare value: x25 = 0x00000000000000fb
   LA(x31, scratch) # load base address into rs1
   SREG x20, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b19_not_equal:
@@ -1381,6 +1483,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b19_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load value in memory: x3 = 0x0000000000000083
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load rs2: x20 = 0x0000000000000065
+  RVTEST_TESTDATA_LOAD_INT(x24, x30) # load rd compare value: x30 = 0x0000000000000083
   LA(x15, scratch) # load base address into rs1
   SREG x3, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b20_equal:
@@ -1394,6 +1497,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b20_equal:
 # Testcase cp_rs2 (Test source rs2 = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load value in memory: x21 = 0x0000000000000093
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load rs2: x20 = 0x00000000000000c7
+  RVTEST_TESTDATA_LOAD_INT(x24, x16) # load rd compare value: x16 = 0x000000000000001c
   LA(x3, scratch) # load base address into rs1
   SREG x21, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b20_not_equal:
@@ -1407,6 +1511,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b20_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load value in memory: x1 = 0x0000000000000075
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rs2: x21 = 0x000000000000001c
+  RVTEST_TESTDATA_LOAD_INT(x24, x7) # load rd compare value: x7 = 0x0000000000000075
   LA(x25, scratch) # load base address into rs1
   SREG x1, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b21_equal:
@@ -1420,6 +1525,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b21_equal:
 # Testcase cp_rs2 (Test source rs2 = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x8) # load value in memory: x8 = 0x0000000000000013
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rs2: x21 = 0x00000000000000e5
+  RVTEST_TESTDATA_LOAD_INT(x24, x13) # load rd compare value: x13 = 0x0000000000000027
   LA(x25, scratch) # load base address into rs1
   SREG x8, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b21_not_equal:
@@ -1433,6 +1539,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b21_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x15) # load value in memory: x15 = 0x000000000000002f
   RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rs2: x22 = 0x0000000000000059
+  RVTEST_TESTDATA_LOAD_INT(x24, x7) # load rd compare value: x7 = 0x000000000000002f
   LA(x10, scratch) # load base address into rs1
   SREG x15, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b22_equal:
@@ -1446,6 +1553,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b22_equal:
 # Testcase cp_rs2 (Test source rs2 = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x14) # load value in memory: x14 = 0x000000000000004b
   RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rs2: x22 = 0x000000000000003a
+  RVTEST_TESTDATA_LOAD_INT(x24, x11) # load rd compare value: x11 = 0x000000000000006f
   LA(x21, scratch) # load base address into rs1
   SREG x14, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b22_not_equal:
@@ -1460,6 +1568,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b22_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x6) # load value in memory: x6 = 0x00000000000000f8
   RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rs2: x23 = 0x0000000000000061
+  RVTEST_TESTDATA_LOAD_INT(x24, x2) # load rd compare value: x2 = 0x00000000000000f8
   LA(x12, scratch) # load base address into rs1
   SREG x6, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b23_equal:
@@ -1473,6 +1582,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b23_equal:
 # Testcase cp_rs2 (Test source rs2 = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x8) # load value in memory: x8 = 0x00000000000000d9
   RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rs2: x23 = 0x000000000000004a
+  RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rd compare value: x21 = 0x000000000000000e
   LA(x22, scratch) # load base address into rs1
   SREG x8, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b23_not_equal:
@@ -1487,6 +1597,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b23_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x10) # load value in memory: x10 = 0x00000000000000b9
   RVTEST_TESTDATA_LOAD_INT(x12, x24) # load rs2: x24 = 0x0000000000000085
+  RVTEST_TESTDATA_LOAD_INT(x12, x18) # load rd compare value: x18 = 0x00000000000000b9
   LA(x6, scratch) # load base address into rs1
   SREG x10, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b24_equal:
@@ -1500,6 +1611,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b24_equal:
 # Testcase cp_rs2 (Test source rs2 = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x17) # load value in memory: x17 = 0x00000000000000c5
   RVTEST_TESTDATA_LOAD_INT(x12, x24) # load rs2: x24 = 0x0000000000000011
+  RVTEST_TESTDATA_LOAD_INT(x12, x16) # load rd compare value: x16 = 0x0000000000000029
   LA(x27, scratch) # load base address into rs1
   SREG x17, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b24_not_equal:
@@ -1513,6 +1625,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b24_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x31) # load value in memory: x31 = 0x0000000000000086
   RVTEST_TESTDATA_LOAD_INT(x12, x25) # load rs2: x25 = 0x000000000000006e
+  RVTEST_TESTDATA_LOAD_INT(x12, x21) # load rd compare value: x21 = 0x0000000000000086
   LA(x29, scratch) # load base address into rs1
   SREG x31, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b25_equal:
@@ -1526,6 +1639,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b25_equal:
 # Testcase cp_rs2 (Test source rs2 = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load value in memory: x1 = 0x00000000000000ce
   RVTEST_TESTDATA_LOAD_INT(x12, x25) # load rs2: x25 = 0x0000000000000005
+  RVTEST_TESTDATA_LOAD_INT(x12, x13) # load rd compare value: x13 = 0x0000000000000041
   LA(x18, scratch) # load base address into rs1
   SREG x1, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b25_not_equal:
@@ -1540,6 +1654,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b25_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x24) # load value in memory: x24 = 0x00000000000000bd
   RVTEST_TESTDATA_LOAD_INT(x12, x26) # load rs2: x26 = 0x000000000000000a
+  RVTEST_TESTDATA_LOAD_INT(x12, x31) # load rd compare value: x31 = 0x00000000000000bd
   LA(x29, scratch) # load base address into rs1
   SREG x24, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b26_equal:
@@ -1553,6 +1668,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b26_equal:
 # Testcase cp_rs2 (Test source rs2 = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load value in memory: x1 = 0x0000000000000049
   RVTEST_TESTDATA_LOAD_INT(x12, x26) # load rs2: x26 = 0x00000000000000be
+  RVTEST_TESTDATA_LOAD_INT(x12, x15) # load rd compare value: x15 = 0x0000000000000067
   LA(x25, scratch) # load base address into rs1
   SREG x1, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b26_not_equal:
@@ -1566,6 +1682,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b26_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x17) # load value in memory: x17 = 0x000000000000009b
   RVTEST_TESTDATA_LOAD_INT(x12, x27) # load rs2: x27 = 0x000000000000009e
+  RVTEST_TESTDATA_LOAD_INT(x12, x22) # load rd compare value: x22 = 0x000000000000009b
   LA(x13, scratch) # load base address into rs1
   SREG x17, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b27_equal:
@@ -1579,6 +1696,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b27_equal:
 # Testcase cp_rs2 (Test source rs2 = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x3) # load value in memory: x3 = 0x0000000000000044
   RVTEST_TESTDATA_LOAD_INT(x12, x27) # load rs2: x27 = 0x00000000000000e3
+  RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rd compare value: x7 = 0x0000000000000018
   LA(x21, scratch) # load base address into rs1
   SREG x3, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b27_not_equal:
@@ -1592,6 +1710,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b27_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x13) # load value in memory: x13 = 0x0000000000000061
   RVTEST_TESTDATA_LOAD_INT(x12, x28) # load rs2: x28 = 0x00000000000000af
+  RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rd compare value: x6 = 0x0000000000000061
   LA(x8, scratch) # load base address into rs1
   SREG x13, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b28_equal:
@@ -1605,6 +1724,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b28_equal:
 # Testcase cp_rs2 (Test source rs2 = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x18) # load value in memory: x18 = 0x0000000000000092
   RVTEST_TESTDATA_LOAD_INT(x12, x28) # load rs2: x28 = 0x00000000000000ae
+  RVTEST_TESTDATA_LOAD_INT(x12, x27) # load rd compare value: x27 = 0x00000000000000b7
   LA(x6, scratch) # load base address into rs1
   SREG x18, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b28_not_equal:
@@ -1618,6 +1738,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b28_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x24) # load value in memory: x24 = 0x00000000000000f1
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rs2: x29 = 0x00000000000000d0
+  RVTEST_TESTDATA_LOAD_INT(x12, x15) # load rd compare value: x15 = 0x00000000000000f1
   LA(x31, scratch) # load base address into rs1
   SREG x24, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b29_equal:
@@ -1631,6 +1752,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b29_equal:
 # Testcase cp_rs2 (Test source rs2 = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x23) # load value in memory: x23 = 0x00000000000000a5
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rs2: x29 = 0x0000000000000021
+  RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rd compare value: x9 = 0x0000000000000087
   LA(x8, scratch) # load base address into rs1
   SREG x23, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b29_not_equal:
@@ -1645,6 +1767,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b29_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x13) # load value in memory: x13 = 0x0000000000000018
   RVTEST_TESTDATA_LOAD_INT(x12, x30) # load rs2: x30 = 0x00000000000000e1
+  RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rd compare value: x9 = 0x0000000000000018
   LA(x27, scratch) # load base address into rs1
   SREG x13, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b30_equal:
@@ -1658,6 +1781,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b30_equal:
 # Testcase cp_rs2 (Test source rs2 = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x21) # load value in memory: x21 = 0x00000000000000a8
   RVTEST_TESTDATA_LOAD_INT(x12, x30) # load rs2: x30 = 0x0000000000000023
+  RVTEST_TESTDATA_LOAD_INT(x12, x15) # load rd compare value: x15 = 0x00000000000000d4
   LA(x11, scratch) # load base address into rs1
   SREG x21, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b30_not_equal:
@@ -1671,6 +1795,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b30_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x3) # load value in memory: x3 = 0x00000000000000b9
   RVTEST_TESTDATA_LOAD_INT(x12, x31) # load rs2: x31 = 0x00000000000000fa
+  RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rd compare value: x10 = 0x00000000000000b9
   LA(x27, scratch) # load base address into rs1
   SREG x3, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b31_equal:
@@ -1684,6 +1809,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b31_equal:
 # Testcase cp_rs2 (Test source rs2 = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x15) # load value in memory: x15 = 0x0000000000000020
   RVTEST_TESTDATA_LOAD_INT(x12, x31) # load rs2: x31 = 0x00000000000000a5
+  RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rd compare value: x7 = 0x00000000000000b2
   LA(x26, scratch) # load base address into rs1
   SREG x15, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rs2_b31_not_equal:
@@ -1701,6 +1827,7 @@ ZacasZabha_amocas_b_cg_cp_rs2_b31_not_equal:
 # Testcase cp_rd (Test destination rd = x0, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x10) # load value in memory: x10 = 0x0000000000000001
   RVTEST_TESTDATA_LOAD_INT(x12, x27) # load rs2: x27 = 0x00000000000000a3
+  RVTEST_TESTDATA_LOAD_INT(x12, x0) # load rd compare value: x0 = 0x0000000000000001
   LA(x28, scratch) # load base address into rs1
   SREG x10, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b0_equal:
@@ -1714,6 +1841,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b0_equal:
 # Testcase cp_rd (Test destination rd = x0, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x31) # load value in memory: x31 = 0x000000000000005c
   RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rs2: x9 = 0x00000000000000cb
+  RVTEST_TESTDATA_LOAD_INT(x12, x0) # load rd compare value: x0 = 0x0000000000000044
   LA(x19, scratch) # load base address into rs1
   SREG x31, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b0_not_equal:
@@ -1727,6 +1855,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b0_not_equal:
 # Testcase cp_rd (Test destination rd = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x19) # load value in memory: x19 = 0x0000000000000021
   RVTEST_TESTDATA_LOAD_INT(x12, x17) # load rs2: x17 = 0x00000000000000c5
+  RVTEST_TESTDATA_LOAD_INT(x12, x1) # load rd compare value: x1 = 0x0000000000000021
   LA(x8, scratch) # load base address into rs1
   SREG x19, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b1_equal:
@@ -1740,6 +1869,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b1_equal:
 # Testcase cp_rd (Test destination rd = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x3) # load value in memory: x3 = 0x000000000000004a
   RVTEST_TESTDATA_LOAD_INT(x12, x28) # load rs2: x28 = 0x0000000000000013
+  RVTEST_TESTDATA_LOAD_INT(x12, x1) # load rd compare value: x1 = 0x000000000000007f
   LA(x29, scratch) # load base address into rs1
   SREG x3, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b1_not_equal:
@@ -1753,6 +1883,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b1_not_equal:
 # Testcase cp_rd (Test destination rd = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x3) # load value in memory: x3 = 0x0000000000000065
   RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rs2: x7 = 0x00000000000000ee
+  RVTEST_TESTDATA_LOAD_INT(x12, x2) # load rd compare value: x2 = 0x0000000000000065
   LA(x15, scratch) # load base address into rs1
   SREG x3, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b2_equal:
@@ -1766,6 +1897,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b2_equal:
 # Testcase cp_rd (Test destination rd = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load value in memory: x1 = 0x00000000000000e8
   RVTEST_TESTDATA_LOAD_INT(x12, x16) # load rs2: x16 = 0x0000000000000095
+  RVTEST_TESTDATA_LOAD_INT(x12, x2) # load rd compare value: x2 = 0x0000000000000058
   LA(x31, scratch) # load base address into rs1
   SREG x1, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b2_not_equal:
@@ -1779,6 +1911,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b2_not_equal:
 # Testcase cp_rd (Test destination rd = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x21) # load value in memory: x21 = 0x00000000000000b1
   RVTEST_TESTDATA_LOAD_INT(x12, x31) # load rs2: x31 = 0x00000000000000ee
+  RVTEST_TESTDATA_LOAD_INT(x12, x3) # load rd compare value: x3 = 0x00000000000000b1
   LA(x30, scratch) # load base address into rs1
   SREG x21, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b3_equal:
@@ -1792,6 +1925,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b3_equal:
 # Testcase cp_rd (Test destination rd = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x18) # load value in memory: x18 = 0x00000000000000e0
   RVTEST_TESTDATA_LOAD_INT(x12, x8) # load rs2: x8 = 0x0000000000000053
+  RVTEST_TESTDATA_LOAD_INT(x12, x3) # load rd compare value: x3 = 0x0000000000000080
   LA(x9, scratch) # load base address into rs1
   SREG x18, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b3_not_equal:
@@ -1807,6 +1941,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b3_not_equal:
 # Testcase cp_rd (Test destination rd = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load value in memory: x1 = 0x000000000000000b
   RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rs2: x10 = 0x0000000000000089
+  RVTEST_TESTDATA_LOAD_INT(x12, x4) # load rd compare value: x4 = 0x000000000000000b
   LA(x3, scratch) # load base address into rs1
   SREG x1, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b4_equal:
@@ -1820,6 +1955,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b4_equal:
 # Testcase cp_rd (Test destination rd = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x19) # load value in memory: x19 = 0x00000000000000d0
   RVTEST_TESTDATA_LOAD_INT(x12, x13) # load rs2: x13 = 0x0000000000000056
+  RVTEST_TESTDATA_LOAD_INT(x12, x4) # load rd compare value: x4 = 0x00000000000000ae
   LA(x24, scratch) # load base address into rs1
   SREG x19, 0(x24) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b4_not_equal:
@@ -1833,6 +1969,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b4_not_equal:
 # Testcase cp_rd (Test destination rd = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x4) # load value in memory: x4 = 0x0000000000000030
   RVTEST_TESTDATA_LOAD_INT(x12, x0) # load rs2: x0 = 0x00000000000000d8
+  RVTEST_TESTDATA_LOAD_INT(x12, x5) # load rd compare value: x5 = 0x0000000000000030
   LA(x31, scratch) # load base address into rs1
   SREG x4, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b5_equal:
@@ -1846,6 +1983,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b5_equal:
 # Testcase cp_rd (Test destination rd = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x21) # load value in memory: x21 = 0x000000000000004b
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rs2: x29 = 0x0000000000000035
+  RVTEST_TESTDATA_LOAD_INT(x12, x5) # load rd compare value: x5 = 0x0000000000000015
   LA(x13, scratch) # load base address into rs1
   SREG x21, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b5_not_equal:
@@ -1860,6 +1998,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b5_not_equal:
 # Testcase cp_rd (Test destination rd = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x22) # load value in memory: x22 = 0x000000000000005f
   RVTEST_TESTDATA_LOAD_INT(x12, x21) # load rs2: x21 = 0x000000000000006e
+  RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rd compare value: x6 = 0x000000000000005f
   LA(x27, scratch) # load base address into rs1
   SREG x22, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b6_equal:
@@ -1873,6 +2012,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b6_equal:
 # Testcase cp_rd (Test destination rd = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x28) # load value in memory: x28 = 0x0000000000000056
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rs2: x29 = 0x0000000000000050
+  RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rd compare value: x6 = 0x00000000000000ab
   LA(x19, scratch) # load base address into rs1
   SREG x28, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b6_not_equal:
@@ -1888,6 +2028,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b6_not_equal:
 # Testcase cp_rd (Test destination rd = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load value in memory: x29 = 0x00000000000000cf
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load rs2: x1 = 0x000000000000006a
+  RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rd compare value: x7 = 0x00000000000000cf
   LA(x4, scratch) # load base address into rs1
   SREG x29, 0(x4) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b7_equal:
@@ -1901,6 +2042,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b7_equal:
 # Testcase cp_rd (Test destination rd = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x24) # load value in memory: x24 = 0x000000000000006f
   RVTEST_TESTDATA_LOAD_INT(x12, x19) # load rs2: x19 = 0x000000000000004a
+  RVTEST_TESTDATA_LOAD_INT(x12, x7) # load rd compare value: x7 = 0x000000000000006c
   LA(x15, scratch) # load base address into rs1
   SREG x24, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b7_not_equal:
@@ -1914,6 +2056,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b7_not_equal:
 # Testcase cp_rd (Test destination rd = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x30) # load value in memory: x30 = 0x00000000000000bc
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rs2: x29 = 0x0000000000000008
+  RVTEST_TESTDATA_LOAD_INT(x12, x8) # load rd compare value: x8 = 0x00000000000000bc
   LA(x2, scratch) # load base address into rs1
   SREG x30, 0(x2) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b8_equal:
@@ -1927,6 +2070,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b8_equal:
 # Testcase cp_rd (Test destination rd = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x31) # load value in memory: x31 = 0x00000000000000b7
   RVTEST_TESTDATA_LOAD_INT(x12, x15) # load rs2: x15 = 0x0000000000000078
+  RVTEST_TESTDATA_LOAD_INT(x12, x8) # load rd compare value: x8 = 0x0000000000000058
   LA(x7, scratch) # load base address into rs1
   SREG x31, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b8_not_equal:
@@ -1940,6 +2084,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b8_not_equal:
 # Testcase cp_rd (Test destination rd = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x7) # load value in memory: x7 = 0x0000000000000031
   RVTEST_TESTDATA_LOAD_INT(x12, x6) # load rs2: x6 = 0x0000000000000055
+  RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rd compare value: x9 = 0x0000000000000031
   LA(x1, scratch) # load base address into rs1
   SREG x7, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b9_equal:
@@ -1953,6 +2098,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b9_equal:
 # Testcase cp_rd (Test destination rd = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load value in memory: x29 = 0x0000000000000035
   RVTEST_TESTDATA_LOAD_INT(x12, x15) # load rs2: x15 = 0x0000000000000012
+  RVTEST_TESTDATA_LOAD_INT(x12, x9) # load rd compare value: x9 = 0x00000000000000a7
   LA(x5, scratch) # load base address into rs1
   SREG x29, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b9_not_equal:
@@ -1966,6 +2112,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b9_not_equal:
 # Testcase cp_rd (Test destination rd = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x20) # load value in memory: x20 = 0x0000000000000048
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load rs2: x1 = 0x00000000000000ce
+  RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rd compare value: x10 = 0x0000000000000048
   LA(x21, scratch) # load base address into rs1
   SREG x20, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b10_equal:
@@ -1979,6 +2126,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b10_equal:
 # Testcase cp_rd (Test destination rd = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x20) # load value in memory: x20 = 0x00000000000000c2
   RVTEST_TESTDATA_LOAD_INT(x12, x18) # load rs2: x18 = 0x00000000000000a4
+  RVTEST_TESTDATA_LOAD_INT(x12, x10) # load rd compare value: x10 = 0x00000000000000c4
   LA(x25, scratch) # load base address into rs1
   SREG x20, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b10_not_equal:
@@ -1992,6 +2140,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b10_not_equal:
 # Testcase cp_rd (Test destination rd = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x10) # load value in memory: x10 = 0x0000000000000062
   RVTEST_TESTDATA_LOAD_INT(x12, x27) # load rs2: x27 = 0x000000000000000e
+  RVTEST_TESTDATA_LOAD_INT(x12, x11) # load rd compare value: x11 = 0x0000000000000062
   LA(x30, scratch) # load base address into rs1
   SREG x10, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b11_equal:
@@ -2005,6 +2154,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b11_equal:
 # Testcase cp_rd (Test destination rd = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x17) # load value in memory: x17 = 0x0000000000000020
   RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rs2: x29 = 0x000000000000009f
+  RVTEST_TESTDATA_LOAD_INT(x12, x11) # load rd compare value: x11 = 0x00000000000000f4
   LA(x1, scratch) # load base address into rs1
   SREG x17, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b11_not_equal:
@@ -2019,6 +2169,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b11_not_equal:
 # Testcase cp_rd (Test destination rd = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x29) # load value in memory: x29 = 0x0000000000000008
   RVTEST_TESTDATA_LOAD_INT(x27, x3) # load rs2: x3 = 0x0000000000000021
+  RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rd compare value: x12 = 0x0000000000000008
   LA(x22, scratch) # load base address into rs1
   SREG x29, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b12_equal:
@@ -2032,6 +2183,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b12_equal:
 # Testcase cp_rd (Test destination rd = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load value in memory: x1 = 0x0000000000000020
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rs2: x10 = 0x0000000000000000
+  RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rd compare value: x12 = 0x00000000000000e4
   LA(x28, scratch) # load base address into rs1
   SREG x1, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b12_not_equal:
@@ -2047,6 +2199,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b12_not_equal:
 # Testcase cp_rd (Test destination rd = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x18) # load value in memory: x18 = 0x000000000000009d
   RVTEST_TESTDATA_LOAD_INT(x27, x2) # load rs2: x2 = 0x0000000000000046
+  RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rd compare value: x13 = 0x000000000000009d
   LA(x29, scratch) # load base address into rs1
   SREG x18, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b13_equal:
@@ -2060,6 +2213,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b13_equal:
 # Testcase cp_rd (Test destination rd = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x6) # load value in memory: x6 = 0x0000000000000097
   RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rs2: x21 = 0x00000000000000f0
+  RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rd compare value: x13 = 0x00000000000000ad
   LA(x3, scratch) # load base address into rs1
   SREG x6, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b13_not_equal:
@@ -2073,6 +2227,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b13_not_equal:
 # Testcase cp_rd (Test destination rd = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x15) # load value in memory: x15 = 0x0000000000000041
   RVTEST_TESTDATA_LOAD_INT(x27, x23) # load rs2: x23 = 0x0000000000000010
+  RVTEST_TESTDATA_LOAD_INT(x27, x14) # load rd compare value: x14 = 0x0000000000000041
   LA(x29, scratch) # load base address into rs1
   SREG x15, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b14_equal:
@@ -2086,6 +2241,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b14_equal:
 # Testcase cp_rd (Test destination rd = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x11) # load value in memory: x11 = 0x00000000000000ce
   RVTEST_TESTDATA_LOAD_INT(x27, x5) # load rs2: x5 = 0x000000000000002f
+  RVTEST_TESTDATA_LOAD_INT(x27, x14) # load rd compare value: x14 = 0x0000000000000012
   LA(x15, scratch) # load base address into rs1
   SREG x11, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b14_not_equal:
@@ -2099,6 +2255,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b14_not_equal:
 # Testcase cp_rd (Test destination rd = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load value in memory: x10 = 0x0000000000000099
   RVTEST_TESTDATA_LOAD_INT(x27, x5) # load rs2: x5 = 0x0000000000000018
+  RVTEST_TESTDATA_LOAD_INT(x27, x15) # load rd compare value: x15 = 0x0000000000000099
   LA(x14, scratch) # load base address into rs1
   SREG x10, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b15_equal:
@@ -2112,6 +2269,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b15_equal:
 # Testcase cp_rd (Test destination rd = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x23) # load value in memory: x23 = 0x00000000000000b3
   RVTEST_TESTDATA_LOAD_INT(x27, x22) # load rs2: x22 = 0x0000000000000013
+  RVTEST_TESTDATA_LOAD_INT(x27, x15) # load rd compare value: x15 = 0x0000000000000043
   LA(x30, scratch) # load base address into rs1
   SREG x23, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b15_not_equal:
@@ -2125,6 +2283,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b15_not_equal:
 # Testcase cp_rd (Test destination rd = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x24) # load value in memory: x24 = 0x000000000000001b
   RVTEST_TESTDATA_LOAD_INT(x27, x11) # load rs2: x11 = 0x00000000000000a5
+  RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rd compare value: x16 = 0x000000000000001b
   LA(x5, scratch) # load base address into rs1
   SREG x24, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b16_equal:
@@ -2138,6 +2297,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b16_equal:
 # Testcase cp_rd (Test destination rd = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x15) # load value in memory: x15 = 0x0000000000000035
   RVTEST_TESTDATA_LOAD_INT(x27, x4) # load rs2: x4 = 0x0000000000000067
+  RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rd compare value: x16 = 0x0000000000000023
   LA(x23, scratch) # load base address into rs1
   SREG x15, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b16_not_equal:
@@ -2151,6 +2311,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b16_not_equal:
 # Testcase cp_rd (Test destination rd = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load value in memory: x1 = 0x00000000000000fa
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rs2: x16 = 0x00000000000000d5
+  RVTEST_TESTDATA_LOAD_INT(x27, x17) # load rd compare value: x17 = 0x00000000000000fa
   LA(x6, scratch) # load base address into rs1
   SREG x1, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b17_equal:
@@ -2164,6 +2325,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b17_equal:
 # Testcase cp_rd (Test destination rd = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load value in memory: x13 = 0x00000000000000a8
   RVTEST_TESTDATA_LOAD_INT(x27, x5) # load rs2: x5 = 0x00000000000000ad
+  RVTEST_TESTDATA_LOAD_INT(x27, x17) # load rd compare value: x17 = 0x0000000000000068
   LA(x21, scratch) # load base address into rs1
   SREG x13, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b17_not_equal:
@@ -2177,6 +2339,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b17_not_equal:
 # Testcase cp_rd (Test destination rd = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x14) # load value in memory: x14 = 0x00000000000000d5
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rs2: x16 = 0x0000000000000051
+  RVTEST_TESTDATA_LOAD_INT(x27, x18) # load rd compare value: x18 = 0x00000000000000d5
   LA(x13, scratch) # load base address into rs1
   SREG x14, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b18_equal:
@@ -2190,6 +2353,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b18_equal:
 # Testcase cp_rd (Test destination rd = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x5) # load value in memory: x5 = 0x00000000000000b5
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rs2: x16 = 0x00000000000000fe
+  RVTEST_TESTDATA_LOAD_INT(x27, x18) # load rd compare value: x18 = 0x00000000000000bd
   LA(x3, scratch) # load base address into rs1
   SREG x5, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b18_not_equal:
@@ -2203,6 +2367,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b18_not_equal:
 # Testcase cp_rd (Test destination rd = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x14) # load value in memory: x14 = 0x0000000000000000
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rs2: x1 = 0x000000000000002a
+  RVTEST_TESTDATA_LOAD_INT(x27, x19) # load rd compare value: x19 = 0x0000000000000000
   LA(x12, scratch) # load base address into rs1
   SREG x14, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b19_equal:
@@ -2216,6 +2381,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b19_equal:
 # Testcase cp_rd (Test destination rd = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x4) # load value in memory: x4 = 0x0000000000000000
   RVTEST_TESTDATA_LOAD_INT(x27, x2) # load rs2: x2 = 0x00000000000000ca
+  RVTEST_TESTDATA_LOAD_INT(x27, x19) # load rd compare value: x19 = 0x0000000000000048
   LA(x13, scratch) # load base address into rs1
   SREG x4, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b19_not_equal:
@@ -2229,6 +2395,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b19_not_equal:
 # Testcase cp_rd (Test destination rd = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x28) # load value in memory: x28 = 0x0000000000000000
   RVTEST_TESTDATA_LOAD_INT(x27, x11) # load rs2: x11 = 0x000000000000005f
+  RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rd compare value: x20 = 0x0000000000000000
   LA(x30, scratch) # load base address into rs1
   SREG x28, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b20_equal:
@@ -2242,6 +2409,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b20_equal:
 # Testcase cp_rd (Test destination rd = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x23) # load value in memory: x23 = 0x000000000000009f
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rs2: x10 = 0x0000000000000041
+  RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rd compare value: x20 = 0x00000000000000f2
   LA(x9, scratch) # load base address into rs1
   SREG x23, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b20_not_equal:
@@ -2255,6 +2423,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b20_not_equal:
 # Testcase cp_rd (Test destination rd = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x23) # load value in memory: x23 = 0x0000000000000099
   RVTEST_TESTDATA_LOAD_INT(x27, x9) # load rs2: x9 = 0x000000000000003f
+  RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rd compare value: x21 = 0x0000000000000099
   LA(x13, scratch) # load base address into rs1
   SREG x23, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b21_equal:
@@ -2268,6 +2437,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b21_equal:
 # Testcase cp_rd (Test destination rd = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x20) # load value in memory: x20 = 0x00000000000000f5
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rs2: x13 = 0x0000000000000047
+  RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rd compare value: x21 = 0x0000000000000063
   LA(x11, scratch) # load base address into rs1
   SREG x20, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b21_not_equal:
@@ -2281,6 +2451,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b21_not_equal:
 # Testcase cp_rd (Test destination rd = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x6) # load value in memory: x6 = 0x000000000000005c
   RVTEST_TESTDATA_LOAD_INT(x27, x15) # load rs2: x15 = 0x0000000000000056
+  RVTEST_TESTDATA_LOAD_INT(x27, x22) # load rd compare value: x22 = 0x000000000000005c
   LA(x10, scratch) # load base address into rs1
   SREG x6, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b22_equal:
@@ -2294,6 +2465,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b22_equal:
 # Testcase cp_rd (Test destination rd = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x5) # load value in memory: x5 = 0x0000000000000037
   RVTEST_TESTDATA_LOAD_INT(x27, x17) # load rs2: x17 = 0x00000000000000a0
+  RVTEST_TESTDATA_LOAD_INT(x27, x22) # load rd compare value: x22 = 0x000000000000003e
   LA(x29, scratch) # load base address into rs1
   SREG x5, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b22_not_equal:
@@ -2307,6 +2479,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b22_not_equal:
 # Testcase cp_rd (Test destination rd = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load value in memory: x16 = 0x00000000000000f8
   RVTEST_TESTDATA_LOAD_INT(x27, x25) # load rs2: x25 = 0x0000000000000070
+  RVTEST_TESTDATA_LOAD_INT(x27, x23) # load rd compare value: x23 = 0x00000000000000f8
   LA(x4, scratch) # load base address into rs1
   SREG x16, 0(x4) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b23_equal:
@@ -2320,6 +2493,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b23_equal:
 # Testcase cp_rd (Test destination rd = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load value in memory: x12 = 0x0000000000000004
   RVTEST_TESTDATA_LOAD_INT(x27, x2) # load rs2: x2 = 0x0000000000000059
+  RVTEST_TESTDATA_LOAD_INT(x27, x23) # load rd compare value: x23 = 0x0000000000000083
   LA(x31, scratch) # load base address into rs1
   SREG x12, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b23_not_equal:
@@ -2333,6 +2507,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b23_not_equal:
 # Testcase cp_rd (Test destination rd = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x11) # load value in memory: x11 = 0x00000000000000a6
   RVTEST_TESTDATA_LOAD_INT(x27, x4) # load rs2: x4 = 0x00000000000000dc
+  RVTEST_TESTDATA_LOAD_INT(x27, x24) # load rd compare value: x24 = 0x00000000000000a6
   LA(x6, scratch) # load base address into rs1
   SREG x11, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b24_equal:
@@ -2346,6 +2521,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b24_equal:
 # Testcase cp_rd (Test destination rd = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x30) # load value in memory: x30 = 0x00000000000000b5
   RVTEST_TESTDATA_LOAD_INT(x27, x3) # load rs2: x3 = 0x0000000000000069
+  RVTEST_TESTDATA_LOAD_INT(x27, x24) # load rd compare value: x24 = 0x00000000000000d7
   LA(x14, scratch) # load base address into rs1
   SREG x30, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b24_not_equal:
@@ -2359,6 +2535,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b24_not_equal:
 # Testcase cp_rd (Test destination rd = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load value in memory: x1 = 0x0000000000000059
   RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rs2: x21 = 0x00000000000000d9
+  RVTEST_TESTDATA_LOAD_INT(x27, x25) # load rd compare value: x25 = 0x0000000000000059
   LA(x5, scratch) # load base address into rs1
   SREG x1, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b25_equal:
@@ -2372,6 +2549,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b25_equal:
 # Testcase cp_rd (Test destination rd = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load value in memory: x10 = 0x000000000000007e
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rs2: x12 = 0x00000000000000f9
+  RVTEST_TESTDATA_LOAD_INT(x27, x25) # load rd compare value: x25 = 0x00000000000000b4
   LA(x9, scratch) # load base address into rs1
   SREG x10, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b25_not_equal:
@@ -2386,6 +2564,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b25_not_equal:
 # Testcase cp_rd (Test destination rd = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load value in memory: x1 = 0x0000000000000001
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rs2: x12 = 0x00000000000000d0
+  RVTEST_TESTDATA_LOAD_INT(x27, x26) # load rd compare value: x26 = 0x0000000000000001
   LA(x19, scratch) # load base address into rs1
   SREG x1, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b26_equal:
@@ -2399,6 +2578,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b26_equal:
 # Testcase cp_rd (Test destination rd = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x14) # load value in memory: x14 = 0x0000000000000027
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rs2: x16 = 0x00000000000000ad
+  RVTEST_TESTDATA_LOAD_INT(x27, x26) # load rd compare value: x26 = 0x0000000000000016
   LA(x25, scratch) # load base address into rs1
   SREG x14, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b26_not_equal:
@@ -2413,6 +2593,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b26_not_equal:
 # Testcase cp_rd (Test destination rd = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x10) # load value in memory: x10 = 0x00000000000000f9
   RVTEST_TESTDATA_LOAD_INT(x26, x9) # load rs2: x9 = 0x000000000000005c
+  RVTEST_TESTDATA_LOAD_INT(x26, x27) # load rd compare value: x27 = 0x00000000000000f9
   LA(x17, scratch) # load base address into rs1
   SREG x10, 0(x17) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b27_equal:
@@ -2426,6 +2607,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b27_equal:
 # Testcase cp_rd (Test destination rd = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x23) # load value in memory: x23 = 0x0000000000000055
   RVTEST_TESTDATA_LOAD_INT(x26, x14) # load rs2: x14 = 0x00000000000000eb
+  RVTEST_TESTDATA_LOAD_INT(x26, x27) # load rd compare value: x27 = 0x0000000000000092
   LA(x3, scratch) # load base address into rs1
   SREG x23, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b27_not_equal:
@@ -2439,6 +2621,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b27_not_equal:
 # Testcase cp_rd (Test destination rd = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x11) # load value in memory: x11 = 0x00000000000000a9
   RVTEST_TESTDATA_LOAD_INT(x26, x23) # load rs2: x23 = 0x00000000000000ae
+  RVTEST_TESTDATA_LOAD_INT(x26, x28) # load rd compare value: x28 = 0x00000000000000a9
   LA(x5, scratch) # load base address into rs1
   SREG x11, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b28_equal:
@@ -2452,6 +2635,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b28_equal:
 # Testcase cp_rd (Test destination rd = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x21) # load value in memory: x21 = 0x000000000000007e
   RVTEST_TESTDATA_LOAD_INT(x26, x19) # load rs2: x19 = 0x0000000000000091
+  RVTEST_TESTDATA_LOAD_INT(x26, x28) # load rd compare value: x28 = 0x0000000000000097
   LA(x4, scratch) # load base address into rs1
   SREG x21, 0(x4) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b28_not_equal:
@@ -2465,6 +2649,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b28_not_equal:
 # Testcase cp_rd (Test destination rd = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x5) # load value in memory: x5 = 0x0000000000000024
   RVTEST_TESTDATA_LOAD_INT(x26, x21) # load rs2: x21 = 0x00000000000000cb
+  RVTEST_TESTDATA_LOAD_INT(x26, x29) # load rd compare value: x29 = 0x0000000000000024
   LA(x31, scratch) # load base address into rs1
   SREG x5, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b29_equal:
@@ -2478,6 +2663,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b29_equal:
 # Testcase cp_rd (Test destination rd = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x15) # load value in memory: x15 = 0x0000000000000057
   RVTEST_TESTDATA_LOAD_INT(x26, x27) # load rs2: x27 = 0x00000000000000d7
+  RVTEST_TESTDATA_LOAD_INT(x26, x29) # load rd compare value: x29 = 0x0000000000000021
   LA(x17, scratch) # load base address into rs1
   SREG x15, 0(x17) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b29_not_equal:
@@ -2491,6 +2677,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b29_not_equal:
 # Testcase cp_rd (Test destination rd = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x3) # load value in memory: x3 = 0x00000000000000ee
   RVTEST_TESTDATA_LOAD_INT(x26, x21) # load rs2: x21 = 0x00000000000000b6
+  RVTEST_TESTDATA_LOAD_INT(x26, x30) # load rd compare value: x30 = 0x00000000000000ee
   LA(x12, scratch) # load base address into rs1
   SREG x3, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b30_equal:
@@ -2504,6 +2691,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b30_equal:
 # Testcase cp_rd (Test destination rd = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x14) # load value in memory: x14 = 0x0000000000000065
   RVTEST_TESTDATA_LOAD_INT(x26, x13) # load rs2: x13 = 0x00000000000000b6
+  RVTEST_TESTDATA_LOAD_INT(x26, x30) # load rd compare value: x30 = 0x00000000000000ab
   LA(x5, scratch) # load base address into rs1
   SREG x14, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b30_not_equal:
@@ -2517,6 +2705,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b30_not_equal:
 # Testcase cp_rd (Test destination rd = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x27) # load value in memory: x27 = 0x00000000000000ca
   RVTEST_TESTDATA_LOAD_INT(x26, x28) # load rs2: x28 = 0x0000000000000047
+  RVTEST_TESTDATA_LOAD_INT(x26, x31) # load rd compare value: x31 = 0x00000000000000ca
   LA(x21, scratch) # load base address into rs1
   SREG x27, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b31_equal:
@@ -2530,6 +2719,7 @@ ZacasZabha_amocas_b_cg_cp_rd_b31_equal:
 # Testcase cp_rd (Test destination rd = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x26, x15) # load value in memory: x15 = 0x000000000000001e
   RVTEST_TESTDATA_LOAD_INT(x26, x30) # load rs2: x30 = 0x00000000000000c9
+  RVTEST_TESTDATA_LOAD_INT(x26, x31) # load rd compare value: x31 = 0x00000000000000d2
   LA(x6, scratch) # load base address into rs1
   SREG x15, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_b_cg_cp_rd_b31_not_equal:
@@ -4613,384 +4803,574 @@ RVTEST_DATA_BEGIN
 // Test data
 .dword 0x00000000000000cd
 .dword 0x0000000000000098
+.dword 0x00000000000000cd
 .dword 0x000000000000002d
 .dword 0x00000000000000dd
+.dword 0x000000000000009c
 .dword 0x0000000000000002
 .dword 0x0000000000000061
+.dword 0x0000000000000002
 .dword 0x000000000000009b
 .dword 0x00000000000000c9
+.dword 0x0000000000000016
 .dword 0x0000000000000043
 .dword 0x0000000000000078
+.dword 0x0000000000000043
 .dword 0x0000000000000093
 .dword 0x000000000000008c
+.dword 0x00000000000000fe
 .dword 0x00000000000000f7
 .dword 0x00000000000000d3
+.dword 0x00000000000000f7
 .dword 0x00000000000000c3
 .dword 0x00000000000000c3
+.dword 0x00000000000000dc
 .dword 0x0000000000000047
 .dword 0x0000000000000069
+.dword 0x0000000000000047
 .dword 0x00000000000000df
 .dword 0x000000000000008e
+.dword 0x0000000000000070
 .dword 0x0000000000000027
 .dword 0x00000000000000a0
+.dword 0x0000000000000027
 .dword 0x00000000000000bc
 .dword 0x00000000000000f8
+.dword 0x0000000000000065
 .dword 0x00000000000000bc
 .dword 0x0000000000000052
+.dword 0x00000000000000bc
 .dword 0x00000000000000f0
 .dword 0x0000000000000054
+.dword 0x0000000000000003
 .dword 0x00000000000000c5
 .dword 0x0000000000000097
+.dword 0x00000000000000c5
 .dword 0x000000000000007c
 .dword 0x00000000000000c4
+.dword 0x0000000000000037
 .dword 0x000000000000000a
 .dword 0x00000000000000d2
+.dword 0x000000000000000a
 .dword 0x00000000000000e7
 .dword 0x0000000000000059
+.dword 0x00000000000000a5
 .dword 0x00000000000000c4
 .dword 0x00000000000000eb
+.dword 0x00000000000000c4
 .dword 0x0000000000000064
 .dword 0x000000000000007e
+.dword 0x0000000000000045
 .dword 0x000000000000005f
 .dword 0x000000000000007b
+.dword 0x000000000000005f
 .dword 0x0000000000000089
 .dword 0x000000000000008d
+.dword 0x00000000000000b6
 .dword 0x0000000000000051
 .dword 0x000000000000004d
+.dword 0x0000000000000051
 .dword 0x00000000000000b7
 .dword 0x00000000000000a6
+.dword 0x000000000000009e
 .dword 0x00000000000000ae
 .dword 0x00000000000000e7
+.dword 0x00000000000000ae
 .dword 0x000000000000004a
 .dword 0x000000000000004e
+.dword 0x00000000000000b8
 .dword 0x0000000000000070
 .dword 0x00000000000000f2
+.dword 0x0000000000000070
 .dword 0x00000000000000dd
 .dword 0x00000000000000e7
+.dword 0x00000000000000c9
 .dword 0x0000000000000095
 .dword 0x000000000000009b
+.dword 0x0000000000000095
 .dword 0x0000000000000064
 .dword 0x00000000000000da
+.dword 0x0000000000000086
 .dword 0x000000000000007d
 .dword 0x0000000000000056
+.dword 0x000000000000007d
 .dword 0x00000000000000ab
 .dword 0x00000000000000dc
+.dword 0x0000000000000056
 .dword 0x000000000000005f
 .dword 0x000000000000009d
+.dword 0x000000000000005f
 .dword 0x0000000000000074
 .dword 0x0000000000000000
+.dword 0x0000000000000041
 .dword 0x0000000000000031
 .dword 0x0000000000000065
+.dword 0x0000000000000031
 .dword 0x000000000000005f
 .dword 0x0000000000000037
+.dword 0x0000000000000079
 .dword 0x000000000000007a
 .dword 0x0000000000000003
+.dword 0x000000000000007a
 .dword 0x000000000000002c
 .dword 0x00000000000000bf
+.dword 0x00000000000000e5
 .dword 0x000000000000005b
 .dword 0x00000000000000ec
+.dword 0x000000000000005b
 .dword 0x00000000000000eb
 .dword 0x00000000000000c2
+.dword 0x0000000000000038
 .dword 0x000000000000001e
 .dword 0x000000000000006a
+.dword 0x000000000000001e
 .dword 0x000000000000007d
 .dword 0x000000000000004d
+.dword 0x0000000000000034
 .dword 0x0000000000000052
 .dword 0x0000000000000058
+.dword 0x0000000000000052
 .dword 0x0000000000000061
 .dword 0x00000000000000a4
+.dword 0x00000000000000c8
 .dword 0x000000000000000b
 .dword 0x000000000000007e
+.dword 0x000000000000000b
 .dword 0x0000000000000077
 .dword 0x00000000000000be
+.dword 0x000000000000008f
 .dword 0x0000000000000032
 .dword 0x000000000000008d
+.dword 0x0000000000000032
 .dword 0x000000000000008e
 .dword 0x000000000000006a
+.dword 0x00000000000000c3
 .dword 0x0000000000000073
 .dword 0x00000000000000c3
+.dword 0x0000000000000073
 .dword 0x00000000000000fc
 .dword 0x0000000000000093
+.dword 0x0000000000000008
 .dword 0x0000000000000064
 .dword 0x00000000000000d6
+.dword 0x0000000000000064
 .dword 0x000000000000002d
 .dword 0x00000000000000ee
+.dword 0x00000000000000ac
 .dword 0x000000000000003b
 .dword 0x00000000000000d4
+.dword 0x000000000000003b
 .dword 0x00000000000000fb
 .dword 0x000000000000003e
+.dword 0x000000000000006e
 .dword 0x0000000000000032
 .dword 0x00000000000000c0
+.dword 0x0000000000000032
 .dword 0x000000000000006c
 .dword 0x0000000000000053
+.dword 0x0000000000000081
 .dword 0x000000000000008b
 .dword 0x0000000000000080
+.dword 0x000000000000008b
 .dword 0x00000000000000ec
 .dword 0x0000000000000047
+.dword 0x0000000000000031
 .dword 0x0000000000000078
 .dword 0x00000000000000e3
+.dword 0x0000000000000078
 .dword 0x000000000000005c
 .dword 0x0000000000000090
+.dword 0x00000000000000a5
 .dword 0x00000000000000df
 .dword 0x0000000000000039
+.dword 0x00000000000000df
 .dword 0x0000000000000089
 .dword 0x00000000000000d0
+.dword 0x000000000000009f
 .dword 0x00000000000000b3
 .dword 0x00000000000000a4
+.dword 0x00000000000000b3
 .dword 0x0000000000000005
 .dword 0x00000000000000f6
+.dword 0x00000000000000c5
 .dword 0x0000000000000015
 .dword 0x0000000000000033
+.dword 0x0000000000000015
 .dword 0x0000000000000023
 .dword 0x000000000000002f
+.dword 0x000000000000003a
 .dword 0x0000000000000030
 .dword 0x000000000000009d
+.dword 0x0000000000000030
 .dword 0x0000000000000097
 .dword 0x0000000000000072
+.dword 0x000000000000002c
 .dword 0x0000000000000052
 .dword 0x0000000000000060
+.dword 0x0000000000000052
 .dword 0x0000000000000067
 .dword 0x0000000000000077
+.dword 0x0000000000000089
 .dword 0x00000000000000cf
 .dword 0x0000000000000003
+.dword 0x00000000000000cf
 .dword 0x0000000000000031
 .dword 0x0000000000000065
+.dword 0x00000000000000f9
 .dword 0x00000000000000c8
 .dword 0x0000000000000098
+.dword 0x00000000000000c8
 .dword 0x00000000000000fc
 .dword 0x0000000000000075
+.dword 0x0000000000000027
 .dword 0x0000000000000040
 .dword 0x0000000000000089
+.dword 0x0000000000000040
 .dword 0x0000000000000090
 .dword 0x00000000000000ea
+.dword 0x000000000000002f
 .dword 0x00000000000000f8
 .dword 0x00000000000000fe
+.dword 0x00000000000000f8
 .dword 0x0000000000000009
 .dword 0x00000000000000ec
+.dword 0x0000000000000075
 .dword 0x00000000000000dd
 .dword 0x000000000000003e
+.dword 0x00000000000000dd
 .dword 0x0000000000000039
 .dword 0x0000000000000073
+.dword 0x00000000000000f0
 .dword 0x00000000000000e5
 .dword 0x0000000000000054
+.dword 0x00000000000000e5
 .dword 0x0000000000000070
 .dword 0x000000000000003d
+.dword 0x00000000000000d4
 .dword 0x0000000000000052
 .dword 0x0000000000000035
+.dword 0x0000000000000052
 .dword 0x00000000000000fb
 .dword 0x00000000000000fc
+.dword 0x000000000000006b
 .dword 0x00000000000000d9
 .dword 0x00000000000000eb
+.dword 0x00000000000000d9
 .dword 0x00000000000000b3
 .dword 0x00000000000000e5
+.dword 0x00000000000000fd
 .dword 0x0000000000000068
 .dword 0x00000000000000c6
+.dword 0x0000000000000068
 .dword 0x000000000000004f
 .dword 0x0000000000000065
+.dword 0x0000000000000023
 .dword 0x00000000000000b2
 .dword 0x00000000000000f8
+.dword 0x00000000000000b2
 .dword 0x0000000000000003
 .dword 0x00000000000000f4
+.dword 0x00000000000000b7
 .dword 0x0000000000000040
 .dword 0x0000000000000052
+.dword 0x0000000000000040
 .dword 0x00000000000000b9
 .dword 0x0000000000000074
+.dword 0x0000000000000035
 .dword 0x0000000000000067
 .dword 0x00000000000000bd
+.dword 0x0000000000000067
 .dword 0x000000000000009c
 .dword 0x00000000000000b4
+.dword 0x0000000000000058
 .dword 0x0000000000000049
 .dword 0x0000000000000050
+.dword 0x0000000000000049
 .dword 0x000000000000009a
 .dword 0x0000000000000025
+.dword 0x000000000000005a
 .dword 0x00000000000000a2
 .dword 0x00000000000000c3
+.dword 0x00000000000000a2
 .dword 0x00000000000000d1
 .dword 0x000000000000004c
+.dword 0x00000000000000af
 .dword 0x000000000000003d
 .dword 0x0000000000000063
+.dword 0x000000000000003d
 .dword 0x000000000000009c
 .dword 0x0000000000000090
+.dword 0x000000000000002b
 .dword 0x0000000000000002
 .dword 0x00000000000000c3
+.dword 0x0000000000000002
 .dword 0x00000000000000ee
 .dword 0x00000000000000f6
+.dword 0x00000000000000fb
 .dword 0x0000000000000083
 .dword 0x0000000000000065
+.dword 0x0000000000000083
 .dword 0x0000000000000093
 .dword 0x00000000000000c7
+.dword 0x000000000000001c
 .dword 0x0000000000000075
 .dword 0x000000000000001c
+.dword 0x0000000000000075
 .dword 0x0000000000000013
 .dword 0x00000000000000e5
+.dword 0x0000000000000027
 .dword 0x000000000000002f
 .dword 0x0000000000000059
+.dword 0x000000000000002f
 .dword 0x000000000000004b
 .dword 0x000000000000003a
+.dword 0x000000000000006f
 .dword 0x00000000000000f8
 .dword 0x0000000000000061
+.dword 0x00000000000000f8
 .dword 0x00000000000000d9
 .dword 0x000000000000004a
+.dword 0x000000000000000e
 .dword 0x00000000000000b9
 .dword 0x0000000000000085
+.dword 0x00000000000000b9
 .dword 0x00000000000000c5
 .dword 0x0000000000000011
+.dword 0x0000000000000029
 .dword 0x0000000000000086
 .dword 0x000000000000006e
+.dword 0x0000000000000086
 .dword 0x00000000000000ce
 .dword 0x0000000000000005
+.dword 0x0000000000000041
 .dword 0x00000000000000bd
 .dword 0x000000000000000a
+.dword 0x00000000000000bd
 .dword 0x0000000000000049
 .dword 0x00000000000000be
+.dword 0x0000000000000067
 .dword 0x000000000000009b
 .dword 0x000000000000009e
+.dword 0x000000000000009b
 .dword 0x0000000000000044
 .dword 0x00000000000000e3
+.dword 0x0000000000000018
 .dword 0x0000000000000061
 .dword 0x00000000000000af
+.dword 0x0000000000000061
 .dword 0x0000000000000092
 .dword 0x00000000000000ae
+.dword 0x00000000000000b7
 .dword 0x00000000000000f1
 .dword 0x00000000000000d0
+.dword 0x00000000000000f1
 .dword 0x00000000000000a5
 .dword 0x0000000000000021
+.dword 0x0000000000000087
 .dword 0x0000000000000018
 .dword 0x00000000000000e1
+.dword 0x0000000000000018
 .dword 0x00000000000000a8
 .dword 0x0000000000000023
+.dword 0x00000000000000d4
 .dword 0x00000000000000b9
 .dword 0x00000000000000fa
+.dword 0x00000000000000b9
 .dword 0x0000000000000020
 .dword 0x00000000000000a5
+.dword 0x00000000000000b2
 .dword 0x0000000000000001
 .dword 0x00000000000000a3
+.dword 0x0000000000000001
 .dword 0x000000000000005c
 .dword 0x00000000000000cb
+.dword 0x0000000000000044
 .dword 0x0000000000000021
 .dword 0x00000000000000c5
+.dword 0x0000000000000021
 .dword 0x000000000000004a
 .dword 0x0000000000000013
+.dword 0x000000000000007f
 .dword 0x0000000000000065
 .dword 0x00000000000000ee
+.dword 0x0000000000000065
 .dword 0x00000000000000e8
 .dword 0x0000000000000095
+.dword 0x0000000000000058
 .dword 0x00000000000000b1
 .dword 0x00000000000000ee
+.dword 0x00000000000000b1
 .dword 0x00000000000000e0
 .dword 0x0000000000000053
+.dword 0x0000000000000080
 .dword 0x000000000000000b
 .dword 0x0000000000000089
+.dword 0x000000000000000b
 .dword 0x00000000000000d0
 .dword 0x0000000000000056
+.dword 0x00000000000000ae
 .dword 0x0000000000000030
 .dword 0x00000000000000d8
+.dword 0x0000000000000030
 .dword 0x000000000000004b
 .dword 0x0000000000000035
+.dword 0x0000000000000015
 .dword 0x000000000000005f
 .dword 0x000000000000006e
+.dword 0x000000000000005f
 .dword 0x0000000000000056
 .dword 0x0000000000000050
+.dword 0x00000000000000ab
 .dword 0x00000000000000cf
 .dword 0x000000000000006a
+.dword 0x00000000000000cf
 .dword 0x000000000000006f
 .dword 0x000000000000004a
+.dword 0x000000000000006c
 .dword 0x00000000000000bc
 .dword 0x0000000000000008
+.dword 0x00000000000000bc
 .dword 0x00000000000000b7
 .dword 0x0000000000000078
+.dword 0x0000000000000058
 .dword 0x0000000000000031
 .dword 0x0000000000000055
+.dword 0x0000000000000031
 .dword 0x0000000000000035
 .dword 0x0000000000000012
+.dword 0x00000000000000a7
 .dword 0x0000000000000048
 .dword 0x00000000000000ce
+.dword 0x0000000000000048
 .dword 0x00000000000000c2
 .dword 0x00000000000000a4
+.dword 0x00000000000000c4
 .dword 0x0000000000000062
 .dword 0x000000000000000e
+.dword 0x0000000000000062
 .dword 0x0000000000000020
 .dword 0x000000000000009f
+.dword 0x00000000000000f4
 .dword 0x0000000000000008
 .dword 0x0000000000000021
+.dword 0x0000000000000008
 .dword 0x0000000000000020
 .dword 0x0000000000000000
+.dword 0x00000000000000e4
 .dword 0x000000000000009d
 .dword 0x0000000000000046
+.dword 0x000000000000009d
 .dword 0x0000000000000097
 .dword 0x00000000000000f0
+.dword 0x00000000000000ad
 .dword 0x0000000000000041
 .dword 0x0000000000000010
+.dword 0x0000000000000041
 .dword 0x00000000000000ce
 .dword 0x000000000000002f
+.dword 0x0000000000000012
 .dword 0x0000000000000099
 .dword 0x0000000000000018
+.dword 0x0000000000000099
 .dword 0x00000000000000b3
 .dword 0x0000000000000013
+.dword 0x0000000000000043
 .dword 0x000000000000001b
 .dword 0x00000000000000a5
+.dword 0x000000000000001b
 .dword 0x0000000000000035
 .dword 0x0000000000000067
+.dword 0x0000000000000023
 .dword 0x00000000000000fa
 .dword 0x00000000000000d5
+.dword 0x00000000000000fa
 .dword 0x00000000000000a8
 .dword 0x00000000000000ad
+.dword 0x0000000000000068
 .dword 0x00000000000000d5
 .dword 0x0000000000000051
+.dword 0x00000000000000d5
 .dword 0x00000000000000b5
 .dword 0x00000000000000fe
+.dword 0x00000000000000bd
 .dword 0x0000000000000000
 .dword 0x000000000000002a
 .dword 0x0000000000000000
+.dword 0x0000000000000000
 .dword 0x00000000000000ca
+.dword 0x0000000000000048
 .dword 0x0000000000000000
 .dword 0x000000000000005f
+.dword 0x0000000000000000
 .dword 0x000000000000009f
 .dword 0x0000000000000041
+.dword 0x00000000000000f2
 .dword 0x0000000000000099
 .dword 0x000000000000003f
+.dword 0x0000000000000099
 .dword 0x00000000000000f5
 .dword 0x0000000000000047
+.dword 0x0000000000000063
 .dword 0x000000000000005c
 .dword 0x0000000000000056
+.dword 0x000000000000005c
 .dword 0x0000000000000037
 .dword 0x00000000000000a0
+.dword 0x000000000000003e
 .dword 0x00000000000000f8
 .dword 0x0000000000000070
+.dword 0x00000000000000f8
 .dword 0x0000000000000004
 .dword 0x0000000000000059
+.dword 0x0000000000000083
 .dword 0x00000000000000a6
 .dword 0x00000000000000dc
+.dword 0x00000000000000a6
 .dword 0x00000000000000b5
 .dword 0x0000000000000069
+.dword 0x00000000000000d7
 .dword 0x0000000000000059
 .dword 0x00000000000000d9
+.dword 0x0000000000000059
 .dword 0x000000000000007e
 .dword 0x00000000000000f9
+.dword 0x00000000000000b4
 .dword 0x0000000000000001
 .dword 0x00000000000000d0
+.dword 0x0000000000000001
 .dword 0x0000000000000027
 .dword 0x00000000000000ad
+.dword 0x0000000000000016
 .dword 0x00000000000000f9
 .dword 0x000000000000005c
+.dword 0x00000000000000f9
 .dword 0x0000000000000055
 .dword 0x00000000000000eb
+.dword 0x0000000000000092
 .dword 0x00000000000000a9
 .dword 0x00000000000000ae
+.dword 0x00000000000000a9
 .dword 0x000000000000007e
 .dword 0x0000000000000091
+.dword 0x0000000000000097
 .dword 0x0000000000000024
 .dword 0x00000000000000cb
+.dword 0x0000000000000024
 .dword 0x0000000000000057
 .dword 0x00000000000000d7
+.dword 0x0000000000000021
 .dword 0x00000000000000ee
 .dword 0x00000000000000b6
+.dword 0x00000000000000ee
 .dword 0x0000000000000065
 .dword 0x00000000000000b6
+.dword 0x00000000000000ab
 .dword 0x00000000000000ca
 .dword 0x0000000000000047
+.dword 0x00000000000000ca
 .dword 0x000000000000001e
 .dword 0x00000000000000c9
+.dword 0x00000000000000d2
 .dword 0xf03ad6f1de507620
 .dword 0x0000000000000000
 .dword 0x531a29487c091525

--- a/tests/rv64i/ZacasZabha/ZacasZabha-amocas.h-00.S
+++ b/tests/rv64i/ZacasZabha/ZacasZabha-amocas.h-00.S
@@ -36,6 +36,7 @@ RVTEST_BEGIN
 # Testcase cp_rs1_nx0 (Test source rs1 = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x27) # load value in memory: x27 = 0x0000000000009f45
   RVTEST_TESTDATA_LOAD_INT(x3, x15) # load rs2: x15 = 0x000000000000c666
+  RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rd compare value: x8 = 0x0000000000009f45
   LA(x1, scratch) # load base address into rs1
   SREG x27, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b1_equal:
@@ -49,6 +50,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b1_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x14) # load value in memory: x14 = 0x0000000000005688
   RVTEST_TESTDATA_LOAD_INT(x3, x25) # load rs2: x25 = 0x000000000000beef
+  RVTEST_TESTDATA_LOAD_INT(x3, x29) # load rd compare value: x29 = 0x00000000000044ef
   LA(x1, scratch) # load base address into rs1
   SREG x14, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b1_not_equal:
@@ -63,6 +65,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b1_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x18) # load value in memory: x18 = 0x000000000000e10d
   RVTEST_TESTDATA_LOAD_INT(x3, x6) # load rs2: x6 = 0x0000000000003d42
+  RVTEST_TESTDATA_LOAD_INT(x3, x8) # load rd compare value: x8 = 0x000000000000e10d
   LA(x2, scratch) # load base address into rs1
   SREG x18, 0(x2) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b2_equal:
@@ -76,6 +79,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b2_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x3, x10) # load value in memory: x10 = 0x000000000000f38e
   RVTEST_TESTDATA_LOAD_INT(x3, x16) # load rs2: x16 = 0x000000000000bd95
+  RVTEST_TESTDATA_LOAD_INT(x3, x0) # load rd compare value: x0 = 0x0000000000003481
   LA(x2, scratch) # load base address into rs1
   SREG x10, 0(x2) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b2_not_equal:
@@ -90,6 +94,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b2_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x31) # load value in memory: x31 = 0x000000000000b5d1
   RVTEST_TESTDATA_LOAD_INT(x20, x16) # load rs2: x16 = 0x000000000000911a
+  RVTEST_TESTDATA_LOAD_INT(x20, x12) # load rd compare value: x12 = 0x000000000000b5d1
   LA(x3, scratch) # load base address into rs1
   SREG x31, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b3_equal:
@@ -103,6 +108,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b3_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x7) # load value in memory: x7 = 0x00000000000050e0
   RVTEST_TESTDATA_LOAD_INT(x20, x24) # load rs2: x24 = 0x00000000000067ec
+  RVTEST_TESTDATA_LOAD_INT(x20, x29) # load rd compare value: x29 = 0x0000000000006335
   LA(x3, scratch) # load base address into rs1
   SREG x7, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b3_not_equal:
@@ -118,6 +124,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b3_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x17) # load value in memory: x17 = 0x0000000000003b4a
   RVTEST_TESTDATA_LOAD_INT(x20, x18) # load rs2: x18 = 0x0000000000004f41
+  RVTEST_TESTDATA_LOAD_INT(x20, x31) # load rd compare value: x31 = 0x0000000000003b4a
   LA(x4, scratch) # load base address into rs1
   SREG x17, 0(x4) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b4_equal:
@@ -131,6 +138,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b4_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x24) # load value in memory: x24 = 0x000000000000e32d
   RVTEST_TESTDATA_LOAD_INT(x20, x9) # load rs2: x9 = 0x000000000000c7d8
+  RVTEST_TESTDATA_LOAD_INT(x20, x16) # load rd compare value: x16 = 0x000000000000ff81
   LA(x4, scratch) # load base address into rs1
   SREG x24, 0(x4) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b4_not_equal:
@@ -144,6 +152,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b4_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x6) # load value in memory: x6 = 0x0000000000000c17
   RVTEST_TESTDATA_LOAD_INT(x20, x28) # load rs2: x28 = 0x00000000000064b7
+  RVTEST_TESTDATA_LOAD_INT(x20, x4) # load rd compare value: x4 = 0x0000000000000c17
   LA(x5, scratch) # load base address into rs1
   SREG x6, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b5_equal:
@@ -157,6 +166,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b5_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x17) # load value in memory: x17 = 0x000000000000c2a8
   RVTEST_TESTDATA_LOAD_INT(x20, x16) # load rs2: x16 = 0x000000000000fbd6
+  RVTEST_TESTDATA_LOAD_INT(x20, x0) # load rd compare value: x0 = 0x0000000000000101
   LA(x5, scratch) # load base address into rs1
   SREG x17, 0(x5) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b5_not_equal:
@@ -170,6 +180,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b5_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x17) # load value in memory: x17 = 0x0000000000006d40
   RVTEST_TESTDATA_LOAD_INT(x20, x24) # load rs2: x24 = 0x000000000000def9
+  RVTEST_TESTDATA_LOAD_INT(x20, x21) # load rd compare value: x21 = 0x0000000000006d40
   LA(x6, scratch) # load base address into rs1
   SREG x17, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b6_equal:
@@ -183,6 +194,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b6_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x24) # load value in memory: x24 = 0x00000000000055c9
   RVTEST_TESTDATA_LOAD_INT(x20, x2) # load rs2: x2 = 0x0000000000003a0e
+  RVTEST_TESTDATA_LOAD_INT(x20, x16) # load rd compare value: x16 = 0x000000000000eca3
   LA(x6, scratch) # load base address into rs1
   SREG x24, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b6_not_equal:
@@ -196,6 +208,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b6_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x1) # load value in memory: x1 = 0x0000000000005adf
   RVTEST_TESTDATA_LOAD_INT(x20, x29) # load rs2: x29 = 0x000000000000b308
+  RVTEST_TESTDATA_LOAD_INT(x20, x23) # load rd compare value: x23 = 0x0000000000005adf
   LA(x7, scratch) # load base address into rs1
   SREG x1, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b7_equal:
@@ -209,6 +222,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b7_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x28) # load value in memory: x28 = 0x000000000000d892
   RVTEST_TESTDATA_LOAD_INT(x20, x10) # load rs2: x10 = 0x000000000000adb5
+  RVTEST_TESTDATA_LOAD_INT(x20, x21) # load rd compare value: x21 = 0x000000000000c917
   LA(x7, scratch) # load base address into rs1
   SREG x28, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b7_not_equal:
@@ -222,6 +236,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b7_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x4) # load value in memory: x4 = 0x000000000000d44f
   RVTEST_TESTDATA_LOAD_INT(x20, x23) # load rs2: x23 = 0x000000000000726b
+  RVTEST_TESTDATA_LOAD_INT(x20, x6) # load rd compare value: x6 = 0x000000000000d44f
   LA(x8, scratch) # load base address into rs1
   SREG x4, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b8_equal:
@@ -235,6 +250,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b8_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x15) # load value in memory: x15 = 0x0000000000006ce6
   RVTEST_TESTDATA_LOAD_INT(x20, x31) # load rs2: x31 = 0x000000000000e828
+  RVTEST_TESTDATA_LOAD_INT(x20, x11) # load rd compare value: x11 = 0x0000000000002d67
   LA(x8, scratch) # load base address into rs1
   SREG x15, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b8_not_equal:
@@ -248,6 +264,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b8_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x22) # load value in memory: x22 = 0x0000000000002eaf
   RVTEST_TESTDATA_LOAD_INT(x20, x16) # load rs2: x16 = 0x000000000000de7d
+  RVTEST_TESTDATA_LOAD_INT(x20, x4) # load rd compare value: x4 = 0x0000000000002eaf
   LA(x9, scratch) # load base address into rs1
   SREG x22, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b9_equal:
@@ -261,6 +278,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b9_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x24) # load value in memory: x24 = 0x00000000000024f9
   RVTEST_TESTDATA_LOAD_INT(x20, x28) # load rs2: x28 = 0x0000000000004a25
+  RVTEST_TESTDATA_LOAD_INT(x20, x3) # load rd compare value: x3 = 0x0000000000004052
   LA(x9, scratch) # load base address into rs1
   SREG x24, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b9_not_equal:
@@ -274,6 +292,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b9_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x1) # load value in memory: x1 = 0x0000000000002cbe
   RVTEST_TESTDATA_LOAD_INT(x20, x22) # load rs2: x22 = 0x000000000000eca6
+  RVTEST_TESTDATA_LOAD_INT(x20, x12) # load rd compare value: x12 = 0x0000000000002cbe
   LA(x10, scratch) # load base address into rs1
   SREG x1, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b10_equal:
@@ -287,6 +306,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b10_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x6) # load value in memory: x6 = 0x0000000000007c98
   RVTEST_TESTDATA_LOAD_INT(x20, x8) # load rs2: x8 = 0x000000000000da89
+  RVTEST_TESTDATA_LOAD_INT(x20, x27) # load rd compare value: x27 = 0x000000000000e9a5
   LA(x10, scratch) # load base address into rs1
   SREG x6, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b10_not_equal:
@@ -300,6 +320,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b10_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x23) # load value in memory: x23 = 0x0000000000007451
   RVTEST_TESTDATA_LOAD_INT(x20, x3) # load rs2: x3 = 0x000000000000cbaf
+  RVTEST_TESTDATA_LOAD_INT(x20, x9) # load rd compare value: x9 = 0x0000000000007451
   LA(x11, scratch) # load base address into rs1
   SREG x23, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b11_equal:
@@ -313,6 +334,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b11_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x25) # load value in memory: x25 = 0x000000000000d729
   RVTEST_TESTDATA_LOAD_INT(x20, x0) # load rs2: x0 = 0x0000000000009925
+  RVTEST_TESTDATA_LOAD_INT(x20, x17) # load rd compare value: x17 = 0x00000000000076b8
   LA(x11, scratch) # load base address into rs1
   SREG x25, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b11_not_equal:
@@ -326,6 +348,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b11_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x23) # load value in memory: x23 = 0x000000000000e5dd
   RVTEST_TESTDATA_LOAD_INT(x20, x31) # load rs2: x31 = 0x000000000000c36f
+  RVTEST_TESTDATA_LOAD_INT(x20, x18) # load rd compare value: x18 = 0x000000000000e5dd
   LA(x12, scratch) # load base address into rs1
   SREG x23, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b12_equal:
@@ -339,6 +362,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b12_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x7) # load value in memory: x7 = 0x0000000000008902
   RVTEST_TESTDATA_LOAD_INT(x20, x30) # load rs2: x30 = 0x000000000000d550
+  RVTEST_TESTDATA_LOAD_INT(x20, x1) # load rd compare value: x1 = 0x000000000000513d
   LA(x12, scratch) # load base address into rs1
   SREG x7, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b12_not_equal:
@@ -354,6 +378,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b12_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x4) # load value in memory: x4 = 0x000000000000dcf8
   RVTEST_TESTDATA_LOAD_INT(x20, x18) # load rs2: x18 = 0x000000000000244e
+  RVTEST_TESTDATA_LOAD_INT(x20, x16) # load rd compare value: x16 = 0x000000000000dcf8
   LA(x13, scratch) # load base address into rs1
   SREG x4, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b13_equal:
@@ -367,6 +392,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b13_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x21) # load value in memory: x21 = 0x0000000000006319
   RVTEST_TESTDATA_LOAD_INT(x20, x18) # load rs2: x18 = 0x0000000000002c06
+  RVTEST_TESTDATA_LOAD_INT(x20, x27) # load rd compare value: x27 = 0x0000000000002a74
   LA(x13, scratch) # load base address into rs1
   SREG x21, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b13_not_equal:
@@ -380,6 +406,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b13_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x28) # load value in memory: x28 = 0x000000000000476b
   RVTEST_TESTDATA_LOAD_INT(x20, x22) # load rs2: x22 = 0x0000000000009e6c
+  RVTEST_TESTDATA_LOAD_INT(x20, x9) # load rd compare value: x9 = 0x000000000000476b
   LA(x14, scratch) # load base address into rs1
   SREG x28, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b14_equal:
@@ -393,6 +420,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b14_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x26) # load value in memory: x26 = 0x0000000000007c51
   RVTEST_TESTDATA_LOAD_INT(x20, x2) # load rs2: x2 = 0x000000000000db71
+  RVTEST_TESTDATA_LOAD_INT(x20, x5) # load rd compare value: x5 = 0x000000000000cf3c
   LA(x14, scratch) # load base address into rs1
   SREG x26, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b14_not_equal:
@@ -406,6 +434,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b14_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x23) # load value in memory: x23 = 0x000000000000bcfd
   RVTEST_TESTDATA_LOAD_INT(x20, x1) # load rs2: x1 = 0x000000000000d2e2
+  RVTEST_TESTDATA_LOAD_INT(x20, x10) # load rd compare value: x10 = 0x000000000000bcfd
   LA(x15, scratch) # load base address into rs1
   SREG x23, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b15_equal:
@@ -419,6 +448,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b15_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x30) # load value in memory: x30 = 0x000000000000e307
   RVTEST_TESTDATA_LOAD_INT(x20, x17) # load rs2: x17 = 0x0000000000001486
+  RVTEST_TESTDATA_LOAD_INT(x20, x14) # load rd compare value: x14 = 0x0000000000000944
   LA(x15, scratch) # load base address into rs1
   SREG x30, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b15_not_equal:
@@ -432,6 +462,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b15_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x28) # load value in memory: x28 = 0x000000000000014d
   RVTEST_TESTDATA_LOAD_INT(x20, x29) # load rs2: x29 = 0x0000000000001afa
+  RVTEST_TESTDATA_LOAD_INT(x20, x27) # load rd compare value: x27 = 0x000000000000014d
   LA(x16, scratch) # load base address into rs1
   SREG x28, 0(x16) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b16_equal:
@@ -445,6 +476,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b16_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x17) # load value in memory: x17 = 0x000000000000bc2d
   RVTEST_TESTDATA_LOAD_INT(x20, x22) # load rs2: x22 = 0x000000000000c50b
+  RVTEST_TESTDATA_LOAD_INT(x20, x25) # load rd compare value: x25 = 0x000000000000c36d
   LA(x16, scratch) # load base address into rs1
   SREG x17, 0(x16) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b16_not_equal:
@@ -458,6 +490,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b16_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x16) # load value in memory: x16 = 0x000000000000c04e
   RVTEST_TESTDATA_LOAD_INT(x20, x25) # load rs2: x25 = 0x0000000000000f2a
+  RVTEST_TESTDATA_LOAD_INT(x20, x13) # load rd compare value: x13 = 0x000000000000c04e
   LA(x17, scratch) # load base address into rs1
   SREG x16, 0(x17) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b17_equal:
@@ -471,6 +504,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b17_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x13) # load value in memory: x13 = 0x00000000000077de
   RVTEST_TESTDATA_LOAD_INT(x20, x5) # load rs2: x5 = 0x00000000000090db
+  RVTEST_TESTDATA_LOAD_INT(x20, x4) # load rd compare value: x4 = 0x0000000000005015
   LA(x17, scratch) # load base address into rs1
   SREG x13, 0(x17) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b17_not_equal:
@@ -484,6 +518,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b17_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x28) # load value in memory: x28 = 0x0000000000001a88
   RVTEST_TESTDATA_LOAD_INT(x20, x6) # load rs2: x6 = 0x0000000000009206
+  RVTEST_TESTDATA_LOAD_INT(x20, x26) # load rd compare value: x26 = 0x0000000000001a88
   LA(x18, scratch) # load base address into rs1
   SREG x28, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b18_equal:
@@ -497,6 +532,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b18_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x23) # load value in memory: x23 = 0x000000000000e698
   RVTEST_TESTDATA_LOAD_INT(x20, x29) # load rs2: x29 = 0x00000000000042cb
+  RVTEST_TESTDATA_LOAD_INT(x20, x6) # load rd compare value: x6 = 0x00000000000044b1
   LA(x18, scratch) # load base address into rs1
   SREG x23, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b18_not_equal:
@@ -511,6 +547,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b18_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x24) # load value in memory: x24 = 0x000000000000eb6f
   RVTEST_TESTDATA_LOAD_INT(x20, x28) # load rs2: x28 = 0x00000000000072e3
+  RVTEST_TESTDATA_LOAD_INT(x20, x21) # load rd compare value: x21 = 0x000000000000eb6f
   LA(x19, scratch) # load base address into rs1
   SREG x24, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b19_equal:
@@ -524,6 +561,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b19_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x20, x5) # load value in memory: x5 = 0x0000000000000d30
   RVTEST_TESTDATA_LOAD_INT(x20, x27) # load rs2: x27 = 0x0000000000005c8d
+  RVTEST_TESTDATA_LOAD_INT(x20, x4) # load rd compare value: x4 = 0x000000000000a478
   LA(x19, scratch) # load base address into rs1
   SREG x5, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b19_not_equal:
@@ -538,6 +576,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b19_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x24) # load value in memory: x24 = 0x0000000000008d9b
   RVTEST_TESTDATA_LOAD_INT(x25, x15) # load rs2: x15 = 0x000000000000cfb2
+  RVTEST_TESTDATA_LOAD_INT(x25, x2) # load rd compare value: x2 = 0x0000000000008d9b
   LA(x20, scratch) # load base address into rs1
   SREG x24, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b20_equal:
@@ -551,6 +590,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b20_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x12) # load value in memory: x12 = 0x000000000000baed
   RVTEST_TESTDATA_LOAD_INT(x25, x15) # load rs2: x15 = 0x0000000000001afb
+  RVTEST_TESTDATA_LOAD_INT(x25, x17) # load rd compare value: x17 = 0x000000000000ccd8
   LA(x20, scratch) # load base address into rs1
   SREG x12, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b20_not_equal:
@@ -564,6 +604,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b20_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x10) # load value in memory: x10 = 0x000000000000cf5c
   RVTEST_TESTDATA_LOAD_INT(x25, x3) # load rs2: x3 = 0x0000000000005bad
+  RVTEST_TESTDATA_LOAD_INT(x25, x14) # load rd compare value: x14 = 0x000000000000cf5c
   LA(x21, scratch) # load base address into rs1
   SREG x10, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b21_equal:
@@ -577,6 +618,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b21_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x9) # load value in memory: x9 = 0x00000000000017e9
   RVTEST_TESTDATA_LOAD_INT(x25, x15) # load rs2: x15 = 0x00000000000049d4
+  RVTEST_TESTDATA_LOAD_INT(x25, x0) # load rd compare value: x0 = 0x000000000000092c
   LA(x21, scratch) # load base address into rs1
   SREG x9, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b21_not_equal:
@@ -590,6 +632,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b21_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x11) # load value in memory: x11 = 0x000000000000bee0
   RVTEST_TESTDATA_LOAD_INT(x25, x28) # load rs2: x28 = 0x0000000000005090
+  RVTEST_TESTDATA_LOAD_INT(x25, x12) # load rd compare value: x12 = 0x000000000000bee0
   LA(x22, scratch) # load base address into rs1
   SREG x11, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b22_equal:
@@ -603,6 +646,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b22_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x16) # load value in memory: x16 = 0x0000000000009ac1
   RVTEST_TESTDATA_LOAD_INT(x25, x27) # load rs2: x27 = 0x00000000000084e2
+  RVTEST_TESTDATA_LOAD_INT(x25, x5) # load rd compare value: x5 = 0x00000000000028e8
   LA(x22, scratch) # load base address into rs1
   SREG x16, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b22_not_equal:
@@ -616,6 +660,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b22_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x19) # load value in memory: x19 = 0x000000000000d3f7
   RVTEST_TESTDATA_LOAD_INT(x25, x4) # load rs2: x4 = 0x0000000000005b62
+  RVTEST_TESTDATA_LOAD_INT(x25, x20) # load rd compare value: x20 = 0x000000000000d3f7
   LA(x23, scratch) # load base address into rs1
   SREG x19, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b23_equal:
@@ -629,6 +674,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b23_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x20) # load value in memory: x20 = 0x0000000000005a5b
   RVTEST_TESTDATA_LOAD_INT(x25, x4) # load rs2: x4 = 0x000000000000bbdb
+  RVTEST_TESTDATA_LOAD_INT(x25, x17) # load rd compare value: x17 = 0x000000000000a0f3
   LA(x23, scratch) # load base address into rs1
   SREG x20, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b23_not_equal:
@@ -642,6 +688,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b23_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x11) # load value in memory: x11 = 0x0000000000000c05
   RVTEST_TESTDATA_LOAD_INT(x25, x14) # load rs2: x14 = 0x0000000000005c4c
+  RVTEST_TESTDATA_LOAD_INT(x25, x18) # load rd compare value: x18 = 0x0000000000000c05
   LA(x24, scratch) # load base address into rs1
   SREG x11, 0(x24) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b24_equal:
@@ -655,6 +702,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b24_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x25, x17) # load value in memory: x17 = 0x0000000000006309
   RVTEST_TESTDATA_LOAD_INT(x25, x27) # load rs2: x27 = 0x0000000000009ab3
+  RVTEST_TESTDATA_LOAD_INT(x25, x14) # load rd compare value: x14 = 0x0000000000000f9a
   LA(x24, scratch) # load base address into rs1
   SREG x17, 0(x24) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b24_not_equal:
@@ -669,6 +717,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b24_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x11) # load value in memory: x11 = 0x0000000000005035
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load rs2: x3 = 0x0000000000003563
+  RVTEST_TESTDATA_LOAD_INT(x24, x27) # load rd compare value: x27 = 0x0000000000005035
   LA(x25, scratch) # load base address into rs1
   SREG x11, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b25_equal:
@@ -682,6 +731,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b25_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x27) # load value in memory: x27 = 0x0000000000000e64
   RVTEST_TESTDATA_LOAD_INT(x24, x31) # load rs2: x31 = 0x000000000000fe78
+  RVTEST_TESTDATA_LOAD_INT(x24, x3) # load rd compare value: x3 = 0x000000000000175e
   LA(x25, scratch) # load base address into rs1
   SREG x27, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b25_not_equal:
@@ -695,6 +745,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b25_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load value in memory: x1 = 0x0000000000006d3a
   RVTEST_TESTDATA_LOAD_INT(x24, x25) # load rs2: x25 = 0x00000000000086a9
+  RVTEST_TESTDATA_LOAD_INT(x24, x10) # load rd compare value: x10 = 0x0000000000006d3a
   LA(x26, scratch) # load base address into rs1
   SREG x1, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b26_equal:
@@ -708,6 +759,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b26_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x31) # load value in memory: x31 = 0x00000000000093e6
   RVTEST_TESTDATA_LOAD_INT(x24, x29) # load rs2: x29 = 0x000000000000d238
+  RVTEST_TESTDATA_LOAD_INT(x24, x0) # load rd compare value: x0 = 0x0000000000007b61
   LA(x26, scratch) # load base address into rs1
   SREG x31, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b26_not_equal:
@@ -721,6 +773,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b26_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load value in memory: x20 = 0x0000000000006cec
   RVTEST_TESTDATA_LOAD_INT(x24, x30) # load rs2: x30 = 0x000000000000f5d4
+  RVTEST_TESTDATA_LOAD_INT(x24, x18) # load rd compare value: x18 = 0x0000000000006cec
   LA(x27, scratch) # load base address into rs1
   SREG x20, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b27_equal:
@@ -734,6 +787,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b27_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x9) # load value in memory: x9 = 0x000000000000effa
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load rs2: x20 = 0x0000000000004a9f
+  RVTEST_TESTDATA_LOAD_INT(x24, x15) # load rd compare value: x15 = 0x000000000000881b
   LA(x27, scratch) # load base address into rs1
   SREG x9, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b27_not_equal:
@@ -747,6 +801,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b27_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x22) # load value in memory: x22 = 0x0000000000001d5a
   RVTEST_TESTDATA_LOAD_INT(x24, x0) # load rs2: x0 = 0x000000000000198d
+  RVTEST_TESTDATA_LOAD_INT(x24, x12) # load rd compare value: x12 = 0x0000000000001d5a
   LA(x28, scratch) # load base address into rs1
   SREG x22, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b28_equal:
@@ -760,6 +815,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b28_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x11) # load value in memory: x11 = 0x0000000000004dc0
   RVTEST_TESTDATA_LOAD_INT(x24, x27) # load rs2: x27 = 0x0000000000003efd
+  RVTEST_TESTDATA_LOAD_INT(x24, x9) # load rd compare value: x9 = 0x00000000000099aa
   LA(x28, scratch) # load base address into rs1
   SREG x11, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b28_not_equal:
@@ -773,6 +829,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b28_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load value in memory: x1 = 0x0000000000005fd7
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rs2: x21 = 0x000000000000601f
+  RVTEST_TESTDATA_LOAD_INT(x24, x5) # load rd compare value: x5 = 0x0000000000005fd7
   LA(x29, scratch) # load base address into rs1
   SREG x1, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b29_equal:
@@ -786,6 +843,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b29_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x22) # load value in memory: x22 = 0x000000000000f66c
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rs2: x21 = 0x000000000000647a
+  RVTEST_TESTDATA_LOAD_INT(x24, x5) # load rd compare value: x5 = 0x000000000000540f
   LA(x29, scratch) # load base address into rs1
   SREG x22, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b29_not_equal:
@@ -799,6 +857,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b29_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load value in memory: x17 = 0x000000000000c1e9
   RVTEST_TESTDATA_LOAD_INT(x24, x29) # load rs2: x29 = 0x0000000000000599
+  RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rd compare value: x21 = 0x000000000000c1e9
   LA(x30, scratch) # load base address into rs1
   SREG x17, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b30_equal:
@@ -812,6 +871,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b30_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x27) # load value in memory: x27 = 0x000000000000a207
   RVTEST_TESTDATA_LOAD_INT(x24, x4) # load rs2: x4 = 0x0000000000007a2e
+  RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rd compare value: x23 = 0x000000000000ca8a
   LA(x30, scratch) # load base address into rs1
   SREG x27, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b30_not_equal:
@@ -825,6 +885,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b30_not_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x28) # load value in memory: x28 = 0x000000000000f47c
   RVTEST_TESTDATA_LOAD_INT(x24, x13) # load rs2: x13 = 0x000000000000e7b8
+  RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rd compare value: x22 = 0x000000000000f47c
   LA(x31, scratch) # load base address into rs1
   SREG x28, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b31_equal:
@@ -838,6 +899,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b31_equal:
 # Testcase cp_rs1_nx0 (Test source rs1 = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x28) # load value in memory: x28 = 0x00000000000015c1
   RVTEST_TESTDATA_LOAD_INT(x24, x9) # load rs2: x9 = 0x0000000000008607
+  RVTEST_TESTDATA_LOAD_INT(x24, x4) # load rd compare value: x4 = 0x0000000000000cf5
   LA(x31, scratch) # load base address into rs1
   SREG x28, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs1_nx0_b31_not_equal:
@@ -855,6 +917,7 @@ ZacasZabha_amocas_h_cg_cp_rs1_nx0_b31_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x0, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x12) # load value in memory: x12 = 0x000000000000fac1
   RVTEST_TESTDATA_LOAD_INT(x24, x0) # load rs2: x0 = 0x00000000000034b3
+  RVTEST_TESTDATA_LOAD_INT(x24, x15) # load rd compare value: x15 = 0x000000000000fac1
   LA(x16, scratch) # load base address into rs1
   SREG x12, 0(x16) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b0_equal:
@@ -868,6 +931,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b0_equal:
 # Testcase cp_rs2 (Test source rs2 = x0, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x4) # load value in memory: x4 = 0x000000000000ace4
   RVTEST_TESTDATA_LOAD_INT(x24, x0) # load rs2: x0 = 0x0000000000001882
+  RVTEST_TESTDATA_LOAD_INT(x24, x28) # load rd compare value: x28 = 0x000000000000abc7
   LA(x1, scratch) # load base address into rs1
   SREG x4, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b0_not_equal:
@@ -881,6 +945,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b0_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x19) # load value in memory: x19 = 0x000000000000192d
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load rs2: x1 = 0x000000000000027b
+  RVTEST_TESTDATA_LOAD_INT(x24, x0) # load rd compare value: x0 = 0x000000000000192d
   LA(x31, scratch) # load base address into rs1
   SREG x19, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b1_equal:
@@ -894,6 +959,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b1_equal:
 # Testcase cp_rs2 (Test source rs2 = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load value in memory: x3 = 0x0000000000001bd6
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load rs2: x1 = 0x0000000000004ed0
+  RVTEST_TESTDATA_LOAD_INT(x24, x2) # load rd compare value: x2 = 0x0000000000005351
   LA(x16, scratch) # load base address into rs1
   SREG x3, 0(x16) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b1_not_equal:
@@ -907,6 +973,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b1_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x23) # load value in memory: x23 = 0x000000000000bb46
   RVTEST_TESTDATA_LOAD_INT(x24, x2) # load rs2: x2 = 0x000000000000f515
+  RVTEST_TESTDATA_LOAD_INT(x24, x29) # load rd compare value: x29 = 0x000000000000bb46
   LA(x11, scratch) # load base address into rs1
   SREG x23, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b2_equal:
@@ -920,6 +987,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b2_equal:
 # Testcase cp_rs2 (Test source rs2 = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load value in memory: x21 = 0x000000000000bb3c
   RVTEST_TESTDATA_LOAD_INT(x24, x2) # load rs2: x2 = 0x000000000000455e
+  RVTEST_TESTDATA_LOAD_INT(x24, x18) # load rd compare value: x18 = 0x00000000000028d9
   LA(x22, scratch) # load base address into rs1
   SREG x21, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b2_not_equal:
@@ -933,6 +1001,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b2_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x11) # load value in memory: x11 = 0x0000000000000304
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load rs2: x3 = 0x0000000000001e4f
+  RVTEST_TESTDATA_LOAD_INT(x24, x17) # load rd compare value: x17 = 0x0000000000000304
   LA(x1, scratch) # load base address into rs1
   SREG x11, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b3_equal:
@@ -946,6 +1015,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b3_equal:
 # Testcase cp_rs2 (Test source rs2 = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x15) # load value in memory: x15 = 0x000000000000d9a4
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load rs2: x3 = 0x000000000000a8d0
+  RVTEST_TESTDATA_LOAD_INT(x24, x17) # load rd compare value: x17 = 0x0000000000004dec
   LA(x26, scratch) # load base address into rs1
   SREG x15, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b3_not_equal:
@@ -959,6 +1029,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b3_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x9) # load value in memory: x9 = 0x0000000000004eba
   RVTEST_TESTDATA_LOAD_INT(x24, x4) # load rs2: x4 = 0x0000000000008822
+  RVTEST_TESTDATA_LOAD_INT(x24, x1) # load rd compare value: x1 = 0x0000000000004eba
   LA(x30, scratch) # load base address into rs1
   SREG x9, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b4_equal:
@@ -972,6 +1043,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b4_equal:
 # Testcase cp_rs2 (Test source rs2 = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x12) # load value in memory: x12 = 0x000000000000f7a1
   RVTEST_TESTDATA_LOAD_INT(x24, x4) # load rs2: x4 = 0x000000000000cb7b
+  RVTEST_TESTDATA_LOAD_INT(x24, x27) # load rd compare value: x27 = 0x000000000000509d
   LA(x9, scratch) # load base address into rs1
   SREG x12, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b4_not_equal:
@@ -985,6 +1057,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b4_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x29) # load value in memory: x29 = 0x00000000000015b6
   RVTEST_TESTDATA_LOAD_INT(x24, x5) # load rs2: x5 = 0x000000000000bf7a
+  RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rd compare value: x22 = 0x00000000000015b6
   LA(x18, scratch) # load base address into rs1
   SREG x29, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b5_equal:
@@ -998,6 +1071,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b5_equal:
 # Testcase cp_rs2 (Test source rs2 = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x4) # load value in memory: x4 = 0x000000000000b809
   RVTEST_TESTDATA_LOAD_INT(x24, x5) # load rs2: x5 = 0x00000000000052de
+  RVTEST_TESTDATA_LOAD_INT(x24, x1) # load rd compare value: x1 = 0x0000000000002a4c
   LA(x20, scratch) # load base address into rs1
   SREG x4, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b5_not_equal:
@@ -1012,6 +1086,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b5_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load value in memory: x1 = 0x00000000000098dc
   RVTEST_TESTDATA_LOAD_INT(x24, x6) # load rs2: x6 = 0x000000000000e878
+  RVTEST_TESTDATA_LOAD_INT(x24, x20) # load rd compare value: x20 = 0x00000000000098dc
   LA(x26, scratch) # load base address into rs1
   SREG x1, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b6_equal:
@@ -1025,6 +1100,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b6_equal:
 # Testcase cp_rs2 (Test source rs2 = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x30) # load value in memory: x30 = 0x000000000000b0c5
   RVTEST_TESTDATA_LOAD_INT(x24, x6) # load rs2: x6 = 0x0000000000007e69
+  RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rd compare value: x23 = 0x0000000000000c78
   LA(x28, scratch) # load base address into rs1
   SREG x30, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b6_not_equal:
@@ -1040,6 +1116,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b6_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load value in memory: x17 = 0x000000000000469a
   RVTEST_TESTDATA_LOAD_INT(x24, x7) # load rs2: x7 = 0x000000000000f779
+  RVTEST_TESTDATA_LOAD_INT(x24, x25) # load rd compare value: x25 = 0x000000000000469a
   LA(x1, scratch) # load base address into rs1
   SREG x17, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b7_equal:
@@ -1053,6 +1130,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b7_equal:
 # Testcase cp_rs2 (Test source rs2 = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x10) # load value in memory: x10 = 0x0000000000003208
   RVTEST_TESTDATA_LOAD_INT(x24, x7) # load rs2: x7 = 0x000000000000faa0
+  RVTEST_TESTDATA_LOAD_INT(x24, x0) # load rd compare value: x0 = 0x0000000000005378
   LA(x20, scratch) # load base address into rs1
   SREG x10, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b7_not_equal:
@@ -1066,6 +1144,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b7_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x29) # load value in memory: x29 = 0x0000000000005216
   RVTEST_TESTDATA_LOAD_INT(x24, x8) # load rs2: x8 = 0x000000000000ef9f
+  RVTEST_TESTDATA_LOAD_INT(x24, x27) # load rd compare value: x27 = 0x0000000000005216
   LA(x19, scratch) # load base address into rs1
   SREG x29, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b8_equal:
@@ -1079,6 +1158,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b8_equal:
 # Testcase cp_rs2 (Test source rs2 = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x10) # load value in memory: x10 = 0x00000000000089b5
   RVTEST_TESTDATA_LOAD_INT(x24, x8) # load rs2: x8 = 0x000000000000afae
+  RVTEST_TESTDATA_LOAD_INT(x24, x3) # load rd compare value: x3 = 0x00000000000062a6
   LA(x28, scratch) # load base address into rs1
   SREG x10, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b8_not_equal:
@@ -1092,6 +1172,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b8_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x7) # load value in memory: x7 = 0x000000000000ade5
   RVTEST_TESTDATA_LOAD_INT(x24, x9) # load rs2: x9 = 0x0000000000008751
+  RVTEST_TESTDATA_LOAD_INT(x24, x10) # load rd compare value: x10 = 0x000000000000ade5
   LA(x29, scratch) # load base address into rs1
   SREG x7, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b9_equal:
@@ -1105,6 +1186,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b9_equal:
 # Testcase cp_rs2 (Test source rs2 = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load value in memory: x17 = 0x000000000000bd99
   RVTEST_TESTDATA_LOAD_INT(x24, x9) # load rs2: x9 = 0x000000000000c13c
+  RVTEST_TESTDATA_LOAD_INT(x24, x2) # load rd compare value: x2 = 0x000000000000802d
   LA(x25, scratch) # load base address into rs1
   SREG x17, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b9_not_equal:
@@ -1118,6 +1200,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b9_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load value in memory: x3 = 0x0000000000006cd5
   RVTEST_TESTDATA_LOAD_INT(x24, x10) # load rs2: x10 = 0x0000000000006d1c
+  RVTEST_TESTDATA_LOAD_INT(x24, x27) # load rd compare value: x27 = 0x0000000000006cd5
   LA(x12, scratch) # load base address into rs1
   SREG x3, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b10_equal:
@@ -1131,6 +1214,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b10_equal:
 # Testcase cp_rs2 (Test source rs2 = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x28) # load value in memory: x28 = 0x000000000000d412
   RVTEST_TESTDATA_LOAD_INT(x24, x10) # load rs2: x10 = 0x0000000000007bea
+  RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rd compare value: x19 = 0x000000000000527b
   LA(x21, scratch) # load base address into rs1
   SREG x28, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b10_not_equal:
@@ -1144,6 +1228,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b10_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load value in memory: x1 = 0x000000000000b64f
   RVTEST_TESTDATA_LOAD_INT(x24, x11) # load rs2: x11 = 0x000000000000e2f3
+  RVTEST_TESTDATA_LOAD_INT(x24, x16) # load rd compare value: x16 = 0x000000000000b64f
   LA(x28, scratch) # load base address into rs1
   SREG x1, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b11_equal:
@@ -1157,6 +1242,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b11_equal:
 # Testcase cp_rs2 (Test source rs2 = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x19) # load value in memory: x19 = 0x0000000000001150
   RVTEST_TESTDATA_LOAD_INT(x24, x11) # load rs2: x11 = 0x000000000000e8a1
+  RVTEST_TESTDATA_LOAD_INT(x24, x16) # load rd compare value: x16 = 0x00000000000029d1
   LA(x22, scratch) # load base address into rs1
   SREG x19, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b11_not_equal:
@@ -1170,6 +1256,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b11_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load value in memory: x1 = 0x0000000000009d3d
   RVTEST_TESTDATA_LOAD_INT(x24, x12) # load rs2: x12 = 0x000000000000bd1d
+  RVTEST_TESTDATA_LOAD_INT(x24, x5) # load rd compare value: x5 = 0x0000000000009d3d
   LA(x16, scratch) # load base address into rs1
   SREG x1, 0(x16) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b12_equal:
@@ -1183,6 +1270,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b12_equal:
 # Testcase cp_rs2 (Test source rs2 = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x11) # load value in memory: x11 = 0x000000000000e6ff
   RVTEST_TESTDATA_LOAD_INT(x24, x12) # load rs2: x12 = 0x000000000000fd0f
+  RVTEST_TESTDATA_LOAD_INT(x24, x6) # load rd compare value: x6 = 0x000000000000ef01
   LA(x7, scratch) # load base address into rs1
   SREG x11, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b12_not_equal:
@@ -1198,6 +1286,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b12_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load value in memory: x3 = 0x000000000000f770
   RVTEST_TESTDATA_LOAD_INT(x24, x13) # load rs2: x13 = 0x00000000000097e4
+  RVTEST_TESTDATA_LOAD_INT(x24, x31) # load rd compare value: x31 = 0x000000000000f770
   LA(x22, scratch) # load base address into rs1
   SREG x3, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b13_equal:
@@ -1211,6 +1300,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b13_equal:
 # Testcase cp_rs2 (Test source rs2 = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x8) # load value in memory: x8 = 0x0000000000002830
   RVTEST_TESTDATA_LOAD_INT(x24, x13) # load rs2: x13 = 0x0000000000009973
+  RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rd compare value: x23 = 0x000000000000bdeb
   LA(x2, scratch) # load base address into rs1
   SREG x8, 0(x2) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b13_not_equal:
@@ -1224,6 +1314,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b13_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x13) # load value in memory: x13 = 0x0000000000000209
   RVTEST_TESTDATA_LOAD_INT(x24, x14) # load rs2: x14 = 0x0000000000005e99
+  RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rd compare value: x22 = 0x0000000000000209
   LA(x16, scratch) # load base address into rs1
   SREG x13, 0(x16) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b14_equal:
@@ -1237,6 +1328,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b14_equal:
 # Testcase cp_rs2 (Test source rs2 = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x3) # load value in memory: x3 = 0x000000000000cf92
   RVTEST_TESTDATA_LOAD_INT(x24, x14) # load rs2: x14 = 0x00000000000080d4
+  RVTEST_TESTDATA_LOAD_INT(x24, x28) # load rd compare value: x28 = 0x0000000000002b78
   LA(x20, scratch) # load base address into rs1
   SREG x3, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b14_not_equal:
@@ -1250,6 +1342,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b14_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x31) # load value in memory: x31 = 0x0000000000003f13
   RVTEST_TESTDATA_LOAD_INT(x24, x15) # load rs2: x15 = 0x0000000000005db6
+  RVTEST_TESTDATA_LOAD_INT(x24, x10) # load rd compare value: x10 = 0x0000000000003f13
   LA(x3, scratch) # load base address into rs1
   SREG x31, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b15_equal:
@@ -1263,6 +1356,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b15_equal:
 # Testcase cp_rs2 (Test source rs2 = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load value in memory: x20 = 0x000000000000e5c0
   RVTEST_TESTDATA_LOAD_INT(x24, x15) # load rs2: x15 = 0x0000000000006626
+  RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rd compare value: x23 = 0x000000000000a4be
   LA(x7, scratch) # load base address into rs1
   SREG x20, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b15_not_equal:
@@ -1276,6 +1370,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b15_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x1) # load value in memory: x1 = 0x0000000000001567
   RVTEST_TESTDATA_LOAD_INT(x24, x16) # load rs2: x16 = 0x0000000000001046
+  RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rd compare value: x19 = 0x0000000000001567
   LA(x11, scratch) # load base address into rs1
   SREG x1, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b16_equal:
@@ -1289,6 +1384,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b16_equal:
 # Testcase cp_rs2 (Test source rs2 = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x12) # load value in memory: x12 = 0x00000000000078e6
   RVTEST_TESTDATA_LOAD_INT(x24, x16) # load rs2: x16 = 0x0000000000004a68
+  RVTEST_TESTDATA_LOAD_INT(x24, x0) # load rd compare value: x0 = 0x0000000000000744
   LA(x14, scratch) # load base address into rs1
   SREG x12, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b16_not_equal:
@@ -1302,6 +1398,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b16_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x31) # load value in memory: x31 = 0x000000000000790b
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load rs2: x17 = 0x00000000000070c6
+  RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rd compare value: x23 = 0x000000000000790b
   LA(x11, scratch) # load base address into rs1
   SREG x31, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b17_equal:
@@ -1315,6 +1412,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b17_equal:
 # Testcase cp_rs2 (Test source rs2 = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x26) # load value in memory: x26 = 0x0000000000009ee3
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load rs2: x17 = 0x0000000000007a75
+  RVTEST_TESTDATA_LOAD_INT(x24, x10) # load rd compare value: x10 = 0x000000000000c84e
   LA(x22, scratch) # load base address into rs1
   SREG x26, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b17_not_equal:
@@ -1329,6 +1427,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b17_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x6) # load value in memory: x6 = 0x0000000000009308
   RVTEST_TESTDATA_LOAD_INT(x24, x18) # load rs2: x18 = 0x0000000000000295
+  RVTEST_TESTDATA_LOAD_INT(x24, x0) # load rd compare value: x0 = 0x0000000000009308
   LA(x12, scratch) # load base address into rs1
   SREG x6, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b18_equal:
@@ -1342,6 +1441,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b18_equal:
 # Testcase cp_rs2 (Test source rs2 = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x14) # load value in memory: x14 = 0x0000000000007a8d
   RVTEST_TESTDATA_LOAD_INT(x24, x18) # load rs2: x18 = 0x000000000000ba3f
+  RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rd compare value: x21 = 0x000000000000b772
   LA(x26, scratch) # load base address into rs1
   SREG x14, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b18_not_equal:
@@ -1355,6 +1455,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b18_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x16) # load value in memory: x16 = 0x000000000000dcdd
   RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rs2: x19 = 0x0000000000008b14
+  RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rd compare value: x22 = 0x000000000000dcdd
   LA(x11, scratch) # load base address into rs1
   SREG x16, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b19_equal:
@@ -1368,6 +1469,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b19_equal:
 # Testcase cp_rs2 (Test source rs2 = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x14) # load value in memory: x14 = 0x000000000000b72d
   RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rs2: x19 = 0x000000000000c8b5
+  RVTEST_TESTDATA_LOAD_INT(x24, x1) # load rd compare value: x1 = 0x0000000000009d06
   LA(x20, scratch) # load base address into rs1
   SREG x14, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b19_not_equal:
@@ -1381,6 +1483,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b19_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x22) # load value in memory: x22 = 0x000000000000f964
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load rs2: x20 = 0x0000000000006581
+  RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rd compare value: x23 = 0x000000000000f964
   LA(x31, scratch) # load base address into rs1
   SREG x22, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b20_equal:
@@ -1394,6 +1497,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b20_equal:
 # Testcase cp_rs2 (Test source rs2 = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x14) # load value in memory: x14 = 0x0000000000007d55
   RVTEST_TESTDATA_LOAD_INT(x24, x20) # load rs2: x20 = 0x000000000000e272
+  RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rd compare value: x19 = 0x000000000000dd14
   LA(x8, scratch) # load base address into rs1
   SREG x14, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b20_not_equal:
@@ -1407,6 +1511,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b20_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x14) # load value in memory: x14 = 0x000000000000b0fa
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rs2: x21 = 0x000000000000860c
+  RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rd compare value: x19 = 0x000000000000b0fa
   LA(x12, scratch) # load base address into rs1
   SREG x14, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b21_equal:
@@ -1420,6 +1525,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b21_equal:
 # Testcase cp_rs2 (Test source rs2 = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x17) # load value in memory: x17 = 0x00000000000028d6
   RVTEST_TESTDATA_LOAD_INT(x24, x21) # load rs2: x21 = 0x000000000000c421
+  RVTEST_TESTDATA_LOAD_INT(x24, x7) # load rd compare value: x7 = 0x0000000000005850
   LA(x27, scratch) # load base address into rs1
   SREG x17, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b21_not_equal:
@@ -1433,6 +1539,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b21_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x23) # load value in memory: x23 = 0x0000000000005b39
   RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rs2: x22 = 0x000000000000b189
+  RVTEST_TESTDATA_LOAD_INT(x24, x27) # load rd compare value: x27 = 0x0000000000005b39
   LA(x9, scratch) # load base address into rs1
   SREG x23, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b22_equal:
@@ -1446,6 +1553,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b22_equal:
 # Testcase cp_rs2 (Test source rs2 = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x25) # load value in memory: x25 = 0x000000000000afdc
   RVTEST_TESTDATA_LOAD_INT(x24, x22) # load rs2: x22 = 0x0000000000006773
+  RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rd compare value: x23 = 0x00000000000064ad
   LA(x9, scratch) # load base address into rs1
   SREG x25, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b22_not_equal:
@@ -1459,6 +1567,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b22_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x29) # load value in memory: x29 = 0x000000000000b4ca
   RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rs2: x23 = 0x000000000000b609
+  RVTEST_TESTDATA_LOAD_INT(x24, x25) # load rd compare value: x25 = 0x000000000000b4ca
   LA(x27, scratch) # load base address into rs1
   SREG x29, 0(x27) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b23_equal:
@@ -1472,6 +1581,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b23_equal:
 # Testcase cp_rs2 (Test source rs2 = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x24, x26) # load value in memory: x26 = 0x0000000000007a41
   RVTEST_TESTDATA_LOAD_INT(x24, x23) # load rs2: x23 = 0x000000000000e72c
+  RVTEST_TESTDATA_LOAD_INT(x24, x19) # load rd compare value: x19 = 0x000000000000b050
   LA(x6, scratch) # load base address into rs1
   SREG x26, 0(x6) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b23_not_equal:
@@ -1486,6 +1596,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b23_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x17) # load value in memory: x17 = 0x0000000000007a77
   RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0x000000000000ef0f
+  RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rd compare value: x29 = 0x0000000000007a77
   LA(x10, scratch) # load base address into rs1
   SREG x17, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b24_equal:
@@ -1499,6 +1610,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b24_equal:
 # Testcase cp_rs2 (Test source rs2 = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load value in memory: x11 = 0x0000000000004a4b
   RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rs2: x24 = 0x0000000000002a7c
+  RVTEST_TESTDATA_LOAD_INT(x1, x14) # load rd compare value: x14 = 0x000000000000bfca
   LA(x25, scratch) # load base address into rs1
   SREG x11, 0(x25) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b24_not_equal:
@@ -1512,6 +1624,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b24_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load value in memory: x11 = 0x0000000000007345
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x00000000000056d9
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rd compare value: x0 = 0x0000000000007345
   LA(x26, scratch) # load base address into rs1
   SREG x11, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b25_equal:
@@ -1525,6 +1638,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b25_equal:
 # Testcase cp_rs2 (Test source rs2 = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load value in memory: x31 = 0x0000000000008d6e
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load rs2: x25 = 0x000000000000fac4
+  RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rd compare value: x26 = 0x0000000000006afa
   LA(x21, scratch) # load base address into rs1
   SREG x31, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b25_not_equal:
@@ -1538,6 +1652,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b25_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x21) # load value in memory: x21 = 0x000000000000b56c
   RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x00000000000007da
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rd compare value: x6 = 0x000000000000b56c
   LA(x11, scratch) # load base address into rs1
   SREG x21, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b26_equal:
@@ -1551,6 +1666,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b26_equal:
 # Testcase cp_rs2 (Test source rs2 = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load value in memory: x22 = 0x000000000000f20d
   RVTEST_TESTDATA_LOAD_INT(x1, x26) # load rs2: x26 = 0x000000000000fe09
+  RVTEST_TESTDATA_LOAD_INT(x1, x3) # load rd compare value: x3 = 0x000000000000fbe2
   LA(x23, scratch) # load base address into rs1
   SREG x22, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b26_not_equal:
@@ -1564,6 +1680,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b26_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load value in memory: x11 = 0x000000000000564b
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x000000000000dd4c
+  RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rd compare value: x18 = 0x000000000000564b
   LA(x7, scratch) # load base address into rs1
   SREG x11, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b27_equal:
@@ -1577,6 +1694,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b27_equal:
 # Testcase cp_rs2 (Test source rs2 = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x25) # load value in memory: x25 = 0x000000000000dc97
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load rs2: x27 = 0x000000000000571f
+  RVTEST_TESTDATA_LOAD_INT(x1, x23) # load rd compare value: x23 = 0x000000000000508b
   LA(x13, scratch) # load base address into rs1
   SREG x25, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b27_not_equal:
@@ -1590,6 +1708,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b27_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load value in memory: x3 = 0x0000000000000282
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x000000000000eae9
+  RVTEST_TESTDATA_LOAD_INT(x1, x20) # load rd compare value: x20 = 0x0000000000000282
   LA(x10, scratch) # load base address into rs1
   SREG x3, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b28_equal:
@@ -1603,6 +1722,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b28_equal:
 # Testcase cp_rs2 (Test source rs2 = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x14) # load value in memory: x14 = 0x000000000000db13
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x000000000000f2fe
+  RVTEST_TESTDATA_LOAD_INT(x1, x10) # load rd compare value: x10 = 0x0000000000006ea5
   LA(x29, scratch) # load base address into rs1
   SREG x14, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b28_not_equal:
@@ -1616,6 +1736,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b28_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x13) # load value in memory: x13 = 0x00000000000018ae
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x0000000000002996
+  RVTEST_TESTDATA_LOAD_INT(x1, x18) # load rd compare value: x18 = 0x00000000000018ae
   LA(x3, scratch) # load base address into rs1
   SREG x13, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b29_equal:
@@ -1629,6 +1750,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b29_equal:
 # Testcase cp_rs2 (Test source rs2 = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load value in memory: x28 = 0x000000000000e627
   RVTEST_TESTDATA_LOAD_INT(x1, x29) # load rs2: x29 = 0x000000000000f626
+  RVTEST_TESTDATA_LOAD_INT(x1, x24) # load rd compare value: x24 = 0x0000000000005239
   LA(x30, scratch) # load base address into rs1
   SREG x28, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b29_not_equal:
@@ -1642,6 +1764,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b29_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x11) # load value in memory: x11 = 0x0000000000000d9d
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x0000000000007a4d
+  RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rd compare value: x17 = 0x0000000000000d9d
   LA(x23, scratch) # load base address into rs1
   SREG x11, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b30_equal:
@@ -1655,6 +1778,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b30_equal:
 # Testcase cp_rs2 (Test source rs2 = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x9) # load value in memory: x9 = 0x000000000000b32d
   RVTEST_TESTDATA_LOAD_INT(x1, x30) # load rs2: x30 = 0x000000000000f334
+  RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rd compare value: x22 = 0x000000000000fdc9
   LA(x7, scratch) # load base address into rs1
   SREG x9, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b30_not_equal:
@@ -1668,6 +1792,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b30_not_equal:
 # Testcase cp_rs2 (Test source rs2 = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x27) # load value in memory: x27 = 0x000000000000f819
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x0000000000003559
+  RVTEST_TESTDATA_LOAD_INT(x1, x17) # load rd compare value: x17 = 0x000000000000f819
   LA(x28, scratch) # load base address into rs1
   SREG x27, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b31_equal:
@@ -1681,6 +1806,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b31_equal:
 # Testcase cp_rs2 (Test source rs2 = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x24) # load value in memory: x24 = 0x000000000000ca0c
   RVTEST_TESTDATA_LOAD_INT(x1, x31) # load rs2: x31 = 0x000000000000d8f8
+  RVTEST_TESTDATA_LOAD_INT(x1, x6) # load rd compare value: x6 = 0x000000000000e2b6
   LA(x8, scratch) # load base address into rs1
   SREG x24, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rs2_b31_not_equal:
@@ -1698,6 +1824,7 @@ ZacasZabha_amocas_h_cg_cp_rs2_b31_not_equal:
 # Testcase cp_rd (Test destination rd = x0, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x19) # load value in memory: x19 = 0x0000000000006d46
   RVTEST_TESTDATA_LOAD_INT(x1, x28) # load rs2: x28 = 0x0000000000006674
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rd compare value: x0 = 0x0000000000006d46
   LA(x3, scratch) # load base address into rs1
   SREG x19, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b0_equal:
@@ -1711,6 +1838,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b0_equal:
 # Testcase cp_rd (Test destination rd = x0, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x1, x3) # load value in memory: x3 = 0x0000000000001eea
   RVTEST_TESTDATA_LOAD_INT(x1, x22) # load rs2: x22 = 0x000000000000c1ba
+  RVTEST_TESTDATA_LOAD_INT(x1, x0) # load rd compare value: x0 = 0x0000000000009b03
   LA(x14, scratch) # load base address into rs1
   SREG x3, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b0_not_equal:
@@ -1725,6 +1853,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b0_not_equal:
 # Testcase cp_rd (Test destination rd = x1, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load value in memory: x10 = 0x000000000000eafb
   RVTEST_TESTDATA_LOAD_INT(x27, x0) # load rs2: x0 = 0x0000000000008329
+  RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rd compare value: x1 = 0x000000000000eafb
   LA(x9, scratch) # load base address into rs1
   SREG x10, 0(x9) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b1_equal:
@@ -1738,6 +1867,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b1_equal:
 # Testcase cp_rd (Test destination rd = x1, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x18) # load value in memory: x18 = 0x000000000000dd8f
   RVTEST_TESTDATA_LOAD_INT(x27, x29) # load rs2: x29 = 0x000000000000dbb4
+  RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rd compare value: x1 = 0x00000000000038ba
   LA(x28, scratch) # load base address into rs1
   SREG x18, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b1_not_equal:
@@ -1751,6 +1881,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b1_not_equal:
 # Testcase cp_rd (Test destination rd = x2, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load value in memory: x31 = 0x00000000000044c8
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rs2: x16 = 0x0000000000000ebc
+  RVTEST_TESTDATA_LOAD_INT(x27, x2) # load rd compare value: x2 = 0x00000000000044c8
   LA(x28, scratch) # load base address into rs1
   SREG x31, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b2_equal:
@@ -1764,6 +1895,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b2_equal:
 # Testcase cp_rd (Test destination rd = x2, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load value in memory: x16 = 0x0000000000004bde
   RVTEST_TESTDATA_LOAD_INT(x27, x3) # load rs2: x3 = 0x0000000000005e9f
+  RVTEST_TESTDATA_LOAD_INT(x27, x2) # load rd compare value: x2 = 0x000000000000b841
   LA(x30, scratch) # load base address into rs1
   SREG x16, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b2_not_equal:
@@ -1777,6 +1909,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b2_not_equal:
 # Testcase cp_rd (Test destination rd = x3, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x11) # load value in memory: x11 = 0x00000000000018a7
   RVTEST_TESTDATA_LOAD_INT(x27, x29) # load rs2: x29 = 0x000000000000a4a1
+  RVTEST_TESTDATA_LOAD_INT(x27, x3) # load rd compare value: x3 = 0x00000000000018a7
   LA(x10, scratch) # load base address into rs1
   SREG x11, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b3_equal:
@@ -1790,6 +1923,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b3_equal:
 # Testcase cp_rd (Test destination rd = x3, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load value in memory: x8 = 0x0000000000006999
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load rs2: x31 = 0x00000000000020a3
+  RVTEST_TESTDATA_LOAD_INT(x27, x3) # load rd compare value: x3 = 0x000000000000f969
   LA(x10, scratch) # load base address into rs1
   SREG x8, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b3_not_equal:
@@ -1805,6 +1939,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b3_not_equal:
 # Testcase cp_rd (Test destination rd = x4, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x5) # load value in memory: x5 = 0x000000000000b497
   RVTEST_TESTDATA_LOAD_INT(x27, x19) # load rs2: x19 = 0x0000000000004840
+  RVTEST_TESTDATA_LOAD_INT(x27, x4) # load rd compare value: x4 = 0x000000000000b497
   LA(x26, scratch) # load base address into rs1
   SREG x5, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b4_equal:
@@ -1818,6 +1953,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b4_equal:
 # Testcase cp_rd (Test destination rd = x4, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x26) # load value in memory: x26 = 0x000000000000f482
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rs2: x12 = 0x00000000000018ce
+  RVTEST_TESTDATA_LOAD_INT(x27, x4) # load rd compare value: x4 = 0x000000000000f023
   LA(x29, scratch) # load base address into rs1
   SREG x26, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b4_not_equal:
@@ -1831,6 +1967,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b4_not_equal:
 # Testcase cp_rd (Test destination rd = x5, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load value in memory: x31 = 0x000000000000d264
   RVTEST_TESTDATA_LOAD_INT(x27, x30) # load rs2: x30 = 0x000000000000274a
+  RVTEST_TESTDATA_LOAD_INT(x27, x5) # load rd compare value: x5 = 0x000000000000d264
   LA(x26, scratch) # load base address into rs1
   SREG x31, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b5_equal:
@@ -1844,6 +1981,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b5_equal:
 # Testcase cp_rd (Test destination rd = x5, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load value in memory: x1 = 0x00000000000098d7
   RVTEST_TESTDATA_LOAD_INT(x27, x26) # load rs2: x26 = 0x000000000000ddc6
+  RVTEST_TESTDATA_LOAD_INT(x27, x5) # load rd compare value: x5 = 0x0000000000006321
   LA(x22, scratch) # load base address into rs1
   SREG x1, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b5_not_equal:
@@ -1857,6 +1995,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b5_not_equal:
 # Testcase cp_rd (Test destination rd = x6, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x14) # load value in memory: x14 = 0x000000000000a213
   RVTEST_TESTDATA_LOAD_INT(x27, x24) # load rs2: x24 = 0x0000000000004eca
+  RVTEST_TESTDATA_LOAD_INT(x27, x6) # load rd compare value: x6 = 0x000000000000a213
   LA(x4, scratch) # load base address into rs1
   SREG x14, 0(x4) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b6_equal:
@@ -1870,6 +2009,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b6_equal:
 # Testcase cp_rd (Test destination rd = x6, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x5) # load value in memory: x5 = 0x000000000000a0cd
   RVTEST_TESTDATA_LOAD_INT(x27, x30) # load rs2: x30 = 0x0000000000009b4d
+  RVTEST_TESTDATA_LOAD_INT(x27, x6) # load rd compare value: x6 = 0x0000000000003074
   LA(x20, scratch) # load base address into rs1
   SREG x5, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b6_not_equal:
@@ -1885,6 +2025,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b6_not_equal:
 # Testcase cp_rd (Test destination rd = x7, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x20) # load value in memory: x20 = 0x0000000000003878
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load rs2: x8 = 0x0000000000002fee
+  RVTEST_TESTDATA_LOAD_INT(x27, x7) # load rd compare value: x7 = 0x0000000000003878
   LA(x29, scratch) # load base address into rs1
   SREG x20, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b7_equal:
@@ -1898,6 +2039,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b7_equal:
 # Testcase cp_rd (Test destination rd = x7, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x19) # load value in memory: x19 = 0x0000000000008850
   RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rs2: x20 = 0x000000000000df58
+  RVTEST_TESTDATA_LOAD_INT(x27, x7) # load rd compare value: x7 = 0x0000000000000b37
   LA(x31, scratch) # load base address into rs1
   SREG x19, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b7_not_equal:
@@ -1911,6 +2053,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b7_not_equal:
 # Testcase cp_rd (Test destination rd = x8, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x7) # load value in memory: x7 = 0x00000000000019e9
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rs2: x13 = 0x0000000000001ead
+  RVTEST_TESTDATA_LOAD_INT(x27, x8) # load rd compare value: x8 = 0x00000000000019e9
   LA(x1, scratch) # load base address into rs1
   SREG x7, 0(x1) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b8_equal:
@@ -1924,6 +2067,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b8_equal:
 # Testcase cp_rd (Test destination rd = x8, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load value in memory: x31 = 0x0000000000005939
   RVTEST_TESTDATA_LOAD_INT(x27, x28) # load rs2: x28 = 0x000000000000194e
+  RVTEST_TESTDATA_LOAD_INT(x27, x8) # load rd compare value: x8 = 0x00000000000018a2
   LA(x29, scratch) # load base address into rs1
   SREG x31, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b8_not_equal:
@@ -1937,6 +2081,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b8_not_equal:
 # Testcase cp_rd (Test destination rd = x9, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load value in memory: x16 = 0x00000000000039d7
   RVTEST_TESTDATA_LOAD_INT(x27, x25) # load rs2: x25 = 0x0000000000007331
+  RVTEST_TESTDATA_LOAD_INT(x27, x9) # load rd compare value: x9 = 0x00000000000039d7
   LA(x20, scratch) # load base address into rs1
   SREG x16, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b9_equal:
@@ -1950,6 +2095,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b9_equal:
 # Testcase cp_rd (Test destination rd = x9, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x19) # load value in memory: x19 = 0x000000000000ac1a
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rs2: x1 = 0x000000000000a5fb
+  RVTEST_TESTDATA_LOAD_INT(x27, x9) # load rd compare value: x9 = 0x0000000000004382
   LA(x24, scratch) # load base address into rs1
   SREG x19, 0(x24) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b9_not_equal:
@@ -1963,6 +2109,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b9_not_equal:
 # Testcase cp_rd (Test destination rd = x10, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x21) # load value in memory: x21 = 0x000000000000b65a
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rs2: x1 = 0x0000000000004b3c
+  RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rd compare value: x10 = 0x000000000000b65a
   LA(x17, scratch) # load base address into rs1
   SREG x21, 0(x17) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b10_equal:
@@ -1976,6 +2123,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b10_equal:
 # Testcase cp_rd (Test destination rd = x10, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x25) # load value in memory: x25 = 0x0000000000005356
   RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rs2: x20 = 0x0000000000000cb2
+  RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rd compare value: x10 = 0x0000000000007f07
   LA(x22, scratch) # load base address into rs1
   SREG x25, 0(x22) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b10_not_equal:
@@ -1989,6 +2137,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b10_not_equal:
 # Testcase cp_rd (Test destination rd = x11, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x26) # load value in memory: x26 = 0x0000000000003913
   RVTEST_TESTDATA_LOAD_INT(x27, x25) # load rs2: x25 = 0x000000000000ced3
+  RVTEST_TESTDATA_LOAD_INT(x27, x11) # load rd compare value: x11 = 0x0000000000003913
   LA(x3, scratch) # load base address into rs1
   SREG x26, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b11_equal:
@@ -2002,6 +2151,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b11_equal:
 # Testcase cp_rd (Test destination rd = x11, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x7) # load value in memory: x7 = 0x0000000000007d75
   RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rs2: x16 = 0x000000000000043c
+  RVTEST_TESTDATA_LOAD_INT(x27, x11) # load rd compare value: x11 = 0x00000000000038b9
   LA(x21, scratch) # load base address into rs1
   SREG x7, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b11_not_equal:
@@ -2015,6 +2165,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b11_not_equal:
 # Testcase cp_rd (Test destination rd = x12, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load value in memory: x1 = 0x000000000000e3c6
   RVTEST_TESTDATA_LOAD_INT(x27, x6) # load rs2: x6 = 0x00000000000051ed
+  RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rd compare value: x12 = 0x000000000000e3c6
   LA(x11, scratch) # load base address into rs1
   SREG x1, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b12_equal:
@@ -2028,6 +2179,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b12_equal:
 # Testcase cp_rd (Test destination rd = x12, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x24) # load value in memory: x24 = 0x0000000000009d1a
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rs2: x10 = 0x000000000000b5f7
+  RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rd compare value: x12 = 0x000000000000ce59
   LA(x31, scratch) # load base address into rs1
   SREG x24, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b12_not_equal:
@@ -2041,6 +2193,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b12_not_equal:
 # Testcase cp_rd (Test destination rd = x13, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x3) # load value in memory: x3 = 0x00000000000047a1
   RVTEST_TESTDATA_LOAD_INT(x27, x6) # load rs2: x6 = 0x0000000000007640
+  RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rd compare value: x13 = 0x00000000000047a1
   LA(x10, scratch) # load base address into rs1
   SREG x3, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b13_equal:
@@ -2054,6 +2207,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b13_equal:
 # Testcase cp_rd (Test destination rd = x13, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load value in memory: x31 = 0x0000000000002348
   RVTEST_TESTDATA_LOAD_INT(x27, x30) # load rs2: x30 = 0x000000000000eddc
+  RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rd compare value: x13 = 0x0000000000008cbc
   LA(x10, scratch) # load base address into rs1
   SREG x31, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b13_not_equal:
@@ -2067,6 +2221,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b13_not_equal:
 # Testcase cp_rd (Test destination rd = x14, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load value in memory: x8 = 0x0000000000008f63
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rs2: x13 = 0x000000000000c25e
+  RVTEST_TESTDATA_LOAD_INT(x27, x14) # load rd compare value: x14 = 0x0000000000008f63
   LA(x28, scratch) # load base address into rs1
   SREG x8, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b14_equal:
@@ -2080,6 +2235,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b14_equal:
 # Testcase cp_rd (Test destination rd = x14, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x29) # load value in memory: x29 = 0x00000000000043d9
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rs2: x1 = 0x000000000000122c
+  RVTEST_TESTDATA_LOAD_INT(x27, x14) # load rd compare value: x14 = 0x0000000000005c7a
   LA(x18, scratch) # load base address into rs1
   SREG x29, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b14_not_equal:
@@ -2094,6 +2250,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b14_not_equal:
 # Testcase cp_rd (Test destination rd = x15, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load value in memory: x13 = 0x0000000000001e5a
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rs2: x10 = 0x0000000000006a6c
+  RVTEST_TESTDATA_LOAD_INT(x27, x15) # load rd compare value: x15 = 0x0000000000001e5a
   LA(x11, scratch) # load base address into rs1
   SREG x13, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b15_equal:
@@ -2107,6 +2264,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b15_equal:
 # Testcase cp_rd (Test destination rd = x15, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x14) # load value in memory: x14 = 0x0000000000009690
   RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rs2: x20 = 0x00000000000005fb
+  RVTEST_TESTDATA_LOAD_INT(x27, x15) # load rd compare value: x15 = 0x0000000000001df4
   LA(x8, scratch) # load base address into rs1
   SREG x14, 0(x8) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b15_not_equal:
@@ -2120,6 +2278,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b15_not_equal:
 # Testcase cp_rd (Test destination rd = x16, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load value in memory: x1 = 0x0000000000000b6a
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rs2: x10 = 0x0000000000005dc7
+  RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rd compare value: x16 = 0x0000000000000b6a
   LA(x24, scratch) # load base address into rs1
   SREG x1, 0(x24) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b16_equal:
@@ -2133,6 +2292,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b16_equal:
 # Testcase cp_rd (Test destination rd = x16, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load value in memory: x8 = 0x0000000000009524
   RVTEST_TESTDATA_LOAD_INT(x27, x15) # load rs2: x15 = 0x0000000000003e2e
+  RVTEST_TESTDATA_LOAD_INT(x27, x16) # load rd compare value: x16 = 0x000000000000986f
   LA(x10, scratch) # load base address into rs1
   SREG x8, 0(x10) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b16_not_equal:
@@ -2146,6 +2306,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b16_not_equal:
 # Testcase cp_rd (Test destination rd = x17, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load value in memory: x12 = 0x00000000000030a8
   RVTEST_TESTDATA_LOAD_INT(x27, x29) # load rs2: x29 = 0x000000000000bc15
+  RVTEST_TESTDATA_LOAD_INT(x27, x17) # load rd compare value: x17 = 0x00000000000030a8
   LA(x3, scratch) # load base address into rs1
   SREG x12, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b17_equal:
@@ -2159,6 +2320,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b17_equal:
 # Testcase cp_rd (Test destination rd = x17, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load value in memory: x13 = 0x0000000000004995
   RVTEST_TESTDATA_LOAD_INT(x27, x14) # load rs2: x14 = 0x000000000000458c
+  RVTEST_TESTDATA_LOAD_INT(x27, x17) # load rd compare value: x17 = 0x0000000000001d9e
   LA(x26, scratch) # load base address into rs1
   SREG x13, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b17_not_equal:
@@ -2172,6 +2334,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b17_not_equal:
 # Testcase cp_rd (Test destination rd = x18, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x26) # load value in memory: x26 = 0x0000000000008526
   RVTEST_TESTDATA_LOAD_INT(x27, x7) # load rs2: x7 = 0x0000000000007815
+  RVTEST_TESTDATA_LOAD_INT(x27, x18) # load rd compare value: x18 = 0x0000000000008526
   LA(x12, scratch) # load base address into rs1
   SREG x26, 0(x12) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b18_equal:
@@ -2185,6 +2348,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b18_equal:
 # Testcase cp_rd (Test destination rd = x18, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load value in memory: x13 = 0x000000000000c76b
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load rs2: x8 = 0x0000000000001f83
+  RVTEST_TESTDATA_LOAD_INT(x27, x18) # load rd compare value: x18 = 0x000000000000e114
   LA(x26, scratch) # load base address into rs1
   SREG x13, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b18_not_equal:
@@ -2198,6 +2362,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b18_not_equal:
 # Testcase cp_rd (Test destination rd = x19, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load value in memory: x8 = 0x0000000000003630
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load rs2: x12 = 0x00000000000009e0
+  RVTEST_TESTDATA_LOAD_INT(x27, x19) # load rd compare value: x19 = 0x0000000000003630
   LA(x18, scratch) # load base address into rs1
   SREG x8, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b19_equal:
@@ -2211,6 +2376,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b19_equal:
 # Testcase cp_rd (Test destination rd = x19, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x22) # load value in memory: x22 = 0x00000000000039ed
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load rs2: x31 = 0x0000000000000bda
+  RVTEST_TESTDATA_LOAD_INT(x27, x19) # load rd compare value: x19 = 0x000000000000296b
   LA(x3, scratch) # load base address into rs1
   SREG x22, 0(x3) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b19_not_equal:
@@ -2224,6 +2390,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b19_not_equal:
 # Testcase cp_rd (Test destination rd = x20, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x30) # load value in memory: x30 = 0x0000000000002b38
   RVTEST_TESTDATA_LOAD_INT(x27, x0) # load rs2: x0 = 0x000000000000133c
+  RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rd compare value: x20 = 0x0000000000002b38
   LA(x23, scratch) # load base address into rs1
   SREG x30, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b20_equal:
@@ -2237,6 +2404,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b20_equal:
 # Testcase cp_rd (Test destination rd = x20, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load value in memory: x8 = 0x000000000000a019
   RVTEST_TESTDATA_LOAD_INT(x27, x29) # load rs2: x29 = 0x00000000000022a8
+  RVTEST_TESTDATA_LOAD_INT(x27, x20) # load rd compare value: x20 = 0x0000000000001187
   LA(x31, scratch) # load base address into rs1
   SREG x8, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b20_not_equal:
@@ -2251,6 +2419,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b20_not_equal:
 # Testcase cp_rd (Test destination rd = x21, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load value in memory: x12 = 0x000000000000437e
   RVTEST_TESTDATA_LOAD_INT(x27, x17) # load rs2: x17 = 0x000000000000889b
+  RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rd compare value: x21 = 0x000000000000437e
   LA(x23, scratch) # load base address into rs1
   SREG x12, 0(x23) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b21_equal:
@@ -2264,6 +2433,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b21_equal:
 # Testcase cp_rd (Test destination rd = x21, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load value in memory: x13 = 0x00000000000027d9
   RVTEST_TESTDATA_LOAD_INT(x27, x6) # load rs2: x6 = 0x000000000000951c
+  RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rd compare value: x21 = 0x000000000000bd99
   LA(x30, scratch) # load base address into rs1
   SREG x13, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b21_not_equal:
@@ -2277,6 +2447,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b21_not_equal:
 # Testcase cp_rd (Test destination rd = x22, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x8) # load value in memory: x8 = 0x0000000000006b49
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load rs2: x31 = 0x0000000000003d38
+  RVTEST_TESTDATA_LOAD_INT(x27, x22) # load rd compare value: x22 = 0x0000000000006b49
   LA(x19, scratch) # load base address into rs1
   SREG x8, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b22_equal:
@@ -2290,6 +2461,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b22_equal:
 # Testcase cp_rd (Test destination rd = x22, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load value in memory: x13 = 0x0000000000004882
   RVTEST_TESTDATA_LOAD_INT(x27, x21) # load rs2: x21 = 0x000000000000821f
+  RVTEST_TESTDATA_LOAD_INT(x27, x22) # load rd compare value: x22 = 0x0000000000001cca
   LA(x18, scratch) # load base address into rs1
   SREG x13, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b22_not_equal:
@@ -2303,6 +2475,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b22_not_equal:
 # Testcase cp_rd (Test destination rd = x23, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x19) # load value in memory: x19 = 0x00000000000009a2
   RVTEST_TESTDATA_LOAD_INT(x27, x24) # load rs2: x24 = 0x000000000000dd5e
+  RVTEST_TESTDATA_LOAD_INT(x27, x23) # load rd compare value: x23 = 0x00000000000009a2
   LA(x21, scratch) # load base address into rs1
   SREG x19, 0(x21) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b23_equal:
@@ -2316,6 +2489,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b23_equal:
 # Testcase cp_rd (Test destination rd = x23, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x31) # load value in memory: x31 = 0x000000000000a193
   RVTEST_TESTDATA_LOAD_INT(x27, x13) # load rs2: x13 = 0x000000000000b7a7
+  RVTEST_TESTDATA_LOAD_INT(x27, x23) # load rd compare value: x23 = 0x000000000000285b
   LA(x28, scratch) # load base address into rs1
   SREG x31, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b23_not_equal:
@@ -2329,6 +2503,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b23_not_equal:
 # Testcase cp_rd (Test destination rd = x24, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load value in memory: x12 = 0x000000000000404e
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load rs2: x10 = 0x000000000000e95e
+  RVTEST_TESTDATA_LOAD_INT(x27, x24) # load rd compare value: x24 = 0x000000000000404e
   LA(x7, scratch) # load base address into rs1
   SREG x12, 0(x7) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b24_equal:
@@ -2342,6 +2517,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b24_equal:
 # Testcase cp_rd (Test destination rd = x24, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x10) # load value in memory: x10 = 0x00000000000075bd
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rs2: x1 = 0x000000000000d7d1
+  RVTEST_TESTDATA_LOAD_INT(x27, x24) # load rd compare value: x24 = 0x000000000000b9bb
   LA(x14, scratch) # load base address into rs1
   SREG x10, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b24_not_equal:
@@ -2355,6 +2531,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b24_not_equal:
 # Testcase cp_rd (Test destination rd = x25, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x12) # load value in memory: x12 = 0x0000000000006b05
   RVTEST_TESTDATA_LOAD_INT(x27, x18) # load rs2: x18 = 0x0000000000006ea7
+  RVTEST_TESTDATA_LOAD_INT(x27, x25) # load rd compare value: x25 = 0x0000000000006b05
   LA(x31, scratch) # load base address into rs1
   SREG x12, 0(x31) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b25_equal:
@@ -2368,6 +2545,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b25_equal:
 # Testcase cp_rd (Test destination rd = x25, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x11) # load value in memory: x11 = 0x000000000000d608
   RVTEST_TESTDATA_LOAD_INT(x27, x1) # load rs2: x1 = 0x000000000000756b
+  RVTEST_TESTDATA_LOAD_INT(x27, x25) # load rd compare value: x25 = 0x0000000000008f2e
   LA(x18, scratch) # load base address into rs1
   SREG x11, 0(x18) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b25_not_equal:
@@ -2381,6 +2559,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b25_not_equal:
 # Testcase cp_rd (Test destination rd = x26, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x18) # load value in memory: x18 = 0x000000000000e9e5
   RVTEST_TESTDATA_LOAD_INT(x27, x14) # load rs2: x14 = 0x00000000000036b8
+  RVTEST_TESTDATA_LOAD_INT(x27, x26) # load rd compare value: x26 = 0x000000000000e9e5
   LA(x15, scratch) # load base address into rs1
   SREG x18, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b26_equal:
@@ -2394,6 +2573,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b26_equal:
 # Testcase cp_rd (Test destination rd = x26, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x27, x29) # load value in memory: x29 = 0x000000000000d86b
   RVTEST_TESTDATA_LOAD_INT(x27, x23) # load rs2: x23 = 0x000000000000550e
+  RVTEST_TESTDATA_LOAD_INT(x27, x26) # load rd compare value: x26 = 0x0000000000004723
   LA(x15, scratch) # load base address into rs1
   SREG x29, 0(x15) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b26_not_equal:
@@ -2408,6 +2588,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b26_not_equal:
 # Testcase cp_rd (Test destination rd = x27, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x8) # load value in memory: x8 = 0x00000000000039e7
   RVTEST_TESTDATA_LOAD_INT(x12, x18) # load rs2: x18 = 0x000000000000440e
+  RVTEST_TESTDATA_LOAD_INT(x12, x27) # load rd compare value: x27 = 0x00000000000039e7
   LA(x14, scratch) # load base address into rs1
   SREG x8, 0(x14) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b27_equal:
@@ -2421,6 +2602,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b27_equal:
 # Testcase cp_rd (Test destination rd = x27, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x7) # load value in memory: x7 = 0x0000000000008b4f
   RVTEST_TESTDATA_LOAD_INT(x12, x23) # load rs2: x23 = 0x00000000000045b9
+  RVTEST_TESTDATA_LOAD_INT(x12, x27) # load rd compare value: x27 = 0x0000000000000b9f
   LA(x30, scratch) # load base address into rs1
   SREG x7, 0(x30) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b27_not_equal:
@@ -2434,6 +2616,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b27_not_equal:
 # Testcase cp_rd (Test destination rd = x28, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x16) # load value in memory: x16 = 0x0000000000005351
   RVTEST_TESTDATA_LOAD_INT(x12, x0) # load rs2: x0 = 0x000000000000044b
+  RVTEST_TESTDATA_LOAD_INT(x12, x28) # load rd compare value: x28 = 0x0000000000005351
   LA(x26, scratch) # load base address into rs1
   SREG x16, 0(x26) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b28_equal:
@@ -2447,6 +2630,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b28_equal:
 # Testcase cp_rd (Test destination rd = x28, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x27) # load value in memory: x27 = 0x00000000000017cd
   RVTEST_TESTDATA_LOAD_INT(x12, x16) # load rs2: x16 = 0x00000000000086a4
+  RVTEST_TESTDATA_LOAD_INT(x12, x28) # load rd compare value: x28 = 0x00000000000064a5
   LA(x20, scratch) # load base address into rs1
   SREG x27, 0(x20) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b28_not_equal:
@@ -2460,6 +2644,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b28_not_equal:
 # Testcase cp_rd (Test destination rd = x29, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x15) # load value in memory: x15 = 0x00000000000074ce
   RVTEST_TESTDATA_LOAD_INT(x12, x1) # load rs2: x1 = 0x0000000000001305
+  RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rd compare value: x29 = 0x00000000000074ce
   LA(x11, scratch) # load base address into rs1
   SREG x15, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b29_equal:
@@ -2473,6 +2658,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b29_equal:
 # Testcase cp_rd (Test destination rd = x29, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x25) # load value in memory: x25 = 0x00000000000078c8
   RVTEST_TESTDATA_LOAD_INT(x12, x30) # load rs2: x30 = 0x0000000000004e83
+  RVTEST_TESTDATA_LOAD_INT(x12, x29) # load rd compare value: x29 = 0x000000000000ba80
   LA(x28, scratch) # load base address into rs1
   SREG x25, 0(x28) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b29_not_equal:
@@ -2486,6 +2672,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b29_not_equal:
 # Testcase cp_rd (Test destination rd = x30, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x26) # load value in memory: x26 = 0x0000000000005938
   RVTEST_TESTDATA_LOAD_INT(x12, x14) # load rs2: x14 = 0x000000000000e2ec
+  RVTEST_TESTDATA_LOAD_INT(x12, x30) # load rd compare value: x30 = 0x0000000000005938
   LA(x19, scratch) # load base address into rs1
   SREG x26, 0(x19) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b30_equal:
@@ -2499,6 +2686,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b30_equal:
 # Testcase cp_rd (Test destination rd = x30, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x14) # load value in memory: x14 = 0x000000000000721d
   RVTEST_TESTDATA_LOAD_INT(x12, x22) # load rs2: x22 = 0x00000000000061ca
+  RVTEST_TESTDATA_LOAD_INT(x12, x30) # load rd compare value: x30 = 0x000000000000e0f6
   LA(x13, scratch) # load base address into rs1
   SREG x14, 0(x13) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b30_not_equal:
@@ -2512,6 +2700,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b30_not_equal:
 # Testcase cp_rd (Test destination rd = x31, matching (rd_val == mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x25) # load value in memory: x25 = 0x000000000000af92
   RVTEST_TESTDATA_LOAD_INT(x12, x23) # load rs2: x23 = 0x00000000000030df
+  RVTEST_TESTDATA_LOAD_INT(x12, x31) # load rd compare value: x31 = 0x000000000000af92
   LA(x11, scratch) # load base address into rs1
   SREG x25, 0(x11) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b31_equal:
@@ -2525,6 +2714,7 @@ ZacasZabha_amocas_h_cg_cp_rd_b31_equal:
 # Testcase cp_rd (Test destination rd = x31, non-matching (rd_val != mem_val))
   RVTEST_TESTDATA_LOAD_INT(x12, x20) # load value in memory: x20 = 0x0000000000005746
   RVTEST_TESTDATA_LOAD_INT(x12, x24) # load rs2: x24 = 0x0000000000003a37
+  RVTEST_TESTDATA_LOAD_INT(x12, x31) # load rd compare value: x31 = 0x00000000000086f5
   LA(x29, scratch) # load base address into rs1
   SREG x20, 0(x29) # store value into memory at address in rs1
 ZacasZabha_amocas_h_cg_cp_rd_b31_not_equal:
@@ -4556,384 +4746,574 @@ RVTEST_DATA_BEGIN
 // Test data
 .dword 0x0000000000009f45
 .dword 0x000000000000c666
+.dword 0x0000000000009f45
 .dword 0x0000000000005688
 .dword 0x000000000000beef
+.dword 0x00000000000044ef
 .dword 0x000000000000e10d
 .dword 0x0000000000003d42
+.dword 0x000000000000e10d
 .dword 0x000000000000f38e
 .dword 0x000000000000bd95
+.dword 0x0000000000003481
 .dword 0x000000000000b5d1
 .dword 0x000000000000911a
+.dword 0x000000000000b5d1
 .dword 0x00000000000050e0
 .dword 0x00000000000067ec
+.dword 0x0000000000006335
 .dword 0x0000000000003b4a
 .dword 0x0000000000004f41
+.dword 0x0000000000003b4a
 .dword 0x000000000000e32d
 .dword 0x000000000000c7d8
+.dword 0x000000000000ff81
 .dword 0x0000000000000c17
 .dword 0x00000000000064b7
+.dword 0x0000000000000c17
 .dword 0x000000000000c2a8
 .dword 0x000000000000fbd6
+.dword 0x0000000000000101
 .dword 0x0000000000006d40
 .dword 0x000000000000def9
+.dword 0x0000000000006d40
 .dword 0x00000000000055c9
 .dword 0x0000000000003a0e
+.dword 0x000000000000eca3
 .dword 0x0000000000005adf
 .dword 0x000000000000b308
+.dword 0x0000000000005adf
 .dword 0x000000000000d892
 .dword 0x000000000000adb5
+.dword 0x000000000000c917
 .dword 0x000000000000d44f
 .dword 0x000000000000726b
+.dword 0x000000000000d44f
 .dword 0x0000000000006ce6
 .dword 0x000000000000e828
+.dword 0x0000000000002d67
 .dword 0x0000000000002eaf
 .dword 0x000000000000de7d
+.dword 0x0000000000002eaf
 .dword 0x00000000000024f9
 .dword 0x0000000000004a25
+.dword 0x0000000000004052
 .dword 0x0000000000002cbe
 .dword 0x000000000000eca6
+.dword 0x0000000000002cbe
 .dword 0x0000000000007c98
 .dword 0x000000000000da89
+.dword 0x000000000000e9a5
 .dword 0x0000000000007451
 .dword 0x000000000000cbaf
+.dword 0x0000000000007451
 .dword 0x000000000000d729
 .dword 0x0000000000009925
+.dword 0x00000000000076b8
 .dword 0x000000000000e5dd
 .dword 0x000000000000c36f
+.dword 0x000000000000e5dd
 .dword 0x0000000000008902
 .dword 0x000000000000d550
+.dword 0x000000000000513d
 .dword 0x000000000000dcf8
 .dword 0x000000000000244e
+.dword 0x000000000000dcf8
 .dword 0x0000000000006319
 .dword 0x0000000000002c06
+.dword 0x0000000000002a74
 .dword 0x000000000000476b
 .dword 0x0000000000009e6c
+.dword 0x000000000000476b
 .dword 0x0000000000007c51
 .dword 0x000000000000db71
+.dword 0x000000000000cf3c
 .dword 0x000000000000bcfd
 .dword 0x000000000000d2e2
+.dword 0x000000000000bcfd
 .dword 0x000000000000e307
 .dword 0x0000000000001486
+.dword 0x0000000000000944
 .dword 0x000000000000014d
 .dword 0x0000000000001afa
+.dword 0x000000000000014d
 .dword 0x000000000000bc2d
 .dword 0x000000000000c50b
+.dword 0x000000000000c36d
 .dword 0x000000000000c04e
 .dword 0x0000000000000f2a
+.dword 0x000000000000c04e
 .dword 0x00000000000077de
 .dword 0x00000000000090db
+.dword 0x0000000000005015
 .dword 0x0000000000001a88
 .dword 0x0000000000009206
+.dword 0x0000000000001a88
 .dword 0x000000000000e698
 .dword 0x00000000000042cb
+.dword 0x00000000000044b1
 .dword 0x000000000000eb6f
 .dword 0x00000000000072e3
+.dword 0x000000000000eb6f
 .dword 0x0000000000000d30
 .dword 0x0000000000005c8d
+.dword 0x000000000000a478
 .dword 0x0000000000008d9b
 .dword 0x000000000000cfb2
+.dword 0x0000000000008d9b
 .dword 0x000000000000baed
 .dword 0x0000000000001afb
+.dword 0x000000000000ccd8
 .dword 0x000000000000cf5c
 .dword 0x0000000000005bad
+.dword 0x000000000000cf5c
 .dword 0x00000000000017e9
 .dword 0x00000000000049d4
+.dword 0x000000000000092c
 .dword 0x000000000000bee0
 .dword 0x0000000000005090
+.dword 0x000000000000bee0
 .dword 0x0000000000009ac1
 .dword 0x00000000000084e2
+.dword 0x00000000000028e8
 .dword 0x000000000000d3f7
 .dword 0x0000000000005b62
+.dword 0x000000000000d3f7
 .dword 0x0000000000005a5b
 .dword 0x000000000000bbdb
+.dword 0x000000000000a0f3
 .dword 0x0000000000000c05
 .dword 0x0000000000005c4c
+.dword 0x0000000000000c05
 .dword 0x0000000000006309
 .dword 0x0000000000009ab3
+.dword 0x0000000000000f9a
 .dword 0x0000000000005035
 .dword 0x0000000000003563
+.dword 0x0000000000005035
 .dword 0x0000000000000e64
 .dword 0x000000000000fe78
+.dword 0x000000000000175e
 .dword 0x0000000000006d3a
 .dword 0x00000000000086a9
+.dword 0x0000000000006d3a
 .dword 0x00000000000093e6
 .dword 0x000000000000d238
+.dword 0x0000000000007b61
 .dword 0x0000000000006cec
 .dword 0x000000000000f5d4
+.dword 0x0000000000006cec
 .dword 0x000000000000effa
 .dword 0x0000000000004a9f
+.dword 0x000000000000881b
 .dword 0x0000000000001d5a
 .dword 0x000000000000198d
+.dword 0x0000000000001d5a
 .dword 0x0000000000004dc0
 .dword 0x0000000000003efd
+.dword 0x00000000000099aa
 .dword 0x0000000000005fd7
 .dword 0x000000000000601f
+.dword 0x0000000000005fd7
 .dword 0x000000000000f66c
 .dword 0x000000000000647a
+.dword 0x000000000000540f
 .dword 0x000000000000c1e9
 .dword 0x0000000000000599
+.dword 0x000000000000c1e9
 .dword 0x000000000000a207
 .dword 0x0000000000007a2e
+.dword 0x000000000000ca8a
 .dword 0x000000000000f47c
 .dword 0x000000000000e7b8
+.dword 0x000000000000f47c
 .dword 0x00000000000015c1
 .dword 0x0000000000008607
+.dword 0x0000000000000cf5
 .dword 0x000000000000fac1
 .dword 0x00000000000034b3
+.dword 0x000000000000fac1
 .dword 0x000000000000ace4
 .dword 0x0000000000001882
+.dword 0x000000000000abc7
 .dword 0x000000000000192d
 .dword 0x000000000000027b
+.dword 0x000000000000192d
 .dword 0x0000000000001bd6
 .dword 0x0000000000004ed0
+.dword 0x0000000000005351
 .dword 0x000000000000bb46
 .dword 0x000000000000f515
+.dword 0x000000000000bb46
 .dword 0x000000000000bb3c
 .dword 0x000000000000455e
+.dword 0x00000000000028d9
 .dword 0x0000000000000304
 .dword 0x0000000000001e4f
+.dword 0x0000000000000304
 .dword 0x000000000000d9a4
 .dword 0x000000000000a8d0
+.dword 0x0000000000004dec
 .dword 0x0000000000004eba
 .dword 0x0000000000008822
+.dword 0x0000000000004eba
 .dword 0x000000000000f7a1
 .dword 0x000000000000cb7b
+.dword 0x000000000000509d
 .dword 0x00000000000015b6
 .dword 0x000000000000bf7a
+.dword 0x00000000000015b6
 .dword 0x000000000000b809
 .dword 0x00000000000052de
+.dword 0x0000000000002a4c
 .dword 0x00000000000098dc
 .dword 0x000000000000e878
+.dword 0x00000000000098dc
 .dword 0x000000000000b0c5
 .dword 0x0000000000007e69
+.dword 0x0000000000000c78
 .dword 0x000000000000469a
 .dword 0x000000000000f779
+.dword 0x000000000000469a
 .dword 0x0000000000003208
 .dword 0x000000000000faa0
+.dword 0x0000000000005378
 .dword 0x0000000000005216
 .dword 0x000000000000ef9f
+.dword 0x0000000000005216
 .dword 0x00000000000089b5
 .dword 0x000000000000afae
+.dword 0x00000000000062a6
 .dword 0x000000000000ade5
 .dword 0x0000000000008751
+.dword 0x000000000000ade5
 .dword 0x000000000000bd99
 .dword 0x000000000000c13c
+.dword 0x000000000000802d
 .dword 0x0000000000006cd5
 .dword 0x0000000000006d1c
+.dword 0x0000000000006cd5
 .dword 0x000000000000d412
 .dword 0x0000000000007bea
+.dword 0x000000000000527b
 .dword 0x000000000000b64f
 .dword 0x000000000000e2f3
+.dword 0x000000000000b64f
 .dword 0x0000000000001150
 .dword 0x000000000000e8a1
+.dword 0x00000000000029d1
 .dword 0x0000000000009d3d
 .dword 0x000000000000bd1d
+.dword 0x0000000000009d3d
 .dword 0x000000000000e6ff
 .dword 0x000000000000fd0f
+.dword 0x000000000000ef01
 .dword 0x000000000000f770
 .dword 0x00000000000097e4
+.dword 0x000000000000f770
 .dword 0x0000000000002830
 .dword 0x0000000000009973
+.dword 0x000000000000bdeb
 .dword 0x0000000000000209
 .dword 0x0000000000005e99
+.dword 0x0000000000000209
 .dword 0x000000000000cf92
 .dword 0x00000000000080d4
+.dword 0x0000000000002b78
 .dword 0x0000000000003f13
 .dword 0x0000000000005db6
+.dword 0x0000000000003f13
 .dword 0x000000000000e5c0
 .dword 0x0000000000006626
+.dword 0x000000000000a4be
 .dword 0x0000000000001567
 .dword 0x0000000000001046
+.dword 0x0000000000001567
 .dword 0x00000000000078e6
 .dword 0x0000000000004a68
+.dword 0x0000000000000744
 .dword 0x000000000000790b
 .dword 0x00000000000070c6
+.dword 0x000000000000790b
 .dword 0x0000000000009ee3
 .dword 0x0000000000007a75
+.dword 0x000000000000c84e
 .dword 0x0000000000009308
 .dword 0x0000000000000295
+.dword 0x0000000000009308
 .dword 0x0000000000007a8d
 .dword 0x000000000000ba3f
+.dword 0x000000000000b772
 .dword 0x000000000000dcdd
 .dword 0x0000000000008b14
+.dword 0x000000000000dcdd
 .dword 0x000000000000b72d
 .dword 0x000000000000c8b5
+.dword 0x0000000000009d06
 .dword 0x000000000000f964
 .dword 0x0000000000006581
+.dword 0x000000000000f964
 .dword 0x0000000000007d55
 .dword 0x000000000000e272
+.dword 0x000000000000dd14
 .dword 0x000000000000b0fa
 .dword 0x000000000000860c
+.dword 0x000000000000b0fa
 .dword 0x00000000000028d6
 .dword 0x000000000000c421
+.dword 0x0000000000005850
 .dword 0x0000000000005b39
 .dword 0x000000000000b189
+.dword 0x0000000000005b39
 .dword 0x000000000000afdc
 .dword 0x0000000000006773
+.dword 0x00000000000064ad
 .dword 0x000000000000b4ca
 .dword 0x000000000000b609
+.dword 0x000000000000b4ca
 .dword 0x0000000000007a41
 .dword 0x000000000000e72c
+.dword 0x000000000000b050
 .dword 0x0000000000007a77
 .dword 0x000000000000ef0f
+.dword 0x0000000000007a77
 .dword 0x0000000000004a4b
 .dword 0x0000000000002a7c
+.dword 0x000000000000bfca
 .dword 0x0000000000007345
 .dword 0x00000000000056d9
+.dword 0x0000000000007345
 .dword 0x0000000000008d6e
 .dword 0x000000000000fac4
+.dword 0x0000000000006afa
 .dword 0x000000000000b56c
 .dword 0x00000000000007da
+.dword 0x000000000000b56c
 .dword 0x000000000000f20d
 .dword 0x000000000000fe09
+.dword 0x000000000000fbe2
 .dword 0x000000000000564b
 .dword 0x000000000000dd4c
+.dword 0x000000000000564b
 .dword 0x000000000000dc97
 .dword 0x000000000000571f
+.dword 0x000000000000508b
 .dword 0x0000000000000282
 .dword 0x000000000000eae9
+.dword 0x0000000000000282
 .dword 0x000000000000db13
 .dword 0x000000000000f2fe
+.dword 0x0000000000006ea5
 .dword 0x00000000000018ae
 .dword 0x0000000000002996
+.dword 0x00000000000018ae
 .dword 0x000000000000e627
 .dword 0x000000000000f626
+.dword 0x0000000000005239
 .dword 0x0000000000000d9d
 .dword 0x0000000000007a4d
+.dword 0x0000000000000d9d
 .dword 0x000000000000b32d
 .dword 0x000000000000f334
+.dword 0x000000000000fdc9
 .dword 0x000000000000f819
 .dword 0x0000000000003559
+.dword 0x000000000000f819
 .dword 0x000000000000ca0c
 .dword 0x000000000000d8f8
+.dword 0x000000000000e2b6
 .dword 0x0000000000006d46
 .dword 0x0000000000006674
+.dword 0x0000000000006d46
 .dword 0x0000000000001eea
 .dword 0x000000000000c1ba
+.dword 0x0000000000009b03
 .dword 0x000000000000eafb
 .dword 0x0000000000008329
+.dword 0x000000000000eafb
 .dword 0x000000000000dd8f
 .dword 0x000000000000dbb4
+.dword 0x00000000000038ba
 .dword 0x00000000000044c8
 .dword 0x0000000000000ebc
+.dword 0x00000000000044c8
 .dword 0x0000000000004bde
 .dword 0x0000000000005e9f
+.dword 0x000000000000b841
 .dword 0x00000000000018a7
 .dword 0x000000000000a4a1
+.dword 0x00000000000018a7
 .dword 0x0000000000006999
 .dword 0x00000000000020a3
+.dword 0x000000000000f969
 .dword 0x000000000000b497
 .dword 0x0000000000004840
+.dword 0x000000000000b497
 .dword 0x000000000000f482
 .dword 0x00000000000018ce
+.dword 0x000000000000f023
 .dword 0x000000000000d264
 .dword 0x000000000000274a
+.dword 0x000000000000d264
 .dword 0x00000000000098d7
 .dword 0x000000000000ddc6
+.dword 0x0000000000006321
 .dword 0x000000000000a213
 .dword 0x0000000000004eca
+.dword 0x000000000000a213
 .dword 0x000000000000a0cd
 .dword 0x0000000000009b4d
+.dword 0x0000000000003074
 .dword 0x0000000000003878
 .dword 0x0000000000002fee
+.dword 0x0000000000003878
 .dword 0x0000000000008850
 .dword 0x000000000000df58
+.dword 0x0000000000000b37
 .dword 0x00000000000019e9
 .dword 0x0000000000001ead
+.dword 0x00000000000019e9
 .dword 0x0000000000005939
 .dword 0x000000000000194e
+.dword 0x00000000000018a2
 .dword 0x00000000000039d7
 .dword 0x0000000000007331
+.dword 0x00000000000039d7
 .dword 0x000000000000ac1a
 .dword 0x000000000000a5fb
+.dword 0x0000000000004382
 .dword 0x000000000000b65a
 .dword 0x0000000000004b3c
+.dword 0x000000000000b65a
 .dword 0x0000000000005356
 .dword 0x0000000000000cb2
+.dword 0x0000000000007f07
 .dword 0x0000000000003913
 .dword 0x000000000000ced3
+.dword 0x0000000000003913
 .dword 0x0000000000007d75
 .dword 0x000000000000043c
+.dword 0x00000000000038b9
 .dword 0x000000000000e3c6
 .dword 0x00000000000051ed
+.dword 0x000000000000e3c6
 .dword 0x0000000000009d1a
 .dword 0x000000000000b5f7
+.dword 0x000000000000ce59
 .dword 0x00000000000047a1
 .dword 0x0000000000007640
+.dword 0x00000000000047a1
 .dword 0x0000000000002348
 .dword 0x000000000000eddc
+.dword 0x0000000000008cbc
 .dword 0x0000000000008f63
 .dword 0x000000000000c25e
+.dword 0x0000000000008f63
 .dword 0x00000000000043d9
 .dword 0x000000000000122c
+.dword 0x0000000000005c7a
 .dword 0x0000000000001e5a
 .dword 0x0000000000006a6c
+.dword 0x0000000000001e5a
 .dword 0x0000000000009690
 .dword 0x00000000000005fb
+.dword 0x0000000000001df4
 .dword 0x0000000000000b6a
 .dword 0x0000000000005dc7
+.dword 0x0000000000000b6a
 .dword 0x0000000000009524
 .dword 0x0000000000003e2e
+.dword 0x000000000000986f
 .dword 0x00000000000030a8
 .dword 0x000000000000bc15
+.dword 0x00000000000030a8
 .dword 0x0000000000004995
 .dword 0x000000000000458c
+.dword 0x0000000000001d9e
 .dword 0x0000000000008526
 .dword 0x0000000000007815
+.dword 0x0000000000008526
 .dword 0x000000000000c76b
 .dword 0x0000000000001f83
+.dword 0x000000000000e114
 .dword 0x0000000000003630
 .dword 0x00000000000009e0
+.dword 0x0000000000003630
 .dword 0x00000000000039ed
 .dword 0x0000000000000bda
+.dword 0x000000000000296b
 .dword 0x0000000000002b38
 .dword 0x000000000000133c
+.dword 0x0000000000002b38
 .dword 0x000000000000a019
 .dword 0x00000000000022a8
+.dword 0x0000000000001187
 .dword 0x000000000000437e
 .dword 0x000000000000889b
+.dword 0x000000000000437e
 .dword 0x00000000000027d9
 .dword 0x000000000000951c
+.dword 0x000000000000bd99
 .dword 0x0000000000006b49
 .dword 0x0000000000003d38
+.dword 0x0000000000006b49
 .dword 0x0000000000004882
 .dword 0x000000000000821f
+.dword 0x0000000000001cca
 .dword 0x00000000000009a2
 .dword 0x000000000000dd5e
+.dword 0x00000000000009a2
 .dword 0x000000000000a193
 .dword 0x000000000000b7a7
+.dword 0x000000000000285b
 .dword 0x000000000000404e
 .dword 0x000000000000e95e
+.dword 0x000000000000404e
 .dword 0x00000000000075bd
 .dword 0x000000000000d7d1
+.dword 0x000000000000b9bb
 .dword 0x0000000000006b05
 .dword 0x0000000000006ea7
+.dword 0x0000000000006b05
 .dword 0x000000000000d608
 .dword 0x000000000000756b
+.dword 0x0000000000008f2e
 .dword 0x000000000000e9e5
 .dword 0x00000000000036b8
+.dword 0x000000000000e9e5
 .dword 0x000000000000d86b
 .dword 0x000000000000550e
+.dword 0x0000000000004723
 .dword 0x00000000000039e7
 .dword 0x000000000000440e
+.dword 0x00000000000039e7
 .dword 0x0000000000008b4f
 .dword 0x00000000000045b9
+.dword 0x0000000000000b9f
 .dword 0x0000000000005351
 .dword 0x000000000000044b
+.dword 0x0000000000005351
 .dword 0x00000000000017cd
 .dword 0x00000000000086a4
+.dword 0x00000000000064a5
 .dword 0x00000000000074ce
 .dword 0x0000000000001305
+.dword 0x00000000000074ce
 .dword 0x00000000000078c8
 .dword 0x0000000000004e83
+.dword 0x000000000000ba80
 .dword 0x0000000000005938
 .dword 0x000000000000e2ec
+.dword 0x0000000000005938
 .dword 0x000000000000721d
 .dword 0x00000000000061ca
+.dword 0x000000000000e0f6
 .dword 0x000000000000af92
 .dword 0x00000000000030df
+.dword 0x000000000000af92
 .dword 0x0000000000005746
 .dword 0x0000000000003a37
+.dword 0x00000000000086f5
 .dword 0x1cefa4cce5457709
 .dword 0x0000000000000000
 .dword 0x04b0394458b11f0c

--- a/tests/rv64i/Zca/Zca-c.mv-00.S
+++ b/tests/rv64i/Zca/Zca-c.mv-00.S
@@ -297,259 +297,259 @@ Zca_c_mv_cg_cp_rs2_nx0_b31:
 /////////////////////////////////
 
 # Testcase cp_rd_nx0 (Test destination rd = x1)
-  RVTEST_TESTDATA_LOAD_INT(x18, x27) # load rd/rs1: x27 = 0xdebef1893128dd9b
+  RVTEST_TESTDATA_LOAD_INT(x18, x1) # load rd/rs1: x1 = 0xdebef1893128dd9b
   RVTEST_TESTDATA_LOAD_INT(x18, x15) # load rs2: x15 = 0x9da3a6059976270f
 Zca_c_mv_cg_cp_rd_nx0_b1:
-  c.mv x27, x15 # perform operation
-  # Check if x27 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x16, x8, x7, x27, Zca_c_mv_cg_cp_rd_nx0_b1, Zca_c_mv_cg_cp_rd_nx0_b1_str)
+  c.mv x1, x15 # perform operation
+  # Check if x1 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x16, x8, x7, x1, Zca_c_mv_cg_cp_rd_nx0_b1, Zca_c_mv_cg_cp_rd_nx0_b1_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x2)
-  RVTEST_TESTDATA_LOAD_INT(x18, x29) # load rd/rs1: x29 = 0x5fd19d214192473b
+  RVTEST_TESTDATA_LOAD_INT(x18, x2) # load rd/rs1: x2 = 0x5fd19d214192473b
   RVTEST_TESTDATA_LOAD_INT(x18, x11) # load rs2: x11 = 0xb437e4cedb43f31f
 Zca_c_mv_cg_cp_rd_nx0_b2:
-  c.mv x29, x11 # perform operation
-  # Check if x29 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x16, x8, x7, x29, Zca_c_mv_cg_cp_rd_nx0_b2, Zca_c_mv_cg_cp_rd_nx0_b2_str)
+  c.mv x2, x11 # perform operation
+  # Check if x2 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x16, x8, x7, x2, Zca_c_mv_cg_cp_rd_nx0_b2, Zca_c_mv_cg_cp_rd_nx0_b2_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x3)
-  RVTEST_TESTDATA_LOAD_INT(x18, x27) # load rd/rs1: x27 = 0x95184c474cabf957
+  RVTEST_TESTDATA_LOAD_INT(x18, x3) # load rd/rs1: x3 = 0x95184c474cabf957
   RVTEST_TESTDATA_LOAD_INT(x18, x15) # load rs2: x15 = 0x8035b2d7301f61ab
 Zca_c_mv_cg_cp_rd_nx0_b3:
-  c.mv x27, x15 # perform operation
-  # Check if x27 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x16, x8, x7, x27, Zca_c_mv_cg_cp_rd_nx0_b3, Zca_c_mv_cg_cp_rd_nx0_b3_str)
+  c.mv x3, x15 # perform operation
+  # Check if x3 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x16, x8, x7, x3, Zca_c_mv_cg_cp_rd_nx0_b3, Zca_c_mv_cg_cp_rd_nx0_b3_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x4)
-  RVTEST_TESTDATA_LOAD_INT(x18, x22) # load rd/rs1: x22 = 0xc04501f9d8228da5
+  RVTEST_TESTDATA_LOAD_INT(x18, x4) # load rd/rs1: x4 = 0xc04501f9d8228da5
   RVTEST_TESTDATA_LOAD_INT(x18, x23) # load rs2: x23 = 0x57d2819f6fe6c6a4
 Zca_c_mv_cg_cp_rd_nx0_b4:
-  c.mv x22, x23 # perform operation
-  # Check if x22 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x16, x8, x7, x22, Zca_c_mv_cg_cp_rd_nx0_b4, Zca_c_mv_cg_cp_rd_nx0_b4_str)
+  c.mv x4, x23 # perform operation
+  # Check if x4 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x16, x8, x7, x4, Zca_c_mv_cg_cp_rd_nx0_b4, Zca_c_mv_cg_cp_rd_nx0_b4_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x5)
-  RVTEST_TESTDATA_LOAD_INT(x18, x19) # load rd/rs1: x19 = 0x78cd8eba7d2b4f44
+  RVTEST_TESTDATA_LOAD_INT(x18, x5) # load rd/rs1: x5 = 0x78cd8eba7d2b4f44
   RVTEST_TESTDATA_LOAD_INT(x18, x25) # load rs2: x25 = 0x3516c4e8662fabc2
 Zca_c_mv_cg_cp_rd_nx0_b5:
-  c.mv x19, x25 # perform operation
-  # Check if x19 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x16, x8, x7, x19, Zca_c_mv_cg_cp_rd_nx0_b5, Zca_c_mv_cg_cp_rd_nx0_b5_str)
+  c.mv x5, x25 # perform operation
+  # Check if x5 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x16, x8, x7, x5, Zca_c_mv_cg_cp_rd_nx0_b5, Zca_c_mv_cg_cp_rd_nx0_b5_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x6)
-  RVTEST_TESTDATA_LOAD_INT(x18, x14) # load rd/rs1: x14 = 0x67436e11cfcb3eda
+  RVTEST_TESTDATA_LOAD_INT(x18, x6) # load rd/rs1: x6 = 0x67436e11cfcb3eda
   RVTEST_TESTDATA_LOAD_INT(x18, x12) # load rs2: x12 = 0xbba5aa6cee0af7e4
 Zca_c_mv_cg_cp_rd_nx0_b6:
-  c.mv x14, x12 # perform operation
-  # Check if x14 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
-  RVTEST_SIGUPD(x16, x8, x7, x14, Zca_c_mv_cg_cp_rd_nx0_b6, Zca_c_mv_cg_cp_rd_nx0_b6_str)
+  c.mv x6, x12 # perform operation
+  # Check if x6 contains the expected result. x16 is the signature ptr, x8 is the link ptr, x7 is a temp reg.
+  RVTEST_SIGUPD(x16, x8, x7, x6, Zca_c_mv_cg_cp_rd_nx0_b6, Zca_c_mv_cg_cp_rd_nx0_b6_str)
 
   mv x4, x7 # switch temp register to avoid conflict with test
   mv x5, x8 # switch link pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x7)
-  RVTEST_TESTDATA_LOAD_INT(x18, x15) # load rd/rs1: x15 = 0x0e503dc9f276edbe
+  RVTEST_TESTDATA_LOAD_INT(x18, x7) # load rd/rs1: x7 = 0x0e503dc9f276edbe
   RVTEST_TESTDATA_LOAD_INT(x18, x27) # load rs2: x27 = 0x1bb9494cd18a51f3
 Zca_c_mv_cg_cp_rd_nx0_b7:
-  c.mv x15, x27 # perform operation
-  # Check if x15 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x16, x5, x4, x15, Zca_c_mv_cg_cp_rd_nx0_b7, Zca_c_mv_cg_cp_rd_nx0_b7_str)
+  c.mv x7, x27 # perform operation
+  # Check if x7 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x16, x5, x4, x7, Zca_c_mv_cg_cp_rd_nx0_b7, Zca_c_mv_cg_cp_rd_nx0_b7_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x8)
-  RVTEST_TESTDATA_LOAD_INT(x18, x0) # load rd/rs1: x0 = 0x093e8f519c82dddb
+  RVTEST_TESTDATA_LOAD_INT(x18, x8) # load rd/rs1: x8 = 0x093e8f519c82dddb
   RVTEST_TESTDATA_LOAD_INT(x18, x26) # load rs2: x26 = 0x06bafb254782328b
 Zca_c_mv_cg_cp_rd_nx0_b8:
-  c.mv x0, x26 # perform operation
-  # Check if x0 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x16, x5, x4, x0, Zca_c_mv_cg_cp_rd_nx0_b8, Zca_c_mv_cg_cp_rd_nx0_b8_str)
+  c.mv x8, x26 # perform operation
+  # Check if x8 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x16, x5, x4, x8, Zca_c_mv_cg_cp_rd_nx0_b8, Zca_c_mv_cg_cp_rd_nx0_b8_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x9)
-  RVTEST_TESTDATA_LOAD_INT(x18, x12) # load rd/rs1: x12 = 0x4260f149ed400e90
+  RVTEST_TESTDATA_LOAD_INT(x18, x9) # load rd/rs1: x9 = 0x4260f149ed400e90
   RVTEST_TESTDATA_LOAD_INT(x18, x24) # load rs2: x24 = 0x46f4e39d922ca581
 Zca_c_mv_cg_cp_rd_nx0_b9:
-  c.mv x12, x24 # perform operation
-  # Check if x12 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x16, x5, x4, x12, Zca_c_mv_cg_cp_rd_nx0_b9, Zca_c_mv_cg_cp_rd_nx0_b9_str)
+  c.mv x9, x24 # perform operation
+  # Check if x9 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x16, x5, x4, x9, Zca_c_mv_cg_cp_rd_nx0_b9, Zca_c_mv_cg_cp_rd_nx0_b9_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x10)
-  RVTEST_TESTDATA_LOAD_INT(x18, x21) # load rd/rs1: x21 = 0x11fb4836073eadfb
+  RVTEST_TESTDATA_LOAD_INT(x18, x10) # load rd/rs1: x10 = 0x11fb4836073eadfb
   RVTEST_TESTDATA_LOAD_INT(x18, x28) # load rs2: x28 = 0x5c2ac25216479e4e
 Zca_c_mv_cg_cp_rd_nx0_b10:
-  c.mv x21, x28 # perform operation
-  # Check if x21 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x16, x5, x4, x21, Zca_c_mv_cg_cp_rd_nx0_b10, Zca_c_mv_cg_cp_rd_nx0_b10_str)
+  c.mv x10, x28 # perform operation
+  # Check if x10 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x16, x5, x4, x10, Zca_c_mv_cg_cp_rd_nx0_b10, Zca_c_mv_cg_cp_rd_nx0_b10_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x11)
-  RVTEST_TESTDATA_LOAD_INT(x18, x27) # load rd/rs1: x27 = 0xcf1dc21194d8af6f
+  RVTEST_TESTDATA_LOAD_INT(x18, x11) # load rd/rs1: x11 = 0xcf1dc21194d8af6f
   RVTEST_TESTDATA_LOAD_INT(x18, x12) # load rs2: x12 = 0x87a7d08d9541f96e
 Zca_c_mv_cg_cp_rd_nx0_b11:
-  c.mv x27, x12 # perform operation
-  # Check if x27 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x16, x5, x4, x27, Zca_c_mv_cg_cp_rd_nx0_b11, Zca_c_mv_cg_cp_rd_nx0_b11_str)
+  c.mv x11, x12 # perform operation
+  # Check if x11 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x16, x5, x4, x11, Zca_c_mv_cg_cp_rd_nx0_b11, Zca_c_mv_cg_cp_rd_nx0_b11_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x12)
-  RVTEST_TESTDATA_LOAD_INT(x18, x21) # load rd/rs1: x21 = 0x56d1ee33b3cd9991
+  RVTEST_TESTDATA_LOAD_INT(x18, x12) # load rd/rs1: x12 = 0x56d1ee33b3cd9991
   RVTEST_TESTDATA_LOAD_INT(x18, x11) # load rs2: x11 = 0xab916e869c8b5007
 Zca_c_mv_cg_cp_rd_nx0_b12:
-  c.mv x21, x11 # perform operation
-  # Check if x21 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x16, x5, x4, x21, Zca_c_mv_cg_cp_rd_nx0_b12, Zca_c_mv_cg_cp_rd_nx0_b12_str)
+  c.mv x12, x11 # perform operation
+  # Check if x12 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x16, x5, x4, x12, Zca_c_mv_cg_cp_rd_nx0_b12, Zca_c_mv_cg_cp_rd_nx0_b12_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x13)
-  RVTEST_TESTDATA_LOAD_INT(x18, x27) # load rd/rs1: x27 = 0x3c18542a18c4aeaa
+  RVTEST_TESTDATA_LOAD_INT(x18, x13) # load rd/rs1: x13 = 0x3c18542a18c4aeaa
   RVTEST_TESTDATA_LOAD_INT(x18, x3) # load rs2: x3 = 0x1e593a9c3c901bdf
 Zca_c_mv_cg_cp_rd_nx0_b13:
-  c.mv x27, x3 # perform operation
-  # Check if x27 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x16, x5, x4, x27, Zca_c_mv_cg_cp_rd_nx0_b13, Zca_c_mv_cg_cp_rd_nx0_b13_str)
+  c.mv x13, x3 # perform operation
+  # Check if x13 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x16, x5, x4, x13, Zca_c_mv_cg_cp_rd_nx0_b13, Zca_c_mv_cg_cp_rd_nx0_b13_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x14)
-  RVTEST_TESTDATA_LOAD_INT(x18, x23) # load rd/rs1: x23 = 0x16ad1ea3ac36e153
+  RVTEST_TESTDATA_LOAD_INT(x18, x14) # load rd/rs1: x14 = 0x16ad1ea3ac36e153
   RVTEST_TESTDATA_LOAD_INT(x18, x30) # load rs2: x30 = 0x2de0282a41789c19
 Zca_c_mv_cg_cp_rd_nx0_b14:
-  c.mv x23, x30 # perform operation
-  # Check if x23 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x16, x5, x4, x23, Zca_c_mv_cg_cp_rd_nx0_b14, Zca_c_mv_cg_cp_rd_nx0_b14_str)
+  c.mv x14, x30 # perform operation
+  # Check if x14 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x16, x5, x4, x14, Zca_c_mv_cg_cp_rd_nx0_b14, Zca_c_mv_cg_cp_rd_nx0_b14_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x15)
-  RVTEST_TESTDATA_LOAD_INT(x18, x2) # load rd/rs1: x2 = 0xed0520f961a6b20e
+  RVTEST_TESTDATA_LOAD_INT(x18, x15) # load rd/rs1: x15 = 0xed0520f961a6b20e
   RVTEST_TESTDATA_LOAD_INT(x18, x28) # load rs2: x28 = 0x3c885443181d6bcf
 Zca_c_mv_cg_cp_rd_nx0_b15:
-  c.mv x2, x28 # perform operation
-  # Check if x2 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x16, x5, x4, x2, Zca_c_mv_cg_cp_rd_nx0_b15, Zca_c_mv_cg_cp_rd_nx0_b15_str)
+  c.mv x15, x28 # perform operation
+  # Check if x15 contains the expected result. x16 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x16, x5, x4, x15, Zca_c_mv_cg_cp_rd_nx0_b15, Zca_c_mv_cg_cp_rd_nx0_b15_str)
 
   mv x20, x16 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x16)
-  RVTEST_TESTDATA_LOAD_INT(x18, x9) # load rd/rs1: x9 = 0xc697e57de1fa0fca
+  RVTEST_TESTDATA_LOAD_INT(x18, x16) # load rd/rs1: x16 = 0xc697e57de1fa0fca
   RVTEST_TESTDATA_LOAD_INT(x18, x12) # load rs2: x12 = 0xe0af8cee6955b064
 Zca_c_mv_cg_cp_rd_nx0_b16:
-  c.mv x9, x12 # perform operation
-  # Check if x9 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x20, x5, x4, x9, Zca_c_mv_cg_cp_rd_nx0_b16, Zca_c_mv_cg_cp_rd_nx0_b16_str)
+  c.mv x16, x12 # perform operation
+  # Check if x16 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x20, x5, x4, x16, Zca_c_mv_cg_cp_rd_nx0_b16, Zca_c_mv_cg_cp_rd_nx0_b16_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x17)
-  RVTEST_TESTDATA_LOAD_INT(x18, x13) # load rd/rs1: x13 = 0x615cffbfcfdf3636
+  RVTEST_TESTDATA_LOAD_INT(x18, x17) # load rd/rs1: x17 = 0x615cffbfcfdf3636
   RVTEST_TESTDATA_LOAD_INT(x18, x14) # load rs2: x14 = 0x1a0b8b8cf2a5feb1
 Zca_c_mv_cg_cp_rd_nx0_b17:
-  c.mv x13, x14 # perform operation
-  # Check if x13 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x20, x5, x4, x13, Zca_c_mv_cg_cp_rd_nx0_b17, Zca_c_mv_cg_cp_rd_nx0_b17_str)
+  c.mv x17, x14 # perform operation
+  # Check if x17 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x20, x5, x4, x17, Zca_c_mv_cg_cp_rd_nx0_b17, Zca_c_mv_cg_cp_rd_nx0_b17_str)
 
   mv x28, x18 # switch data pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x18)
-  RVTEST_TESTDATA_LOAD_INT(x28, x11) # load rd/rs1: x11 = 0xc17b22d8d28faaad
+  RVTEST_TESTDATA_LOAD_INT(x28, x18) # load rd/rs1: x18 = 0xc17b22d8d28faaad
   RVTEST_TESTDATA_LOAD_INT(x28, x1) # load rs2: x1 = 0x84dfc3699dd663c2
 Zca_c_mv_cg_cp_rd_nx0_b18:
-  c.mv x11, x1 # perform operation
-  # Check if x11 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x20, x5, x4, x11, Zca_c_mv_cg_cp_rd_nx0_b18, Zca_c_mv_cg_cp_rd_nx0_b18_str)
+  c.mv x18, x1 # perform operation
+  # Check if x18 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x20, x5, x4, x18, Zca_c_mv_cg_cp_rd_nx0_b18, Zca_c_mv_cg_cp_rd_nx0_b18_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x19)
-  RVTEST_TESTDATA_LOAD_INT(x28, x13) # load rd/rs1: x13 = 0x7c0c914162d0d1b4
+  RVTEST_TESTDATA_LOAD_INT(x28, x19) # load rd/rs1: x19 = 0x7c0c914162d0d1b4
   RVTEST_TESTDATA_LOAD_INT(x28, x25) # load rs2: x25 = 0x1638265c664c5897
 Zca_c_mv_cg_cp_rd_nx0_b19:
-  c.mv x13, x25 # perform operation
-  # Check if x13 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x20, x5, x4, x13, Zca_c_mv_cg_cp_rd_nx0_b19, Zca_c_mv_cg_cp_rd_nx0_b19_str)
+  c.mv x19, x25 # perform operation
+  # Check if x19 contains the expected result. x20 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x20, x5, x4, x19, Zca_c_mv_cg_cp_rd_nx0_b19, Zca_c_mv_cg_cp_rd_nx0_b19_str)
 
   mv x27, x20 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x20)
-  RVTEST_TESTDATA_LOAD_INT(x28, x11) # load rd/rs1: x11 = 0x839ffdc016431584
+  RVTEST_TESTDATA_LOAD_INT(x28, x20) # load rd/rs1: x20 = 0x839ffdc016431584
   RVTEST_TESTDATA_LOAD_INT(x28, x22) # load rs2: x22 = 0xb687daba2f87208d
 Zca_c_mv_cg_cp_rd_nx0_b20:
-  c.mv x11, x22 # perform operation
-  # Check if x11 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x27, x5, x4, x11, Zca_c_mv_cg_cp_rd_nx0_b20, Zca_c_mv_cg_cp_rd_nx0_b20_str)
+  c.mv x20, x22 # perform operation
+  # Check if x20 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x27, x5, x4, x20, Zca_c_mv_cg_cp_rd_nx0_b20, Zca_c_mv_cg_cp_rd_nx0_b20_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x21)
-  RVTEST_TESTDATA_LOAD_INT(x28, x22) # load rd/rs1: x22 = 0x8108b2cfb76c1328
+  RVTEST_TESTDATA_LOAD_INT(x28, x21) # load rd/rs1: x21 = 0x8108b2cfb76c1328
   RVTEST_TESTDATA_LOAD_INT(x28, x16) # load rs2: x16 = 0xb82adcf54c96da89
 Zca_c_mv_cg_cp_rd_nx0_b21:
-  c.mv x22, x16 # perform operation
-  # Check if x22 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x27, x5, x4, x22, Zca_c_mv_cg_cp_rd_nx0_b21, Zca_c_mv_cg_cp_rd_nx0_b21_str)
+  c.mv x21, x16 # perform operation
+  # Check if x21 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x27, x5, x4, x21, Zca_c_mv_cg_cp_rd_nx0_b21, Zca_c_mv_cg_cp_rd_nx0_b21_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x22)
-  RVTEST_TESTDATA_LOAD_INT(x28, x9) # load rd/rs1: x9 = 0xb38c303c41edae8f
+  RVTEST_TESTDATA_LOAD_INT(x28, x22) # load rd/rs1: x22 = 0xb38c303c41edae8f
   RVTEST_TESTDATA_LOAD_INT(x28, x20) # load rs2: x20 = 0xce5a4441310e1dc3
 Zca_c_mv_cg_cp_rd_nx0_b22:
-  c.mv x9, x20 # perform operation
-  # Check if x9 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x27, x5, x4, x9, Zca_c_mv_cg_cp_rd_nx0_b22, Zca_c_mv_cg_cp_rd_nx0_b22_str)
+  c.mv x22, x20 # perform operation
+  # Check if x22 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x27, x5, x4, x22, Zca_c_mv_cg_cp_rd_nx0_b22, Zca_c_mv_cg_cp_rd_nx0_b22_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x23)
-  RVTEST_TESTDATA_LOAD_INT(x28, x1) # load rd/rs1: x1 = 0xee35a1c3c8b316fa
+  RVTEST_TESTDATA_LOAD_INT(x28, x23) # load rd/rs1: x23 = 0xee35a1c3c8b316fa
   RVTEST_TESTDATA_LOAD_INT(x28, x18) # load rs2: x18 = 0x13eeaf241f46ff91
 Zca_c_mv_cg_cp_rd_nx0_b23:
-  c.mv x1, x18 # perform operation
-  # Check if x1 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x27, x5, x4, x1, Zca_c_mv_cg_cp_rd_nx0_b23, Zca_c_mv_cg_cp_rd_nx0_b23_str)
+  c.mv x23, x18 # perform operation
+  # Check if x23 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x27, x5, x4, x23, Zca_c_mv_cg_cp_rd_nx0_b23, Zca_c_mv_cg_cp_rd_nx0_b23_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x24)
-  RVTEST_TESTDATA_LOAD_INT(x28, x3) # load rd/rs1: x3 = 0x599cb6fc8d2af7d6
+  RVTEST_TESTDATA_LOAD_INT(x28, x24) # load rd/rs1: x24 = 0x599cb6fc8d2af7d6
   RVTEST_TESTDATA_LOAD_INT(x28, x31) # load rs2: x31 = 0x33f206f9c6b0c2e8
 Zca_c_mv_cg_cp_rd_nx0_b24:
-  c.mv x3, x31 # perform operation
-  # Check if x3 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x27, x5, x4, x3, Zca_c_mv_cg_cp_rd_nx0_b24, Zca_c_mv_cg_cp_rd_nx0_b24_str)
+  c.mv x24, x31 # perform operation
+  # Check if x24 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x27, x5, x4, x24, Zca_c_mv_cg_cp_rd_nx0_b24, Zca_c_mv_cg_cp_rd_nx0_b24_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x25)
-  RVTEST_TESTDATA_LOAD_INT(x28, x16) # load rd/rs1: x16 = 0x08b6665aefc10f3a
+  RVTEST_TESTDATA_LOAD_INT(x28, x25) # load rd/rs1: x25 = 0x08b6665aefc10f3a
   RVTEST_TESTDATA_LOAD_INT(x28, x24) # load rs2: x24 = 0x0d27fef362f8c949
 Zca_c_mv_cg_cp_rd_nx0_b25:
-  c.mv x16, x24 # perform operation
-  # Check if x16 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x27, x5, x4, x16, Zca_c_mv_cg_cp_rd_nx0_b25, Zca_c_mv_cg_cp_rd_nx0_b25_str)
+  c.mv x25, x24 # perform operation
+  # Check if x25 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x27, x5, x4, x25, Zca_c_mv_cg_cp_rd_nx0_b25, Zca_c_mv_cg_cp_rd_nx0_b25_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x26)
-  RVTEST_TESTDATA_LOAD_INT(x28, x19) # load rd/rs1: x19 = 0x5b23c730a539f8b5
+  RVTEST_TESTDATA_LOAD_INT(x28, x26) # load rd/rs1: x26 = 0x5b23c730a539f8b5
   RVTEST_TESTDATA_LOAD_INT(x28, x9) # load rs2: x9 = 0xf4dd91317e73a467
 Zca_c_mv_cg_cp_rd_nx0_b26:
-  c.mv x19, x9 # perform operation
-  # Check if x19 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x27, x5, x4, x19, Zca_c_mv_cg_cp_rd_nx0_b26, Zca_c_mv_cg_cp_rd_nx0_b26_str)
+  c.mv x26, x9 # perform operation
+  # Check if x26 contains the expected result. x27 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x27, x5, x4, x26, Zca_c_mv_cg_cp_rd_nx0_b26, Zca_c_mv_cg_cp_rd_nx0_b26_str)
 
   mv x17, x27 # switch signature pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x27)
-  RVTEST_TESTDATA_LOAD_INT(x28, x7) # load rd/rs1: x7 = 0x067ef05747a5067c
+  RVTEST_TESTDATA_LOAD_INT(x28, x27) # load rd/rs1: x27 = 0x067ef05747a5067c
   RVTEST_TESTDATA_LOAD_INT(x28, x11) # load rs2: x11 = 0x35f42e2413c45e51
 Zca_c_mv_cg_cp_rd_nx0_b27:
-  c.mv x7, x11 # perform operation
-  # Check if x7 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x17, x5, x4, x7, Zca_c_mv_cg_cp_rd_nx0_b27, Zca_c_mv_cg_cp_rd_nx0_b27_str)
+  c.mv x27, x11 # perform operation
+  # Check if x27 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x17, x5, x4, x27, Zca_c_mv_cg_cp_rd_nx0_b27, Zca_c_mv_cg_cp_rd_nx0_b27_str)
 
   mv x18, x28 # switch data pointer register to avoid conflict with test
 # Testcase cp_rd_nx0 (Test destination rd = x28)
-  RVTEST_TESTDATA_LOAD_INT(x18, x16) # load rd/rs1: x16 = 0xa531abcf21e5f358
+  RVTEST_TESTDATA_LOAD_INT(x18, x28) # load rd/rs1: x28 = 0xa531abcf21e5f358
   RVTEST_TESTDATA_LOAD_INT(x18, x29) # load rs2: x29 = 0x12c21f0d07aa9eb4
 Zca_c_mv_cg_cp_rd_nx0_b28:
-  c.mv x16, x29 # perform operation
-  # Check if x16 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x17, x5, x4, x16, Zca_c_mv_cg_cp_rd_nx0_b28, Zca_c_mv_cg_cp_rd_nx0_b28_str)
+  c.mv x28, x29 # perform operation
+  # Check if x28 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x17, x5, x4, x28, Zca_c_mv_cg_cp_rd_nx0_b28, Zca_c_mv_cg_cp_rd_nx0_b28_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x29)
-  RVTEST_TESTDATA_LOAD_INT(x18, x25) # load rd/rs1: x25 = 0x63328376078b2be3
+  RVTEST_TESTDATA_LOAD_INT(x18, x29) # load rd/rs1: x29 = 0x63328376078b2be3
   RVTEST_TESTDATA_LOAD_INT(x18, x6) # load rs2: x6 = 0xa5b31ffd111a7d5c
 Zca_c_mv_cg_cp_rd_nx0_b29:
-  c.mv x25, x6 # perform operation
-  # Check if x25 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x17, x5, x4, x25, Zca_c_mv_cg_cp_rd_nx0_b29, Zca_c_mv_cg_cp_rd_nx0_b29_str)
+  c.mv x29, x6 # perform operation
+  # Check if x29 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x17, x5, x4, x29, Zca_c_mv_cg_cp_rd_nx0_b29, Zca_c_mv_cg_cp_rd_nx0_b29_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x30)
-  RVTEST_TESTDATA_LOAD_INT(x18, x26) # load rd/rs1: x26 = 0x2c0b0e0f07e501d0
+  RVTEST_TESTDATA_LOAD_INT(x18, x30) # load rd/rs1: x30 = 0x2c0b0e0f07e501d0
   RVTEST_TESTDATA_LOAD_INT(x18, x7) # load rs2: x7 = 0x5940694368385d0c
 Zca_c_mv_cg_cp_rd_nx0_b30:
-  c.mv x26, x7 # perform operation
-  # Check if x26 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x17, x5, x4, x26, Zca_c_mv_cg_cp_rd_nx0_b30, Zca_c_mv_cg_cp_rd_nx0_b30_str)
+  c.mv x30, x7 # perform operation
+  # Check if x30 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x17, x5, x4, x30, Zca_c_mv_cg_cp_rd_nx0_b30, Zca_c_mv_cg_cp_rd_nx0_b30_str)
 
 # Testcase cp_rd_nx0 (Test destination rd = x31)
-  RVTEST_TESTDATA_LOAD_INT(x18, x25) # load rd/rs1: x25 = 0x1de2fe4136a188a5
+  RVTEST_TESTDATA_LOAD_INT(x18, x31) # load rd/rs1: x31 = 0x1de2fe4136a188a5
   RVTEST_TESTDATA_LOAD_INT(x18, x6) # load rs2: x6 = 0xf7193f65157eab7f
 Zca_c_mv_cg_cp_rd_nx0_b31:
-  c.mv x25, x6 # perform operation
-  # Check if x25 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
-  RVTEST_SIGUPD(x17, x5, x4, x25, Zca_c_mv_cg_cp_rd_nx0_b31, Zca_c_mv_cg_cp_rd_nx0_b31_str)
+  c.mv x31, x6 # perform operation
+  # Check if x31 contains the expected result. x17 is the signature ptr, x5 is the link ptr, x4 is a temp reg.
+  RVTEST_SIGUPD(x17, x5, x4, x31, Zca_c_mv_cg_cp_rd_nx0_b31, Zca_c_mv_cg_cp_rd_nx0_b31_str)
 
 /////////////////////////////////
 // cp_rs2_edges


### PR DESCRIPTION
Issue #2147 item 1.

`generate_random_params` builds `InstructionParams` from the caller's kwargs, so a coverpoint can set
an operand the formatter never reads — nothing warns, and the testcase is generated with a different
operand than its bin name claims. (The issue says the field is *discarded*; it isn't, it is just
never read.) Two cases were live:

- **A-type never read `rdval`**, so amocas ran its compare-succeeds testcases without seeding the
  comparand — the equal and not-equal bins were both generated from an unseeded `rd`.
- **CR-type ignored `rd`** (the destination is encoded in the `rs1` field), so `c.mv`'s 31
  `cp_rd_nx0` testcases swept only 20 distinct destinations, one of them x0.

`InstructionTypeConfig` gains `optional_params`, and `generate_random_params` now rejects any operand
in neither set. Declaring `rdval` *optional* rather than required is what keeps this small: `rdval`
is drawn before `rs1`/`rs2`, so making it required would shift the random stream for every Zaamo and
Zabha testcase too — 79 files instead of 11.

11 files regenerate (amocas in Zacas/ZacasZabha, and c.mv); Zaamo and Zabha are untouched.
`amocas.w` goes from 6 to 196 comparand loads, and all 31 `c.mv` `cp_rd_nx0` testcases now use the
register their bin names. Zacas, ZacasZabha, Zca, Zaamo and Zabha pass 73/73 on spike-rv64-max and
57/57 on spike-rv32-max.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTjX9BBLNAQkWwTTq6vfxq
