### PR TITLE
Cite XLEN-matched covergroups in the Zknh and Zkne norm YAMLs

### DIFF
--- a/coverpoints/norm/Zkne.yaml
+++ b/coverpoints/norm/Zkne.yaml
@@ -14,7 +14,7 @@ normative_rule_definitions:
     coverpoint: ["Definition, checked through UDB"]
 
   - name: zk_scalar_xreg_op
-    coverpoint: ["Zkne_aes32esi_cg/{cr_rs1_rs2_edges}"]
+    coverpoint: ["{Zkne_aes32esi_cg, Zkne_aes64es_cg}/{cr_rs1_rs2_edges}"]
 
   - name: aes32esi_enc
     coverpoint: ["Zkne_aes32esi_cg/{cr_rs1_rs2_edges}"]

--- a/coverpoints/norm/Zknh.yaml
+++ b/coverpoints/norm/Zknh.yaml
@@ -75,13 +75,13 @@ normative_rule_definitions:
     coverpoint: ["Zknh_sha512sig1_cg/cr_rs1_rs2_edges"]
 
   - name: sha512sum0_enc
-    coverpoint: ["Zknh_sha512sum0r_cg/cr_rs1_rs2_edges"]
+    coverpoint: ["Zknh_sha512sum0_cg/cr_rs1_rs2_edges"]
 
   - name: sha512sum0_op
-    coverpoint: ["Zknh_sha512sum0r_cg/cr_rs1_rs2_edges"]
+    coverpoint: ["Zknh_sha512sum0_cg/cr_rs1_rs2_edges"]
 
   - name: sha512sum1_enc
-    coverpoint: ["Zknh_sha512sum1r_cg/cr_rs1_rs2_edges"]
+    coverpoint: ["Zknh_sha512sum1_cg/cr_rs1_rs2_edges"]
 
   - name: sha512sum1_op
-    coverpoint: ["Zknh_sha512sum1r_cg/cr_rs1_rs2_edges"]
+    coverpoint: ["Zknh_sha512sum1_cg/cr_rs1_rs2_edges"]


### PR DESCRIPTION
Issue #2147 item 54.

`sha512sum0` and `sha512sum1` normative rules referenced the wrong covergroups.