### PR TITLE
Reject unknown suffixes in the floating-point edge coverpoint variants

### DIFF
--- a/generators/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py
@@ -14,19 +14,33 @@ from testgen.data.test_chunk import TestChunk
 from testgen.formatters import format_single_testcase
 from testgen.instructions.params import generate_random_params
 
+# Recognised tokens in a cp_fs*/cr_fs* coverpoint suffix. The width tokens select the edge set;
+# the rest only affect how the variant is generated. Anything else is a testplan typo, which
+# would otherwise fall through to the single-precision default and generate the wrong edges.
+_FP_EDGE_WIDTHS = {"D": "double", "H": "half", "BF16": "bf16"}
+_FP_EDGE_MODIFIERS = {"frm", "frm4", "v", "bf16"}
+
+
+def _fp_edges_for(coverpoint: str, base: str) -> list[int]:
+    """Select the edge set for a cp_fs*/cr_fs* variant, rejecting unknown suffix tokens."""
+    tokens = [t for t in coverpoint[len(base) :].split("_") if t]
+    width = "single"
+    for token in tokens:
+        if token in _FP_EDGE_WIDTHS:
+            width = _FP_EDGE_WIDTHS[token]
+        elif token not in _FP_EDGE_MODIFIERS:
+            raise ValueError(
+                f"Unknown suffix '{token}' in coverpoint {coverpoint!r}; "
+                f"expected width {sorted(_FP_EDGE_WIDTHS)} or modifier {sorted(_FP_EDGE_MODIFIERS)}"
+            )
+    return getattr(FLOAT_EDGES, width)
+
 
 def _make_fs_edges(
     operand: str, instr_name: str, instr_type: str, coverpoint: str, test_data: TestData
 ) -> list[TestChunk]:
     """Shared body for cp_fs1_edges / cp_fs2_edges / cp_fs3_edges."""
-    if coverpoint.endswith("_D"):
-        edges = FLOAT_EDGES.double
-    elif coverpoint.endswith("_H"):
-        edges = FLOAT_EDGES.half
-    elif coverpoint.endswith("_BF16"):
-        edges = FLOAT_EDGES.bf16
-    else:
-        edges = FLOAT_EDGES.single
+    edges = _fp_edges_for(coverpoint, f"cp_{operand}_edges")
 
     cross_frm = "_frm" in coverpoint
     frm_modes = ("dyn", "rdn", "rmm", "rne", "rtz", "rup") if cross_frm else [None]

--- a/generators/testgen/src/testgen/coverpoints/cr_fp_reg_edges.py
+++ b/generators/testgen/src/testgen/coverpoints/cr_fp_reg_edges.py
@@ -7,8 +7,8 @@
 
 """Floating point cross-product register edge value coverpoint generators (cr_fs1_fs2_edges, cr_fs1_fs2_edges_frm, etc.)."""
 
+from testgen.coverpoints.cp_fp_reg_edges import _fp_edges_for
 from testgen.coverpoints.registry import add_coverpoint_generator
-from testgen.data.edges import FLOAT_EDGES
 from testgen.data.state import TestData, return_testcase_registers
 from testgen.data.test_chunk import TestChunk
 from testgen.formatters import format_single_testcase
@@ -18,18 +18,7 @@ from testgen.instructions.params import generate_random_params
 @add_coverpoint_generator("cr_fs1_fs2_edges")
 def make_cr_fs1_fs2_edges(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[TestChunk]:
     """Generate tests for cross-product of fs1 and fs2 edge values."""
-    if coverpoint.endswith("_D"):
-        edges1 = FLOAT_EDGES.double
-        edges2 = FLOAT_EDGES.double
-    elif coverpoint.endswith("_H"):
-        edges1 = FLOAT_EDGES.half
-        edges2 = FLOAT_EDGES.half
-    elif coverpoint.endswith("_BF16"):
-        edges1 = FLOAT_EDGES.bf16
-        edges2 = FLOAT_EDGES.bf16
-    else:
-        edges1 = FLOAT_EDGES.single
-        edges2 = FLOAT_EDGES.single
+    edges1 = edges2 = _fp_edges_for(coverpoint, "cr_fs1_fs2_edges")
 
     cross_frm = "_frm" in coverpoint
 
@@ -55,18 +44,7 @@ def make_cr_fs1_fs2_edges(instr_name: str, instr_type: str, coverpoint: str, tes
 @add_coverpoint_generator("cr_fs1_fs3_edges")
 def make_cr_fs1_fs3_edges(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[TestChunk]:
     """Generate tests for cross-product of fs1 and fs3 edge values."""
-    if coverpoint.endswith("_D"):
-        edges1 = FLOAT_EDGES.double
-        edges2 = FLOAT_EDGES.double
-    elif coverpoint.endswith("_H"):
-        edges1 = FLOAT_EDGES.half
-        edges2 = FLOAT_EDGES.half
-    elif coverpoint.endswith("_BF16"):
-        edges1 = FLOAT_EDGES.bf16
-        edges2 = FLOAT_EDGES.bf16
-    else:
-        edges1 = FLOAT_EDGES.single
-        edges2 = FLOAT_EDGES.single
+    edges1 = edges2 = _fp_edges_for(coverpoint, "cr_fs1_fs3_edges")
 
     cross_frm = "_frm" in coverpoint
 


### PR DESCRIPTION
Issue #2147 item 31, scalar half only — the vector generators are left alone.

`cp_fs*_edges` and `cr_fs*_edges` picked their edge set with `endswith("_D") / "_H" / "_BF16"` and an `else` that fell through to single precision, so a testplan typo silently generated single-precision edges instead of failing. The suffix is now tokenised against an allowlist of widths (`D`, `H`, `BF16`) and modifiers (`frm`, `frm4`, `v`, `bf16`), and anything else raises.

The width selection is unchanged for every suffix in use today, so regeneration produces no diff.

The `v` and `bf16` modifier tokens are defensive only: `cp_fs1_edges_v` and `cp_fs1_edges_v_bf16` are dispatched by the standalone vector generator (`vector-testgen-unpriv.py`), which selects `fedgesBF16` for bf16 instructions at SEW=16, so they never reach this function. They are allowlisted so that the registry prefix match cannot turn into a hard error if one is ever added to a scalar testplan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQggocKy44ZFXK3VXYPkfw