### PR TITLE
Drop the nonexistent MISALIGNED_LDST_FULLY_HW_SUPPORTED rule from the Misalign YAMLs

### DIFF
--- a/coverpoints/norm/Misalign.yaml
+++ b/coverpoints/norm/Misalign.yaml
@@ -1,8 +1,6 @@
 # Mapping of normative rules to coverpoints for a test suite
 
 normative_rule_definitions:
-  - name: MISALIGNED_LDST_FULLY_HW_SUPPORTED
-    coverpoint: ["{Misalign_lw_cg,Misalign_sw_cg}/{cp_misalign}"]
   - name: lh_op
     # LH loads a 16-bit value from memory, then sign-extends to 32-bits before storing
     # in rd.

--- a/coverpoints/norm/MisalignD.yaml
+++ b/coverpoints/norm/MisalignD.yaml
@@ -1,8 +1,6 @@
 # Mapping of normative rules to coverpoints for a test suite
 
 normative_rule_definitions:
-  - name: MISALIGNED_LDST_FULLY_HW_SUPPORTED
-    coverpoint: ["{MisalignD_fld_cg,MisalignD_fsd_cg}/{cp_misalign}"]
   - name: fp_misaligned
     coverpoint: ["{MisalignD_fld_cg,MisalignD_fsd_cg}/{cp_misalign}"]
   - name: fld_op

--- a/coverpoints/norm/MisalignF.yaml
+++ b/coverpoints/norm/MisalignF.yaml
@@ -1,8 +1,6 @@
 # Mapping of normative rules to coverpoints for a test suite
 
 normative_rule_definitions:
-  - name: MISALIGNED_LDST_FULLY_HW_SUPPORTED
-    coverpoint: ["{MisalignF_flw_cg,MisalignF_fsw_cg}/{cp_misalign}"]
   - name: fp_misaligned
     coverpoint: ["{MisalignF_flw_cg,MisalignF_fsw_cg}/{cp_misalign}"]
   - name: flw_op

--- a/coverpoints/norm/MisalignQ.yaml
+++ b/coverpoints/norm/MisalignQ.yaml
@@ -1,8 +1,6 @@
 # Mapping of normative rules to coverpoints for a test suite
 
 normative_rule_definitions:
-  - name: MISALIGNED_LDST_FULLY_HW_SUPPORTED
-    coverpoint: ["{MisalignQ_flq_cg,MisalignQ_fsq_cg}/{cp_misalign}"]
   - name: fp_misaligned
     coverpoint: ["{MisalignQ_flq_cg,MisalignQ_fsq_cg}/{cp_misalign}"]
   - name: flq_op

--- a/coverpoints/norm/MisalignZca.yaml
+++ b/coverpoints/norm/MisalignZca.yaml
@@ -1,8 +1,6 @@
 # Mapping of normative rules to coverpoints for a test suite
 
 normative_rule_definitions:
-  - name: MISALIGNED_LDST_FULLY_HW_SUPPORTED
-    coverpoint: ["{MisalignZca_c_lw_cg,MisalignZca_c_sw_cg}/{cp_misalign}"]
   - name: c-lw_op
     # C.LW loads a 32-bit value from memory into register
     # rd′. It computes an effective address by adding the


### PR DESCRIPTION
Issue #2147 item 56.

`MISALIGNED_LDST_FULLY_HW_SUPPORTED` is not a normative rule — it is a UDB parameter value.