### PR TITLE
Map the uncompressed NTL rules onto the uncompressed Zihintntl tests

### DIFF
--- a/coverpoints/norm/Zihintntl.yaml
+++ b/coverpoints/norm/Zihintntl.yaml
@@ -4,7 +4,7 @@ normative_rule_definitions:
   # The NTL.P1 instruction indicates that the target instruction does not exhibit
   # temporal locality within the capacity of the innermost level of private cache in
   # the memory hierarchy.
-  - name: C-NTL-P1_op
+  - name: NTL-P1_op
     coverpoint: ["Zihintntl_ntl_p1_cg/cp_asm_count"]
   # NTL.P1 is encoded as ADD x0, x0, x2.
   - name: NTL-P1_enc
@@ -12,31 +12,31 @@ normative_rule_definitions:
   # The NTL.ALL instruction indicates that the target instruction does not exhibit
   # temporal locality within the capacity of any level of cache in the memory
   # hierarchy.
-  - name: C-NTL-ALL_op
+  - name: NTL-ALL_op
     coverpoint: ["Zihintntl_ntl_all_cg/cp_asm_count"]
   # NTL.ALL is encoded as ADD x0, x0, x5.
-  - name: C-NTL-ALL_end
+  - name: NTL-ALL_enc
     coverpoint: ["Zihintntl_ntl_all_cg/cp_asm_count"]
   # The NTL.PALL instruction indicates that the target instruction does not exhibit
   # temporal locality within the capacity of any level of private cache in the
   # memory hierarchy.
-  - name: C-NTL-PALL_op
+  - name: NTL-PALL_op
     coverpoint: ["Zihintntl_ntl_pall_cg/cp_asm_count"]
   # NTL.PALL is encoded as ADD x0, x0, x3.
-  - name: C-NTL-PALL_enc
+  - name: NTL-PALL_enc
     coverpoint: ["Zihintntl_ntl_pall_cg/cp_asm_count"]
   # The NTL.S1 instruction indicates that the target instruction does not exhibit
   # temporal locality within the capacity of the innermost level of shared cache in
   # the memory hierarchy.
-  - name: C-NTL-S1_op
+  - name: NTL-S1_op
     coverpoint: ["Zihintntl_ntl_s1_cg/cp_asm_count"]
   # NTL.S1 is encoded as ADD x0, x0, x4.
-  - name: C-NTL-S1_enc
+  - name: NTL-S1_enc
     coverpoint: ["Zihintntl_ntl_s1_cg/cp_asm_count"]
 
   # The NTL instructions do not change architectural state, nor do they alter the
   # architecturally visible effects of the target instruction.
-  - name: NTL-target_definition
+  - name: NTL_target_definition
     coverpoint: ["Untested - hint"]
 
   # The NTL instructions affect all memory-access instructions except the
@@ -47,7 +47,7 @@ normative_rule_definitions:
   # When an NTL instruction is applied to a prefetch hint in the Zicbop extension,
   # it indicates that a cache line should be prefetched into a cache that is outer
   # from the level specified by the NTL.
-  - name: NTL_Zicob_prefetch_outer
+  - name: NTL_Zicbop_prefetch_outer
     coverpoint: ["not tested - no architectural observable effects"]
 
   - name: NTL_TRAP_BEHAVIOR

--- a/coverpoints/norm/ZihintntlZca.yaml
+++ b/coverpoints/norm/ZihintntlZca.yaml
@@ -61,7 +61,7 @@ normative_rule_definitions:
   # also provided: C.NTL.P1 is encoded as C.ADD x0, x2; C.NTL.PALL is encoded as
   # C.ADD x0, x3; C.NTL.S1 is encoded as C.ADD x0, x4; and C.NTL.ALL is encoded as
   # C.ADD x0, x5.
-  - name: C-NTL-availability
+  - name: C-NTL_availability
     coverpoint:
       [
         "{ZihintntlZca_c_ntl_p1_cg, ZihintntlZca_c_ntl_pall_cg, ZihintntlZca_c_ntl_s1_cg, ZihintntlZca_c_ntl_all_cg}/cp_asm_count",


### PR DESCRIPTION
Issue #2147 item 57.

`Zihintntl.yaml` referred to the `C-NTL-*` rule names instead of the "NTL-*" rule names. Also fixes a few misspelled rules.