### PR TITLE
Reject testplan rows that do not match the header

### DIFF
--- a/generators/testgen/src/testgen/io/testplans.py
+++ b/generators/testgen/src/testgen/io/testplans.py
@@ -71,6 +71,22 @@ def read_testplan(testplan_path: Path) -> list[TestPlanData]:
                     f"Error: 'Type' column missing in testplan {testplan_path}. Make sure you remembered to shrink the CSV."
                 )
                 raise
+            # csv.DictReader collects fields past the end of the header under the None key and
+            # pads a short row with None values. Both mean the row and the header disagree, and
+            # both are silently dropped by the coverpoint loop below, so reject them here.
+            extra = row.pop(None, None)
+            if extra:
+                raise ValueError(
+                    f"{testplan_path}: row for {instr!r} has {len(extra)} field(s) past the end of "
+                    f"the header: {extra}. Add the missing column(s) or remove the trailing commas."
+                )
+            missing = [key for key, value in row.items() if value is None]
+            if missing:
+                raise ValueError(
+                    f"{testplan_path}: row for {instr!r} is missing field(s) {missing}; "
+                    f"it has fewer columns than the header."
+                )
+
             rv32 = row["RV32"].strip().lower() == "x"
             rv64 = row["RV64"].strip().lower() == "x"
             sews = []


### PR DESCRIPTION
Issue #2147 item 36, first half.

`csv.DictReader` puts fields past the end of the header under the `None` key and pads a short row with `None` values. The coverpoint loop tests `isinstance(value, str)`, so both cases were dropped without a word — a stray trailing comma silently discarded a column. `read_testplan` now raises on either, naming the file and the instruction.

Not included: the `Type` validation half. `read_testplan` also serves the vector suites, and 25 vector `Type`s (`FVV`, `FVVF`, `VV_EGS4`, …) have no registered formatter, so checking `Type` against the formatter registry there would fail the build. `I.csv`'s `fence` declaring `Type = F` is the one scalar instance and wants that same change, so the two belong together in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQggocKy44ZFXK3VXYPkfw