### PR TITLE
Fix several normative rule coverpoint mapping typos

### DIFF
--- a/coverpoints/norm/D.yaml
+++ b/coverpoints/norm/D.yaml
@@ -2,7 +2,7 @@
 
 normative_rule_definitions:
   - name: D_fpr_regs
-    coverpoint: ["D_fadd_d_cg/{cp_fs1_fs2_edges_frm_D}"] # one of many possible
+    coverpoint: ["D_fadd_d_cg/{cr_fs1_fs2_edges_frm_D}"] # one of many possible
   - names: ["fsd_atomic_align, fld_atomic_align"]
     coverpoint: ["UNCHECKED"]
   - name: fsd_bits_maintained
@@ -183,7 +183,7 @@ normative_rule_definitions:
     # frm
     coverpoint:
       [
-        "D_fcvt_l_d_cg/{cp_rd, cp_fs1, cp_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
+        "D_fcvt_l_d_cg/{cp_rd, cp_fs1, cr_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
       ]
   - name: fcvt-lu-d_op
     # FCVT.WU.D, FCVT.LU.D, FCVT.D.WU, and FCVT.D.LU variants convert to
@@ -209,7 +209,7 @@ normative_rule_definitions:
     # frm
     coverpoint:
       [
-        "D_fcvt_lu_d_cg/{cp_rd, cp_fs1, cp_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
+        "D_fcvt_lu_d_cg/{cp_rd, cp_fs1, cr_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
       ]
   - name: fcvt-s-d_op
     # The double-precision to single-precision and single-precision to
@@ -222,7 +222,7 @@ normative_rule_definitions:
     # never round
     coverpoint:
       [
-        "D_fcvt_s_d_cg/{cp_fs1, cp_fd, cp_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_voun, cp_csr_frm, cp_NaNBox_D_S}",
+        "D_fcvt_s_d_cg/{cp_fs1, cp_fd, cr_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_voun, cp_csr_frm, cp_NaNBox_D_S}",
       ]
   - name: fcvt-w-d_op
     # FCVT.W.D or
@@ -249,7 +249,7 @@ normative_rule_definitions:
     # frm
     coverpoint:
       [
-        "D_fcvt_w_d_cg/{cp_rd, cp_fs1, cp_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
+        "D_fcvt_w_d_cg/{cp_rd, cp_fs1, cr_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
       ]
   - name: fcvt-wu-d_op
     # FCVT.WU.D, FCVT.LU.D, FCVT.D.WU, and FCVT.D.LU variants convert to
@@ -274,7 +274,7 @@ normative_rule_definitions:
     # frm
     coverpoint:
       [
-        "D_fcvt_wu_d_cg/{cp_rd, cp_fs1, cp_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
+        "D_fcvt_wu_d_cg/{cp_rd, cp_fs1, cr_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
       ]
   - name: fdiv-d_op
     # FDIV.S performs the single-precision floating-point division of rs1 by rs2

--- a/coverpoints/norm/ExceptionsSm.yaml
+++ b/coverpoints/norm/ExceptionsSm.yaml
@@ -191,7 +191,7 @@ normative_rule_definitions:
   - name: mepc_op
     coverpoint:
       [
-        "ExceptionsSm/{cp_instr_adr_misaligned_branch, cp_instr_access_fault, cp_illegal_instruction, cp_breakpoint, cp_load_address_misaligned, cp_load_access_fault, cp_store_address_misaligned, cp_store_access_fault, cp_ecall_m}",
+        "ExceptionsSm_cg/{cp_instr_adr_misaligned_branch, cp_instr_access_fault, cp_illegal_instruction, cp_breakpoint, cp_load_address_misaligned, cp_load_access_fault, cp_store_address_misaligned, cp_store_access_fault, cp_ecall_m}",
       ]
 
   # When a trap is taken into M-mode, mcause is written with a code indicating the

--- a/coverpoints/norm/F.yaml
+++ b/coverpoints/norm/F.yaml
@@ -52,7 +52,7 @@ normative_rule_definitions:
     # frm
     coverpoint:
       [
-        "F_fcvt_l_s_cg/{cp_rd, cp_fs1, cp_fs1_edges_frm, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
+        "F_fcvt_l_s_cg/{cp_rd, cp_fs1, cr_fs1_edges_frm, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
       ]
   - name: fcvt-lu-s_op
     # FCVT.WU.S, FCVT.LU.S, FCVT.S.WU,
@@ -80,7 +80,7 @@ normative_rule_definitions:
     # frm
     coverpoint:
       [
-        "F_fcvt_lu_s_cg/{cp_rd, cp_fs1, cp_fs1_edges_frm, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
+        "F_fcvt_lu_s_cg/{cp_rd, cp_fs1, cr_fs1_edges_frm, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
       ]
   - name: fcvt-s-l_op
     # FCVT.S.W or FCVT.S.L converts a 32-bit or 64-bit signed
@@ -210,7 +210,7 @@ normative_rule_definitions:
     # frm
     coverpoint:
       [
-        "F_fcvt_w_s_cg/{cp_rd, cp_fs1, cp_fs1_edges_frm, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
+        "F_fcvt_w_s_cg/{cp_rd, cp_fs1, cr_fs1_edges_frm, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
       ]
   - name: fcvt-wu-s_op
     # FCVT.WU.S, FCVT.LU.S, FCVT.S.WU,
@@ -237,7 +237,7 @@ normative_rule_definitions:
     # frm
     coverpoint:
       [
-        "F_fcvt_wu_s_cg/{cp_rd, cp_fs1, cp_fs1_edges_frm, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
+        "F_fcvt_wu_s_cg/{cp_rd, cp_fs1, cr_fs1_edges_frm, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm}",
       ]
   - name: fdiv-s_op
     # FDIV.S performs the single-precision floating-point division of rs1 by rs2

--- a/coverpoints/norm/PMPSm.yaml
+++ b/coverpoints/norm/PMPSm.yaml
@@ -7,7 +7,7 @@ normative_rule_definitions:
   - name: pmp_access_fault_exception
     coverpoint:
       [
-        "PMPSm_cg/{cp_misaligned_na4_wrap, cp_misaligned_tor_wrap,cp_misaligned_napot, cp_misaligned_na4, cp_misaligned_tor, cp_cfg_A_off_all, cp_cfg_A_napot_all, cp_na4_boundary, cp_tor_boundary, cp_tor_doubleregionfail",
+        "PMPSm_cg/{cp_misaligned_na4_wrap, cp_misaligned_tor_wrap,cp_misaligned_napot, cp_misaligned_na4, cp_misaligned_tor, cp_cfg_A_off_all, cp_cfg_A_napot_all, cp_na4_boundary, cp_tor_boundary, cp_tor_doubleregionfail}",
       ]
 
   # &lt;&lt;pmpcfg&gt;&gt; shows the layout of a PMP configuration register. The R,

--- a/coverpoints/norm/SvZicbo.yaml
+++ b/coverpoints/norm/SvZicbo.yaml
@@ -17,7 +17,7 @@ normative_rule_definitions:
   # During address translation, the instruction also checks the accessed bit and may
   # either raise an exception or set the bit as required.
   - name: cbm_unperm_translate
-    coverpoint: ["SvZicbo_cg/Abit_unset_cbo_s", "TODO: guest page fault"]
+    coverpoint: ["SvZicbo_cg/cp_Abit_unset_cbo_s", "TODO: guest page fault"]
 
   # If access to the cache block is not permitted, a cache-block zero instruction
   # raises a store page-fault or store guest-page-fault exception if address
@@ -29,9 +29,9 @@ normative_rule_definitions:
   # During address translation, the instruction also checks the accessed and dirty
   # bits and may either raise an exception or set the bits as required.
   - name: cbz_unperm_translate
-    coverpoint: ["SvZicbo_cg/{Abit_unset_cbo_s,Dbit_unset_zicbom_s}"]
+    coverpoint: ["SvZicbo_cg/{cp_Abit_unset_cbo_s,cp_Dbit_unset_zicbom_s}"]
 
   # During address translation, the instruction does not check the accessed and
   # dirty bits and neither raises an exception nor sets the bits.
   - name: cbp_unperm_translate
-    coverpoint: ["SvZicbo_cg/{Abit_unset_cbo_s,Dbit_unset_zicbom_s}"]
+    coverpoint: ["SvZicbo_cg/{cp_Abit_unset_cbo_s,cp_Dbit_unset_zicbom_s}"]

--- a/coverpoints/norm/Zfbfmin.yaml
+++ b/coverpoints/norm/Zfbfmin.yaml
@@ -3,9 +3,11 @@
 normative_rule_definitions:
   - name: fcvt-bf16-s_op
     coverpoint:
-      ["Zfbfmin_fcvt_bf16_s/{cp_fs1, cp_fd, cp_fs1_edges, cp_NaNBox_S_H}"]
+      ["Zfbfmin_fcvt_bf16_s_cg/{cp_fs1, cp_fd, cp_fs1_edges, cp_NaNBox_S_H}"]
       # Narrowing convert FP32 value to a BF16 value. Round according to the RM field.
   - name: fcvt-s-bf16_op
     coverpoint:
-      ["Zfbfmin_fcvt_bf16_s/{cp_fs1, cp_fd, cp_fs1_edges_H, cp_fs1_badNB_S_H}"]
+      [
+        "Zfbfmin_fcvt_bf16_s_cg/{cp_fs1, cp_fd, cp_fs1_edges_H, cp_fs1_badNB_S_H}",
+      ]
       # Converts a BF16 value to an FP32 value. The conversion is exact.

--- a/coverpoints/norm/Zfh.yaml
+++ b/coverpoints/norm/Zfh.yaml
@@ -87,7 +87,7 @@ normative_rule_definitions:
     # never round
     coverpoint:
       [
-        "Zfh_fcvt_h_s_cg/{cp_fs1, cp_fd, cp_fs1_edges_frm, cp_frm_2, cp_csr_fflags_voun, cp_csr_frm, cp_NaNBox_S_H}",
+        "Zfh_fcvt_h_s_cg/{cp_fs1, cp_fd, cr_fs1_edges_frm, cp_frm_2, cp_csr_fflags_voun, cp_csr_frm, cp_NaNBox_S_H}",
       ]
   - name: fcvt-h-w_op
     # FCVT.H.W or FCVT.H.L converts a 32-bit or 64-bit signed
@@ -161,7 +161,7 @@ normative_rule_definitions:
     # frm
     coverpoint:
       [
-        "Zfh_fcvt_l_h_cg/{cp_rd, cp_fs1, cp_fs1_edges_frm_H, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm, cp_fs1_badNB_S_H}",
+        "Zfh_fcvt_l_h_cg/{cp_rd, cp_fs1, cr_fs1_edges_frm_H, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm, cp_fs1_badNB_S_H}",
       ]
   - name: fcvt-lu-h_op
     # FCVT.WU.H, FCVT.LU.H, FCVT.H.WU, and FCVT.H.LU variants convert to or
@@ -188,7 +188,7 @@ normative_rule_definitions:
     # frm
     coverpoint:
       [
-        "Zfh_fcvt_lu_h_cg/{cp_rd, cp_fs1, cp_fs1_edges_frm_H, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm, cp_fs1_badNB_S_H}",
+        "Zfh_fcvt_lu_h_cg/{cp_rd, cp_fs1, cr_fs1_edges_frm_H, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm, cp_fs1_badNB_S_H}",
       ]
   - name: fcvt-s-h_op
     # FCVT.S.H or
@@ -224,7 +224,7 @@ normative_rule_definitions:
     # frm
     coverpoint:
       [
-        "Zfh_fcvt_w_h_cg/{cp_rd, cp_fs1, cp_fs1_edges_frm_H, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm, cp_fs1_badNB_S_H}",
+        "Zfh_fcvt_w_h_cg/{cp_rd, cp_fs1, cr_fs1_edges_frm_H, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm, cp_fs1_badNB_S_H}",
       ]
   - name: fcvt-wu-h_op
     # FCVT.WU.H, FCVT.LU.H, FCVT.H.WU, and FCVT.H.LU variants convert to or
@@ -249,7 +249,7 @@ normative_rule_definitions:
     # frm
     coverpoint:
       [
-        "Zfh_fcvt_wu_h_cg/{cp_rd, cp_fs1, cp_fs1_edges_frm_H, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm, cp_fs1_badNB_S_H}",
+        "Zfh_fcvt_wu_h_cg/{cp_rd, cp_fs1, cr_fs1_edges_frm_H, cp_frm_2, cp_csr_fflags_vn, cp_csr_frm, cp_fs1_badNB_S_H}",
       ]
   - name: fdiv-h_op
     # FDIV.S performs the single-precision floating-point division of rs1 by rs2

--- a/coverpoints/norm/ZfhD.yaml
+++ b/coverpoints/norm/ZfhD.yaml
@@ -21,7 +21,7 @@ normative_rule_definitions:
     # never round
     coverpoint:
       [
-        "ZfhD_fcvt_h_d_cg/{cp_fs1, cp_fd, cp_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_voun, cp_csr_frm, cp_NaNBox_D_H}",
+        "ZfhD_fcvt_h_d_cg/{cp_fs1, cp_fd, cr_fs1_edges_frm_D, cp_frm_2, cp_csr_fflags_voun, cp_csr_frm, cp_NaNBox_D_H}",
       ]
   - name: fadd-h_op
     # FADD.S and FMUL.S


### PR DESCRIPTION
**Syntax**
- `PMPSm.yaml:10` — the misaligned-access rule's coverpoint list was never closed (`… cp_tor_doubleregionfail",`
  with no `}`).

**Covergroup names**
- `ExceptionsSm.yaml:194` named `ExceptionsSm`; the generated group is `ExceptionsSm_cg`.
- `Zfbfmin.yaml:6,10` named `Zfbfmin_fcvt_bf16_s`; the generated group is `Zfbfmin_fcvt_bf16_s_cg`.

**Coverpoint names**
- `D`, `F`, `Zfh` and `ZfhD` spell the frm crosses `cp_fs1_edges_frm{,_D,_H}` and `cp_fs1_fs2_edges_frm_D`.
  The generator emits these as crosses, so the names begin with `cr_`. (17 references.)
- `SvZicbo` names `Abit_unset_cbo_s` and `Dbit_unset_zicbom_s` without the `cp_` prefix the covergroup
  declares. (4 references.)